### PR TITLE
Make event alliances endpoint cronjob run more often

### DIFF
--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -107,9 +107,20 @@ class FMSAPIEventAlliancesEnqueue(webapp.RequestHandler):
     Handles enqueing getting alliances from the FMS API
     """
     def get(self, when):
+        events = skipped_events = []
         if when == "now":
             events = EventHelper.getEventsWithinADay()
             events = filter(lambda e: e.official, events)
+
+            # Check if we should do a full query, or temporarily skip events
+            # that are not ending today. (All events will be checked on
+            # half-hour intervals, and events ending today whenever the cron
+            # job runs.)
+            minutes_from_full = (((int(time.time()) / 60) + 15) % 30) - 15
+            full_query = abs(minutes_from_full) <= 2
+            if not full_query:
+                skipped_events = filter(lambda e: not e.ends_today, events)
+                events = filter(lambda e: e.ends_today, events)
         else:
             event_keys = Event.query(Event.official == True).filter(Event.year == int(when)).fetch(500, keys_only=True)
             events = ndb.get_multi(event_keys)
@@ -122,6 +133,7 @@ class FMSAPIEventAlliancesEnqueue(webapp.RequestHandler):
 
         template_values = {
             'events': events,
+            'skipped_events': skipped_events
         }
 
         path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_event_alliances_enqueue.html')

--- a/cron.yaml
+++ b/cron.yaml
@@ -24,7 +24,7 @@ cron:
 
 - description: FIRST event alliance scraping for current events
   url: /tasks/enqueue/fmsapi_event_alliances/now
-  schedule: every 30 minutes
+  schedule: every 5 minutes
 
 - description: FIRST award scraping for current events
   url: /tasks/enqueue/fmsapi_awards/now

--- a/cron.yaml
+++ b/cron.yaml
@@ -24,6 +24,10 @@ cron:
 
 - description: FIRST event alliance scraping for current events
   url: /tasks/enqueue/fmsapi_event_alliances/now
+  schedule: every 30 minutes
+
+- description: FIRST event alliance scraping for current events on their last day
+  url: /tasks/enqueue/fmsapi_event_alliances/last_day_only
   schedule: every 5 minutes
 
 - description: FIRST award scraping for current events

--- a/models/event.py
+++ b/models/event.py
@@ -124,9 +124,7 @@ class Event(ndb.Model):
                 self.get_matches_async().wait()
         return self._matches
 
-    def withinDays(self, negative_days_before, days_after):
-        if not self.start_date or not self.end_date:
-            return False
+    def local_time(self):
         now = datetime.datetime.now()
         if self.timezone_id is not None:
             tz = pytz.timezone(self.timezone_id)
@@ -134,6 +132,12 @@ class Event(ndb.Model):
                 now = now + tz.utcoffset(now)
             except pytz.NonExistentTimeError:  # may happen during DST
                 now = now + tz.utcoffset(now + datetime.timedelta(hours=1))  # add offset to get out of non-existant time
+        return now
+
+    def withinDays(self, negative_days_before, days_after):
+        if not self.start_date or not self.end_date:
+            return False
+        now = self.local_time()
         after_start = self.start_date.date() + datetime.timedelta(days=negative_days_before) <= now.date()
         before_end = self.end_date.date() + datetime.timedelta(days=days_after) >= now.date()
 
@@ -157,6 +161,14 @@ class Event(ndb.Model):
     @property
     def future(self):
         return self.start_date.date() > datetime.date.today() and not self.within_a_day
+
+    @property
+    def starts_today(self):
+        return self.start_date.date() == self.local_time().date()
+
+    @property
+    def ends_today(self):
+        return self.end_date.date() == self.local_time().date()
 
     @ndb.tasklet
     def get_teams_async(self):

--- a/templates/datafeeds/usfirst_event_alliances_enqueue.html
+++ b/templates/datafeeds/usfirst_event_alliances_enqueue.html
@@ -4,3 +4,13 @@
 <li>{{event.key_name}}</li>
 {% endfor %}
 </ul>
+
+<h2>Skipped enqueuing for {{skipped_events|length}} events</h2>
+{% if skipped_events|length > 0 %}
+<p>These have not been enqueued this time because they are not ending today:</p>
+<ul>
+{% for event in skipped_events %}
+<li>{{event.key_name}} (ends {{event.end_date.date}})</li>
+{% endfor %}
+</ul>
+{% endif %}

--- a/templates/datafeeds/usfirst_event_alliances_enqueue.html
+++ b/templates/datafeeds/usfirst_event_alliances_enqueue.html
@@ -4,13 +4,3 @@
 <li>{{event.key_name}}</li>
 {% endfor %}
 </ul>
-
-<h2>Skipped enqueuing for {{skipped_events|length}} events</h2>
-{% if skipped_events|length > 0 %}
-<p>These have not been enqueued this time because they are not ending today:</p>
-<ul>
-{% for event in skipped_events %}
-<li>{{event.key_name}} (ends {{event.end_date.date}})</li>
-{% endfor %}
-</ul>
-{% endif %}

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,8 +5,12 @@ import json
 from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
+from consts.event_type import EventType
+from helpers.event_manipulator import EventManipulator
 from helpers.event.event_test_creator import EventTestCreator
-
+from helpers.event_team.event_team_test_creator import EventTeamTestCreator
+from helpers.match.match_test_creator import MatchTestCreator
+from models.event import Event
 
 class TestEventManipulator(unittest2.TestCase):
     def setUp(self):
@@ -19,6 +23,8 @@ class TestEventManipulator(unittest2.TestCase):
         self.future_event = EventTestCreator.createFutureEvent(only_event=True)
         self.present_event = EventTestCreator.createPresentEvent(only_event=True)
         self.past_event = EventTestCreator.createPastEvent(only_event=True)
+        self.event_starts_today = self.createEventStartsToday(only_event=True)
+        self.event_ends_today = self.createEventEndsToday(only_event=True)
 
     def tearDown(self):
         self.future_event.key.delete()
@@ -46,3 +52,57 @@ class TestEventManipulator(unittest2.TestCase):
         self.assertTrue(self.present_event.withinDays(-1, 1))
         self.assertFalse(self.present_event.future)
         self.assertFalse(self.present_event.past)
+
+    def test_datesStartsToday(self):
+        self.assertTrue(self.event_starts_today.starts_today)
+        self.assertFalse(self.event_starts_today.ends_today)
+
+    def test_datesEndsToday(self):
+        self.assertFalse(self.event_ends_today.starts_today)
+        self.assertTrue(self.event_ends_today.ends_today)
+
+    @classmethod
+    def createEventStartsToday(self, only_event=False):
+        id_string = "{}teststartstoday".format(datetime.datetime.now().year)
+        event = Event(
+            id=id_string,
+            end_date=datetime.datetime.today() + datetime.timedelta(days=2),
+            event_short="teststartstoday",
+            event_type_enum=EventType.REGIONAL,
+            first_eid="5561",
+            name="Test Event (Starts Today)",
+            start_date=datetime.datetime.today(),
+            year=datetime.datetime.now().year,
+            venue_address="123 Fake Street, California, USA",
+            website="http://www.google.com"
+        )
+        event = EventManipulator.createOrUpdate(event)
+        if not only_event:
+            EventTeamTestCreator.createEventTeams(event)
+            mtc = MatchTestCreator(event)
+            mtc.createCompleteQuals()
+            mtc.createIncompleteQuals()
+        return event
+
+    @classmethod
+    def createEventEndsToday(self, only_event=False):
+        id_string = "{}testendstoday".format(datetime.datetime.now().year)
+        event = Event(
+            id=id_string,
+            end_date=datetime.datetime.today(),
+            event_short="testendstoday",
+            event_type_enum=EventType.REGIONAL,
+            first_eid="5561",
+            name="Test Event (Ends Today)",
+            start_date=datetime.datetime.today() - datetime.timedelta(days=2),
+            year=datetime.datetime.now().year,
+            venue_address="123 Fake Street, California, USA",
+            website="http://www.google.com"
+        )
+        event = EventManipulator.createOrUpdate(event)
+        if not only_event:
+            EventTeamTestCreator.createEventTeams(event)
+            mtc = MatchTestCreator(event)
+            mtc.createCompleteQuals()
+            mtc.createIncompleteQuals()
+        return event


### PR DESCRIPTION
Accomplishes a wish-list item from #1191. The event alliances endpoint cronjob now runs every 5 minutes, but event endpoints are only actually hit that often on the final day of each event. This way alliance selection notifications can go out more quickly with minimal extra load.

I am a newbie to this, so I expect there will be plenty of feedback on this. :)

Also, one question - should I have included tests for the `starts_today` and `ends_today` methods I added to the event model?