### PR TITLE
Add application/json Content-Type to webhooks

### DIFF
--- a/helpers/notification_sender.py
+++ b/helpers/notification_sender.py
@@ -35,6 +35,7 @@ class NotificationSender(object):
             checksum = ch.hexdigest()
 
             request = urllib2.Request(url, payload)
+            request.add_header("Content-Type", 'application/json; charset="utf-8"')
             request.add_header("X-TBA-Checksum", checksum)
             request.add_header("X-TBA-Version", '{}'.format(cls.WEBHOOK_VERSION))
             try:


### PR DESCRIPTION
Same as apiv2 (see
https://github.com/the-blue-alliance/the-blue-alliance/blob/master/controllers/api/api_base_controller.py#L60)
Fixes #1178