### PR TITLE
removed 'einstein' from event_short_exceptions

### DIFF
--- a/datafeeds/datafeed_usfirst.py
+++ b/datafeeds/datafeed_usfirst.py
@@ -31,7 +31,6 @@ class DatafeedUsfirst(DatafeedBase):
         "cur": "Curie",
         "gal": "Galileo",
         "new": "Newton",
-        "ein": "Einstein",  # Weird, seems like only 2008 follows this format
     }
 
     MATCH_RESULTS_URL_PATTERN = "http://www2.usfirst.org/%scomp/events/%s/matchresults.html" # % (year, event_short)


### PR DESCRIPTION
Seems like only 2008 had this issue. Now that we have 2008 awards, removing this exception so that we don't use it for future events. Removing seemed cleaner than having multiple exceptions depending on year.
