### PR TITLE
Return full event models for event list API request

### DIFF
--- a/controllers/api/api_event_controller.py
+++ b/controllers/api/api_event_controller.py
@@ -106,7 +106,9 @@ class ApiEventListController(ApiBaseController):
             self._errors = json.dumps({"404": "No events found for %s" % self.year})
             self.abort(404)
 
-        event_keys = Event.query(Event.year == self.year).fetch(1000, keys_only=True)
-        keys = [key.string_id() for key in event_keys]
+        keys = Event.query(Event.year == self.year).fetch(1000, keys_only=True)
+        events = ndb.get_multi(keys)
 
-        return json.dumps(keys, ensure_ascii=True)
+        event_list = [ModelToDict.eventConverter(event) for event in events]
+
+        return json.dumps(event_list, ensure_ascii=True)

--- a/tests/test_apiv2_event_controller.py
+++ b/tests/test_apiv2_event_controller.py
@@ -223,7 +223,15 @@ class TestEventListApiController(unittest2.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
 
+    def assertEventJson(self, event):
+        self.assertEqual(event["key"], self.event.key_name)
+        self.assertEqual(event["name"], self.event.name)
+        self.assertEqual(event["short_name"], self.event.short_name)
+        self.assertEqual(event["official"], self.event.official)
+        self.assertEqual(event["start_date"], self.event.start_date.date().isoformat())
+        self.assertEqual(event["end_date"], self.event.end_date.date().isoformat())
+
     def testEventListApi(self):
         response = self.testapp.get('/2010', headers={"X-TBA-App-Id": "tba-tests:event-controller-test:v01"})
         event_dict = json.loads(response.body)
-        self.assertEqual(event_dict[0], self.event.key_name)
+        self.assertEventJson(event_dict[0])


### PR DESCRIPTION
Certainly works better for apps.

![](http://24.media.tumblr.com/ea3884f17979500c2406fd4d21891195/tumblr_mr4humiiCH1r4xjo2o1_250.gif)
