### PR TITLE
Add OPRS to event API controller

### DIFF
--- a/api_main.py
+++ b/api_main.py
@@ -7,7 +7,7 @@ from controllers.api_controller import ApiEventsShow, ApiTeamDetails, ApiTeamsSh
                                        ApiEventList, ApiEventDetails, ApiMatchDetails, \
                                        CsvTeamsAll
 from controllers.api.api_team_controller import ApiTeamController
-from controllers.api.api_event_controller import ApiEventController, ApiEventTeamsController, \
+from controllers.api.api_event_controller import ApiEventController, ApiEventTeamsController, ApiEventOprsController, \
                                                  ApiEventMatchesController, ApiEventListController
 from controllers.api.api_trusted_controller import ApiTrustedAddMatchYoutubeVideo
 
@@ -30,6 +30,9 @@ app = webapp2.WSGIApplication([('/api/v1/team/details', ApiTeamDetails),
                                              methods=['GET']),
                                webapp2.Route(r'/api/v2/event/<event_key:>/teams',
                                              ApiEventTeamsController,
+                                             methods=['GET']),
+                               webapp2.Route(r'/api/v2/event/<event_key:>/oprs',
+                                             ApiEventOprsController,
                                              methods=['GET']),
                                webapp2.Route(r'/api/v2/event/<event_key:>/matches',
                                              ApiEventMatchesController,


### PR DESCRIPTION
Giving the people what they want.

Output looks like:

{
    "oprs": {
        "8": 29.9620009434885,
        "100": 35.937212713898454,
        "114": 58.81942916776424,
        "115": 13.62708373072654,
        "192": 83.48672614568586,
        "254": 95.10577202206018,
        "256": 36.36876580335982,
        "295": 54.610678322091644,
        "368": 89.98878732017863,
        "581": 23.322290185880778,
        "604": 43.86218241363306,
        "668": 40.25565499584042,
        "670": 59.6369973474397,
        "692": 16.23164567181332,
        "751": 26.699177147435673,
        "766": 13.88799842040225,
        "840": 44.64959810502451,
        "841": 33.660187940556014,
        "846": 69.79986002542536,
        "852": 41.898573975193685,
        "971": 90.97332300739338,
        "1072": 34.25287218138358,
        "1280": 40.30166017210765,
        "1323": 78.47480304598136,
        "1351": 37.34505491460557,
        "1388": 23.59253665676068,
        "1662": 26.015006013077258,
        "1678": 107.89334054865056,
        "1700": 39.90426510279449,
        "1868": 30.87734198047387,
        "1967": 29.711210973972662,
        "2035": 76.37926462635728,
        "2135": 9.643461888842754,
        "2141": 0.27689343058478977,
        "2144": 62.90033471113969,
        "2367": 16.420917449723454,
        "2473": 48.14960279976225,
        "2489": 20.59737152971526,
        "2813": 24.44337027983136,
        "2854": 3.1295160227716514,
        "3045": 22.458640726930692,
        "3256": 47.80443831508201,
        "3482": 18.217734965809452,
        "3669": 14.264390101630788,
        "4047": -0.21586993150087855,
        "4171": 13.963667169926916,
        "4186": -1.2507486015465,
        "4255": 18.885019858620435,
        "4543": 55.22885656140307,
        "4765": 19.128503064555698,
        "4904": 12.738925187963217,
        "4990": 35.949359003241625,
        "5023": 24.473756804128637,
        "5026": 13.913698233633147,
        "5027": 12.344431228359532,
        "5104": 26.26890042932293,
        "5171": 40.91204169553107,
        "5311": -0.2903466028464147
    },
    "stats": {
        "median": 30.419671461981185,
        "stdev": 25.647220968427423,
        "mean": 35.99807186110473
    }
}
