### PR TITLE
Change Team.name to be a TextProperty (fixes #1110)

### DIFF
--- a/models/team.py
+++ b/models/team.py
@@ -10,7 +10,7 @@ class Team(ndb.Model):
     key_name is like 'frc177'
     """
     team_number = ndb.IntegerProperty(required=True)
-    name = ndb.StringProperty(indexed=False)
+    name = ndb.TextProperty(indexed=False)
     nickname = ndb.StringProperty(indexed=False)
     address = ndb.StringProperty(indexed=False)  # in the format "locality, region, country". similar to Event.location
     website = ndb.StringProperty(indexed=False)


### PR DESCRIPTION
StringProperty will truncate at 500 characters, and some teams
have names that are longer than that.

My quick read of the [docs](https://cloud.google.com/appengine/articles/update_schema) indicates that this should just work with old datastore entries but I didn't test that.