### PR TITLE
Fixes #69: Handles null year with 302 redirect.

### DIFF
--- a/controllers/team_controller.py
+++ b/controllers/team_controller.py
@@ -33,6 +33,10 @@ class TeamList(webapp.RequestHandler):
 # The view of a single Team.
 class TeamDetail(webapp.RequestHandler):
     def get(self, team_number, year=None):
+
+        if year is '':
+            return self.redirect("/team/" + team_number)
+
         if type(year) == str: 
             year = int(year)
             explicit_year = True


### PR DESCRIPTION
Checks year, if nothing is in the string then redirect using 302 to
"/team/team_number".
