### PR TITLE
Add trailing / in paver help when linking to the admin page

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -82,7 +82,7 @@ def test_fast():
 def setup_function():
   make()
 
-  print("Set up test data at http://localhost:8088/admin")
+  print("Set up test data at http://localhost:8088/admin/")
   print("1/ Click 'Get Teams' and 'Create Test Events'")
   print("2/ Click 'Create Test Events'")
 


### PR DESCRIPTION
So people don't end up shouting "Oh noes!1!!" ;-)
