### PR TITLE
Changed inheritance for .end_header

### DIFF
--- a/static/css/tba_base.less
+++ b/static/css/tba_base.less
@@ -81,7 +81,7 @@
   background-image: url('/images/appengine.png');
 }
 
-.container > .end_header {
+.end_header {
   margin-bottom: 15px;
 }
 


### PR DESCRIPTION
The match detail page was breaking (not enough space between the event name and the "back to event" link) after changes made in https://github.com/gregmarra/the-blue-alliance/commit/b15f46ce34cf674e7452e4665a60e9c4d14b788d
