### PR TITLE
Templates: Fix GitHub link

### DIFF
--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -47,7 +47,7 @@
       programmatically accessing data.</p>
       <p>The API and code are open source. If you find a bug, want a new
       feature, or are interested in helping us improve it, visit us on <a
-      href="http://www.github.com/the-blue-alliance/the-blue-alliance">GitHub</a>
+      href="https://github.com/the-blue-alliance/the-blue-alliance">GitHub</a>
       and file an issue or send a pull request. If you have any questions
       about this API or would like to stay up-to-date on its development,
       you can join our <a href="https://groups.google.com/forum/#!forum/thebluealliance-developers">developer's mailing list</a>.</p>


### PR DESCRIPTION
I used an `https` URL and stripped off the `www` part.
