### PR TITLE
Adds local test team creation to bypass broken FMS list.

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -18,7 +18,7 @@ from controllers.admin.admin_sitevar_controller import AdminSitevarCreate, Admin
 from controllers.admin.suggestions.admin_event_webcast_suggestions_review_controller import AdminEventWebcastSuggestionsReviewController
 from controllers.admin.suggestions.admin_match_video_suggestions_review_controller import AdminMatchVideoSuggestionsReviewController
 from controllers.admin.suggestions.admin_media_suggestions_review_controller import AdminMediaSuggestionsReviewController
-from controllers.admin.admin_team_controller import AdminTeamDetail, AdminTeamList
+from controllers.admin.admin_team_controller import AdminTeamCreateTest, AdminTeamDetail, AdminTeamList
 from controllers.admin.admin_migration_controller import AdminMigration
 from controllers.admin.admin_user_controller import AdminUserList, AdminUserEdit, AdminUserDetail
 
@@ -60,6 +60,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/suggestions/media/review', AdminMediaSuggestionsReviewController),
                                ('/admin/tasks', AdminTasksHandler),
                                ('/admin/teams', AdminTeamList),
+                               ('/admin/team/create/test', AdminTeamCreateTest),
                                ('/admin/team/(.*)', AdminTeamDetail),
                                ('/admin/users', AdminUserList),
                                ('/admin/user/edit/(.*)', AdminUserEdit),

--- a/controllers/admin/admin_team_controller.py
+++ b/controllers/admin/admin_team_controller.py
@@ -3,9 +3,12 @@ import os
 from google.appengine.ext.webapp import template
 
 from controllers.base_controller import LoggedInHandler
+from helpers.team.team_test_creator import TeamTestCreator
 from models.event_team import EventTeam
 from models.team import Team
 from models.media import Media
+
+import tba_config
 
 
 class AdminTeamList(LoggedInHandler):
@@ -51,3 +54,19 @@ class AdminTeamDetail(LoggedInHandler):
 
         path = os.path.join(os.path.dirname(__file__), '../../templates/admin/team_details.html')
         self.response.out.write(template.render(path, self.template_values))
+
+
+class AdminTeamCreateTest(LoggedInHandler):
+    """
+    Create 6 test teams.
+    """
+    def get(self):
+        self._require_admin()
+
+        if tba_config.CONFIG["env"] != "prod":
+            TeamTestCreator.createSixTeams()
+            self.redirect("/teams/")
+        else:
+            logging.error("{} tried to create test teams in prod! No can do.".format(
+                self.user_bundle.user.email()))
+            self.redirect("/admin/")

--- a/helpers/event_team/event_team_test_creator.py
+++ b/helpers/event_team/event_team_test_creator.py
@@ -2,6 +2,7 @@ from helpers.event_team_manipulator import EventTeamManipulator
 from models.event_team import EventTeam
 from models.team import Team
 
+import logging
 
 class EventTeamTestCreator(object):
     @classmethod

--- a/helpers/event_team/event_team_test_creator.py
+++ b/helpers/event_team/event_team_test_creator.py
@@ -2,8 +2,6 @@ from helpers.event_team_manipulator import EventTeamManipulator
 from models.event_team import EventTeam
 from models.team import Team
 
-import logging
-
 class EventTeamTestCreator(object):
     @classmethod
     def createEventTeams(self, event):

--- a/helpers/team/team_test_creator.py
+++ b/helpers/team/team_test_creator.py
@@ -1,0 +1,25 @@
+from helpers.team_manipulator import TeamManipulator
+from models.team import Team
+
+
+class TeamTestCreator(object):
+
+    TEAMS = ["Red Jaguars", "Blue Barracudas", "Green Monkeys", "Orange Iguanas", "Purple Parrots", "Silver Snakes"]
+
+    @classmethod
+    def createTeam(cls, number, name=None):
+        team = Team(
+            id = "frc{}".format(number),
+            team_number = number,
+            name = name,
+            nickname = name,
+        )
+        team = TeamManipulator.createOrUpdate(team)
+        return team
+
+    @classmethod
+    def createSixTeams(cls):
+        teams = []
+        for n in range(1, 7):
+            teams.append(cls.createTeam(n, cls.TEAMS[n-1]))
+        return teams

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -82,7 +82,10 @@ $(function () {
             <div class="panel-body">
                 <div class="alert alert-info">Run <code>paver setup</code> to set up a dev instance.</div>
                 <div class="btn-group">
-                    <a class="btn btn-default" href="/tasks/get/fms_team_list">Get Teams</a>
+                    <a class="btn btn-default" href="/tasks/get/fms_team_list">Get FMS Teams</a>
+                </div>
+                <div class="btn-group">
+                    <a class="btn btn-default" href="/admin/team/create/test">Create Test Teams</a>
                     <a class="btn btn-default" href="/admin/event/create/test">Create Test Events</a>
                 </div>
                 <br /><br />

--- a/tests/test_team_test_creator.py
+++ b/tests/test_team_test_creator.py
@@ -4,7 +4,6 @@ import unittest2
 from google.appengine.ext import testbed
 
 from helpers.team.team_test_creator import TeamTestCreator
-
 from models.team import Team
 
 

--- a/tests/test_team_test_creator.py
+++ b/tests/test_team_test_creator.py
@@ -1,0 +1,30 @@
+import datetime
+import unittest2
+
+from google.appengine.ext import testbed
+
+from helpers.team.team_test_creator import TeamTestCreator
+
+from models.team import Team
+
+
+class TestEventTeamCreator(unittest2.TestCase):
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+
+        self.teams = []
+
+    def tearDown(self):
+        for team in self.teams:
+            team.key.delete()
+
+        self.testbed.deactivate()
+
+    def test_creates(self):
+        self.teams.extend(TeamTestCreator.createSixTeams())
+
+        teams = Team.query().order(Team.team_number).fetch(60)
+        self.assertEqual(len(teams), 6)


### PR DESCRIPTION
While #1103 exists, allows creating local test teams to create test matches, events, etc.