### PR TITLE
Remove OPR overwrite on event update

### DIFF
--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -75,16 +75,20 @@ class EventUpdater(object):
         """
         Given an "old" and a "new" Event object, replace the fields in the
         "old" event that are present in the "new" event, but keep fields from
-        the "old" event that are null in the "new" event.
+        the "old" event that are null or the empty list in the "new" event.
+        We need to be careful, because ListProperty defaults to [] instead of
+        None.
         """
         
         for attr, value in vars(new_event).iteritems():
             try:
+                # If value is a non-empty list or string set it in old_event.
                 if len(value)>0:
                     setattr(old_event,attr,value)
-            except Exception, e:
-                if value is not None:
-                    setattr(old_event,attr,value)
+            except Exception:
+                # An exception was raised because value is None. We don't do
+                # anything so that old_event retains whatever value it had.
+                pass
 
 
         return old_event


### PR DESCRIPTION
The issue was that ListProperty defaults to the empty list instead of None.

I tried checking for the length of the value, but this throws an exception if value is None. I figure there is a cleaner way to do this.

Now we can really announce OPRs on TBA. :)
