### PR TITLE
Missing closing </a> tag on events page fix

### DIFF
--- a/templates/event_details.html
+++ b/templates/event_details.html
@@ -48,11 +48,11 @@
 		            </tr>{% endif %}
 		            {% if event.facebook_eid %}<tr>
 		                <th>Facebook</th>
-		                <td><a href="{{ event.getFacebookEventUrl }}" title="Facebook Event">RSVP</td>
+		                <td><a href="{{ event.getFacebookEventUrl }}" title="Facebook Event">RSVP</a></td>
 		            </tr>{% endif %}
 		            {% if event.webcast_url %}<tr>
 		                <th>Live Webcast</th>
-		                <td><a href="{{ event.webcast_url }}" title="">{{ event.webcast_url }}</td>
+		                <td><a href="{{ event.webcast_url }}" title="">{{ event.webcast_url }}</a></td>
 		            </tr>{% endif %}
 					{% if num_teams %}<tr>
 						<th>Teams</th>


### PR DESCRIPTION
Now we pass HTML5 validation except for the fb and g+ links (not much we can do) and the links to google maps (the spaces and commas need to be urlencoded but applying the |urlencode filter doesn't seem to escape the spaces properly...)
