### PR TITLE
Left-align game manual links to align icons

### DIFF
--- a/static/css/less_css/less/tba/tba_misc.less
+++ b/static/css/less_css/less/tba/tba_misc.less
@@ -8,7 +8,7 @@
     box-shadow: none;
     color: #000000;
   }
-    
+
   td > .gsc-search-button {
     margin: 0;
   }
@@ -48,4 +48,8 @@
 
 .year_list {
   padding-bottom: 20px;
+}
+
+.game-manual .btn {
+  text-align: left;
 }

--- a/templates/index_buildseason.html
+++ b/templates/index_buildseason.html
@@ -12,7 +12,7 @@
     <div class="col-sm-8">
       <h2><span class="countdown-number countdown-days">--</span><span class="countdown-label day-label"> Days</span> Left to Build! <small>Build Season ends {{endbuild_datetime_est|date:"F jS"}}</small></h2>
       <div id="countdown-finish-time">{{endbuild_datetime_utc|date:"c"}}</div>
-      <div class="btn-group">
+      <div class="btn-group game-manual">
         <a class="btn btn-default" href="http://frc-manual.usfirst.org/" target="_blank"><span class="glyphicon glyphicon-file"></span> Game Manual PDF</a>
         <a class="btn btn-default" href="https://itunes.apple.com/us/app/frc-manual/id488793605"><span class="glyphicon glyphicon-download"></span> iPhone Manual </a>
         <a class="btn btn-default" href="https://play.google.com/store/apps/details?id=org.usfirst.manual.frc"><span class="glyphicon glyphicon-download"></span> Android Manual</a>

--- a/templates/index_kickoff.html
+++ b/templates/index_kickoff.html
@@ -36,7 +36,7 @@
       <p><em>More coming soon!</em></p>
       <p><a class="btn btn-default disabled" href="#"><span class="glyphicon glyphicon-film"></span> {{kickoff_datetime_est|date:"Y"}} Game Video</a></p>
       <h4>{{kickoff_datetime_est|date:"Y"}} Game Manual</h4>
-      <div class="btn-group-vertical">
+      <div class="btn-group-vertical game-manual">
         <a class="btn btn-default" href="http://frc-manual.usfirst.org/" target="_blank"><span class="glyphicon glyphicon-file"></span> PDF Version</a>
         <a class="btn btn-default" href="https://itunes.apple.com/us/app/frc-manual/id488793605" target="_blank"><span class="glyphicon glyphicon-download"></span> iPhone App</a>
         <a class="btn btn-default" href="https://play.google.com/store/apps/details?id=org.usfirst.manual.frc" target="_blank"><span class="glyphicon glyphicon-download"></span> Android App</a>


### PR DESCRIPTION
Currently, the buttons under "2015 Game Manual" on the front page are not completely aligned, as they are centered in the button. Using a left text-align fixes this problem.
