### PR TITLE
Expand .gitignore for Windows and OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 # OS generated files #
 ######################
 # OS X
-.DS_Store
+.DS_Store*
 .AppleDouble
 .LSOverride
 Icon


### PR DESCRIPTION
Just expanded the `.gitignore` with some other OS rules, obtained from the [github/gitignore](https://github.com/github/gitignore) repo.
