### PR TITLE
Bumps Django version.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -11,7 +11,7 @@ builtins:
 
 libraries:
 - name: django
-  version: "1.2"
+  version: "1.5"
 - name: numpy
   version: "1.6.1"
 - name: endpoints


### PR DESCRIPTION
Old Django is getting deprecated. https://cloud.google.com/appengine/docs/deprecations/django

Tested locally by browsing around to a few pages, they all worked. Tests pass.