### PR TITLE
Remove unneeded prints to make tests less verbose. Towards #1275

### DIFF
--- a/tests/test_apiv2_team_controller.py
+++ b/tests/test_apiv2_team_controller.py
@@ -295,7 +295,6 @@ class TestTeamHistoryRobotsApiController(unittest2.TestCase):
 
     def testRobotApi(self):
         response = self.testapp.get('/frc1124', headers={"X-TBA-App-Id": "tba-tests:team_list-controller-test:v01"})
-        print response.body
         robot_dict = json.loads(response.body)
 
         self.assertTrue("2015" in robot_dict)

--- a/tests/test_award_type_parser.py
+++ b/tests/test_award_type_parser.py
@@ -78,5 +78,4 @@ class TestUsfirstEventTypeParser(unittest2.TestCase):
         # test 2015 award names
         with open('test_data/fms_api/2015_award_types.json', 'r') as f:
             for award in json.loads(f.read()):
-                print award['description']
                 self.assertNotEqual(AwardHelper.parse_award_type(award['description']), None)


### PR DESCRIPTION
These don't do anything useful, and clutter tests.