### PR TITLE
travis: Remove deprecated --use-mirrors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ python: 2.7
 
 before_script:
   - mkdir -p vendors
-  - wget http://googleappengine.googlecode.com/files/google_appengine_1.8.7.zip  -nv
+  - wget http://googleappengine.googlecode.com/files/google_appengine_1.8.7.zip -nv
   - unzip -qd vendors google_appengine_1.8.7.zip
   - ln -s vendors/google_appengine/dev_appserver.py .
 
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 
 :script: paver test
 


### PR DESCRIPTION
It'll be removed in a later version of `pip`, so we might as well remove it now.