### PR TITLE
Expose Match Times to API

### DIFF
--- a/helpers/api_helper.py
+++ b/helpers/api_helper.py
@@ -172,7 +172,11 @@ class ApiHelper(object):
             match_dict["match_number"] = match.match_number
             match_dict["team_keys"] = match.team_key_names
             match_dict["alliances"] = json.loads(match.alliances_json)
-            match_dict["time"] = json.loads(match.time.strftime("%s"))
+            match_dict["time_string"] = match.time_string
+            if match.time is not None:
+                match_dict["time"] =  match.time.strftime("%s")
+            else:
+                match_dict["time"] = None
 
             if tba_config.CONFIG["memcache"]:
                 memcache.set(memcache_key, match_dict, (2 * (60 * 60)))

--- a/helpers/model_to_dict.py
+++ b/helpers/model_to_dict.py
@@ -67,7 +67,11 @@ class ModelToDict(object):
         match_dict["comp_level"] = match.comp_level
         match_dict["match_number"] = match.match_number
         match_dict["set_number"] = match.set_number
-        match_dict["time"] = json.loads(match.time.strftime("%s"))
+        match_dict["time_string"] = match.time_string
+        if match.time is not None:
+            match_dict["time"] = match.time.strftime("%s")
+        else:
+            match_dict["time"] = None
 
         return match_dict
 

--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -265,9 +265,15 @@
             <td>2011sc</td>
           </tr>
           <tr>
+            <td>time_string</td>
+            <td>Time string for this match, as published on the official schedule. Of course, this may or may not be accurate, as events often run ahead or behind schedule</td>
+            <td>11:15 AM</td>
+          </tr>
+          <tr>
             <td>time</td>
             <td>UNIX timestamp of match time, as taken from the published schedule</td>
             <td>1394904600</td>
+          </tr>
         </tbody>
       </table>
 

--- a/tests/test_apiv2_event_controller.py
+++ b/tests/test_apiv2_event_controller.py
@@ -186,7 +186,11 @@ class TestEventMatchApiController(unittest2.TestCase):
         self.assertEqual(match["set_number"], self.match.set_number)
         self.assertEqual(match["match_number"], self.match.match_number)
         self.assertEqual(match["time_string"], self.match.time_string)
-
+        if self.match.time is None:
+            self.assertEqual(match["time"], None)
+        else:
+            self.assertEqual(match["time"], self.match.time.strftime("%s"))
+    
     def testEventMatchApi(self):
         response = self.testapp.get('/2010sc', headers={"X-TBA-App-Id": "tba-tests:event-controller-test:v01"})
 


### PR DESCRIPTION
Resolves #992

Also for use in mobile apps while displaying match data - I'm nearing the point writing the Android version where having this will be useful
