### PR TITLE
Fixing a Typo (possibly intentional) on 404.html

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@
       <div class="jumbotron">
         <div class="row">
           <div class="col-xs-12 col-sm-7">
-            <h1>Oh Noes!1!!</h1>
+            <h1>Oh Noes!!!!</h1>
             <h2>Error 404</h2>
             <p>Sorry, we couldn't find the thing you were looking for. Try searching for it.</p>
             <form action="http://www.thebluealliance.com/search">


### PR DESCRIPTION
I would like to point out the following issue on 404.html: 
![capture](https://cloud.githubusercontent.com/assets/12914467/8217699/98944aec-1504-11e5-9a37-f7d99ce685b9.PNG)

I have replaced Oh Noes!1!! with Oh Noes!!!! as shown in the pull request.

EDIT: It appears that this could be intentional. That was not known at the time of this pull request.

Thanks, Alex Webber
1810