### PR TITLE
Fix RSS support

### DIFF
--- a/controllers/api_controller.py
+++ b/controllers/api_controller.py
@@ -264,7 +264,7 @@ class CsvTeamsAll(MainApiHandler):
             if tba_config.CONFIG["memcache"]:
                 memcache.set(memcache_key, output, 86400)
 
-        self.response.headers.add_header("content-type", "text/csv")
+        self.response.headers["content-type"] = "text/csv"
         self.response.out.write(output)
 
         self._track_call('teams/list')

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -192,5 +192,5 @@ class EventRss(CacheableHandler):
         }
 
         path = os.path.join(os.path.dirname(__file__), '../templates/event_rss.xml')
-        self.response.headers.add_header('content-type', 'application/xml; charset=UTF-8')
+        self.response.headers['content-type'] = 'application/xml; charset=UTF-8'
         return template.render(path, template_values)


### PR DESCRIPTION
This PR makes a number of changes; namely, it makes sure that the RSS feeds are actually served with the right `Content-Type`, and it also ensures that `<link>` and `<guid>` have working URLs (`verbose_url` is an non-existent property).
