### PR TITLE
Fix typo in Media model

### DIFF
--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -414,7 +414,7 @@
         </thead>
         <tbody>
           <tr>
-            <td>Type</td>
+            <td>type</td>
             <td>The string type of the media element, as determined <a href="https://github.com/the-blue-alliance/the-blue-alliance/blob/master/models/media.py#L16">here</a>.</td>
             <td>cdphotothread</td>
           </tr>


### PR DESCRIPTION
Changes "Type" to be "type", to match the rest of the models (and the capitalization that the key should be)