### PR TITLE
Provide team links with event year on both sides of the table

### DIFF
--- a/templates/event_details.html
+++ b/templates/event_details.html
@@ -215,8 +215,8 @@
             <tbody>
               {% for team in teams_b %}
               <tr>
-                <td><a class="team_table" href="/team/{{ team.team_number }}">{{ team.team_number }}</a></td>
-                <td><a href="/team/{{ team.team_number }}">{% if team.nickname %}{{ team.nickname }}{% else %}--{% endif %}</a></td>
+                <td><a class="team_table" href="/team/{{ team.team_number }}/{{ event.year }}">{{ team.team_number }}</a></td>
+                <td><a href="/team/{{ team.team_number }}/{{ event.year }}">{% if team.nickname %}{{ team.nickname }}{% else %}--{% endif %}</a></td>
                 <td>{% if team.location %}{{ team.location }}{% else %}--{% endif %}</td>
               </tr>
               {% endfor %}


### PR DESCRIPTION
For some reason, only the left side of the table had team links
with the year. This adds the year to links on the right side.
