### PR TITLE
API: Team List

### DIFF
--- a/api_main.py
+++ b/api_main.py
@@ -5,7 +5,8 @@ import webapp2
 import tba_config
 
 from controllers.api_controller import ApiEventsShow, ApiTeamDetails, ApiTeamsShow,\
-                                       ApiEventList, ApiEventDetails, ApiMatchDetails
+                                       ApiEventList, ApiEventDetails, ApiMatchDetails,\
+                                       ApiListTeams
 
 app = webapp2.WSGIApplication([('/api/v1/team/details', ApiTeamDetails),
                                ('/api/v1/teams/show', ApiTeamsShow),
@@ -13,5 +14,6 @@ app = webapp2.WSGIApplication([('/api/v1/team/details', ApiTeamDetails),
                                ('/api/v1/events/list', ApiEventList),
                                ('/api/v1/event/details', ApiEventDetails),
                                ('/api/v1/match/details', ApiMatchDetails),
+                               ('/api/v1/teams/list', ApiListTeams),
                                ],
                                debug=tba_config.DEBUG)

--- a/helpers/api_helper.py
+++ b/helpers/api_helper.py
@@ -174,3 +174,17 @@ class ApiHelper(object):
             if tba_config.CONFIG["memcache"]: memcache.set(memcache_key, match_dict, (2 * (60 * 60)) )
 
         return match_dict
+
+class DataHelper(object):
+
+    @classmethod
+    def thinTeam(self, team=None, team_key=None):
+        if team_key:
+            team = Team.get_by_id(team_key)
+
+        team_dict = dict()
+        team_dict["key"] = team.key_name
+        team_dict["team_number"] = team.team_number
+        team_dict["name"] = team.nickname
+
+        return team_dict


### PR DESCRIPTION
Only return 50 teams at a time, but provide an offset parameter as an option. I really couldn't think of a reason to have to request more than 50 teams at a time. Maybe it should be closer to 20?

I am very open to other methods of doing this. Unless we cache a list of all the teams there is no way we can return all the teams, and honestly, even if we could, we shouldn't. If people want all 3,700 teams (current production count) we can provide a CSV dump.
