### PR TITLE
Subdivide trusted api permissions

### DIFF
--- a/consts/auth_type.py
+++ b/consts/auth_type.py
@@ -4,8 +4,19 @@ class AuthType(object):
     """
     EVENT_DATA = 0
     MATCH_VIDEO = 1
+    EVENT_TEAMS = 2
+    EVENT_SCHEDULE = 3
+    EVENT_MATCHES = 4
+    EVENT_RANKINGS = 5
+    EVENT_ALLIANCES = 6
+    EVENT_AWARDS = 7
 
     type_names = {
         EVENT_DATA: "event data",
         MATCH_VIDEO: "match video",
+        EVENT_TEAMS: "event teams",
+        EVENT_MATCHES: "event matches",
+        EVENT_RANKINGS: "event rankings",
+        EVENT_ALLIANCES: "event alliances",
+        EVENT_AWARDS: "event awrads"
     }

--- a/consts/auth_type.py
+++ b/consts/auth_type.py
@@ -2,14 +2,16 @@ class AuthType(object):
     """
     An auth type defines what write privileges an authenticated agent has.
     """
-    MATCH_VIDEO = 0
-    EVENT_TEAMS = 1
-    EVENT_MATCHES = 2
-    EVENT_RANKINGS = 3
-    EVENT_ALLIANCES = 4
-    EVENT_AWARDS = 5
+    EVENT_DATA = 0
+    MATCH_VIDEO = 1
+    EVENT_TEAMS = 2
+    EVENT_MATCHES = 3
+    EVENT_RANKINGS = 4
+    EVENT_ALLIANCES = 5
+    EVENT_AWARDS = 6
 
     type_names = {
+        EVENT_DATA: "event data",
         MATCH_VIDEO: "match video",
         EVENT_TEAMS: "event teams",
         EVENT_MATCHES: "event matches",

--- a/consts/auth_type.py
+++ b/consts/auth_type.py
@@ -2,16 +2,14 @@ class AuthType(object):
     """
     An auth type defines what write privileges an authenticated agent has.
     """
-    EVENT_DATA = 0
-    MATCH_VIDEO = 1
-    EVENT_TEAMS = 2
-    EVENT_MATCHES = 3
-    EVENT_RANKINGS = 4
-    EVENT_ALLIANCES = 5
-    EVENT_AWARDS = 6
+    MATCH_VIDEO = 0
+    EVENT_TEAMS = 1
+    EVENT_MATCHES = 2
+    EVENT_RANKINGS = 3
+    EVENT_ALLIANCES = 4
+    EVENT_AWARDS = 5
 
     type_names = {
-        EVENT_DATA: "event data",
         MATCH_VIDEO: "match video",
         EVENT_TEAMS: "event teams",
         EVENT_MATCHES: "event matches",

--- a/consts/auth_type.py
+++ b/consts/auth_type.py
@@ -2,7 +2,7 @@ class AuthType(object):
     """
     An auth type defines what write privileges an authenticated agent has.
     """
-    EVENT_DATA = 0
+    EVENT_DATA = 0  # DEPRECATED - USE FINER PERMISSIONS INSTEAD
     MATCH_VIDEO = 1
     EVENT_TEAMS = 2
     EVENT_MATCHES = 3

--- a/consts/auth_type.py
+++ b/consts/auth_type.py
@@ -5,11 +5,10 @@ class AuthType(object):
     EVENT_DATA = 0
     MATCH_VIDEO = 1
     EVENT_TEAMS = 2
-    EVENT_SCHEDULE = 3
-    EVENT_MATCHES = 4
-    EVENT_RANKINGS = 5
-    EVENT_ALLIANCES = 6
-    EVENT_AWARDS = 7
+    EVENT_MATCHES = 3
+    EVENT_RANKINGS = 4
+    EVENT_ALLIANCES = 5
+    EVENT_AWARDS = 6
 
     type_names = {
         EVENT_DATA: "event data",

--- a/controllers/admin/admin_api_controller.py
+++ b/controllers/admin/admin_api_controller.py
@@ -82,8 +82,16 @@ class AdminApiAuthEdit(LoggedInHandler):
         auth = ApiAuthAccess.get_by_id(auth_id)
 
         auth_types_enum = []
-        if self.request.get('allow_edit_data'):
-            auth_types_enum.append(AuthType.EVENT_DATA)
+        if self.request.get('allow_edit_teams'):
+            auth_types_enum.append(AuthType.EVENT_TEAMS)
+        if self.request.get('allow_edit_matches'):
+            auth_types_enum.append(AuthType.EVENT_MATCHES)
+        if self.request.get('allow_edit_rankings'):
+            auth_types_enum.append(AuthType.EVENT_RANKINGS)
+        if self.request.get('allow_edit_alliances'):
+            auth_types_enum.append(AuthType.EVENT_ALLIANCES)
+        if self.request.get('allow_edit_awards'):
+            auth_types_enum.append(AuthType.EVENT_AWARDS)
         if self.request.get('allow_edit_match_video'):
             auth_types_enum.append(AuthType.MATCH_VIDEO)
 

--- a/controllers/api/api_trusted_controller.py
+++ b/controllers/api/api_trusted_controller.py
@@ -32,7 +32,7 @@ class ApiTrustedEventAllianceSelectionsUpdate(ApiTrustedBaseController):
     """
     Overwrites an event's alliance_selections_json with new data
     """
-    REQUIRED_AUTH_TYPES = {AuthType.EVENT_DATA}
+    REQUIRED_AUTH_TYPES = {AuthType.EVENT_ALLIANCES}
 
     def _process_request(self, request, event_key):
         alliance_selections = JSONAllianceSelectionsParser.parse(request.body)
@@ -49,7 +49,7 @@ class ApiTrustedEventAwardsUpdate(ApiTrustedBaseController):
     """
     Removes all awards for an event and adds the awards given in the request
     """
-    REQUIRED_AUTH_TYPES = {AuthType.EVENT_DATA}
+    REQUIRED_AUTH_TYPES = {AuthType.EVENT_AWARDS}
 
     def _process_request(self, request, event_key):
         event = Event.get_by_id(event_key)
@@ -80,7 +80,7 @@ class ApiTrustedEventMatchesUpdate(ApiTrustedBaseController):
     """
     Creates/updates matches
     """
-    REQUIRED_AUTH_TYPES = {AuthType.EVENT_DATA}
+    REQUIRED_AUTH_TYPES = {AuthType.EVENT_MATCHES}
 
     def _process_request(self, request, event_key):
         event = Event.get_by_id(event_key)
@@ -122,7 +122,7 @@ class ApiTrustedEventMatchesDelete(ApiTrustedBaseController):
     """
     Deletes given match keys
     """
-    REQUIRED_AUTH_TYPES = {AuthType.EVENT_DATA}
+    REQUIRED_AUTH_TYPES = {AuthType.EVENT_MATCHES}
 
     def _process_request(self, request, event_key):
         keys_to_delete = set()
@@ -144,7 +144,7 @@ class ApiTrustedEventRankingsUpdate(ApiTrustedBaseController):
     """
     Overwrites an event's rankings_json with new data
     """
-    REQUIRED_AUTH_TYPES = {AuthType.EVENT_DATA}
+    REQUIRED_AUTH_TYPES = {AuthType.EVENT_RANKINGS}
 
     def _process_request(self, request, event_key):
         rankings = JSONRankingsParser.parse(request.body)
@@ -162,7 +162,7 @@ class ApiTrustedEventTeamListUpdate(ApiTrustedBaseController):
     Creates/updates EventTeams for teams given in the request
     and removes EventTeams for teams not in the request
     """
-    REQUIRED_AUTH_TYPES = {AuthType.EVENT_DATA}
+    REQUIRED_AUTH_TYPES = {AuthType.EVENT_TEAMS}
 
     def _process_request(self, request, event_key):
         team_keys = JSONTeamListParser.parse(request.body)

--- a/models/api_auth_access.py
+++ b/models/api_auth_access.py
@@ -17,8 +17,24 @@ class ApiAuthAccess(ndb.Model):
     auth_types_enum = ndb.IntegerProperty(repeated=True)
 
     @property
-    def can_edit_event_data(self):
-        return AuthType.EVENT_DATA in self.auth_types_enum
+    def can_edit_event_teams(self):
+        return AuthType.EVENT_TEAMS in self.auth_types_enum
+
+    @property
+    def can_edit_event_matches(self):
+        return AuthType.EVENT_MATCHES in self.auth_types_enum
+
+    @property
+    def can_edit_event_rankings(self):
+        return AuthType.EVENT_RANKINGS in self.auth_types_enum
+
+    @property
+    def can_edit_event_alliances(self):
+        return AuthType.EVENT_ALLIANCES in self.auth_types_enum
+
+    @property
+    def can_edit_event_awards(self):
+        return AuthType.EVENT_AWARDS in self.auth_types_enum
 
     @property
     def can_edit_match_video(self):

--- a/templates/admin/api_add_auth.html
+++ b/templates/admin/api_add_auth.html
@@ -16,8 +16,24 @@
             <td><input class="form-control" type="text" name="event_list_str" placeholder="2014cc,2014mttd"/></td>
         </tr>
         <tr>
-            <td>Allow Event Data Edit</td>
-            <td><input type="checkbox" name="allow_edit_data"></td>
+            <td>Allow Event Teams Edit</td>
+            <td><input type="checkbox" name="allow_edit_teams"></td>
+        </tr>
+        <tr>
+            <td>Allow Event Matches Edit</td>
+            <td><input type="checkbox" name="allow_edit_matches"></td>
+        </tr>
+        <tr>
+            <td>Allow Event Rankings Edit</td>
+            <td><input type="checkbox" name="allow_edit_rankings"></td>
+        </tr>
+       <tr>
+            <td>Allow Event Alliances Edit</td>
+            <td><input type="checkbox" name="allow_edit_alliances"></td>
+        </tr>
+        <tr>
+            <td>Allow Event Awards Edit</td>
+            <td><input type="checkbox" name="allow_edit_awards"></td>
         </tr>
         <tr>
             <td>Allow Match Video Edit</td>

--- a/templates/admin/api_edit_auth.html
+++ b/templates/admin/api_edit_auth.html
@@ -19,10 +19,25 @@
             <td><input type="text" name="event_list_str" value="{{auth.event_list_str}}" /></td>
         </tr>
         <tr>
-            <td>Allow Event Data Edit</td>
-            <td><input type="checkbox" name="allow_edit_data" {% if auth.can_edit_event_data %}checked{% endif %}></td>
+            <td>Allow Event Teams Edit</td>
+            <td><input type="checkbox" name="allow_edit_teams" {% if auth.can_edit_event_teams %}checked{% endif %}></td>
         </tr>
         <tr>
+            <td>Allow Event Matches Edit</td>
+            <td><input type="checkbox" name="allow_edit_matches" {% if auth.can_edit_event_matches %}checked{% endif %}></td>
+        </tr>
+        <tr>
+            <td>Allow Event Rankings Edit</td>
+            <td><input type="checkbox" name="allow_edit_rankings" {% if auth.can_edit_event_rankings %}checked{% endif %}></td>
+        </tr>
+       <tr>
+            <td>Allow Event Alliances Edit</td>
+            <td><input type="checkbox" name="allow_edit_alliances" {% if auth.can_edit_event_alliances %}checked{% endif %}></td>
+        </tr>
+        <tr>
+            <td>Allow Event Awards Edit</td>
+            <td><input type="checkbox" name="allow_edit_awards" {% if auth.can_edit_event_awards %}checked{% endif %}></td>
+        </tr>        <tr>
             <td>Allow Match Video Edit</td>
             <td><input type="checkbox" name="allow_edit_match_video" {% if auth.can_edit_match_video %}checked{% endif %}></td>
         </tr>

--- a/templates/admin/api_manage_auth.html
+++ b/templates/admin/api_manage_auth.html
@@ -12,7 +12,11 @@
     <th>ID</th>
     <th>Secret</th>
     <th>Events</th>
-    <th>Event Data</th>
+    <th>Event Teams</th>
+    <th>Event Matches</th>
+    <th>Event Rankings</th>
+    <th>Event Alliances</th>
+    <th>Event Awards</th>
     <th>Match Video</th>
   </tr>
   {% for auth in auths %}
@@ -25,7 +29,11 @@
         <a href="/admin/event/{{event_key.id}}">{{event_key.id}}</a>
       {% endfor %}
     </td>
-    <td>{% if auth.can_edit_event_data %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
+    <td>{% if auth.can_edit_event_teams %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
+    <td>{% if auth.can_edit_event_matches %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
+    <td>{% if auth.can_edit_event_rankings %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
+    <td>{% if auth.can_edit_event_alliances %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
+    <td>{% if auth.can_edit_event_awards %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
     <td>{% if auth.can_edit_match_video %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
   </tr>
   {% endfor %}

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -34,23 +34,47 @@ class TestApiTrustedController(unittest2.TestCase):
         self.testbed.init_memcache_stub()
         self.testbed.init_taskqueue_stub(root_path=".")
 
-        self.aaa = ApiAuthAccess(id='tEsT_id_1',
-                                 secret='321tEsTsEcReT',
-                                 description='test',
-                                 event_list=[ndb.Key(Event, '2014casj')],
-                                 auth_types_enum=[AuthType.EVENT_TEAMS, AuthType.EVENT_MATCHES, AuthType.EVENT_RANKINGS, AuthType.EVENT_ALLIANCES, AuthType.EVENT_AWARDS])
+        self.teams_auth = ApiAuthAccess(id='tEsT_id_0',
+                                        secret='321tEsTsEcReT',
+                                        description='test',
+                                        event_list=[ndb.Key(Event, '2014casj')],
+                                        auth_types_enum=[AuthType.EVENT_TEAMS])
 
-        self.aaa2 = ApiAuthAccess(id='tEsT_id_2',
-                                 secret='321tEsTsEcReT',
-                                 description='test',
-                                 event_list=[ndb.Key(Event, '2014casj')],
-                                 auth_types_enum=[AuthType.MATCH_VIDEO])
+        self.matches_auth = ApiAuthAccess(id='tEsT_id_1',
+                                          secret='321tEsTsEcReT',
+                                          description='test',
+                                          event_list=[ndb.Key(Event, '2014casj')],
+                                          auth_types_enum=[AuthType.EVENT_MATCHES])
+
+        self.rankings_auth = ApiAuthAccess(id='tEsT_id_2',
+                                           secret='321tEsTsEcReT',
+                                           description='test',
+                                           event_list=[ndb.Key(Event, '2014casj')],
+                                           auth_types_enum=[AuthType.EVENT_RANKINGS])
+
+        self.alliances_auth = ApiAuthAccess(id='tEsT_id_3',
+                                            secret='321tEsTsEcReT',
+                                            description='test',
+                                            event_list=[ndb.Key(Event, '2014casj')],
+                                            auth_types_enum=[AuthType.EVENT_ALLIANCES])
+
+        self.awards_auth = ApiAuthAccess(id='tEsT_id_4',
+                                         secret='321tEsTsEcReT',
+                                         description='test',
+                                         event_list=[ndb.Key(Event, '2014casj')],
+                                         auth_types_enum=[AuthType.EVENT_AWARDS])
+
+        self.video_auth = ApiAuthAccess(id='tEsT_id_5',
+                                        secret='321tEsTsEcReT',
+                                        description='test',
+                                        event_list=[ndb.Key(Event, '2014casj')],
+                                        auth_types_enum=[AuthType.MATCH_VIDEO])
 
         self.event = Event(
-                id='2014casj',
-                event_type_enum=EventType.REGIONAL,
-                event_short='casj',
-                year=2014,
+            id='2014casj',
+            event_type_enum=EventType.REGIONAL,
+            event_short='casj',
+            year=2014,
         )
         self.event.put()
 
@@ -72,8 +96,8 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertTrue('Error' in response.json)
 
-        self.aaa.put()
-        self.aaa2.put()
+        self.rankings_auth.put()
+        self.matches_auth.put()
 
         # Pass
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
@@ -111,7 +135,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_alliance_selections_update(self):
-        self.aaa.put()
+        self.alliances_auth.put()
 
         alliances = [['frc971', 'frc254', 'frc1662'],
                      ['frc1678', 'frc368', 'frc4171'],
@@ -125,7 +149,7 @@ class TestApiTrustedController(unittest2.TestCase):
 
         request_path = '/api/trusted/v1/event/2014casj/alliance_selections/update'
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_3', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
 
@@ -133,7 +157,7 @@ class TestApiTrustedController(unittest2.TestCase):
             self.assertEqual(alliances[i], selection['picks'])
 
     def test_awards_update(self):
-        self.aaa.put()
+        self.awards_auth.put()
 
         awards = [{'name_str': 'Winner', 'team_key': 'frc254'},
                   {'name_str': 'Winner', 'team_key': 'frc604'},
@@ -142,7 +166,7 @@ class TestApiTrustedController(unittest2.TestCase):
 
         request_path = '/api/trusted/v1/event/2014casj/awards/update'
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_4', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
 
@@ -156,7 +180,7 @@ class TestApiTrustedController(unittest2.TestCase):
         request_body = json.dumps(awards)
 
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_4', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
 
@@ -165,7 +189,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertTrue('2014casj_1' in [a.key.id() for a in db_awards])
 
     def test_matches_update(self):
-        self.aaa.put()
+        self.matches_auth.put()
 
         update_request_path = '/api/trusted/v1/event/2014casj/matches/update'
         delete_request_path = '/api/trusted/v1/event/2014casj/matches/delete'
@@ -179,7 +203,7 @@ class TestApiTrustedController(unittest2.TestCase):
                 'red': {'teams': ['frc1', 'frc2', 'frc3'],
                         'score': 25},
                 'blue': {'teams': ['frc4', 'frc5', 'frc6'],
-                        'score': 26},
+                         'score': 26},
             },
             'time_string': '9:00 AM',
             'time_utc': '2014-08-31T16:00:00',
@@ -203,7 +227,7 @@ class TestApiTrustedController(unittest2.TestCase):
                 'red': {'teams': ['frc1', 'frc2', 'frc3'],
                         'score': 250},
                 'blue': {'teams': ['frc4', 'frc5', 'frc6'],
-                        'score': 260},
+                         'score': 260},
             },
             'time_string': '10:00 AM',
             'time_utc': '2014-08-31T17:00:00',
@@ -227,7 +251,7 @@ class TestApiTrustedController(unittest2.TestCase):
                 'red': {'teams': ['frc1', 'frc2', 'frc3'],
                         'score': 250},
                 'blue': {'teams': ['frc4', 'frc5', 'frc6'],
-                        'score': 260},
+                         'score': 260},
             },
             'score_breakdown': {
                 'red': {'auto': 20, 'assist': 40, 'truss+catch': 20, 'teleop_goal+foul': 20},
@@ -266,7 +290,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(match.score_breakdown['red']['truss+catch'], 20)
 
     def test_rankings_update(self):
-        self.aaa.put()
+        self.rankings_auth.put()
 
         rankings = {
             'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C'],
@@ -279,14 +303,14 @@ class TestApiTrustedController(unittest2.TestCase):
 
         request_path = '/api/trusted/v1/event/2014casj/rankings/update'
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_2', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'DQ', 'Played'])
         self.assertEqual(self.event.rankings[1], [1, '254', 20, 500, 500, 200, 0, 10])
 
     def test_rankings_wlt_update(self):
-        self.aaa.put()
+        self.rankings_auth.put()
 
         rankings = {
             'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C', 'wins', 'losses', 'ties'],
@@ -299,21 +323,21 @@ class TestApiTrustedController(unittest2.TestCase):
 
         request_path = '/api/trusted/v1/event/2014casj/rankings/update'
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_2', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)', 'DQ', 'Played'])
         self.assertEqual(self.event.rankings[1], [1, '254', 20, 500, 500, 200, '10-0-0', 0, 10])
 
     def test_eventteams_update(self):
-        self.aaa.put()
+        self.teams_auth.put()
 
         team_list = ['frc254', 'frc971', 'frc604']
         request_body = json.dumps(team_list)
 
         request_path = '/api/trusted/v1/event/2014casj/team_list/update'
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_0', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
 
@@ -327,7 +351,7 @@ class TestApiTrustedController(unittest2.TestCase):
         request_body = json.dumps(team_list)
 
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_0', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
 
@@ -337,7 +361,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertTrue('2014casj_frc100' in [et.key.id() for et in db_eventteams])
 
     def test_match_videos_add(self):
-        self.aaa2.put()
+        self.video_auth.put()
 
         match1 = Match(
             id="2014casj_qm1",
@@ -370,7 +394,7 @@ class TestApiTrustedController(unittest2.TestCase):
 
         request_path = '/api/trusted/v1/event/2014casj/match_videos/add'
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
-        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_2', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_5', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
 
         self.assertEqual(response.status_code, 200)
 

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -38,7 +38,7 @@ class TestApiTrustedController(unittest2.TestCase):
                                  secret='321tEsTsEcReT',
                                  description='test',
                                  event_list=[ndb.Key(Event, '2014casj')],
-                                 auth_types_enum=[AuthType.EVENT_DATA])
+                                 auth_types_enum=[AuthType.EVENT_TEAMS, AuthType.EVENT_MATCHES, AuthType.EVENT_RANKINGS, AuthType.EVENT_ALLIANCES, AuthType.EVENT_AWARDS])
 
         self.aaa2 = ApiAuthAccess(id='tEsT_id_2',
                                  secret='321tEsTsEcReT',


### PR DESCRIPTION
Removes EVENT_DATA permission and splits it up so each endpoint has its own permission. 

Split from #1197 