### PR TITLE
Moved imports to top level

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -3,6 +3,10 @@ import datetime
 import json
 import logging
 
+from models.award import Award
+from models.match import Match
+from models.event_team import EventTeam
+
 class Event(ndb.Model):
     """
     Events represent FIRST Robotics Competition events, both official and unofficial.
@@ -42,14 +46,11 @@ class Event(ndb.Model):
         super(Event, self).__init__(*args, **kw)
     
     def prepAwards(self):
-        from models.award import Award
         if self._awards_future is None:
             self._awards_future = Award.query(Award.event == self.key).fetch_async(500)
 
     @property
     def awards(self):
-        # This import is ugly, and maybe all the models should be in one file again -gregmarra 20121006
-        from models.award import Award
         if self._awards is None:
             self.prepAwards()
             self._awards = self._awards_future.get_result()
@@ -62,8 +63,6 @@ class Event(ndb.Model):
 
     @property
     def matches(self):
-        # This import is ugly, and maybe all the models should be in one file again -gregmarra 20121006
-        from models.match import Match
         if self._matches is None:
             self.prepMatches()
             self._matches = self._matches_future.get_result()
@@ -97,8 +96,6 @@ class Event(ndb.Model):
 
     @property
     def teams(self):
-        # This import is ugly, and maybe all the models should be in one file again -gregmarra 20121006
-        from models.event_team import EventTeam
         if self._teams is None:
             team_keys = [event_team.team for event_team in self._event_teams_future.get_result()]
             teams = ndb.get_multi(team_keys)


### PR DESCRIPTION
Moved imports of `models.award.Award`, `models.match.Match`, and `models.event_team.EventTeam` to the top in order to avoid repeat imports by the methods.
