### PR TITLE
UsfirstEventGet in datafeed_controller does bulk request for teams.

### DIFF
--- a/helpers/datafeed_helper.py
+++ b/helpers/datafeed_helper.py
@@ -1,0 +1,13 @@
+class DatafeedHelper(object):
+
+    @classmethod
+    def getTeamKeyNames(self, team_dict):
+        """
+        Takes a dictionary of teams from USFIRST, and returns a list of team key names.
+        """
+        team_list = list()
+        for team in team_dict:
+            team_list.append("frc" + team["number"])
+
+        return team_list
+


### PR DESCRIPTION
Refactored UsfirstEventGet now makes bulk request via get_by_key_name
to grab team information.
Created datafeed_helper with getTeamKeyNames that takes a list of team
dictionaries created by getEventRegistration and returns a list of team
keynames with the same index.
