### PR TITLE
Update country_name key in API docs.

### DIFF
--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -133,7 +133,7 @@
             <td>SC</td>
           </tr>
           <tr>
-            <td>country</td>
+            <td>country_name</td>
             <td>Country of team derived from parsing the address registered with <em>FIRST</em></td>
             <td>USA</td>
           </tr>


### PR DESCRIPTION
Stubbed my toe on this one a bit earlier. The docs declare `country` as being the key, when the API actually uses `country_name`. 