### PR TITLE
API Updates for Match & Awards

### DIFF
--- a/helpers/model_to_dict.py
+++ b/helpers/model_to_dict.py
@@ -42,7 +42,7 @@ class ModelToDict(object):
         event_dict["short_name"] = event.short_name
         event_dict["event_code"] = event.event_short
         event_dict["event_type_string"] = event.event_type_str
-        event_dict["event_type_enum"] = event.event_type_enum
+        event_dict["event_type"] = event.event_type_enum
         event_dict["year"] = event.year
         event_dict["location"] = event.location
         event_dict["official"] = event.official

--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -155,7 +155,7 @@
             more</a></td>
           </tr>
           <tr>
-            <td>event_type_enum</td>
+            <td>event_type</td>
             <td>An integer that represents the event type as a constant.</td>
             <td><a href="https://github.com/gregmarra/the-blue-alliance/blob/master/consts/event_type.py#L2">List of constants to event type</a></td>
           </tr>

--- a/tests/test_apiv2_team_controller.py
+++ b/tests/test_apiv2_team_controller.py
@@ -115,7 +115,7 @@ class TestTeamApiController(unittest2.TestCase):
         self.assertEqual(event["start_date"], self.event.start_date.isoformat())
         self.assertEqual(event["end_date"], self.event.end_date.isoformat())
         self.assertEqual(event["event_type_string"], self.event.event_type_str)
-        self.assertEqual(event["event_type_enum"], self.event.event_type_enum)
+        self.assertEqual(event["event_type"], self.event.event_type_enum)
 
     def assertMatchJson(self, match):
         self.assertEqual(str(match["key"]), self.match.key.string_id())


### PR DESCRIPTION
As discussed in #846 :
• Don't return team list for a match
• Don't return game for a match
• Actually return a usable string for event type
• Change 'name_str' on award to 'name' to be consistent with other models
• Doc and test updates for the above

![Take a look](http://speedysinvestigation.tripod.com/sitebuildercontent/sitebuilderpictures/look---.gif)
