### PR TITLE
added admin script to generate past district teams.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ $RECYCLE.BIN/
 *.project
 *.pydevproject
 
+# IDEA
+.idea/**
+
 # Temp files #
 ##############
 *.temp

--- a/admin_main.py
+++ b/admin_main.py
@@ -5,7 +5,7 @@ import webapp2
 import tba_config
 
 from controllers.admin.admin_api_controller import AdminApiAuthAdd, AdminApiAuthDelete, AdminApiAuthEdit, AdminApiAuthManage
-
+from controllers.admin.admin_cron_controller import AdminCreateDistrictTeamsEnqueue, AdminCreateDistrictTeamsDo
 from controllers.admin.admin_event_controller import AdminEventAddAllianceSelections, AdminEventAddTeams, AdminEventAddWebcast, AdminEventCreate, AdminEventCreateTest, AdminEventDelete, AdminEventDetail, AdminEventEdit, AdminEventList
 from controllers.admin.admin_main_controller import AdminDebugHandler, AdminMain, AdminTasksHandler
 from controllers.admin.admin_award_controller import AdminAwardDashboard, AdminAwardEdit, AdminAwardAdd
@@ -32,6 +32,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/api_auth/manage', AdminApiAuthManage),
                                ('/admin/apistatus', AdminApiStatus),
                                ('/admin/debug', AdminDebugHandler),
+                               ('/admin/district_teams_update/([0-9]+)', AdminCreateDistrictTeamsEnqueue),
                                ('/admin/events', AdminEventList),
                                ('/admin/events/([0-9]*)', AdminEventList),
                                ('/admin/event/add_alliance_selections/(.*)', AdminEventAddAllianceSelections),

--- a/controllers/admin/admin_cron_controller.py
+++ b/controllers/admin/admin_cron_controller.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import date
 import logging
 import os
@@ -8,10 +9,16 @@ from google.appengine.ext import ndb
 from google.appengine.ext.webapp import template
 
 from consts.client_type import ClientType
+from consts.district_type import DistrictType
 from controllers.base_controller import LoggedInHandler
+from helpers.district_team_manipulator import DistrictTeamManipulator
 from helpers.notification_sender import NotificationSender
+from models.district_team import DistrictTeam
+from models.event import Event
+from models.event_team import EventTeam
 from models.mobile_client import MobileClient
 from models.subscription import Subscription
+from models.team import Team
 from notifications.ping import PingNotification
 
 
@@ -128,3 +135,38 @@ class AdminWebhooksClear(LoggedInHandler):
         template_values = {'count': count}
         path = os.path.join(os.path.dirname(__file__), '../../templates/admin/webhooks_clear_do.html')
         self.response.out.write(template.render(path, template_values))
+
+class AdminCreateDistrictTeamsEnqueue(LoggedInHandler):
+    """
+    Trying to Enqueue a task to rebuild old district teams from event teams.
+    """
+    def get(self, year):
+        self._require_admin()
+        taskqueue.add(
+            queue_name='admin',
+            url='/tasks/admin/rebuild_district_teams/{}'.format(year),
+            method='GET')
+
+        self.response.out.write("Enqueued district teams for {}".format(year))
+
+class AdminCreateDistrictTeamsDo(LoggedInHandler):
+    def get(self, year):
+        year = int(year)
+        team_districts = defaultdict(list)
+        logging.info("Fetching events in {}".format(year))
+        year_events = Event.query(year == Event.year, Event.event_district_enum != DistrictType.NO_DISTRICT).fetch()
+        for event in year_events:
+            logging.info("Fetching EventTeams for {}".format(event.key_name))
+            event_teams = EventTeam.query(EventTeam.event == event.key).fetch()
+            for event_team in event_teams:
+                team_districts[event_team.team.id()].append(event.event_district_enum)
+
+        new_district_teams = []
+        for team_key, districts in team_districts.iteritems():
+            most_frequent_district = max(set(districts), key=districts.count)
+            logging.info("Assuming team {} belongs to {}".format(team_key, DistrictType.type_names[most_frequent_district]))
+            dt_key = DistrictTeam.renderKeyName(year, most_frequent_district, team_key)
+            new_district_teams.append(DistrictTeam(id=dt_key, year=year, team=ndb.Key(Team, team_key), district=most_frequent_district))
+
+        logging.info("Finishing updating old district teams from event teams")
+        DistrictTeamManipulator.createOrUpdate(new_district_teams)

--- a/controllers/api/api_district_controller.py
+++ b/controllers/api/api_district_controller.py
@@ -155,4 +155,3 @@ class ApiDistrictRankingsController(ApiDistrictControllerBase):
             current_rank += 1
 
         return json.dumps(rankings)
-

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -444,7 +444,8 @@ class EventDetailsGet(webapp.RequestHandler):
         teams = TeamManipulator.mergeModels(teams, df2.getEventTeams(event))
 
         # Write new models
-        teams = TeamManipulator.createOrUpdate(teams)
+        if teams:
+            teams = TeamManipulator.createOrUpdate(teams)
         district_teams = DistrictTeamManipulator.createOrUpdate(district_teams)
         robots = RobotManipulator.createOrUpdate(robots)
 

--- a/cron_main.py
+++ b/cron_main.py
@@ -19,8 +19,7 @@ from controllers.cron_controller import YearInsightsEnqueue, YearInsightsDo, Ove
 from controllers.cron_controller import UpcomingNotificationDo
 
 from controllers.admin.admin_cron_controller import AdminMobileClearEnqueue, AdminMobileClear, AdminSubsClearEnqueue, AdminSubsClear, \
-    AdminWebhooksClearEnqueue, AdminWebhooksClear
-
+    AdminWebhooksClearEnqueue, AdminWebhooksClear, AdminCreateDistrictTeamsDo
 
 app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackupEventsEnqueue),
                                ('/tasks/enqueue/csv_backup_events/([0-9]*)', TbaCSVBackupEventsEnqueue),
@@ -63,5 +62,6 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/admin/clear_old_subs', AdminSubsClear),
                                ('/tasks/admin/enqueue/clear_old_webhooks', AdminWebhooksClearEnqueue),
                                ('/tasks/admin/clear_old_webhooks', AdminWebhooksClear),
+                               ('/tasks/admin/rebuild_district_teams/([0-9]+)', AdminCreateDistrictTeamsDo),
                                ],
                               debug=tba_config.DEBUG)

--- a/index.yaml
+++ b/index.yaml
@@ -39,6 +39,11 @@ indexes:
 - kind: Event
   properties:
   - name: year
+  - name: event_district_enum
+
+- kind: Event
+  properties:
+  - name: year
   - name: first_eid
 
 - kind: Event


### PR DESCRIPTION
Admin task to run at /admin/district_teams_update/<year> that will fetch all district events in the year,
and select the district each team competed in most often to use as the "home" district.

Closes #1231