### PR TITLE
Basic user support [FIXED]

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -11,6 +11,7 @@ from controllers.admin.admin_match_controller import AdminVideosAdd, AdminMatchC
 from controllers.admin.admin_memcache_controller import AdminMemcacheMain
 from controllers.admin.admin_sitevar_controller import AdminSitevarCreate, AdminSitevarEdit, AdminSitevarList
 from controllers.admin.admin_team_controller import AdminTeamDetail, AdminTeamList
+from controllers.admin.admin_user_controller import AdminUserList, AdminUserDetail, AdminUserEdit, AdminUserDelete
 
 app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/debug', AdminDebugHandler),
@@ -36,6 +37,10 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/tasks', AdminTasksHandler),
                                ('/admin/teams', AdminTeamList),
                                ('/admin/team/(.*)', AdminTeamDetail),
+                               ('/admin/users', AdminUserList),
+                               ('/admin/user/delete/(.*)', AdminUserDelete),
+                               ('/admin/user/edit/(.*)', AdminUserEdit),
+                               ('/admin/user/(.*)', AdminUserDetail),
                                ('/admin/videos/add', AdminVideosAdd),
                                ],
                               debug=tba_config.DEBUG)

--- a/controllers/admin/admin_user_controller.py
+++ b/controllers/admin/admin_user_controller.py
@@ -1,0 +1,90 @@
+import logging
+from datetime import datetime
+import os
+
+from google.appengine.api import users
+from google.appengine.ext import webapp, db
+from google.appengine.ext import ndb
+from google.appengine.ext.webapp import template
+from webapp2_extras import auth
+from webapp2_extras.appengine.auth.models import User
+from webapp2_extras.appengine.auth.models import Unique
+
+class AdminUserList(webapp.RequestHandler):
+    """
+    List all Users.
+    """
+    def get(self):
+        users = User.query().fetch(10000)
+        
+        template_values = {
+            "users": users,
+        }
+        
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/user_list.html')
+        self.response.out.write(template.render(path, template_values))
+
+class AdminUserDetail(webapp.RequestHandler):
+    """
+    Show a User.
+    """
+    def get(self, user_id):
+        user = auth.get_auth().store.user_model.get_by_id(int(user_id))
+
+        template_values = {
+            "user": user
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/user_details.html')
+        self.response.out.write(template.render(path, template_values))
+
+class AdminUserDelete(webapp.RequestHandler):
+    """
+    Delete a User.
+    """
+    def get(self, user_id):
+        user = auth.get_auth().store.user_model.get_by_id(int(user_id))
+
+        template_values = {
+            "user": user
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/user_delete.html')
+        self.response.out.write(template.render(path, template_values))
+
+    def post(self, user_id):
+        user = auth.get_auth().store.user_model.get_by_id(int(user_id))
+        logging.warning("Deleting %s at the request of %s / %s" % (
+            user,
+            users.get_current_user().user_id(),
+            users.get_current_user().email()))
+        ndb.Key(User, int(user_id)).delete()
+        UNIQUE_AUTH_ID_KEYS = []
+        for auth_id in user.auth_ids:
+            UNIQUE_AUTH_ID_KEYS.append('User.auth_id:'+auth_id)
+        Unique.delete_multi(UNIQUE_AUTH_ID_KEYS)
+
+        self.redirect("/admin/users?deleted=%s" % user_id)
+
+
+class AdminUserEdit(webapp.RequestHandler):
+    """
+    Edit a User.
+    """
+    def get(self, user_id):
+        user = auth.get_auth().store.user_model.get_by_id(int(user_id))
+        template_values = {
+            "user": user
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/user_edit.html')
+        self.response.out.write(template.render(path, template_values))
+
+    def post(self, user_id):
+        user = auth.get_auth().store.user_model.get_by_id(int(user_id))
+
+        user.name = self.request.get("name")
+        user.email = self.request.get("email")
+        user.put()
+
+        self.redirect("/admin/user/" + user_id)

--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -2,15 +2,21 @@ import os
 import logging
 import datetime
 import time
+import secrets
+import json
+import sys
 
 from google.appengine.api import memcache
 from google.appengine.ext import ndb, webapp
+sys.modules['ndb'] = ndb
 from google.appengine.ext.webapp import template
 
 import tba_config
 
 from base_controller import BaseHandler, CacheableHandler
+from simpleauth import SimpleAuthHandler
 from helpers.event_helper import EventHelper
+from webapp2_extras import auth, sessions
 
 from models.event import Event
 from models.team import Team
@@ -227,3 +233,145 @@ class RecordHandler(CacheableHandler):
     def _render(self, *args, **kw):
         path = os.path.join(os.path.dirname(__file__), "../templates/record.html")
         return template.render(path, {})
+
+class AccountHandler(BaseHandler):
+    def get(self):
+        if self.logged_in:
+            template_values = {
+                'user': self.current_user,
+                'session': self.auth.get_user_by_session().items(),
+            }
+        else:
+            template_values = {
+                'msg': self.session.get_flashes('msg'),
+            }
+        path = os.path.join(os.path.dirname(__file__), '../templates/account.html')
+        self.response.out.write(template.render(path, template_values))
+
+class AuthHandler(BaseHandler, SimpleAuthHandler):
+    """Authentication handler for OAuth 2.0, 1.0(a) and OpenID."""
+
+    # Enable optional OAuth 2.0 CSRF guard
+    OAUTH2_CSRF_STATE = True
+  
+    USER_ATTRS = {
+        'facebook' : {
+            'id'     : lambda id: ('avatar_url', 
+                'http://graph.facebook.com/{0}/picture?type=large'.format(id)),
+            'name'   : 'name',
+            'link'   : 'link',
+            'email'  : 'email'
+        },
+        'google'   : {
+            'picture': 'avatar_url',
+            'name'   : 'name',
+            'link'   : 'link',
+            'email'  : 'email'
+        },
+        'windows_live': {
+            'avatar_url': 'avatar_url',
+            'name'      : 'name',
+            'link'      : 'link'
+        },
+        'twitter'  : {
+            'profile_image_url': 'avatar_url',
+            'screen_name'      : 'name',
+            'link'             : 'link'
+        },
+        'linkedin' : {
+            'picture-url'       : 'avatar_url',
+            'first-name'        : 'name',
+            'public-profile-url': 'link'
+        },
+        'foursquare'   : {
+            'photo'    : lambda photo: ('avatar_url', photo.get('prefix') + '100x100' + photo.get('suffix')),
+            'firstName': 'firstName',
+            'lastName' : 'lastName',
+            'contact'  : lambda contact: ('email',contact.get('email')),
+            'id'       : lambda id: ('link', 'http://foursquare.com/user/{0}'.format(id))
+        },
+        'openid'   : {
+            'id'      : lambda id: ('avatar_url', '/img/missing-avatar.png'),
+            'nickname': 'name',
+            'email'   : 'link'
+        }
+    }
+
+    def _on_signin(self, data, auth_info, provider):
+        """Callback whenever a new or existing user is logging in.
+         data is a user info dictionary.
+         auth_info contains access token or oauth token and secret.
+        """
+        auth_whitelist = Sitevar.get_by_id("auth.whitelist")
+        if data['id'] in auth_whitelist.values_json:
+            auth_id = '%s:%s' % (provider, data['id'])
+            logging.info('Looking for a user with id %s', auth_id)
+    
+            user = self.auth.store.user_model.get_by_auth_id(auth_id)
+            _attrs = self._to_user_model_attrs(data, self.USER_ATTRS[provider])
+
+            if user:
+                logging.info('Found existing user to log in')
+                # Existing users might've changed their profile data so we update our
+                # local model anyway. This might result in quite inefficient usage
+                # of the Datastore, but we do this anyway for demo purposes.
+                #
+                # In a real app you could compare _attrs with user's properties fetched
+                # from the datastore and update local user in case something's changed.
+                user.populate(**_attrs)
+                user.put()
+                self.auth.set_session(
+                self.auth.store.user_to_dict(user))
+      
+            else:
+                # check whether there's a user currently logged in
+                # then, create a new user if nobody's signed in, 
+                # otherwise add this auth_id to currently logged in user.
+
+                if self.logged_in:
+                    logging.info('Updating currently logged in user')
+        
+                    u = self.current_user
+                    u.populate(**_attrs)
+                    # The following will also do u.put(). Though, in a real app
+                    # you might want to check the result, which is
+                    # (boolean, info) tuple where boolean == True indicates success
+                    # See webapp2_extras.appengine.auth.models.User for details.
+                    u.add_auth_id(auth_id)
+        
+                else:
+                    logging.info('Creating a brand new user')
+                    ok, user = self.auth.store.user_model.create_user(auth_id, **_attrs)
+                    if ok:
+                        self.auth.set_session(self.auth.store.user_to_dict(user))
+
+            # Go to the profile page
+            self.redirect('/account')
+        else:
+            self.session.add_flash('Error: Unauthorized user ID', key='msg')
+            self.redirect('/account')
+
+    def logout(self):
+        self.auth.unset_session()
+        self.redirect('/')
+
+    def handle_exception(self, exception, debug):
+        logging.error(exception)
+        self.session.add_flash('Error. Please try again later.', key='msg')
+        self.redirect('/account')
+
+    def _callback_uri_for(self, provider):
+        return self.uri_for('auth_callback', provider=provider, _full=True)
+    
+    def _get_consumer_info_for(self, provider):
+        """Returns a tuple (key, secret) for auth init requests."""
+        return secrets.AUTH_CONFIG[provider]
+    
+    def _to_user_model_attrs(self, data, attrs_map):
+        """Get the needed information from the provider dataset."""
+        user_attrs = {}
+        for k, v in attrs_map.iteritems():
+            attr = (v, data.get(k)) if isinstance(v, str) else v(data.get(k))
+            user_attrs.setdefault(*attr)
+
+        return user_attrs

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from controllers.main_controller import ContactHandler, HashtagsHandler, \
       MainKickoffHandler, MainBuildseasonHandler, MainCompetitionseasonHandler, \
       OprHandler, SearchHandler, AboutHandler, ThanksHandler, \
       PageNotFoundHandler, ChannelHandler, GamedayHandler, \
-      WebcastsHandler, RecordHandler
+      WebcastsHandler, RecordHandler, AuthHandler, AccountHandler
 from controllers.match_controller import MatchDetail
 from controllers.team_controller import TeamList, TeamDetail
 from controllers.ajax_controller import TypeaheadHandler, WebcastHandler
@@ -24,6 +24,10 @@ landing_handler = {tba_config.KICKOFF: MainKickoffHandler,
 
 app = webapp2.WSGIApplication([('/', landing_handler[tba_config.CONFIG['landing_handler']]),
                                ('/about', AboutHandler),
+                               ('/account', AccountHandler),
+                               webapp2.Route('/logout', handler='controllers.main_controller.AuthHandler:logout', name='logout'),
+                               webapp2.Route('/auth/<provider>/callback', handler='controllers.main_controller.AuthHandler:_auth_callback', name='auth_callback'),
+                               webapp2.Route('/auth/<provider>', handler='controllers.main_controller.AuthHandler:_simple_auth', name='auth_login'),
                                ('/channel', ChannelHandler),
                                ('/contact', ContactHandler),
                                ('/events', EventList),
@@ -48,4 +52,5 @@ app = webapp2.WSGIApplication([('/', landing_handler[tba_config.CONFIG['landing_
                                ('/_/webcast/(.*)/(.*)', WebcastHandler),
                                ('/.*', PageNotFoundHandler),
                                ],
-                              debug=tba_config.DEBUG)
+                              debug=tba_config.DEBUG,
+                              config=tba_config.CONFIG)

--- a/secrets.py
+++ b/secrets.py
@@ -1,0 +1,52 @@
+import logging
+from models.sitevar import Sitevar
+
+facebook_secrets = Sitevar.get_by_id('facebook.secrets')
+
+try:
+    # Google APIs
+    #GOOGLE_APP_ID = '892192653518.apps.googleusercontent.com'
+    #GOOGLE_APP_SECRET = 'csHnsLRlOicNxDbTCeUQnOoe'
+
+    # Facebook auth apis
+    FACEBOOK_APP_ID = facebook_secrets.contents['FACEBOOK_APP_ID']
+    FACEBOOK_APP_SECRET = facebook_secrets.contents['FACEBOOK_APP_SECRET']
+
+    # https://www.linkedin.com/secure/developer
+    #LINKEDIN_CONSUMER_KEY = 'consumer key'
+    #LINKEDIN_CONSUMER_SECRET = 'consumer secret'
+
+    # https://manage.dev.live.com/AddApplication.aspx
+    # https://manage.dev.live.com/Applications/Index
+    #WL_CLIENT_ID = 'client id'
+    #WL_CLIENT_SECRET = 'client secret'
+
+    # https://dev.twitter.com/apps
+    #TWITTER_CONSUMER_KEY = 'oauth1.0a consumer key'
+    #TWITTER_CONSUMER_SECRET = 'oauth1.0a consumer secret'
+
+    # https://foursquare.com/developers/apps
+    #FOURSQUARE_CLIENT_ID = 'client id'
+    #FOURSQUARE_CLIENT_SECRET = 'client secret'
+except:
+    logging.warning("Missing secrets. Can't use authentication.")
+
+# config that summarizes the above
+AUTH_CONFIG = {
+  # OAuth 2.0 providers
+#  'google'      : (GOOGLE_APP_ID, GOOGLE_APP_SECRET,
+#                  'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/a$
+  'facebook'    : (FACEBOOK_APP_ID, FACEBOOK_APP_SECRET,
+                  'user_about_me,email'),
+#  'windows_live': (WL_CLIENT_ID, WL_CLIENT_SECRET,
+#                  'wl.signin'),
+#  'foursquare'  : (FOURSQUARE_CLIENT_ID,FOURSQUARE_CLIENT_SECRET,
+#                  'authorization_code'),
+
+  # OAuth 1.0 providers don't have scopes
+#  'twitter'     : (TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET),
+#  'linkedin'    : (LINKEDIN_CONSUMER_KEY, LINKEDIN_CONSUMER_SECRET),
+
+  # OpenID doesn't need any key/secret
+}
+

--- a/simpleauth/__init__.py
+++ b/simpleauth/__init__.py
@@ -1,0 +1,13 @@
+"""
+A simple auth handler for Google App Engine supporting 
+OAuth 1.0a, 2.0 and OpenID.
+"""
+
+__version__ = '0.1.4'
+__license__ = "MIT"
+__author__ = "Alex Vagin (http://alex.cloudware.it)"
+
+__all__ = []
+
+from handler import *
+__all__ += handler.__all__

--- a/simpleauth/handler.py
+++ b/simpleauth/handler.py
@@ -1,0 +1,520 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import logging
+
+from urllib import urlencode
+import urlparse
+
+# for CSRF state tokens
+import time
+import base64
+
+# Get available json parser
+try:
+  # should be the fastest on App Engine py27.
+  import json
+except ImportError:
+  try: 
+    import simplejson as json
+  except ImportError:
+    from django.utils import simplejson as json
+    # at this point ImportError will be raised 
+    # if none of the above could be imported
+
+# it's a OAuth 1.0 spec even though the lib is called oauth2
+import oauth2 as oauth1
+
+# users module is needed for OpenID authentication.
+from google.appengine.api import urlfetch, users
+from webapp2_extras import security
+
+__all__ = ['SimpleAuthHandler',
+           'Error',
+           'UnknownAuthMethodError',
+           'AuthProviderResponseError',
+           'InvalidCSRFTokenError',
+           'InvalidOAuthRequestToken',
+           'InvalidOpenIDUserError']
+
+
+class Error(Exception):
+  """Base error class for this module"""
+  pass
+
+class UnknownAuthMethodError(Error):
+  """Raised when there's no method to call for a specific auth type"""
+  pass
+
+class AuthProviderResponseError(Error):
+  """Error coming from a provider"""
+  pass
+
+class InvalidCSRFTokenError(Error):
+  """Currently used only in OAuth 2.0 with CSRF protection enabled"""
+  pass
+
+class InvalidOAuthRequestToken(Error):
+  """OAuth1 request token -related error"""
+  pass
+
+class InvalidOpenIDUserError(Error):
+  """Error during OpenID auth callback"""
+  pass
+
+
+class SimpleAuthHandler(object):
+  """A mixin to be used with a real request handler, 
+  e.g. webapp2.RequestHandler. See README for getting started and 
+  a usage example, or look through the code. It really is simple.
+
+  See README for docs on authentication flows.
+  """
+  
+  PROVIDERS = {
+    'google'      : ('oauth2', 
+      'https://accounts.google.com/o/oauth2/auth?{0}', 
+      'https://accounts.google.com/o/oauth2/token'),
+    'windows_live': ('oauth2',
+      'https://login.live.com/oauth20_authorize.srf?{0}',
+      'https://login.live.com/oauth20_token.srf'),
+    'facebook'    : ('oauth2',
+      'https://www.facebook.com/dialog/oauth?{0}',
+      'https://graph.facebook.com/oauth/access_token'),
+    'linkedin'    : ('oauth1', {
+      'request': 'https://api.linkedin.com/uas/oauth/requestToken', 
+      'auth'   : 'https://www.linkedin.com/uas/oauth/authenticate?{0}'
+    },           'https://api.linkedin.com/uas/oauth/accessToken'),
+    'twitter'     : ('oauth1', {
+       'request': 'https://api.twitter.com/oauth/request_token', 
+       'auth'   : 'https://api.twitter.com/oauth/authenticate?{0}'
+    },            'https://api.twitter.com/oauth/access_token'),
+    'foursquare': ('oauth2',
+       'https://foursquare.com/oauth2/authenticate?{0}',
+       'https://foursquare.com/oauth2/access_token'),
+    'openid'      : ('openid', None)
+  }
+  
+  
+  TOKEN_RESPONSE_PARSERS = {
+    'google'      : '_json_parser',
+    'windows_live': '_json_parser',
+    'foursquare'  : '_json_parser',
+    'facebook'    : '_query_string_parser',
+    'linkedin'    : '_query_string_parser',
+    'twitter'     : '_query_string_parser'
+  }
+
+  # Set this to True in your handler if you want to use 
+  # 'state' param during authorization phase to guard agains
+  # cross-site-request-forgery
+  # 
+  # CSRF protection assumes there's self.session method on the handler 
+  # instance. See BaseRequestHandler in example/handlers.py for sample usage.
+  OAUTH2_CSRF_STATE = False
+  OAUTH2_CSRF_SESSION_PARAM = 'oauth2_state'
+  OAUTH2_CSRF_TOKEN_TIMEOUT = 3600 # 1 hour
+  # This will form the actual state parameter, e.g. token:timestamp
+  # You don't normally need to override it.
+  OAUTH2_CSRF_DELIMITER = ':'
+  
+  def _simple_auth(self, provider=None):
+    """Dispatcher of auth init requests, e.g.
+    GET /auth/PROVIDER
+    
+    Calls _<authtype>_init() method, where <authtype> is
+    oauth2, oauth1 or openid (defined in PROVIDERS dict).
+    
+    May raise one of the exceptions defined at the beginning
+    of the module. See README for details on error handling.
+    """
+    cfg = self.PROVIDERS.get(provider, (None,))
+    meth = self._auth_method(cfg[0], 'init')
+    # We don't respond directly in here. Specific methods are in charge
+    # with redirecting user to an auth endpoint
+    meth(provider, cfg[1])
+      
+  def _auth_callback(self, provider=None):
+    """Dispatcher of callbacks from auth providers, e.g.
+    /auth/PROVIDER/callback?params=...
+    
+    Calls _<authtype>_callback() method, where <authtype> is
+    oauth2, oauth1 or openid (defined in PROVIDERS dict).
+    
+    May raise one of the exceptions defined at the beginning
+    of the module. See README for details on error handling.
+    """
+    cfg = self.PROVIDERS.get(provider, (None,))
+    meth = self._auth_method(cfg[0], 'callback')
+    # Get user profile data and their access token
+    user_data, auth_info = meth(provider, *cfg[-1:])
+    # The rest should be implemented by the actual app
+    self._on_signin(user_data, auth_info, provider)
+
+  def _auth_method(self, auth_type, step):
+    """Constructs proper method name and returns a callable.
+
+    Args:
+      auth_type: string, One of 'oauth2', 'oauth1' or 'openid'
+      step: string, Phase of the auth flow. Either 'init' or 'callback'
+
+    Raises UnknownAuthMethodError if expected method doesn't exist on the
+    handler instance processing the request.
+    """
+    method = '_%s_%s' % (auth_type, step)
+    try:
+      return getattr(self, method)
+    except AttributeError:
+      raise UnknownAuthMethodError(method)
+
+  def _oauth2_init(self, provider, auth_url):
+    """Initiates OAuth 2.0 web flow"""
+    key, secret, scope = self._get_consumer_info_for(provider)
+    callback_url = self._callback_uri_for(provider)
+
+    params = {
+      'response_type': 'code',
+      'client_id': key, 
+      'redirect_uri': callback_url 
+    }
+
+    if scope:
+      params.update(scope=scope)
+
+    if self.OAUTH2_CSRF_STATE:
+      state = self._generate_csrf_token()
+      params.update(state=state)
+      self.session[self.OAUTH2_CSRF_SESSION_PARAM] = state
+
+    target_url = auth_url.format(urlencode(params)) 
+    logging.debug('Redirecting user to %s', target_url)
+
+    self.redirect(target_url)      
+    
+  def _oauth2_callback(self, provider, access_token_url):
+    """Step 2 of OAuth 2.0, whenever the user accepts or denies access."""
+    error = self.request.get('error')
+    if error:
+      raise AuthProviderResponseError(error, provider)
+
+    code = self.request.get('code')
+    callback_url = self._callback_uri_for(provider)
+    client_id, client_secret, scope = self._get_consumer_info_for(provider)
+
+    if self.OAUTH2_CSRF_STATE:
+      _expected = self.session.pop(self.OAUTH2_CSRF_SESSION_PARAM, '')
+      _actual = self.request.get('state')
+      # If _expected is '' it won't validate anyway.
+      if not self._validate_csrf_token(_expected, _actual):
+        raise InvalidCSRFTokenError(
+          '[%s] vs [%s]' % (_expected, _actual), provider)
+      
+    payload = {
+      'code': code,
+      'client_id': client_id,
+      'client_secret': client_secret,
+      'redirect_uri': callback_url,
+      'grant_type': 'authorization_code'
+    }
+    
+    resp = urlfetch.fetch(
+      url=access_token_url, 
+      payload=urlencode(payload), 
+      method=urlfetch.POST,
+      headers={'Content-Type': 'application/x-www-form-urlencoded'}
+    )
+
+    _parser = getattr(self, self.TOKEN_RESPONSE_PARSERS[provider])
+    _fetcher = getattr(self, '_get_%s_user_info' % provider)
+
+    auth_info = _parser(resp.content)
+    user_data = _fetcher(auth_info, key=client_id, secret=client_secret)
+    return (user_data, auth_info)
+    
+  def _oauth1_init(self, provider, auth_urls):
+    """Initiates OAuth 1.0 dance"""
+    key, secret = self._get_consumer_info_for(provider)
+    callback_url = self._callback_uri_for(provider)
+    token_request_url = auth_urls.get('request', None)
+    auth_url = auth_urls.get('auth', None)
+    _parser = getattr(self, self.TOKEN_RESPONSE_PARSERS[provider], None)
+      
+    # make a request_token request
+    client = self._oauth1_client(consumer_key=key, consumer_secret=secret)
+    resp, content = client.request(auth_urls['request'], "GET")
+    
+    if resp.status != 200:
+      raise AuthProviderResponseError(
+        '%s (status: %d)' % (content, resp.status), provider)
+    
+    # parse token request response
+    request_token = _parser(content)
+    if not request_token.get('oauth_token', None):
+      raise AuthProviderResponseError(
+        "Couldn't get a request token from %s" % str(request_token), provider)
+      
+    target_url = auth_urls['auth'].format(urlencode({
+      'oauth_token': request_token.get('oauth_token', None),
+      'oauth_callback': callback_url
+    }))
+    
+    logging.debug('Redirecting user to %s', target_url)
+    
+    # save request token for later, the callback
+    self.session['req_token'] = request_token
+    self.redirect(target_url)      
+    
+  def _oauth1_callback(self, provider, access_token_url):
+    """Third step of OAuth 1.0 dance."""
+    request_token = self.session.pop('req_token', None)
+    if not request_token:
+      raise InvalidOAuthRequestToken(
+        "No request token in user session", provider)
+
+    verifier = self.request.get('oauth_verifier')
+    if not verifier:
+      raise AuthProviderResponseError(
+        "No OAuth verifier was provided", provider)
+
+    consumer_key, consumer_secret = self._get_consumer_info_for(provider)
+    token = oauth1.Token(request_token['oauth_token'], 
+                         request_token['oauth_token_secret'])
+    token.set_verifier(verifier)
+    client = self._oauth1_client(token, consumer_key, consumer_secret)
+    resp, content = client.request(access_token_url, "POST")
+
+    _parser = getattr(self, self.TOKEN_RESPONSE_PARSERS[provider])
+    _fetcher = getattr(self, '_get_%s_user_info' % provider)
+
+    auth_info = _parser(content)
+    user_data = _fetcher(auth_info, key=consumer_key, secret=consumer_secret)
+    return (user_data, auth_info)
+    
+  def _openid_init(self, provider='openid', identity=None):
+    """Initiates OpenID dance using App Engine users module API."""
+    identity_url = identity or self.request.get('identity_url')
+    callback_url = self._callback_uri_for(provider)
+
+    target_url = users.create_login_url(
+      dest_url=callback_url, federated_identity=identity_url)
+    logging.debug('Redirecting user to %s', target_url)
+    self.redirect(target_url)
+      
+  def _openid_callback(self, provider='openid', _identity=None):
+    """Being called back by an OpenID provider 
+    after the user has been authenticated.
+    """
+    user = users.get_current_user()
+    
+    if not user or not user.federated_identity():
+      raise InvalidOpenIDUserError(user, provider)
+      
+    uinfo = {
+      'id'      : user.federated_identity(),
+      'nickname': user.nickname(),
+      'email'   : user.email()
+    }
+    
+    return (uinfo, {'provider': user.federated_provider()})
+
+    
+  #
+  # callbacks and consumer key/secrets
+  #
+  
+  def _callback_uri_for(self, provider):
+    """Returns a callback URL for a 2nd step of the auth process.
+    
+    Override this with something like:
+    self.uri_for('auth_callback', provider=provider, _full=True)
+    """
+    return None
+    
+  def _get_consumer_info_for(self, provider):
+    """Returns a (key, secret, desired_scopes) tuple.
+
+    Defaults to None. You should redefine this method and return real values.
+
+    For OAuth 2.0 it should be a 3 elements tuple:
+    (client_ID, client_secret, scopes)
+
+    OAuth 1.0 doesn't have scope so this should return just a
+    (consumer_key, consumer_secret) tuple.
+
+    OpenID needs neither scope nor key/secret, so this method is never called
+    for OpenID authentication.
+
+    See README for more info on scopes and where to get consumer/client
+    key/secrets.
+    """
+    return (None, None, None)
+    
+  #
+  # user profile/info
+  #
+    
+  def _get_google_user_info(self, auth_info, key=None, secret=None):
+    """Returns a dict of currenly logging in user.
+    Google API endpoint:
+    https://www.googleapis.com/oauth2/v1/userinfo
+    """
+    resp = self._oauth2_request(
+      'https://www.googleapis.com/oauth2/v1/userinfo?{0}', 
+      auth_info['access_token']
+    )
+    return json.loads(resp)
+    
+  def _get_windows_live_user_info(self, auth_info, key=None, secret=None):
+    """Windows Live API user profile endpoint.
+    https://apis.live.net/v5.0/me
+    
+    Profile picture:
+    https://apis.live.net/v5.0/USER_ID/picture
+    """
+    resp = self._oauth2_request('https://apis.live.net/v5.0/me?{0}', 
+                                auth_info['access_token'])
+    uinfo = json.loads(resp)
+    avurl = 'https://apis.live.net/v5.0/{0}/picture'.format(uinfo['id'])
+    uinfo.update(avatar_url=avurl)
+    return uinfo
+    
+  def _get_facebook_user_info(self, auth_info, key=None, secret=None):
+    """Facebook Graph API endpoint.
+    https://graph.facebook.com/me
+    """
+    resp = self._oauth2_request('https://graph.facebook.com/me?{0}', 
+                                auth_info['access_token'])
+    return json.loads(resp)
+    
+  def _get_foursquare_user_info(self, auth_info, key=None, secret=None):
+    """Returns a dict of currenly logging in user.
+    foursquare API endpoint:
+    https://api.foursquare.com/v2/users/self
+    """
+    resp = self._oauth2_request(
+      'https://api.foursquare.com/v2/users/self?{0}&v=20130204',
+      auth_info['access_token'],'oauth_token'
+    )
+    data = json.loads(resp)
+    if data['meta']['code'] != 200:
+      logging.error(data['meta']['errorDetail'])
+    return data['response'].get('user')
+
+  def _get_linkedin_user_info(self, auth_info, key=None, secret=None):
+    """Returns a dict of currently logging in linkedin user.
+
+    LinkedIn user profile API endpoint:
+    http://api.linkedin.com/v1/people/~
+    or
+    http://api.linkedin.com/v1/people/~:<fields>
+    where <fields> is something like
+    (id,first-name,last-name,picture-url,public-profile-url,headline)
+    """
+    try:
+        # already in the App Engine libs, see app.yaml on how to specify
+        # libraries need this for providers like LinkedIn
+        from lxml import etree
+    except ImportError:
+        logging.error('requirement `lxml.etree` was not provided. please '
+                      'make sure you have enabled it in app.yaml')
+        raise
+
+    token = oauth1.Token(key=auth_info['oauth_token'], 
+                         secret=auth_info['oauth_token_secret'])
+    client = self._oauth1_client(token, key, secret)
+
+    fields = 'id,first-name,last-name,picture-url,public-profile-url,headline'
+    url = 'http://api.linkedin.com/v1/people/~:(%s)' % fields
+    resp, content = client.request(url)
+    
+    person = etree.fromstring(content)
+    uinfo = {}
+    for e in person:
+      uinfo.setdefault(e.tag, e.text)
+    
+    return uinfo
+    
+  def _get_twitter_user_info(self, auth_info, key=None, secret=None):
+    """Returns a dict of twitter user using
+    https://api.twitter.com/1/account/verify_credentials.json
+    """
+    token = oauth1.Token(key=auth_info['oauth_token'],
+                         secret=auth_info['oauth_token_secret'])
+    client = self._oauth1_client(token, key, secret)
+    
+    resp, content = client.request(
+      'https://api.twitter.com/1/account/verify_credentials.json'
+    )
+    uinfo = json.loads(content)
+    uinfo.setdefault('link', 'http://twitter.com/%s' % uinfo['screen_name'])
+    return uinfo
+    
+  #
+  # aux methods
+  #
+  
+  def _oauth1_client(self, token=None, consumer_key=None, 
+                     consumer_secret=None):
+    """Returns OAuth 1.0 client that is capable of signing requests."""
+    args = [oauth1.Consumer(key=consumer_key, secret=consumer_secret)]
+    if token:
+      args.append(token)
+    
+    return oauth1.Client(*args)
+  
+  def _oauth2_request(self, url, token, token_param='access_token'):
+    """Makes an HTTP request with OAuth 2.0 access token using App Engine 
+    URLfetch API.
+    """
+    target_url = url.format(urlencode({token_param:token}))
+    return urlfetch.fetch(target_url).content
+    
+  def _query_string_parser(self, body):
+    """Parses response body of an access token request query and returns
+    the result in JSON format.
+    
+    Facebook, LinkedIn and Twitter respond with a query string, not JSON.
+    """
+    return dict(urlparse.parse_qsl(body))
+    
+  def _json_parser(self, body):
+    """Parses body string into JSON dict"""
+    return json.loads(body)
+
+  def _generate_csrf_token(self, _time=None):
+    """Creates a new random token that can be safely used as a URL param.
+
+    Token would normally be stored in a user session and passed as 'state' 
+    parameter during OAuth 2.0 authorization step.
+    """
+    now = str(_time or long(time.time()))
+    secret = security.generate_random_string(30, pool=security.ASCII_PRINTABLE)
+    token = self.OAUTH2_CSRF_DELIMITER.join([secret, now])
+    return base64.urlsafe_b64encode(token)
+
+  def _validate_csrf_token(self, expected, actual):
+    """Validates expected token against the actual.
+
+    Args:
+      expected: String, existing token. Normally stored in a user session.
+      actual: String, token provided via 'state' param.
+    """
+    if expected != actual:
+      return False
+
+    try:
+      decoded = base64.urlsafe_b64decode(expected.encode('ascii'))
+      token_key, token_time = decoded.rsplit(self.OAUTH2_CSRF_DELIMITER, 1)
+      token_time = long(token_time)
+      if not token_key:
+        return False
+    except (TypeError, ValueError, UnicodeDecodeError):
+      return False
+
+    now = long(time.time())
+    timeout = now - token_time > self.OAUTH2_CSRF_TOKEN_TIMEOUT
+
+    if timeout:
+      logging.error("CSRF token timeout (issued at %d)", token_time)
+
+    return not timeout

--- a/static/javascript/tba_js/tba.js
+++ b/static/javascript/tba_js/tba.js
@@ -5,34 +5,8 @@ FB.init({
   channelUrl : '//www.thebluealliance.com/channel', // Channel File
   status     : true, // check login status
   cookie     : true, // enable cookies to allow the server to access the session
-  xfbml      : true  // parse XFBML
-});
-
-// Additional initialization code here
-// listen for and handle auth.statusChange events
-FB.Event.subscribe('auth.statusChange', function(response) {
-  if (response.authResponse) {
-    // user has auth'd your app and is logged into Facebook
-    FB.api('/me', function(me){
-      if (me.name) {
-        $('#auth-displayname').html(me.name);
-      }
-    })
-    $('#auth-loggedout').hide();
-    $('#auth-loggedin').show();
-  } else {
-    // user has not auth'd your app, or is not logged into Facebook
-    $('#auth-loggedout').show();
-    $('#auth-loggedin').hide();
-  }
-});
-
-// respond to clicks on the login and logout links
-$('#auth-loginlink').click(function(){
-  FB.login();
-});
-$('#auth-logoutlink').click(function(){
-  FB.logout();
+  xfbml      : true,  // parse XFBML
+  oauth      : true // enable oauth to allow server to get login status
 });
 };
 

--- a/tba_config.py
+++ b/tba_config.py
@@ -26,3 +26,4 @@ else:
 
 CONFIG['landing_handler'] = COMPETITIONSEASON
 CONFIG["static_resource_version"] = 5
+CONFIG['webapp2_extras.sessions'] = {'secret_key': '7674B2D97DEA0AC5DA452389BDD41E0DAB9B'}

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}The Blue Alliance - Account{% endblock %}
+
+{% block meta_description %}Log in to your TBA account or register a new account.{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="span8 offset2">
+    {% for k, v in msg %}
+        <pre>{{ k }}</pre>
+    {% endfor %}
+    {% if not user %}
+        <a href="/auth/facebook" class="btn btn-info">Login</a>
+    {% endif %}
+    {% if user %}
+        <h2>My Account</h2>
+        <div class="media">
+         <div class="img avatar">
+           <img src="{{ user.avatar_url }}">
+         </div>
+          <div class="body">
+            <h1 style="margin-top: 0; padding-top: 0">{{ user.name }}</h1>
+          </div>
+        </div>
+      <pre>{{user}}</pre>
+  
+        <p style="margin-top: 2em;">
+          <a href="/logout" class="btn">logout</a>
+        </p>    
+    {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/admin/user_delete.html
+++ b/templates/admin/user_delete.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}{{user.name}} - Delete{% endblock %}
+
+{% block content %}
+
+<h1>Delete {{ user.name }}?</h1>
+
+<form action="/admin/user/delete/{{user.key.id}}" method="post">
+    <legend>Delete {{ user.name }} ({{ user.key.id }})?</legend>
+
+    <a href="/admin/user/{{user.key.id}}" class="btn btn-large"><i class="icon-ban-circle"></i> Cancel Delete</a>
+
+    <button type="submit" class="btn btn-danger btn-mini pull-right"><i class="icon-trash icon-white"></i> Delete User</button>
+</form>
+
+{% endblock %}

--- a/templates/admin/user_details.html
+++ b/templates/admin/user_details.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}{{user.name}}{% endblock %}
+
+{% block content %}
+
+<h1>{{ user.name }}</h1>
+
+<div class="btn-group">
+    <a href="/admin/user/edit/{{user.key.id}}" class="btn btn-primary"><i class="icon-edit icon-white"></i> Edit</a>
+   <!-- <a href="/event/{{event.key_name}}" class="btn"><i class="icon-eye-open"></i> View on TBA</a>-->
+</div>
+<br />
+
+<table class="table table-striped table-hover">
+    <tr>
+        <td>Name</td>
+        <td>{{ user.name }}</td>
+    </tr>
+    <tr>
+        <td>User ID</td>
+        <td>{{ user.key.id }}</td>
+    </tr>
+    <tr>
+        <td>Email</td>
+        <td>{{ user.email }}</td>
+    </tr> 
+    <tr>
+        <td>Created</td>
+        <td>{{ user.created }}</td>
+    </tr>
+    <tr>
+        <td>Updated</td>
+        <td>{{ user.updated  }}</td>
+    </tr>
+</table>
+
+{% endblock %}

--- a/templates/admin/user_edit.html
+++ b/templates/admin/user_edit.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}{{user.name}} - Edit{% endblock %}
+
+{% block content %}
+
+<p class="pull-right"><a class="btn btn-danger btn-mini" href="/admin/user/delete/{{user.key.id}}"><i class="icon-trash icon-white"></i> Delete</a></p>
+
+<h1>Edit {{ user.name }}</h1>
+
+<form action="/admin/user/edit/{{user.key.id}}" method="post">
+    <legend>Edit {{ user.name }} ({{ user.key.id }})</legend>
+    <table class="table table-striped table-hover table-condensed">
+        <tr>
+            <td>Name</td>
+            <td><input type="text" name="name" value="{{user.name}}" /></td>
+        </tr>
+        <tr>
+            <td>Email</td>
+            <td><input type="text" name="email" value="{{user.email}}" /></td>
+        </tr>
+    </table>
+
+    <button type="submit" class="btn btn-primary"><i class="icon-thumbs-up icon-white"></i> Save User</button>
+    <a href="/admin/user/{{user.key.id}}" class="btn"><i class="icon-thumbs-down"></i> Cancel Edit</a>
+</form>
+
+{% endblock %}

--- a/templates/admin/user_list.html
+++ b/templates/admin/user_list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}User List{% endblock %}
+
+{% block content %}
+
+<h1>All {{ users|length }} Users</h1>
+<table class="table table-striped table-hover">
+    <caption>{{ users|length }} total users</caption>
+    <thead>
+        <th>Name</th>
+        <th>ID</th>
+	<th>Created</th>
+    </thead>
+    
+    {% for user in users %}
+    <tr>
+        <td><a href="/admin/user/{{ user.key.id  }}">{{ user.name }}</a></td>
+        <td>{{ user.key.id }}</td>
+	<td>{{ user.created|date:"M d, Y" }}</td>
+    </tr>
+    {% endfor %}
+</table>
+
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -90,18 +90,9 @@
         <a href="/about">about</a> - 
         <a href="/contact">contact</a> - 
         <a href="/thanks">thanks</a> -
+        <a href="/account">account</a><!-- make auth-aware when templates are reworked --> -
         <a href="/admin/">admin</a>  
       </div>
-      <!--
-      <div id="auth-status" class="user-status">
-        <div id="auth-loggedout">
-          <a href="#" id="auth-loginlink">login</a>
-        </div>
-        <div id="auth-loggedin" style="display:none">
-          Logged in as: <span id="auth-displayname"></span> | <a href="#" id="auth-logoutlink">logout</a>
-        </div>
-      </div>
-      -->
 	  </div>
 	</div>
 </div>


### PR DESCRIPTION
Allows logging in using Facebook (with other providers easily available) at the `/account` URL.

**Notes**
User edit and deletion in the admin panel is supported, although any user's data that is edited in the backend is overwritten with their Facebook data on next login. Can be fixed with more 1s and 0s.

Deletion doesn't handle removing the user's cookies (obviously). Also doesn't remove their auth tokens (gotta fix that, too).

This does not use the user model that we defined in a file, but instead uses webapp2's Expando-based user model.

Whitelist is setup to pull from the `auth.whitelist` sitevar with a JSON dict of authorized IDs.
Ex: `{"100001996614213", "100005694099700"}`
