### PR TITLE
Trusted api updates

### DIFF
--- a/datafeeds/parsers/json/json_rankings_parser.py
+++ b/datafeeds/parsers/json/json_rankings_parser.py
@@ -9,15 +9,12 @@ class JSONRankingsParser(ParserBase):
     def parse(self, rankings_json):
         """
         Parse JSON that contains a dict of:
-        breakdowns: List of ranking breakdowns, such as "QS", "Auton", "Teleop", etc. Breakdowns will be shown in the order given.
+        breakdowns: List of ranking breakdowns, such as "Wins", "Qual Avg", "QS", "Auton", "Teleop", etc. Breakdowns will be shown in the order given.
         rankings: List of ranking dicts
 
         Ranking dict format:
         team_key: String corresponding to a particular team in the format "frcXXX"
         rank: Integer rank of the particular team
-        wins: Integer of the number of non-surrogate wins
-        losses: Integer of the number of non-surrogate losses
-        ties: Integer of the number of non-surrogate ties
         played: Integer of the number of non-surrogate matches played
         dqs: Integer of the number of non-surrogate DQed matches
         breakdown: Dict where the key is a breakdown and the value is its value
@@ -34,20 +31,20 @@ class JSONRankingsParser(ParserBase):
         if 'rankings' not in data or type(data['rankings']) is not list:
             raise ParserInputException("Data must have a list 'rankings'")
 
-        rankings = [['Rank', 'Team'] + data['breakdowns'] + ['Record (W-L-T)', 'DQ', 'Played']]
+        rankings = [['Rank', 'Team'] + data['breakdowns'] + ['DQ', 'Played']]
         for ranking in data['rankings']:
             if type(ranking) is not dict:
                 raise ParserInputException("Ranking must be a dict.")
             if 'team_key' not in ranking or not re.match(r'frc\d+', str(ranking['team_key'])):
                 raise ParserInputException("Ranking must have a 'team_key' that follows the format 'frcXXX'")
-            for attr in ['rank', 'wins', 'losses', 'ties', 'played', 'dqs']:
+            for attr in ['rank', 'played', 'dqs']:
                 if attr not in ranking or type(ranking[attr]) is not int:
                     raise ParserInputException("Ranking must have a integer '{}'".format(attr))
 
             row = [ranking['rank'], ranking['team_key'][3:]]
             for b in data['breakdowns']:
-                row.append(ranking.get(b, '--'))
-            row.extend(['{}-{}-{}'.format(ranking['wins'], ranking['losses'], ranking['ties']), ranking['dqs'], ranking['played']])
+                row.append(ranking['breakdown'].get(b, '--'))
+            row.extend([ranking['dqs'], ranking['played']])
             rankings.append(row)
 
         return rankings

--- a/datafeeds/parsers/json/json_rankings_parser.py
+++ b/datafeeds/parsers/json/json_rankings_parser.py
@@ -43,7 +43,7 @@ class JSONRankingsParser(ParserBase):
 
             row = [ranking['rank'], ranking['team_key'][3:]]
             for b in data['breakdowns']:
-                row.append(ranking['breakdown'].get(b, '--'))
+                row.append(ranking.get(b, '--'))
             row.extend([ranking['dqs'], ranking['played']])
             rankings.append(row)
 

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -285,6 +285,26 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)', 'DQ', 'Played'])
         self.assertEqual(self.event.rankings[1], [1, '254', 20, 500, 500, 200, '10-0-0', 0, 10])
 
+    def test_rankings_wlt_update(self):
+        self.aaa.put()
+
+        rankings = {
+            'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C', 'wins', 'losses', 'ties'],
+            'rankings': [
+                {'team_key': 'frc254', 'rank': 1, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc971', 'rank': 2, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200}
+            ],
+        }
+        request_body = json.dumps(rankings)
+
+        request_path = '/api/trusted/v1/event/2014casj/rankings/update'
+        sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)', 'DQ', 'Played'])
+        self.assertEqual(self.event.rankings[1], [1, '254', 20, 500, 500, 200, '10-0-0', 0, 10])
+
     def test_eventteams_update(self):
         self.aaa.put()
 

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -269,10 +269,10 @@ class TestApiTrustedController(unittest2.TestCase):
         self.aaa.put()
 
         rankings = {
-            'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C'],
+            'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)'],
             'rankings': [
-                {'team_key': 'frc254', 'rank': 1, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
-                {'team_key': 'frc971', 'rank': 2, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200}
+                {'team_key': 'frc254', 'rank': 1, 'Record (W-L-T)': '10-0-0', 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc971', 'rank': 2, 'Record (W-L-T)': '10-0-0', 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200}
             ],
         }
         request_body = json.dumps(rankings)

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -269,10 +269,10 @@ class TestApiTrustedController(unittest2.TestCase):
         self.aaa.put()
 
         rankings = {
-            'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)'],
+            'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C'],
             'rankings': [
-                {'team_key': 'frc254', 'rank': 1, 'Record (W-L-T)': '10-0-0', 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
-                {'team_key': 'frc971', 'rank': 2, 'Record (W-L-T)': '10-0-0', 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200}
+                {'team_key': 'frc254', 'rank': 1, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc971', 'rank': 2, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200}
             ],
         }
         request_body = json.dumps(rankings)
@@ -282,8 +282,8 @@ class TestApiTrustedController(unittest2.TestCase):
         response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)', 'DQ', 'Played'])
-        self.assertEqual(self.event.rankings[1], [1, '254', 20, 500, 500, 200, '10-0-0', 0, 10])
+        self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'DQ', 'Played'])
+        self.assertEqual(self.event.rankings[1], [1, '254', 20, 500, 500, 200, 0, 10])
 
     def test_rankings_wlt_update(self):
         self.aaa.put()


### PR DESCRIPTION
Broken off from #1197 

Changed the trusted API to take W/L/T out of required parameters (moved to generic breakdown category) to accommodate this year's game. This will require an update to Cheesy Arena (which I'll take care of).

Closes #1115 