### PR TITLE
Fetch EventTeams from FMSAPI

### DIFF
--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -368,6 +368,14 @@ class FMSAPIEventListGet(webapp.RequestHandler):
 
         new_events = EventManipulator.createOrUpdate(df.getEventList(year))
 
+        # Fetch EventTeams for each event
+        for event in new_events:
+            taskqueue.add(
+                queue_name='fms-api',
+                url='/tasks/get/fmsapi_eventteams/'+event.key_name,
+                method='GET'
+            )
+
         template_values = {
             "events": new_events
         }

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -401,6 +401,7 @@ class FMSAPIEventTeamsEnqueue(webapp.RequestHandler):
         path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/fmsapi_eventteams_enqueue.html')
         self.response.out.write(template.render(path, template_values))
 
+
 class FMSAPIEventTeamsGet(webapp.RequestHandler):
     """
     Fetch list of teams attending a single event
@@ -426,6 +427,10 @@ class FMSAPIEventTeamsGet(webapp.RequestHandler):
         teams = TeamManipulator.createOrUpdate(teams)
         district_teams = DistrictTeamManipulator.createOrUpdate(district_teams)
         robots = RobotManipulator.createOrUpdate(robots)
+
+        if not teams:
+            # No teams found registered for this event
+            teams = []
 
         # Build EventTeams
         event_teams = [EventTeam(

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -30,8 +30,10 @@ from helpers.team_manipulator import TeamManipulator
 from helpers.district_team_manipulator import DistrictTeamManipulator
 from helpers.robot_manipulator import RobotManipulator
 
+from models.district_team import DistrictTeam
 from models.event import Event
 from models.event_team import EventTeam
+from models.robot import Robot
 from models.team import Team
 
 
@@ -371,6 +373,77 @@ class FMSAPIEventListGet(webapp.RequestHandler):
         }
 
         path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/fms_event_list_get.html')
+        self.response.out.write(template.render(path, template_values))
+
+
+class FMSAPIEventTeamsEnqueue(webapp.RequestHandler):
+    """
+    Handlers enqueueing fetching a list of teams attending an event
+    """
+    def get(self, event_key):
+        taskqueue.add(
+            queue_name='fms-api',
+            url='/tasks/get/fmsapi_eventteams/'+event_key,
+            method='GET')
+
+        template_values = {
+            'event_key': event_key
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/fmsapi_eventteams_enqueue.html')
+        self.response.out.write(template.render(path, template_values))
+
+class FMSAPIEventTeamsGet(webapp.RequestHandler):
+    """
+    Fetch list of teams attending a single event
+    """
+    def get(self, event_key):
+        df = DatafeedFMSAPI('v2.0')
+        event = Event.get_by_id(event_key)
+
+        models = df.getEventTeams(event_key)
+        teams = []
+        district_teams = []
+        robots = []
+        for group in models:
+            # models is a list of tuples (team, districtTeam, robot)
+            if isinstance(group[0], Team):
+                teams.append(group[0])
+            if isinstance(group[1], DistrictTeam):
+                district_teams.append(group[1])
+            if isinstance(group[2], Robot):
+                robots.append(group[2])
+
+        # Write new models
+        teams = TeamManipulator.createOrUpdate(teams)
+        district_teams = DistrictTeamManipulator.createOrUpdate(district_teams)
+        robots = RobotManipulator.createOrUpdate(robots)
+
+        # Build EventTeams
+        event_teams = [EventTeam(
+            id=event.key_name + "_" + team.key_name,
+            event=event.key,
+            team=team.key,
+            year=event.year)
+            for team in teams]
+
+        # Delete eventteams of teams that are no longer registered
+        if event.future:
+            existing_event_team_keys = set(EventTeam.query(EventTeam.event == event.key).fetch(1000, keys_only=True))
+            event_team_keys = set([et.key for et in event_teams])
+            et_keys_to_delete = existing_event_team_keys.difference(event_team_keys)
+            EventTeamManipulator.delete_keys(et_keys_to_delete)
+
+        event_teams = EventTeamManipulator.createOrUpdate(event_teams)
+        if type(event_teams) is not list:
+            event_teams = [event_teams]
+
+        template_values = {
+            'event': event,
+            'event_teams': event_teams,
+        }
+
+        path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_event_details_get.html')
         self.response.out.write(template.render(path, template_values))
 
 

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -940,7 +940,7 @@ class UsfirstTeamDetailsGet(webapp.RequestHandler):
         # Start with lowest priority
         legacy_team = legacy_df.getTeamDetails(Team.get_by_id(key_name))
         usfirst_team = usfirst_df.getTeamDetails(Team.get_by_id(key_name))
-        fms_details = fms_df.getTeamDetails(tba_config.MAX_YEAR)
+        fms_details = fms_df.getTeamDetails(tba_config.MAX_YEAR, key_name)
 
         # Separate out the multiple models returned from FMSAPI call
         # Since we're only hitting one team at a time, the response won't

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -854,10 +854,14 @@ class UsfirstTeamDetailsGet(webapp.RequestHandler):
         # Start with lowest priority
         legacy_team = legacy_df.getTeamDetails(Team.get_by_id(key_name))
         usfirst_team = usfirst_df.getTeamDetails(Team.get_by_id(key_name))
-        fms_details = fms_df.getTeamDetails(tba_config.MAX_YEAR, key_name)
+        fms_details = fms_df.getTeamDetails(tba_config.MAX_YEAR)
 
-        if fms_details:
-            fms_team, district_team, robot = fms_details
+        # Separate out the multiple models returned from FMSAPI call
+        # Since we're only hitting one team at a time, the response won't
+        # ever be paginated so we can ignore the possibility
+        if fms_details and fms_details[0]:
+            models, more_pages = fms_details
+            fms_team, district_team, robot = models[0]
         else:
             fms_team = None
             district_team = None

--- a/cron_main.py
+++ b/cron_main.py
@@ -17,6 +17,7 @@ from controllers.datafeed_controller import UsfirstEventDetailsEnqueue, UsfirstE
 from controllers.datafeed_controller import UsfirstAwardsEnqueue, UsfirstAwardsGet
 from controllers.datafeed_controller import UsfirstEventAlliancesEnqueue, UsfirstEventAlliancesGet
 from controllers.datafeed_controller import FMSAPIEventListEnqueue, FMSAPIEventListGet
+from controllers.datafeed_controller import FMSAPIEventTeamsEnqueue, FMSAPIEventTeamsGet
 from controllers.datafeed_controller import UsfirstMatchesEnqueue, UsfirstMatchesGet, UsfirstEventRankingsEnqueue, UsfirstEventRankingsGet
 from controllers.datafeed_controller import UsfirstTeamDetailsEnqueue, UsfirstTeamDetailsRollingEnqueue, UsfirstTeamDetailsGet, UsfirstTeamsTpidsGet
 from controllers.datafeed_controller import UsfirstPre2003TeamEventsEnqueue, UsfirstPre2003TeamEventsGet
@@ -49,6 +50,7 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/enqueue/fmsapi_team_details', FMSAPITeamDetailsEnqueue),
                                ('/tasks/enqueue/fmsapi_team_details_rolling', FMSAPITeamDetailsRollingEnqueue),
                                ('/tasks/enqueue/fmsapi_event_list/([0-9]*)', FMSAPIEventListEnqueue),
+                               ('/tasks/enqueue/fmsapi_eventteams/(.*)', FMSAPIEventTeamsEnqueue),
                                ('/tasks/enqueue/usfirst_event_alliances/(.*)', UsfirstEventAlliancesEnqueue),
                                ('/tasks/enqueue/usfirst_event_details/([0-9]*)', UsfirstEventDetailsEnqueue),
                                ('/tasks/enqueue/usfirst_event_rankings/(.*)', UsfirstEventRankingsEnqueue),
@@ -68,6 +70,7 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/get/fmsapi_matches/(.*)', FMSAPIMatchesGet),
                                ('/tasks/get/fmsapi_team_details/(.*)', FMSAPITeamDetailsGet),
                                ('/tasks/get/fmsapi_event_list/([0-9]*)', FMSAPIEventListGet),
+                               ('/tasks/get/fmsapi_eventteams/(.*)', FMSAPIEventTeamsGet),
                                ('/tasks/get/usfirst_event_alliances/(.*)', UsfirstEventAlliancesGet),
                                ('/tasks/get/usfirst_event_list/([0-9]*)', UsfirstEventListGet),
                                ('/tasks/get/usfirst_event_details/([0-9]*)/([0-9]*)', UsfirstEventDetailsGet),

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -152,7 +152,7 @@ class DatafeedFMSAPI(object):
     def getTeamDetails(self, year, team_key):
         team_number = team_key[3:]  # everything after 'frc'
 
-        team = self._parse(self.FMS_API_TEAM_DETAILS_URL_PATTERN % (year, team_number), FMSAPITeamDetailsParser(year, team_key))
+        team = self._parse(self.FMS_API_TEAM_DETAILS_URL_PATTERN % (year, team_number), FMSAPITeamDetailsParser(year))
         return team
 
     def getEventList(self, year):

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -59,6 +59,7 @@ class DatafeedFMSAPI(object):
             self.FMS_API_EVENT_ALLIANCES_URL_PATTERN = FMS_API_URL_BASE + '/alliances/%s/%s'  # (year, event_short)
             self.FMS_API_TEAM_DETAILS_URL_PATTERN = FMS_API_URL_BASE + '/teams/%s/?teamNumber=%s'  # (year, teamNumber)
             self.FMS_API_EVENT_LIST_URL_PATTERN = FMS_API_URL_BASE + '/events/season=%s'
+            self.FMS_API_EVENTTEAM_LIST_URL_PATTERN = FMS_API_URL_BASE + '/teams/?season=%s&eventCode=%s&page=%s'  # (year, eventCode, page)
         elif version == 'v2.0':
             FMS_API_URL_BASE = 'https://frc-api.usfirst.org/v2.0'
             self.FMS_API_AWARDS_URL_PATTERN = FMS_API_URL_BASE + '/%s/awards/%s'  # (year, event_short)
@@ -70,6 +71,7 @@ class DatafeedFMSAPI(object):
             self.FMS_API_EVENT_ALLIANCES_URL_PATTERN = FMS_API_URL_BASE + '/%s/alliances/%s'  # (year, event_short)
             self.FMS_API_TEAM_DETAILS_URL_PATTERN = FMS_API_URL_BASE + '/%s/teams/?teamNumber=%s'  # (year, teamNumber)
             self.FMS_API_EVENT_LIST_URL_PATTERN = FMS_API_URL_BASE + '/%s/events'  # year
+            self.FMS_API_EVENTTEAM_LIST_URL_PATTERN = FMS_API_URL_BASE + '/%s/teams/?eventCode=%s&page=%s'  # (year, eventCode, page)
         else:
             raise Exception("Unknown FMS API version: {}".format(version))
 
@@ -156,3 +158,19 @@ class DatafeedFMSAPI(object):
     def getEventList(self, year):
         events = self._parse(self.FMS_API_EVENT_LIST_URL_PATTERN % (year), FMSAPIEventListParser(year))
         return events
+
+    # Returns list of tuples (team, districtteam, robot)
+    def getEventTeams(self, event_key):
+        year = int(event_key[:4])
+        event_code = event_key[4:]
+        parser = FMSAPITeamDetailsParser(year)
+        models = []  # will be list of tuples (team, districtteam, robot) model
+        for page in range(1, 9):  # Ensure this won't loop forever. 8 pages should be more than enough
+            url = self.FMS_API_EVENTTEAM_LIST_URL_PATTERN % (year, event_code, page)
+            partial_models, more_pages = self._parse(url, parser)
+            models.extend(partial_models)
+
+            if not more_pages:
+                break
+
+        return models

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -167,7 +167,10 @@ class DatafeedFMSAPI(object):
         models = []  # will be list of tuples (team, districtteam, robot) model
         for page in range(1, 9):  # Ensure this won't loop forever. 8 pages should be more than enough
             url = self.FMS_API_EVENTTEAM_LIST_URL_PATTERN % (year, event_code, page)
-            partial_models, more_pages = self._parse(url, parser)
+            result = self._parse(url, parser)
+            if result is None:
+                break
+            partial_models, more_pages = result
             models.extend(partial_models)
 
             if not more_pages:

--- a/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -29,6 +29,7 @@ class FMSAPITeamDetailsParser(object):
             address = u"{}, {}, {}".format(teamData['city'], teamData['stateProv'], teamData['country'])
 
             team = Team(
+                id="frc{}".format(teamData['teamNumber']),
                 team_number=teamData['teamNumber'],
                 name=teamData['nameFull'],
                 nickname=teamData['nameShort'],

--- a/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -34,6 +34,7 @@ class FMSAPITeamDetailsParser(object):
                 name=teamData['nameFull'],
                 nickname=teamData['nameShort'],
                 address=address,
+                website=teamData['website'],
                 rookie_year=teamData['rookieYear']
             )
 

--- a/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -1,7 +1,3 @@
-import datetime
-import json
-import logging
-
 from google.appengine.ext import ndb
 
 from consts.district_type import DistrictType
@@ -11,50 +7,54 @@ from models.robot import Robot
 
 
 class FMSAPITeamDetailsParser(object):
-    def __init__(self, year, team_key):
+    def __init__(self, year):
         self.year = year
-        self.team_key = team_key
 
     def parse(self, response):
         """
         Parse team info from FMSAPI
-        Returns a tuple of models (Team, DistrictTeam, Robot)
+        Returns a tuple of: list of models (Team, DistrictTeam, Robot),
+        and a Boolean indicating if there are more pages to be fetched
         """
 
         # Get team json
         # don't need to null check, if error, HTTP code != 200, so we wont' get here
+        current_page = response['pageCurrent']
+        total_pages = response['pageTotal']
         teams = response['teams']
-        teamData = teams[0]
+        ret_models = []
 
-        # concat city/state/country to get address
-        address = u"{}, {}, {}".format(teamData['city'], teamData['stateProv'], teamData['country'])
+        for teamData in teams:
+            # concat city/state/country to get address
+            address = u"{}, {}, {}".format(teamData['city'], teamData['stateProv'], teamData['country'])
 
-        team = Team(
-            team_number=teamData['teamNumber'],
-            name=teamData['nameFull'],
-            nickname=teamData['nameShort'],
-            address=address,
-            rookie_year=teamData['rookieYear'],
-            website=teamData['website']
-        )
-
-        districtTeam = None
-        if teamData['districtCode']:
-            districtAbbrev = DistrictType.abbrevs[teamData['districtCode'].lower()]
-            districtTeam = DistrictTeam(
-                id=DistrictTeam.renderKeyName(self.year, districtAbbrev, team.key_name),
-                team=ndb.Key(Team, team.key_name),
-                year=self.year,
-                district=districtAbbrev
+            team = Team(
+                team_number=teamData['teamNumber'],
+                name=teamData['nameFull'],
+                nickname=teamData['nameShort'],
+                address=address,
+                rookie_year=teamData['rookieYear']
             )
 
-        robot = None
-        if teamData['robotName']:
-            robot = Robot(
-                id=Robot.renderKeyName(team.key_name, self.year),
-                team=ndb.Key(Team, team.key_name),
-                year=self.year,
-                robot_name=teamData['robotName'].strip()
-            )
+            districtTeam = None
+            if teamData['districtCode']:
+                districtAbbrev = DistrictType.abbrevs[teamData['districtCode'].lower()]
+                districtTeam = DistrictTeam(
+                    id=DistrictTeam.renderKeyName(self.year, districtAbbrev, team.key_name),
+                    team=ndb.Key(Team, team.key_name),
+                    year=self.year,
+                    district=districtAbbrev
+                )
 
-        return (team, districtTeam, robot)
+            robot = None
+            if teamData['robotName']:
+                robot = Robot(
+                    id=Robot.renderKeyName(team.key_name, self.year),
+                    team=ndb.Key(Team, team.key_name),
+                    year=self.year,
+                    robot_name=teamData['robotName'].strip()
+                )
+
+            ret_models.append((team, districtTeam, robot))
+
+        return (ret_models, (current_page < total_pages))

--- a/models/district_team.py
+++ b/models/district_team.py
@@ -35,8 +35,8 @@ class DistrictTeam(ndb.Model):
 
     @property
     def district_key(self):
-        districtAbbrev = DistrictType.type_abbrevs[districtEnum]
-        return '{}{}'.format(year, districtAbbrev)
+        districtAbbrev = DistrictType.type_abbrevs[self.district]
+        return '{}{}'.format(self.year, districtAbbrev)
 
     @classmethod
     def renderKeyName(self, year, districtEnum, teamKey):

--- a/templates/datafeeds/fmsapi_eventteams_enqueue.html
+++ b/templates/datafeeds/fmsapi_eventteams_enqueue.html
@@ -1,0 +1,1 @@
+<h2>EventTeams Enqueued for {{event_key}}!</h2>

--- a/tests/test_fms_api_team_parser.py
+++ b/tests/test_fms_api_team_parser.py
@@ -25,7 +25,12 @@ class TestFMSAPITeamParser(unittest2.TestCase):
 
     def test_parseTeamWithDistrict(self):
         with open('test_data/fms_api/2015_frc1124.json', 'r') as f:
-            team, districtTeam, robot = FMSAPITeamDetailsParser(2015, "frc1124").parse(json.loads(f.read()))
+            models, more_pages = FMSAPITeamDetailsParser(2015).parse(json.loads(f.read()))
+
+            self.assertFalse(more_pages)
+            self.assertEqual(len(models), 1)
+
+            team, districtTeam, robot = models[0]
 
             # Ensure we get the proper Team model back
             self.assertEqual(team.key_name, "frc1124")
@@ -50,7 +55,12 @@ class TestFMSAPITeamParser(unittest2.TestCase):
 
     def test_parseTeamWithNoDistrict(self):
         with open('test_data/fms_api/2015_frc254.json', 'r') as f:
-            team, districtTeam, robot = FMSAPITeamDetailsParser(2015, "frc254").parse(json.loads(f.read()))
+            models, more_pages = FMSAPITeamDetailsParser(2015).parse(json.loads(f.read()))
+
+            self.assertFalse(more_pages)
+            self.assertEqual(len(models), 1)
+
+            team, districtTeam, robot = models[0]
 
             # Ensure we get the proper Team model back
             self.assertEqual(team.key_name, "frc254")


### PR DESCRIPTION
This is the continuation of #1270 - MERGE THAT FIRST

This PR updates the FMSAPI Team Details parser to account for paginated responses,
see f77e4b8. Otherwise, it'll add a task into the queue for each event for eventteams
after fetching event details.

Since the FMSAPI response is the same endpoint as team details, we can update & store
full Team, DistrictTeam, and Robot models from it. This might make the regular rolling
team update cronjob obsolete.