### PR TITLE
Add link to event info on usfirst.org

### DIFF
--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -58,6 +58,10 @@
                 <th>Website</th>
                 <td><a href="{{ event.website }}" title="{{ event.name }}">{{ event.website }}</a></td>
             </tr>{% endif %}
+            {% if event.name %}<tr>
+                <th>USFIRST Page</th>
+                <td><a href="https://my.usfirst.org/myarea/index.lasso?page=teamlist&event_type=FRC&sort_teams=number&year={{ event.year }}&event={{ event.event_short }}">{{ event.name }} on usfirst.org</a></td>
+            </tr>{% endif %}
             {% if event.facebook_eid %}<tr>
                 <th>Facebook</th>
                 <td><a href="{{ event.getFacebookEventUrl }}" title="Facebook Event">RSVP</td>


### PR DESCRIPTION
I did not know what to name it. Probably a better name than USFIRST Page.
