### PR TITLE
Refine the server's name shortener like the Android app's

### DIFF
--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -193,22 +193,28 @@ class EventHelper(object):
 
     @classmethod
     def getShortName(self, name_str):
+        """
+        Extracts a short name like "Silicon Valley" from an event name like
+        "Silicon Valley Regional sponsored by Google.org".
+
+        See https://github.com/the-blue-alliance/the-blue-alliance-android/blob/master/android/src/test/java/com/thebluealliance/androidclient/test/helpers/EventHelperTest.java
+        """
         # 2015+ districts
-        re_string = '(' + '|'.join(DistrictType.abbrevs.keys()).upper() + ') District -(.*)'
-        match = re.match(re.compile(re_string), name_str)
+        re_string = '(?:' + '|'.join(DistrictType.abbrevs.keys()).upper() + ') District -(.+)'
+        match = re.match(re_string, name_str)
         if match:
-            partial = match.group(2).strip()
-            match2 = re.match('(.*)Event(.*)', partial)
+            partial = match.group(1).strip()
+            match2 = re.match(r'(.+)Event', partial)
             if match2:
                 return match2.group(1).strip()
             else:
                 return partial
 
         # other districts and regionals
-        match = re.match(r'(MAR |PNW )?(FIRST Robotics|FRC)?(.*)(FIRST Robotics|FRC)?(District|Regional|Region|State|Tournament|FRC|Field)( Competition| Event| Championship)?', name_str)
+        match = re.match(r'\s*(?:MAR |PNW |)(?:FIRST Robotics|FRC|)(.+)(?:District|Regional|Region|State|Tournament|FRC|Field)\b', name_str)
         if match:
-            short = match.group(3)
-            match = re.match(r'(.*)(FIRST Robotics|FRC)', short)
+            short = match.group(1)
+            match = re.match(r'(.+)(?:FIRST Robotics|FRC)', short)
             if match:
                 return match.group(1).strip()
             else:

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,7 +9,7 @@ import warnings
 # Install the Python unittest2 package before you run this script.
 import unittest2
 
-USAGE = """%prog SDK_PATH
+USAGE = """%prog -s SDK_PATH -t TEST_PATTERN
 Run unit tests for App Engine apps.
 The SDK Path is probably /usr/local/google_appengine on Mac OS
 

--- a/tests/test_event_get_short_name.py
+++ b/tests/test_event_get_short_name.py
@@ -5,9 +5,31 @@ from helpers.event_helper import EventHelper
 
 class TestEventGetShortName(unittest2.TestCase):
     def test_event_get_short_name(self):
-        """
-        A bunch of tests from various years
-        """
+        # Edge cases.
+        self.assertEquals(EventHelper.getShortName("  { Random 2.718 stuff! }  "), "{ Random 2.718 stuff! }")
+        self.assertEquals(EventHelper.getShortName("IN District -Bee's Knee's LX  "), "Bee's Knee's LX")
+        self.assertEquals(EventHelper.getShortName("MAR District - Brussels Int'l Event sponsored by Sprouts"), "Brussels Int'l")
+        self.assertEquals(EventHelper.getShortName("FIM District - Brussels Int'l Eventapalooza sponsored by TBA"), "Brussels Int'l")
+        self.assertEquals(EventHelper.getShortName("NE District - ReallyBigEvent Scaling Up Every Year"), "ReallyBig")
+        self.assertEquals(EventHelper.getShortName("PNW District -  Event!  "), "Event!")
+
+        self.assertEquals(EventHelper.getShortName("FRC Detroit FIRST Robotics District Competition"), "Detroit")
+        self.assertEquals(EventHelper.getShortName("FIRST Robotics Detroit FRC State Championship"), "Detroit")
+        self.assertEquals(EventHelper.getShortName("Maui FIRST Robotics Regional and Luau"), "Maui")
+        self.assertEquals(EventHelper.getShortName("California State Surf and Turf sponsored by TBA"), "California")
+        self.assertEquals(EventHelper.getShortName("CarTalk Plaza Tournament"), "CarTalk Plaza")
+        self.assertEquals(EventHelper.getShortName("IRI FRC Be-all and End-all"), "IRI")
+        self.assertEquals(EventHelper.getShortName("   Ada    Field  "), "Ada")
+        self.assertEquals(EventHelper.getShortName(" FIRST Robotics Einstein Field Equations "), "Einstein")
+        self.assertEquals(EventHelper.getShortName("FRC Martin Luther King Jr. Region Championship"), "Martin Luther King Jr.")
+        self.assertEquals(EventHelper.getShortName("PNW   Ada Lovelace    Tournament of Software  "), "Ada Lovelace")
+        self.assertEquals(EventHelper.getShortName("\tPNW   Ada Lovelace    Tournament of Software  "), "Ada Lovelace")
+        self.assertEquals(EventHelper.getShortName(" MAR FIRST Robotics   Rosa Parks    FRC Tournament of Roses  "), "Rosa Parks")
+        self.assertEquals(EventHelper.getShortName("Washington D.C. FIRST Robotics Region"), "Washington D.C.")
+        self.assertEquals(EventHelper.getShortName("Washington D.C. FIRST Robotics Region."), "Washington D.C.")
+        self.assertEquals(EventHelper.getShortName("Washington D.C. FIRST Robotics Regiontonian"), "Washington D.C. FIRST Robotics Regiontonian") # Does not match "Region\b"
+
+        # Tests from various years
         self.assertEqual(EventHelper.getShortName("FIRST Robotics Competition"), "FIRST Robotics Competition")
         self.assertEqual(EventHelper.getShortName("National Championship"), "National Championship")
         self.assertEqual(EventHelper.getShortName("New England Tournament"), "New England")


### PR DESCRIPTION
Also simplify and link to the Android code to make it easier to keep them
in sync. E.g. '(.*)' is as good as '(.*)(FIRST Robotics|FRC)?' since the
"greedy quantifier" .* keeps (FIRST Robotics|FRC)? from matching any chars.
re.match() matches the start of the input string, so .* on the end of the pattern
does nothing.