### PR TITLE
Put typeaheadhandler above pagenotfoundhandler

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ app = webapp2.WSGIApplication([('/', MainHandler),
                                ('/team/([0-9]*)/(.*)', TeamDetail),
                                ('/thanks', ThanksHandler),
                                ('/opr', OprHandler),
-                               ('/.*', PageNotFoundHandler),
                                ('/_/typeahead', TypeaheadHandler),
+                               ('/.*', PageNotFoundHandler),
                                ],
                               debug=tba_config.DEBUG)


### PR DESCRIPTION
Fixes bug introduced in https://github.com/gregmarra/the-blue-alliance/commit/c585260c950b99fcb7748a5da22f1d5967287df1
