### PR TITLE
Events From FMSAPI

### DIFF
--- a/consts/event_type.py
+++ b/consts/event_type.py
@@ -3,6 +3,7 @@ class EventType(object):
     DISTRICT = 1
     DISTRICT_CMP = 2
     CMP_DIVISION = 3
+    CMP_SUBDIVISION = 5
     CMP_FINALS = 4
     OFFSEASON = 99
     PRESEASON = 100
@@ -13,6 +14,7 @@ class EventType(object):
         DISTRICT: 'District',
         DISTRICT_CMP: 'District Championship',
         CMP_DIVISION: 'Championship Division',
+        CMP_SUBDIVISION: 'Championship Subdivision',
         CMP_FINALS: 'Championship Finals',
         OFFSEASON: 'Offseason',
         PRESEASON: 'Preseason',
@@ -27,5 +29,6 @@ class EventType(object):
 
     CMP_EVENT_TYPES = {
         CMP_DIVISION,
+        CMP_SUBDIVISION,
         CMP_FINALS,
     }

--- a/consts/event_type.py
+++ b/consts/event_type.py
@@ -3,7 +3,6 @@ class EventType(object):
     DISTRICT = 1
     DISTRICT_CMP = 2
     CMP_DIVISION = 3
-    CMP_SUBDIVISION = 5
     CMP_FINALS = 4
     OFFSEASON = 99
     PRESEASON = 100
@@ -14,7 +13,6 @@ class EventType(object):
         DISTRICT: 'District',
         DISTRICT_CMP: 'District Championship',
         CMP_DIVISION: 'Championship Division',
-        CMP_SUBDIVISION: 'Championship Subdivision',
         CMP_FINALS: 'Championship Finals',
         OFFSEASON: 'Offseason',
         PRESEASON: 'Preseason',
@@ -29,6 +27,5 @@ class EventType(object):
 
     CMP_EVENT_TYPES = {
         CMP_DIVISION,
-        CMP_SUBDIVISION,
         CMP_FINALS,
     }

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -353,7 +353,7 @@ class FMSAPIEventListEnqueue(webapp.RequestHandler):
             'event_count': year
         }
 
-        path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_event_details_enqueue.html')
+        path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_events_details_enqueue.html')
         self.response.out.write(template.render(path, template_values))
 
 

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -336,6 +336,44 @@ class FMSAPITeamDetailsGet(webapp.RequestHandler):
         self.response.out.write(template.render(path, template_values))
 
 
+class FMSAPIEventListEnqueue(webapp.RequestHandler):
+    """
+    Handles enqueing fetching a year's worth of events from FMSAPI
+    """
+    def get(self, year):
+
+        taskqueue.add(
+            queue_name='fms-api',
+            url='/tasks/get/fmsapi_event_list/'+year,
+            method='GET'
+        )
+
+        template_values = {
+            'year': year,
+            'event_count': year
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_event_details_enqueue.html')
+        self.response.out.write(template.render(path, template_values))
+
+
+class FMSAPIEventListGet(webapp.RequestHandler):
+    """
+    Fetch one year of events from FMS API
+    """
+    def get(self, year):
+        df = DatafeedFMSAPI('v2.0')
+
+        new_events = EventManipulator.createOrUpdate(df.getEventList(year))
+
+        template_values = {
+            "events": new_events
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/fms_event_list_get.html')
+        self.response.out.write(template.render(path, template_values))
+
+
 class FmsEventListGet(webapp.RequestHandler):
     """
     Fetch basic data about all current season events at once.

--- a/cron_main.py
+++ b/cron_main.py
@@ -16,6 +16,7 @@ from controllers.datafeed_controller import FMSAPIAwardsGet, FMSAPIEventAlliance
 from controllers.datafeed_controller import UsfirstEventDetailsEnqueue, UsfirstEventDetailsGet, UsfirstEventListGet
 from controllers.datafeed_controller import UsfirstAwardsEnqueue, UsfirstAwardsGet
 from controllers.datafeed_controller import UsfirstEventAlliancesEnqueue, UsfirstEventAlliancesGet
+from controllers.datafeed_controller import FMSAPIEventListEnqueue, FMSAPIEventListGet
 from controllers.datafeed_controller import UsfirstMatchesEnqueue, UsfirstMatchesGet, UsfirstEventRankingsEnqueue, UsfirstEventRankingsGet
 from controllers.datafeed_controller import UsfirstTeamDetailsEnqueue, UsfirstTeamDetailsRollingEnqueue, UsfirstTeamDetailsGet, UsfirstTeamsTpidsGet
 from controllers.datafeed_controller import UsfirstPre2003TeamEventsEnqueue, UsfirstPre2003TeamEventsGet
@@ -47,6 +48,7 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/enqueue/fmsapi_matches/(.*)', FMSAPIMatchesEnqueue),
                                ('/tasks/enqueue/fmsapi_team_details', FMSAPITeamDetailsEnqueue),
                                ('/tasks/enqueue/fmsapi_team_details_rolling', FMSAPITeamDetailsRollingEnqueue),
+                               ('/tasks/enqueue/fmsapi_event_list/([0-9]*)', FMSAPIEventListEnqueue),
                                ('/tasks/enqueue/usfirst_event_alliances/(.*)', UsfirstEventAlliancesEnqueue),
                                ('/tasks/enqueue/usfirst_event_details/([0-9]*)', UsfirstEventDetailsEnqueue),
                                ('/tasks/enqueue/usfirst_event_rankings/(.*)', UsfirstEventRankingsEnqueue),
@@ -65,6 +67,7 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/get/fmsapi_event_rankings/(.*)', FMSAPIEventRankingsGet),
                                ('/tasks/get/fmsapi_matches/(.*)', FMSAPIMatchesGet),
                                ('/tasks/get/fmsapi_team_details/(.*)', FMSAPITeamDetailsGet),
+                               ('/tasks/get/fmsapi_event_list/([0-9]*)', FMSAPIEventListGet),
                                ('/tasks/get/usfirst_event_alliances/(.*)', UsfirstEventAlliancesGet),
                                ('/tasks/get/usfirst_event_list/([0-9]*)', UsfirstEventListGet),
                                ('/tasks/get/usfirst_event_details/([0-9]*)/([0-9]*)', UsfirstEventDetailsGet),

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -12,6 +12,7 @@ from models.sitevar import Sitevar
 
 from parsers.fms_api.fms_api_awards_parser import FMSAPIAwardsParser
 from parsers.fms_api.fms_api_event_alliances_parser import FMSAPIEventAlliancesParser
+from parsers.fms_api.fms_api_event_list_parser import FMSAPIEventListParser
 from parsers.fms_api.fms_api_event_rankings_parser import FMSAPIEventRankingsParser
 from parsers.fms_api.fms_api_match_parser import FMSAPIHybridScheduleParser, FMSAPIMatchDetailsParser
 from parsers.fms_api.fms_api_team_details_parser import FMSAPITeamDetailsParser
@@ -57,6 +58,7 @@ class DatafeedFMSAPI(object):
             self.FMS_API_EVENT_RANKINGS_URL_PATTERN = FMS_API_URL_BASE + '/rankings/%s/%s'  # (year, event_short)
             self.FMS_API_EVENT_ALLIANCES_URL_PATTERN = FMS_API_URL_BASE + '/alliances/%s/%s'  # (year, event_short)
             self.FMS_API_TEAM_DETAILS_URL_PATTERN = FMS_API_URL_BASE + '/teams/%s/?teamNumber=%s'  # (year, teamNumber)
+            self.FMS_API_EVENT_LIST_URL_PATTERN = FMS_API_URL_BASE + '/events/season=%s'
         elif version == 'v2.0':
             FMS_API_URL_BASE = 'https://frc-api.usfirst.org/v2.0'
             self.FMS_API_AWARDS_URL_PATTERN = FMS_API_URL_BASE + '/%s/awards/%s'  # (year, event_short)
@@ -67,8 +69,9 @@ class DatafeedFMSAPI(object):
             self.FMS_API_EVENT_RANKINGS_URL_PATTERN = FMS_API_URL_BASE + '/%s/rankings/%s'  # (year, event_short)
             self.FMS_API_EVENT_ALLIANCES_URL_PATTERN = FMS_API_URL_BASE + '/%s/alliances/%s'  # (year, event_short)
             self.FMS_API_TEAM_DETAILS_URL_PATTERN = FMS_API_URL_BASE + '/%s/teams/?teamNumber=%s'  # (year, teamNumber)
+            self.FMS_API_EVENT_LIST_URL_PATTERN = FMS_API_URL_BASE + '/%s/events'  # year
         else:
-            raise Exception("Unknown FMS API version: {}".formation(version))
+            raise Exception("Unknown FMS API version: {}".format(version))
 
     def _get_event_short(self, event_short):
         return self.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)
@@ -149,3 +152,7 @@ class DatafeedFMSAPI(object):
 
         team = self._parse(self.FMS_API_TEAM_DETAILS_URL_PATTERN % (year, team_number), FMSAPITeamDetailsParser(year, team_key))
         return team
+
+    def getEventList(self, year):
+        events = self._parse(self.FMS_API_EVENT_LIST_URL_PATTERN % (year), FMSAPIEventListParser(year))
+        return events

--- a/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -31,7 +31,7 @@ class FMSAPIEventListParser(object):
             # TODO read timezone from API
 
             # Do not read in CMP divisions, we'll add those manually
-            if event_type not in EventType.NON_CMP_EVENT_TYPES:
+            if event_type in EventType.CMP_EVENT_TYPES:
                 continue
 
             events.append(Event(

--- a/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -1,6 +1,7 @@
 import datetime
 
 from consts.district_type import DistrictType
+from consts.event_type import EventType
 from helpers.event_helper import EventHelper
 
 from models.event import Event
@@ -28,6 +29,10 @@ class FMSAPIEventListParser(object):
             end = datetime.datetime.strptime(event['dateEnd'], self.DATE_FORMAT_STR)
 
             # TODO read timezone from API
+
+            # Do not read in CMP divisions, we'll add those manually
+            if event_type not in EventType.NON_CMP_EVENT_TYPES:
+                continue
 
             events.append(Event(
                 id=key,

--- a/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -1,0 +1,47 @@
+import datetime
+
+from consts.district_type import DistrictType
+from helpers.event_helper import EventHelper
+
+from models.event import Event
+
+
+class FMSAPIEventListParser(object):
+
+    DATE_FORMAT_STR = "%Y-%m-%dT%H:%M:%S"
+
+    def __init__(self, season):
+        self.season = int(season)
+
+    def parse(self, response):
+        events = []
+        for event in response['Events']:
+            code = event['code'].lower()
+            key = "{}{}".format(self.season, code)
+            name = event['name']
+            short_name = EventHelper.getShortName(name)
+            event_type = EventHelper.parseEventType(event['type'])
+            district_enum = EventHelper.parseDistrictName(event['districtCode'].lower()) if event['districtCode'] else DistrictType.NO_DISTRICT
+            venue = event['venue']
+            location = "{}, {}, {}".format(event['city'], event['stateprov'], event['country'])
+            start = datetime.datetime.strptime(event['dateStart'], self.DATE_FORMAT_STR)
+            end = datetime.datetime.strptime(event['dateEnd'], self.DATE_FORMAT_STR)
+
+            # TODO read timezone from API
+
+            events.append(Event(
+                id=key,
+                name=name,
+                short_name=short_name,
+                event_short=code,
+                event_type_enum=event_type,
+                official=True,
+                start_date=start,
+                end_date=end,
+                venue=venue,
+                location=location,
+                venue_address="{}, {}".format(venue, location),
+                year=self.season,
+                event_district_enum=district_enum
+            ))
+        return events

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -287,7 +287,10 @@ class EventHelper(object):
 
     @classmethod
     def parseDistrictName(cls, district_name_str):
-        return DistrictType.names.get(district_name_str, DistrictType.NO_DISTRICT)
+        district = DistrictType.names.get(district_name_str, DistrictType.NO_DISTRICT)
+
+        # Fall back to checking abbreviations if needed
+        return district if district != DistrictType.NO_DISTRICT else DistrictType.abbrevs.get(district_name_str, DistrictType.NO_DISTRICT)
 
     @classmethod
     def parseEventType(self, event_type_str):

--- a/test_data/fms_api/2015_event_list.json
+++ b/test_data/fms_api/2015_event_list.json
@@ -1,0 +1,75 @@
+{
+    "Events": [
+        {
+            "code":"NYNY",
+            "divisionCode":null,
+            "name":"New York City Regional",
+            "type":"Regional",
+            "districtCode":null,
+            "venue":"Jacob K. Javits Convention Center",
+            "city":"New York",
+            "stateprov":"NY",
+            "country":"USA",
+            "timezone":"Eastern Standard Time",
+            "dateStart":"2015-03-12T00:00:00",
+            "dateEnd":"2015-03-15T23:59:59"
+        },
+        {
+            "code":"CTHAR",
+            "divisionCode":null,
+            "name":"NE District - Hartford Event",
+            "type":"DistrictEvent",
+            "districtCode":"NE",
+            "venue":"Hartford Public High School",
+            "city":"Hartford",
+            "stateprov":"CT",
+            "country":"USA",
+            "timezone":"Eastern Standard Time",
+            "dateStart":"2015-03-27T00:00:00",
+            "dateEnd":"2015-03-29T23:59:59"
+        },
+        {
+            "code":"NECMP",
+            "divisionCode":null,
+            "name":"NE FIRST District Championship presented by United Technologies",
+            "type":"DistrictChampionship",
+            "districtCode":"NE",
+            "venue":"Sports and Recreation Center, WPI",
+            "city":"Worcester",
+            "stateprov":"MA",
+            "country":"USA",
+            "timezone":"Eastern Standard Time",
+            "dateStart":"2015-04-08T00:00:00",
+            "dateEnd":"2015-04-11T23:59:59"
+        },
+        {
+            "code":"CMP-TESLA",
+            "divisionCode":"CMP-ARTE",
+            "name":"FIRST Championship - Tesla Subdivision",
+            "type":"ChampionshipSubdivision",
+            "districtCode":null,
+            "venue":"Edward Jones Dome",
+            "city":"St. Louis",
+            "stateprov":"MO",
+            "country":"USA",
+            "timezone":"Central Standard Time",
+            "dateStart":"2015-04-22T00:00:00",
+            "dateEnd":"2015-04-25T23:59:59"
+        },
+        {
+            "code":"CMP-ARTE",
+            "divisionCode":"CMP",
+            "name":"FIRST Championship - ARTE Division",
+            "type":"ChampionshipDivision",
+            "districtCode":null,
+            "venue":"Edward Jones Dome",
+            "city":"St. Louis",
+            "stateprov":"MO",
+            "country":"USA",
+            "timezone":"Central Standard Time",
+            "dateStart":"2015-04-22T00:00:00",
+            "dateEnd":"2015-04-25T23:59:59"
+        }
+    ],
+    "eventCount": 5
+}

--- a/tests/test_fms_api_event_list_parser.py
+++ b/tests/test_fms_api_event_list_parser.py
@@ -1,0 +1,89 @@
+import datetime
+import json
+import unittest2
+
+from datafeeds.parsers.fms_api.fms_api_event_list_parser import FMSAPIEventListParser
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.district_type import DistrictType
+from consts.event_type import EventType
+from models.event import Event
+
+
+class TestFMSAPIEventListParser(unittest2.TestCase):
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_parse_event_list(self):
+        with open('test_data/fms_api/2015_event_list.json', 'r') as f:
+            events = FMSAPIEventListParser(2015).parse(json.loads(f.read()))
+
+            self.assertTrue(isinstance(events, list))
+
+            # File has 5 events, but we ignore CMP events, so only 3 are expected back
+            self.assertEquals(len(events), 3)
+
+    def test_parse_regional_event(self):
+        with open('test_data/fms_api/2015_event_list.json', 'r') as f:
+            events = FMSAPIEventListParser(2015).parse(json.loads(f.read()))
+            event = events[0]
+
+            self.assertEquals(event.key_name, "2015nyny")
+            self.assertEquals(event.name, "New York City Regional")
+            self.assertEquals(event.short_name, "New York City")
+            self.assertEquals(event.event_short, "nyny")
+            self.assertEquals(event.official, True)
+            self.assertEquals(event.start_date, datetime.datetime(year=2015, month=3, day=12, hour=0, minute=0, second=0))
+            self.assertEquals(event.end_date, datetime.datetime(year=2015, month=3, day=15, hour=23, minute=59, second=59))
+            self.assertEquals(event.venue, "Jacob K. Javits Convention Center")
+            self.assertEquals(event.location, "New York, NY, USA")
+            self.assertEquals(event.venue_address, "Jacob K. Javits Convention Center, New York, NY, USA")
+            self.assertEquals(event.year, 2015)
+            self.assertEquals(event.event_type_enum, EventType.REGIONAL)
+            self.assertEquals(event.event_district_enum, DistrictType.NO_DISTRICT)
+
+    def test_parse_district_event(self):
+        with open('test_data/fms_api/2015_event_list.json', 'r') as f:
+            events = FMSAPIEventListParser(2015).parse(json.loads(f.read()))
+            event = events[1]
+
+            self.assertEquals(event.key_name, "2015cthar")
+            self.assertEquals(event.name, "NE District - Hartford Event")
+            self.assertEquals(event.short_name, "Hartford")
+            self.assertEquals(event.event_short, "cthar")
+            self.assertEquals(event.official, True)
+            self.assertEquals(event.start_date, datetime.datetime(year=2015, month=3, day=27, hour=0, minute=0, second=0))
+            self.assertEquals(event.end_date, datetime.datetime(year=2015, month=3, day=29, hour=23, minute=59, second=59))
+            self.assertEquals(event.venue, "Hartford Public High School")
+            self.assertEquals(event.location, "Hartford, CT, USA")
+            self.assertEquals(event.venue_address, "Hartford Public High School, Hartford, CT, USA")
+            self.assertEquals(event.year, 2015)
+            self.assertEquals(event.event_type_enum, EventType.DISTRICT)
+            self.assertEquals(event.event_district_enum, DistrictType.NEW_ENGLAND)
+
+    def test_parse_district_cmp(self):
+        with open('test_data/fms_api/2015_event_list.json', 'r') as f:
+            events = FMSAPIEventListParser(2015).parse(json.loads(f.read()))
+            event = events[2]
+
+            self.assertEquals(event.key_name, "2015necmp")
+            self.assertEquals(event.name, "NE FIRST District Championship presented by United Technologies")
+            self.assertEquals(event.short_name, "NE FIRST")
+            self.assertEquals(event.event_short, "necmp")
+            self.assertEquals(event.official, True)
+            self.assertEquals(event.start_date, datetime.datetime(year=2015, month=4, day=8, hour=0, minute=0, second=0))
+            self.assertEquals(event.end_date, datetime.datetime(year=2015, month=4, day=11, hour=23, minute=59, second=59))
+            self.assertEquals(event.venue, "Sports and Recreation Center, WPI")
+            self.assertEquals(event.location, "Worcester, MA, USA")
+            self.assertEquals(event.venue_address, "Sports and Recreation Center, WPI, Worcester, MA, USA")
+            self.assertEquals(event.year, 2015)
+            self.assertEquals(event.event_type_enum, EventType.DISTRICT_CMP)
+            self.assertEquals(event.event_district_enum, DistrictType.NEW_ENGLAND)


### PR DESCRIPTION
Use FMSAPI for event list. Hits [Event Listing](http://docs.frcevents2.apiary.io/#reference/season-data/event-listings/retrieve-event-listings) endpoint. 

Current functionality maintained (e.g. skips over CMP events).

The only things missing from the API are the venue address and event website and I've submitted a feature request for them: https://usfirst.collab.net/sf/go/artf4727

This does not import EventTeams yet, that will be a separate PR