### PR TITLE
Access match details from the API fixes #180

### DIFF
--- a/api_main.py
+++ b/api_main.py
@@ -4,12 +4,14 @@ import webapp2
 
 import tba_config
 
-from controllers.api_controller import ApiEventsShow, ApiTeamDetails, ApiTeamsShow, ApiEventList, ApiEventDetails
+from controllers.api_controller import ApiEventsShow, ApiTeamDetails, ApiTeamsShow,\
+                                       ApiEventList, ApiEventDetails, ApiMatchDetails
 
 app = webapp2.WSGIApplication([('/api/v1/team/details', ApiTeamDetails),
                                ('/api/v1/teams/show', ApiTeamsShow),
                                ('/api/v1/events/show', ApiEventsShow),
                                ('/api/v1/events/list', ApiEventList),
                                ('/api/v1/event/details', ApiEventDetails),
+                               ('/api/v1/match/details', ApiMatchDetails),
                                ],
                                debug=tba_config.DEBUG)

--- a/controllers/api_controller.py
+++ b/controllers/api_controller.py
@@ -126,3 +126,24 @@ class ApiEventDetails(webapp.RequestHandler):
         event_dict = ApiHelper.getEventInfo(event_key)
 
         self.response.out.write(json.dumps(event_dict))
+
+class ApiMatchDetails(webapp.RequestHandler):
+    """
+    Returns a specifc
+    """
+    def get(self):
+        if self.request.get('match') is not '':
+            match_key = self.request.get('match')
+
+        if self.request.get('matches') is not '':
+            match_keys = self.request.get('matches').split(',')
+
+        if 'match_keys' in locals():
+            match_json = list()
+            for match in match_keys:
+                match_json.append(ApiHelper.getMatchDetails(match))
+        else:
+            match_json = ApiHelper.getMatchDetails(match_key)
+
+        self.response.headers.add_header("content-type", "application/json")
+        self.response.out.write(json.dumps(match_json))

--- a/helpers/api_helper.py
+++ b/helpers/api_helper.py
@@ -144,9 +144,33 @@ class ApiHelper(object):
                 match_dict["team_keys"] = match.team_key_names
                 match_dict["alliances"] = json.loads(match.alliances_json)
                 matches_list.append(match_dict)
-            
+
             #TODO: Reduce caching time before 2013 season. 2592000 is one month -gregmarra
             if tba_config.CONFIG["memcache"]: memcache.set(memcache_key, matches_list, 2592000)
-        
+
         team_dict["matches"] = matches_list
         return team_dict
+
+    @classmethod
+    def getMatchDetails(self, match_key):
+        """
+        Returns match details
+        """
+        memcache_key = "api_match_details_%s" % match_key
+        match_dict = memcache.get(memcache_key)
+
+        if match_dict is None:
+            match = Match.get_by_id(match_key)
+
+            match_dict = {}
+            match_dict["key"] = match.key_name
+            match_dict["event"] = match.event.id()
+            match_dict["competition_level"] = match.name
+            match_dict["set_number"] = match.set_number
+            match_dict["match_number"] = match.match_number
+            match_dict["team_keys"] = match.team_key_names
+            match_dict["alliances"] = json.loads(match.alliances_json)
+
+            if tba_config.CONFIG["memcache"]: memcache.set(memcache_key, match_dict, (2 * (60 * 60)) )
+
+        return match_dict

--- a/models/match.py
+++ b/models/match.py
@@ -155,6 +155,10 @@ class Match(ndb.Model):
     def details_url(self):
         return "/match/%s" % self.key_name
 
+    @property
+    def name(self):
+        return "%s" % (self.COMP_LEVELS_VERBOSE[self.comp_level])
+
     @classmethod
     def getKeyName(self, event, comp_level, set_number, match_number):
         if comp_level == "qm":

--- a/tests/test_event_api.py
+++ b/tests/test_event_api.py
@@ -1,17 +1,19 @@
 import unittest2
 import webtest
 import json
+
 from datetime import datetime
 
 from google.appengine.ext import webapp
 from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
-from controllers.api_controller import ApiEventsShow
+from controllers.api_controller import ApiEventsShow, ApiEventList, ApiMatchDetails
 
 from models.event import Event
-from models.team import Team
 from models.event_team import EventTeam
+from models.match import Match
+from models.team import Team
 
 class TestApiEventShow(unittest2.TestCase):
 
@@ -84,3 +86,109 @@ class TestApiEventShow(unittest2.TestCase):
         event_dict = json.loads(response.body)
         self.assertEventJson(event_dict[0])
 
+class TestApiEventList(unittest2.TestCase):
+
+    def setUp(self):
+        app = webapp.WSGIApplication([(r'/', ApiEventList)], debug=True)
+        self.testapp = webtest.TestApp(app)
+
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_urlfetch_stub()
+        self.testbed.init_memcache_stub()
+
+        self.event = Event(
+                id = "2010sc",
+                name = "Palmetto Regional",
+                event_type = "Regional",
+                short_name = "Palmetto",
+                event_short = "sc",
+                year = 2010,
+                end_date = datetime(2010, 03, 27),
+                official = True,
+                location = 'Clemson, SC',
+                start_date = datetime(2010, 03, 24),
+        )
+        self.event.put()
+
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def assertEventJson(self, event_dict):
+        self.assertEqual(event_dict["key"], self.event.key_name)
+        self.assertEqual(event_dict["name"], self.event.name)
+        self.assertEqual(event_dict["short_name"], self.event.short_name)
+        self.assertEqual(event_dict["official"], self.event.official)
+        self.assertEqual(event_dict["start_date"], self.event.start_date.isoformat())
+        self.assertEqual(event_dict["end_date"], self.event.end_date.isoformat())
+
+    def testEventShow(self):
+        response = self.testapp.get('/?year=2010')
+
+        event_dict = json.loads(response.body)
+        self.assertEventJson(event_dict[0])
+
+class TestApiMatchDetails(unittest2.TestCase):
+
+    def setUp(self):
+        app = webapp.WSGIApplication([(r'/', ApiMatchDetails)], debug=True)
+        self.testapp = webtest.TestApp(app)
+
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_urlfetch_stub()
+        self.testbed.init_memcache_stub()
+
+        self.event = Event(
+                id = "2010sc",
+                name = "Palmetto Regional",
+                event_type = "Regional",
+                short_name = "Palmetto",
+                event_short = "sc",
+                year = 2010,
+                end_date = datetime(2010, 03, 27),
+                official = True,
+                location = 'Clemson, SC',
+                start_date = datetime(2010, 03, 24),
+        )
+        self.event.put()
+
+        self.match_json = '{"blue": {"score": "14", "teams": ["frc469", "frc1114", "frc2041"]}, "red": {"score": "16", "teams": ["frc177", "frc67", "frc294"]}}'
+        match_team_key_names = ["frc177", "frc67", "frc294", "frc469", "frc1114", "frc2041"]
+
+        self.match = Match(
+                id = '2010cmp_f1m1',
+                comp_level = 'f',
+                match_number = 1,
+                team_key_names = match_team_key_names,
+                alliances_json = self.match_json,
+                set_number = 1,
+                game = 'frc_2010_bkwy',
+                event = self.event.key
+        )
+        self.match.put()
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def assertMatch(self, match_dict):
+        self.assertEqual(match_dict["key"], self.match.key_name)
+        self.assertEqual(match_dict["event"], self.event.key_name)
+        self.assertEqual(match_dict["competition_level"], self.match.name)
+        self.assertEqual(match_dict["set_number"], self.match.set_number)
+        self.assertEqual(match_dict["match_number"], self.match.match_number)
+        self.assertEqual(match_dict["team_keys"], self.match.team_key_names)
+
+        #FIXME: urgh. strings. - brandondean 10/21/2012
+        #self.assertEqual(match_dict["alliances"], self.match_json)
+
+
+    def testMatchDetails(self):
+        response = self.testapp.get("/?match=2010cmp_f1m1")
+
+        match_dict = json.loads(response.body)
+        match_dict["alliances"] = str(match_dict["alliances"])
+        self.assertMatch(match_dict)


### PR DESCRIPTION
Example response:

<pre>
  {
   "match_number":1,
   "team_keys":[
      "frc177",
      "frc67",
      "frc294",
      "frc469",
      "frc1114",
      "frc2041"
   ],
   "set_number":1,
   "competition_level":"Finals",
   "key":"2010cmp_f1m1",
   "alliances":{
      "blue":{
         "score":"14",
         "teams":[
            "frc469",
            "frc1114",
            "frc2041"
         ]
      },
      "red":{
         "score":"16",
         "teams":[
            "frc177",
            "frc67",
            "frc294"
         ]
      }
   },
   "event":"2010cmp"
}
</pre>
