### PR TITLE
fix error when fixing event.rankings_json error

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -35,7 +35,7 @@ class Event(db.Model):
         Lazy load parsing rankings JSON
         """
         if self._rankings is None:
-            if type(self.rankings_json) == str:
+            if type(self.rankings_json) == db.Text:
                 self._rankings = json.loads(self.rankings_json)
             else:
                 self._rankings = None


### PR DESCRIPTION
self.rankings_json is of type "<class 'google.appengine.api.datastore_types.Text'>," not string. Was resulting in no rankings being loaded.
