### PR TITLE
Add Firebase feeds for events/districts

### DIFF
--- a/notifications/alliance_selections.py
+++ b/notifications/alliance_selections.py
@@ -7,6 +7,8 @@ class AllianceSelectionNotification(BaseNotification):
 
     def __init__(self, event):
         self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
 
     @property
     def _type(self):

--- a/notifications/awards_updated.py
+++ b/notifications/awards_updated.py
@@ -8,6 +8,8 @@ class AwardsUpdatedNotification(BaseNotification):
 
     def __init__(self, event):
         self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
 
     @property
     def _type(self):

--- a/notifications/base_notification.py
+++ b/notifications/base_notification.py
@@ -19,6 +19,14 @@ class BaseNotification(object):
     # Can be overridden by subclasses to only send to some types
     _supported_clients = [ClientType.OS_ANDROID, ClientType.WEBHOOK]
 
+    # If not None, the event feed to post this notification to
+    # Typically the event key
+    _event_feed = None
+
+    # If not None, the district feed to post this notificatoin to
+    # Typically, district abbreviation from consts/district_type
+    _district_feed = None
+
     # Send analytics updates for this notification?
     # Can be overridden by subclasses if not
     _track_call = True

--- a/notifications/district_points_updated.py
+++ b/notifications/district_points_updated.py
@@ -10,6 +10,7 @@ class DistrictPointsUpdatedNotification(BaseNotification):
     def __init__(self, district_key):
         self.district_key = district_key
         self.district_enum = DistrictType.abbrevs[district_key[4:]]
+        self._district_feed = self.district_enum
 
     @property
     def _type(self):

--- a/notifications/level_starting.py
+++ b/notifications/level_starting.py
@@ -9,6 +9,8 @@ class CompLevelStartingNotification(BaseNotification):
     def __init__(self, match, event):
         self.match = match
         self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
 
     @property
     def _type(self):

--- a/notifications/match_score.py
+++ b/notifications/match_score.py
@@ -7,6 +7,8 @@ class MatchScoreNotification(BaseNotification):
 
     def __init__(self, match):
         self.match = match
+        self._event_feed = match.event.id
+        # TODO Add notion of District to Match model?
 
     @property
     def _type(self):

--- a/notifications/match_score.py
+++ b/notifications/match_score.py
@@ -7,8 +7,9 @@ class MatchScoreNotification(BaseNotification):
 
     def __init__(self, match):
         self.match = match
-        self._event_feed = match.event.id
-        # TODO Add notion of District to Match model?
+        self.event = match.event.get()
+        self._event_feed = self.event.key_name
+        self._district_feed = self.event.event_district_enum
 
     @property
     def _type(self):
@@ -18,6 +19,6 @@ class MatchScoreNotification(BaseNotification):
         data = {}
         data['message_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
-        data['message_data']['event_name'] = self.match.event.get().name
+        data['message_data']['event_name'] = self.event.name
         data['message_data']['match'] = ModelToDict.matchConverter(self.match)
         return data

--- a/notifications/schedule_updated.py
+++ b/notifications/schedule_updated.py
@@ -9,6 +9,8 @@ class ScheduleUpdatedNotification(BaseNotification):
     def __init__(self, event):
         from helpers.match_helper import MatchHelper  # recursive import issues
         self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
         upcoming = MatchHelper.upcomingMatches(event.matches, 1)
         self.next_match = upcoming[0] if upcoming[0] else None
 

--- a/notifications/upcoming_match.py
+++ b/notifications/upcoming_match.py
@@ -10,6 +10,8 @@ class UpcomingMatchNotification(BaseNotification):
     def __init__(self, match, event):
         self.match = match
         self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_enum
 
     @property
     def _type(self):


### PR DESCRIPTION
Working towards #1262

For every notification (which we currently push to the ticker firebase), also push it to an endpoint for the specific event (at event/<key>) and for the parent district, only if the event is within a district (at district/<abbrev>).