### PR TITLE
Feedbar Updates

### DIFF
--- a/static/css/less_css/less/tba/tba_gameday.less
+++ b/static/css/less_css/less/tba/tba_gameday.less
@@ -173,7 +173,7 @@ body {
     cursor: pointer;
   }
 
-  .new{
+  .new_scores{
     background-color: #000033;
   }
   

--- a/static/javascript/tba_js/gameday_feedbar.js
+++ b/static/javascript/tba_js/gameday_feedbar.js
@@ -22,21 +22,21 @@ function updateFeedbar(match) {
   var blue_score = $('<div>', {'class': 'blue ' + blue_win, text: blue_teams + ' - ' + blue_score});
   var div_helper = $('<div>', {'class': 'div_helper'});
   
-  var new_match = $('<div>', {'class': 'scores new'}).append(match_number).append(red_score).append(blue_score).append(div_helper);
+  var new_match = $('<div>', {'class': 'scores new_scores'}).append(match_number).append(red_score).append(blue_score).append(div_helper);
   $('.feed_bar').prepend(new_match);
   $('.scores').click(function(){
     $(".scores").fancybox({
       'overlayColor'  : '#333',
-      'overlayShow' : true,
+      'overlayShow'   : true,
       'autoDimensions': false,
-      'width'     :   0.9*$(".video_container").width(),
-      'height'    : 0.9*$(".video_container").height(),
-      'type'      : 'iframe',
-      'href'      : '/event/' + getEventKey(match)
+      'width'         : 0.9*$(".video_container").width(),
+      'height'        : 0.9*$(".video_container").height(),
+      'type'          : 'iframe',
+      'href'          : '/event/' + getEventKey(match)
     });
   });
   new_match.focus();
-  new_match.removeClass('new');
+  new_match.removeClass('new_scores');
 }
 
 function getEventKey(match) {


### PR DESCRIPTION
New scores pushed now start with a subtle blue background color that quickly fades away.
Clicking on a score card will bring up that event's results page (same as the upper-right dropdown).
