### PR TITLE
Moved imports to top level

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -3,9 +3,14 @@ import datetime
 import json
 import logging
 
+#note about these imports: match.py, event_team.py, and award.py all import event.py.
+#using from import results in a namespacing issue due to python's import mechanism, and so a direct
+#import statement is needed to circumvent this issue.
+#-pyprogrammer 2013 20130415
 import models.match as match
 import models.event_team as event_team
 import models.award as award
+
 
 class Event(ndb.Model):
     """


### PR DESCRIPTION
This one should fix the previous issue.  Using `from _____ import _____` results in a circular import since the module itself is run, but using a straight `import ______ as ______` should be fine.
