### PR TITLE
Combine API for match= and matches=; fixes #733 and #734

### DIFF
--- a/controllers/api_controller.py
+++ b/controllers/api_controller.py
@@ -139,6 +139,7 @@ class ApiEventDetails(MainApiHandler):
 
         event_dict = ApiHelper.getEventInfo(event_key)
 
+        self.response.headers.add_header("content-type", "application/json")
         self.response.out.write(json.dumps(event_dict))
 
 

--- a/models/match.py
+++ b/models/match.py
@@ -16,7 +16,7 @@ class Match(ndb.Model):
     """
 
     COMP_LEVELS = ["qm", "ef", "qf", "sf", "f"]
-    ELIM_LEVELS = {'ef', 'qf', 'sf', 'f'}
+    ELIM_LEVELS = ["ef", "qf", "sf", "f"]
     COMP_LEVELS_VERBOSE = {
         "qm": "Quals",
         "ef": "Eighths",

--- a/tests/test_event_api.py
+++ b/tests/test_event_api.py
@@ -31,16 +31,16 @@ class TestApiEventList(unittest2.TestCase):
         self.testbed.init_memcache_stub()
 
         self.event = Event(
-                id="2010sc",
-                name="Palmetto Regional",
-                event_type_enum=EventType.REGIONAL,
-                short_name="Palmetto",
-                event_short="sc",
-                year=2010,
-                end_date=datetime(2010, 03, 27),
-                official=True,
-                location='Clemson, SC',
-                start_date=datetime(2010, 03, 24),
+            id="2010sc",
+            name="Palmetto Regional",
+            event_type_enum=EventType.REGIONAL,
+            short_name="Palmetto",
+            event_short="sc",
+            year=2010,
+            end_date=datetime(2010, 03, 27),
+            official=True,
+            location='Clemson, SC',
+            start_date=datetime(2010, 03, 24)
         )
         self.event.put()
 
@@ -55,7 +55,7 @@ class TestApiEventList(unittest2.TestCase):
         self.assertEqual(event_dict["start_date"], self.event.start_date.isoformat())
         self.assertEqual(event_dict["end_date"], self.event.end_date.isoformat())
 
-    def testEventShow(self):
+    def test_event_show(self):
         response = self.testapp.get('/?year=2010')
 
         event_dict = json.loads(response.body)
@@ -74,52 +74,114 @@ class TestApiMatchDetails(unittest2.TestCase):
         self.testbed.init_urlfetch_stub()
         self.testbed.init_memcache_stub()
 
-        self.event = Event(
-                id="2010sc",
-                name="Palmetto Regional",
-                event_type_enum=EventType.REGIONAL,
-                short_name="Palmetto",
-                event_short="sc",
+        events = {
+            '2010cmp': Event(
+                id="2010cmp",
+                name="Einstein Field",
+                event_type_enum=EventType.CMP_FINALS,
+                short_name="Einstein",
+                event_short="cmp",
                 year=2010,
-                end_date=datetime(2010, 03, 27),
+                start_date=datetime(2010, 04, 17),
+                end_date=datetime(2010, 04, 17),
                 official=True,
-                location='Clemson, SC',
-                start_date=datetime(2010, 03, 24),
-        )
-        self.event.put()
+                location='Atlanta, GA'
+            ),
+            '2011cmp': Event(
+                id="2011cmp",
+                name="Einstein Field",
+                event_type_enum=EventType.CMP_FINALS,
+                short_name="Einstein",
+                event_short="cmp",
+                year=2011,
+                start_date=datetime(2011, 04, 30),
+                end_date=datetime(2011, 04, 30),
+                official=True,
+                location='St. Louis, MO'
+            ),
+            '2012cmp': Event(
+                id="2012cmp",
+                name="Einstein Field",
+                event_type_enum=EventType.CMP_FINALS,
+                short_name="Einstein",
+                event_short="cmp",
+                year=2012,
+                start_date=datetime(2012, 04, 26),
+                end_date=datetime(2012, 04, 28),
+                official=True,
+                location='St. Louis, MO'
+            )
+        }
 
-        self.match_json = '{"blue": {"score": "14", "teams": ["frc469", "frc1114", "frc2041"]}, "red": {"score": "16", "teams": ["frc177", "frc67", "frc294"]}}'
-        match_team_key_names = ["frc177", "frc67", "frc294", "frc469", "frc1114", "frc2041"]
+        event_keys = {}
 
-        self.match = Match(
+        for event_id, event in events.items():
+            event_keys[event_id] = event.put()
+
+        self.matches = {
+            '2010cmp_f1m1': Match(
                 id='2010cmp_f1m1',
                 comp_level='f',
                 match_number=1,
-                team_key_names=match_team_key_names,
-                alliances_json=self.match_json,
+                team_key_names=["frc177", "frc67", "frc294", "frc469", "frc1114", "frc2041"],
+                alliances_json='{"blue": {"score": "14", "teams": ["frc469", "frc1114", "frc2041"]}, "red": {"score": "16", "teams": ["frc177", "frc67", "frc294"]}}',
                 set_number=1,
                 game='frc_2010_bkwy',
-                event=self.event.key
-        )
-        self.match.put()
+                event=event_keys['2010cmp']
+            ),
+            '2011cmp_f1m1': Match(
+                id='2011cmp_f1m1',
+                comp_level='f',
+                match_number=1,
+                team_key_names=["frc973", "frc254", "frc111", "frc177", "frc2016", "frc781"],
+                alliances_json='{"blue": {"score": 79, "teams": ["frc177", "frc2016", "frc781"]}, "red": {"score": 147, "teams": ["frc973", "frc254", "frc111"]}}',
+                set_number=1,
+                game='frc_2011_logo',
+                event=event_keys['2011cmp']
+            ),
+            '2012cmp_f1m1': Match(
+                id='2012cmp_f1m1',
+                comp_level='f',
+                match_number=1,
+                team_key_names=["frc25", "frc180", "frc16", "frc207", "frc233", "frc987"],
+                alliances_json='{"blue": {"score": 45, "teams": ["frc207", "frc233", "frc987"]}, "red": {"score": 89, "teams": ["frc25", "frc180", "frc16"]}}',
+                set_number=1,
+                game='frc_2012_rebr',
+                event=event_keys['2012cmp']
+            )
+        }
+
+        for match in self.matches.values():
+            match.put()
 
     def tearDown(self):
         self.testbed.deactivate()
 
-    def assertMatch(self, match_dict):
-        self.assertEqual(match_dict["key"], self.match.key_name)
-        self.assertEqual(match_dict["event"], self.event.key_name)
-        self.assertEqual(match_dict["competition_level"], self.match.name)
-        self.assertEqual(match_dict["set_number"], self.match.set_number)
-        self.assertEqual(match_dict["match_number"], self.match.match_number)
-        self.assertEqual(match_dict["team_keys"], self.match.team_key_names)
+    def assertMatch(self, match):
+        match_id = match["key"]
+
+        self.assertEqual(match["event"], self.matches[match_id].event.get().key_name)
+        self.assertEqual(match["competition_level"], self.matches[match_id].name)
+        self.assertEqual(match["set_number"], self.matches[match_id].set_number)
+        self.assertEqual(match["match_number"], self.matches[match_id].match_number)
+        self.assertEqual(match["team_keys"], self.matches[match_id].team_key_names)
 
         # FIXME: urgh. strings. - brandondean 10/21/2012
-        #self.assertEqual(match_dict["alliances"], self.match_json)
+        #self.assertEqual(match["alliances"], self.matches[match_id].alliances_json)
+    
+    def assertMatchNames(self, match_list):
+        match_names = ",".join(match_list)
+        api_names = ["match", "matches"]
 
-    def testMatchDetails(self):
-        response = self.testapp.get("/?match=2010cmp_f1m1")
+        for api_name in api_names:
+            response = self.testapp.get("/?" + api_name + "=" + match_names)
 
-        match_dict = json.loads(response.body)
-        match_dict["alliances"] = str(match_dict["alliances"])
-        self.assertMatch(match_dict)
+            matches = json.loads(response.body)
+            for match in matches:
+                match["alliances"] = str(match["alliances"])
+                self.assertIn(match["key"], self.matches)
+                self.assertMatch(match)
+
+    def test_match_details(self):
+        self.assertMatchNames(["2010cmp_f1m1"])
+        self.assertMatchNames(["2010cmp_f1m1", "2011cmp_f1m1", "2012cmp_f1m1"])

--- a/tests/test_event_team_repairer.py
+++ b/tests/test_event_team_repairer.py
@@ -52,7 +52,7 @@ class TestEventTeamRepairer(unittest2.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
 
-    def testRepair(self):
+    def test_repair(self):
         event_team = EventTeam.get_by_id("2011ct_frc177")
         self.assertEqual(event_team.year, None)
 

--- a/tests/test_event_test_creator.py
+++ b/tests/test_event_test_creator.py
@@ -28,7 +28,7 @@ class TestEventTeamCreator(unittest2.TestCase):
 
         self.testbed.deactivate()
 
-    def testCreates(self):
+    def test_creates(self):
         self.events.append(EventTestCreator.createPastEvent())
         self.events.append(EventTestCreator.createFutureEvent())
         self.events.append(EventTestCreator.createPresentEvent())


### PR DESCRIPTION
This should allow the use of both `match` and `matches` in the API for multiple matches.
