### PR TITLE
Update the server setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Personal development files #
+##############################
+mydeploy.sh
+
 # Compiled source #
 ###################
 *.com

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Run a local dev server
 	* Also see [localhost:8088/admin/](http://localhost:8088/admin/)
 4. Get some data into the local server
 	* NOTE: These steps are intended for local dev servers. They might also work on a deployed server if you edit `tba_config.py` to set `DEBUG = True`.
-	* NOTE: The /admin/ page's buttons "Get FMS Teams" and "Create Test Teams" are obsolete. They try to access decomissioned usfirst.org data feeds. "Create Test Events" still works *if* you have teams in the database.
+	* NOTE: The /admin/ page's buttons "Get FMS Teams" and "Create Test Teams" and the existing import /tasks are broken due to the move to FMSAPI datafeed. "Create Test Events" still works *if* you have teams in the database. Try visiting the urls /tasks/enqueue/csv_restore_events/YEAR (for a chosen year) or /tasks/enqueue/csv_restore_events.
 	* Visit, say, [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0), [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000), ...
 	* Also visit [localhost:8088/tasks/enqueue/usfirst_event_details/2015](http://localhost:8088/tasks/enqueue/usfirst_event_details/2015), [2014](http://localhost:8088/tasks/enqueue/usfirst_event_details/2014), ...
 	* Once you have events for a certain year, you can visit [localhost:8088/tasks/enqueue/csv_restore_events/2015](http://localhost:8088/tasks/enqueue/csv_restore_events/2015), [2014](http://localhost:8088/tasks/enqueue/csv_restore_events/2014), ... etc. to get data from [github.com/the-blue-alliance/the-blue-alliance-data](https://github.com/the-blue-alliance/the-blue-alliance-data) instead of hitting up usfirst.org lots of times.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Run a local dev server
 	* Visit [localhost:8088](http://localhost:8088) to see your local version of The Blue Alliance
 	* Also see [localhost:8088/admin/](http://localhost:8088/admin/)
 4. Get some data into the local server
-	* NOTE: These steps are intended for local dev servers. They might also work on a deployed server if you set DEBUG to True.
-	* NOTE: The /admin/ page's buttons like "Create Test Teams" and "Create Test Events" are obsolete. They try to access decomissioned usfirst.org data feeds.
+	* NOTE: These steps are intended for local dev servers. They might also work on a deployed server if you edit `tba_config.py` to set `DEBUG = True`.
+	* NOTE: The /admin/ page's buttons "Get FMS Teams" and "Create Test Teams" are obsolete. They try to access decomissioned usfirst.org data feeds. "Create Test Events" still works *if* you have teams in the database.
 	* Visit, say, [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0), [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000), ...
 	* Also visit [localhost:8088/tasks/enqueue/usfirst_event_details/2015](http://localhost:8088/tasks/enqueue/usfirst_event_details/2015), [2014](http://localhost:8088/tasks/enqueue/usfirst_event_details/2014), ...
 	* Once you have events for a certain year, you can visit [localhost:8088/tasks/enqueue/csv_restore_events/2015](http://localhost:8088/tasks/enqueue/csv_restore_events/2015), [2014](http://localhost:8088/tasks/enqueue/csv_restore_events/2014), ... etc. to get data from [github.com/the-blue-alliance/the-blue-alliance-data](https://github.com/the-blue-alliance/the-blue-alliance-data) instead of hitting up usfirst.org lots of times.
@@ -73,6 +73,10 @@ Setup notes:
 
 * Note that it needs your application's "Project ID", not its "Project name".
 * The `--oauth2` argument of `appcfg.py` [saves repeating the login steps each time](https://cloud.google.com/appengine/docs/python/tools/uploadinganapp#Python_Password-less_login_with_OAuth2). If you skip it or deploy via the App Engine Launcher, you'll have to enter your name and password each time. If you use 2-Step Verification for your Google account (you should!), that means generating an [App password](https://security.google.com/settings/security/apppasswords) each time.
+* The `cron.yaml` file in master will create cron jobs that use up daily free AE Datastore quotas.
+	* To avoid that in a dev server, checkout [a no-op version of cron.yaml](https://github.com/the-blue-alliance/the-blue-alliance/blob/c5d173f23310caf9f2c80d08829083c22ea1c0c3/cron.yaml).
+	* If it's already happening in a dev server, deploy a no-op `cron.yaml` via `appcfg.py update_cron`, then delete the tasks in the `usfirst` queue.)
+	* If you try to deploy a server while it's over Datastore quota, appcfg will say "there was an error updating your indexes. Please retry later with appcfg.py update_indexes." The fix is to wait until the next day's quota then use `appcfg.py update_indexes` or `appcfg.py update`.
 * When you set sitevars, the server automatically internalizes them.
 * You don't need a sitevar for `firebase.secrets` even though that's the placeholder text for a new sitevar name.
 * Ignore these deployment warnings:

--- a/README.md
+++ b/README.md
@@ -28,17 +28,20 @@ Setup
 	* Run `git clone git://github.com/USERNAME/the-blue-alliance.git` where _USERNAME_ is your GitHub username, or use GitHub's Windows or OS X app to clone it to your computer
 	* For detailed instructions see [the GitHub guide on contributing](https://guides.github.com/activities/contributing-to-open-source/index.html#contributing)
 3. Install [numpy](http://www.numpy.org/)
-	* Download [the latest version of numpy](http://sourceforge.net/projects/numpy/files/latest/download?source=files)
-	* Unpack the archive
-	* cd into the archive
-	* Run `setup.py install` or `python setup.py install`
+	* You can use your favorite package manager.
+	* Or download a binary of [the latest version of numpy](http://sourceforge.net/projects/numpy/files/latest/download?source=files).
+		* Unpack the archive
+		* cd into the archive
+		* Run `setup.py install` or `python setup.py install`
+	* Or compile it from source code. (On Windows, use the [Microsoft Visual C++ Compiler for Python 2.7](http://www.microsoft.com/en-us/download/details.aspx?id=44266).)
 4. Install [Node.js](https://nodejs.org/) which includes [Node Package Manager](https://www.npmjs.org/)
 5. Install LESS via Node Package Manager
 	* `npm install -g less`
 6. Install Paver
 	* `easy_install -U Paver`
 	* or `pip install -U Paver`
-7. Run `paver setup`
+7. Run `easy_install pep8` to avoid the `lint` error `[Error 2] The system cannot find the file specified`.
+8. Run `paver setup`
 
 Run a local dev server
 ----------------------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Blue Alliance is a FIRST Robotics tool to help teams scout for, compete at, 
 
 Contributing
 ------------
-0. Join https://groups.google.com/forum/#!forum/thebluealliance-developers to stay up to date with development
+0. Join [thebluealliance-developers on groups.google.com](https://groups.google.com/forum/#!forum/thebluealliance-developers) to stay up to date with development
 1. Fork this project!
 2. Make your changes on a branch.
 3. Make changes!

--- a/README.md
+++ b/README.md
@@ -16,51 +16,99 @@ If you're having trouble getting set up, reach out to us at [our mailing list](h
 Setup
 -----
 0. Learn a bit about Git and GitHub:
+	* Install git on your PATH
 	* [GitHub help](https://help.github.com/)
 	* [Try Git](https://try.github.io/)
-1. Install [App Engine](http://developers.google.com/appengine/)
-	* Specifically use the [Python SDK](http://developers.google.com/appengine/downloads#Google_App_Engine_SDK_for_Python)
-	* Run installer and allow it make symbolic links (you will be asked to enter your root password)
+1. Install [Python 2.7.X](https://www.python.org/downloads/)
+1. Install [App Engine](https://cloud.google.com/appengine/docs)
+	* Specifically use the [Python SDK](https://cloud.google.com/appengine/downloads#Google_App_Engine_SDK_for_Python)
+	* Run the installer and allow it make symbolic links (it might ask you to enter your root password)
 2. Get the latest version of The Blue Alliance
-	* First make sure you have forked TBA by clicking on "Fork" in the top right of the page
-	* Run `git clone git://github.com/username/the-blue-alliance.git` where username is your GitHub username
+	* Fork TBA by clicking on "Fork" in the top right of [its GitHub page](https://github.com/the-blue-alliance/the-blue-alliance)
+	* Run `git clone git://github.com/USERNAME/the-blue-alliance.git` where _USERNAME_ is your GitHub username, or use GitHub's Windows or OS X app to clone it to your computer
 	* For detailed instructions see [the GitHub guide on contributing](https://guides.github.com/activities/contributing-to-open-source/index.html#contributing)
-3. Import the project into Google App Engine Launcher
-	* By default TBA uses port **8088**, make sure your local setup is consistent with this
-4. Run the app in App Engine
-5. Get some test data: In your terminal console, from the `the-blue-alliance` directory, run the following command
-	* `paver setup` (Make sure that you already have [Paver installed](#paver-commands))
-6. You should now have a basic development installation!
+3. Install [numpy](http://www.numpy.org/)
+	* Download [the latest version of numpy](http://sourceforge.net/projects/numpy/files/latest/download?source=files)
+	* Unpack the archive
+	* cd into the archive
+	* Run `setup.py install` or `python setup.py install`
+4. Install [Node.js](https://nodejs.org/) which includes [Node Package Manager](https://www.npmjs.org/)
+5. Install LESS via Node Package Manager
+	* `npm install -g less`
+6. Install Paver
+	* `easy_install -U Paver`
+	* or `pip install -U Paver`
+7. Run `paver setup`
+
+Run a local dev server
+----------------------
+1. Import the project into Google App Engine Launcher
+	* Open App Engine Launcher
+	* File > Add Existing Application...
+	* Set the Application Path to your `the-blue-alliance` directory
+	* Set port **8088**
+2. Run the app in App Engine Launcher and view its Logs window
+3. You should now have a basic development installation!
 	* Visit [localhost:8088](http://localhost:8088) to see your local version of The Blue Alliance
-	* Visit [localhost:8088/admin/debug](http://localhost:8088/admin/debug) to run more commands and populate your install with extra data
+	* Also see [localhost:8088/admin/](http://localhost:8088/admin/)
+4. Get some data into the local server
+	* NOTE: These steps are intended for local dev servers. They might also work on a deployed server if you set DEBUG to True.
+	* NOTE: The /admin/ page's buttons like "Create Test Teams" and "Create Test Events" are obsolete. They try to access decomissioned usfirst.org data feeds.
+	* Visit, say, [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0), [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000), ...
+	* Also visit [localhost:8088/tasks/enqueue/usfirst_event_details/2015](http://localhost:8088/tasks/enqueue/usfirst_event_details/2015), [2014](http://localhost:8088/tasks/enqueue/usfirst_event_details/2014), ...
+	* Once you have events for a certain year, you can visit [localhost:8088/tasks/enqueue/csv_restore_events/2015](http://localhost:8088/tasks/enqueue/csv_restore_events/2015), [2014](http://localhost:8088/tasks/enqueue/csv_restore_events/2014), ... etc. to get data from [github.com/the-blue-alliance/the-blue-alliance-data](https://github.com/the-blue-alliance/the-blue-alliance-data) instead of hitting up usfirst.org lots of times.
+5. Ignore these warnings in the local dev server:
+	* `pytz is required to calculate future run times for cron jobs with timezones` (The pytz library is in the source tree and works fine.)
+
+Run an App Engine server
+------------------------
+See [myTBA Configuration](https://github.com/the-blue-alliance/the-blue-alliance-android/wiki/myTBA-Configuration) for how to create and configure an App Engine server.
+
+Setup notes:
+
+* You _could_ edit the `app.yaml` file to change its `application:` setting from `tbatv-dev-hrd` to your app's Project ID, but then you'll have to remember to not check in that edit. Better yet, write a script like the following `mydeploy.sh` file (that filename is in `.gitignore`):
+
+	    #!/bin/sh
+	    appcfg.py --oauth2 --application=<MY_PROJECT_ID> update
+
+* Note that it needs your application's "Project ID", not its "Project name".
+* The `--oauth2` argument of `appcfg.py` [saves repeating the login steps each time](https://cloud.google.com/appengine/docs/python/tools/uploadinganapp#Python_Password-less_login_with_OAuth2). If you skip it or deploy via the App Engine Launcher, you'll have to enter your name and password each time. If you use 2-Step Verification for your Google account (you should!), that means generating an [App password](https://security.google.com/settings/security/apppasswords) each time.
+* When you set sitevars, the server automatically internalizes them.
+* You don't need a sitevar for `firebase.secrets` even though that's the placeholder text for a new sitevar name.
+* Ignore these deployment warnings:
+	* `Cannot upload both <filename>.py and <filename>.pyc`
+	* `Could not guess mimetype for static/ovp/<filename>.xap.  Using application/octet-stream.`
+	* `WARNING old_run.py:88 This function, oauth2client.tools.run(), and the use of the gflags library are deprecated and will be removed in a future version of the library.`
+* Ignore these warnings in a deployed server's logs:
+	* `Exception: Missing sitevar: firebase.secrets. Can't write to Firebase` (It just means that no push notifications to GameDay will be sent, which is OK for a dev server.)
+
+Notes:
+
+* See [localhost:8088/apidocs](http://localhost:8088/apidocs) and [localhost:8088/apidocs/webhooks](http://localhost:8088/apidocs/webhooks) for self-hosted API docs.
+
 
 Paver Commands
 --------------
 Paver is an easy way automate repetitive tasks. For The Blue Alliance, these tasks are stored in _pavement.py_. 
 To install paver, use one of the methods below:
+
 * Download and install paver from [http://pypi.python.org/pypi/Paver/](http://pypi.python.org/pypi/Paver/ "Paver") 
 * Run `easy_install Paver`
 
-## Simple Commands
-* `paver clean` - Deletes artifacts that the app creates that you don't need.
+Paver commands include:
+
+* `paver javascript`  -- combine and compress JavaScript files
+* `paver less`  -- translate LESS files to CSS and combine with other CSS files
+* `paver setup`  -- build CSS and JavaScript files
+* `paver lint`
+* `paver test_fast`  -- run tests that don't require HTTP
 
 CSS Icon Sprites
 -----------
-If possible, icons are combined into single files called sprites to reduce the number of requests needed to render a page.
+Icons get combined into single files called sprites to reduce the number of HTTP requests needed to render a page.
 To simplify development, we add icons normally (not to the sprite), and every so often we will combine them all into a sprite and fix all necessary CSS.
+
 Potentially useful: http://spriteme.org/
-
-LESS
-----
-The CSS files are compiled from LESS to ease in development. Make sure you have [Node Package Manager](https://www.npmjs.org/) installed, and install lessc by running `npm install -g less`. Now, you can run `paver less` to compile the LESS into CSS.
-
-CSS/JavaScript Combination and Compression
-------------------------------------------
-Once the LESS files are compressed into CSS, we combine the resulting file with other precompiled CSS files. Similarly, we combine all relevant JavaScript files into a single file and compress them.
-This means that whenever changes are made to CSS or JavaScript, you must run of the following:
-* `paver less`
-* `paver javascript`
-* `paver make` (builds both LESS and JS)
 
 Testing
 -------
@@ -69,5 +117,6 @@ Testing
 Testing is implemented using a combination of [unittest2](http://pypi.python.org/pypi/unittest2 "Uniter Test 2") and the Google App Engine testbed framework. Test coverage is a work in progress, and focuses on maintaining datafeed integrity in the face of optimizations and changes to FIRST's data formats.
 
 To run the tests, or just the offline (fast) tests:
+
 * `paver test`
 * `paver test_fast`

--- a/pavement.py
+++ b/pavement.py
@@ -86,10 +86,6 @@ def test_fast():
 def setup_function():
   make()
 
-  print("Set up test data at http://localhost:8088/admin/")
-  print("1/ Click 'Get Teams' and 'Create Test Events'")
-  print("2/ Click 'Create Test Events'")
-
 
 def test_function(args):
   print("Running Tests")


### PR DESCRIPTION
This incorporates what I've learned so far on setting up a TBA server:
additional tool installations, updated hyperlinks, and updated
configuration steps. Thanks, Eugene.

Also, saving a personal deploy.sh file (.gitignored) avoids needing to edit
app.yaml and avoid checking in that edit.

[TIL: When the GitHub Windows app creates a PR, it defaults to the repo fork rather than the original repo.]