### PR TITLE
Implement 2009 - 2013 District Point Math

### DIFF
--- a/consts/district_point_values.py
+++ b/consts/district_point_values.py
@@ -1,0 +1,92 @@
+from consts.award_type import AwardType
+
+class DistrictPointValues(object):
+    """
+    A class that contains various district point constants over the years:
+    Documents containing point systems:
+     - 2016: same as 2015
+     - 2015: http://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/game-and-season-info/archive/2015/AdminManual20150407.pdf
+     - 2014: http://www.firstinmichigan.org/FRC_2014/District_Standard_Points_Ranking_System.pdf
+     - 2013: http://www.firstinmichigan.org/FRC_2013/2013_Rules_Supplement.pdf
+     - 2012: http://www.firstinmichigan.org/FRC_2012/2012_Rules_Supplement.pdf
+     - 2011: http://www.firstinmichigan.org/FRC_2011/2011_Rules_Supplement.pdf
+     - 2010: http://www.firstinmichigan.org/FRC_2010/2010_Update_3.pdf
+     - 2009: http://www.chiefdelphi.com/forums/showpost.php?p=759453&postcount=67
+    """
+
+    STANDARD_MULTIPLIER = 1
+
+    # Since 2014, points earned at District CMP has 3x bonus
+    DISTRICT_CMP_MULIPLIER_DEFAULT = 3
+    DISTRICT_CMP_MULTIPLIER = {
+        2013: 1,
+        2012: 1,
+        2011: 1,
+        2010: 1,
+        2009: 1
+    }
+
+    # In years prior to 2015, teams get points for a win/tie in a qualification match
+    MATCH_WIN_DEFAULT = 2
+    MATCH_WIN = {}
+
+    MATCH_TIE_DEFAULT = 1
+    MATCH_TIE = {}
+
+    # Used to determine alliance selection points
+    # Captain/First pick get 17-alliance number, second pick gets 17 - draft order
+    ALLIANCE_MAX_DEFAULT = 17
+
+    # In 2009 - 2013 (except 2010), second pick teams got fewer elim round advancement points as captain/pick 1
+    ELIM_SECOND_PICK_MULTIPLIER_DEFAULT = 1
+    ELIM_SECOND_PICK_MULTIPLIER = {
+        2013: 0.8,
+        2012: 0.8,
+        2011: 0.8,
+        2009: 0.8
+    }
+
+    # Used to determine elim/playoff points.
+    # Teams on each round's winning alliance gets points per match won
+    # For the 2015 game, these are awarded for participating in a qf/sf match, since there were no wins
+    QF_WIN_DEFAULT = 5
+    QF_WIN = {}
+
+    SF_WIN_DEFAULT = 5
+    SF_WIN = {
+        2015: 3.3,
+    }
+
+    F_WIN_DEFAULT = 5
+    F_WIN = {}
+
+    # Chairman's Award
+    CHAIRMANS_DEFAULT = 10
+    CHAIRMANS = {
+        2013: 0,
+        2012: 0,
+        2011: 0,
+        2009: 0
+    }
+
+    # Engineering Inspiration and Rookie All-Star
+    EI_DEFAULT = 8
+    RAS_DEFAULT = 8
+    OTHER_AWARD_DEFAULT = 5
+
+    # Pre-2014 Awards, all worth either 5 or 2 points
+    LEGACY_5_PT_AWARDS = {
+        2013: [AwardType.INDUSTRIAL_DEESIGN, AwardType.QUALITY, AwardType.ENGINEERING_EXCELLENCE, AwardType.INNOVATION_IN_CONTROL, AwardType.CREATIVITY],
+        2012: [AwardType.INDUSTRIAL_DEESIGN, AwardType.QUALITY, AwardType.ENGINEERING_EXCELLENCE, AwardType.INNOVATION_IN_CONTROL, AwardType.CREATIVITY, AwardType.ENTREPRENEURSHIP, AwardType.COOPERTITION],
+        2011: [AwardType.INDUSTRIAL_DEESIGN, AwardType.QUALITY, AwardType.ENGINEERING_EXCELLENCE, AwardType.INNOVATION_IN_CONTROL, AwardType.CREATIVITY, AwardType.ENTREPRENEURSHIP, AwardType.COOPERTITION, AwardType.EXCELLENCE_IN_DESIGN],
+        2010: [AwardType.INDUSTRIAL_DEESIGN, AwardType.QUALITY, AwardType.ENGINEERING_EXCELLENCE, AwardType.INNOVATION_IN_CONTROL, AwardType.CREATIVITY, AwardType.ROOKIE_ALL_STAR, AwardType.ENGINEERING_INSPIRATION, AwardType.ENTREPRENEURSHIP, AwardType.COOPERTITION],
+        2009: [AwardType.INDUSTRIAL_DEESIGN, AwardType.QUALITY, AwardType.DRIVING_TOMORROWS_TECHNOLOGY, AwardType.INNOVATION_IN_CONTROL, AwardType.CREATIVITY]
+    }
+
+    LEGACY_2_PT_AWARDS = {
+        2013: [AwardType.SPIRIT, AwardType.GRACIOUS_PROFESSIONALISM, AwardType.IMAGERY, AwardType.HIGHEST_ROOKIE_SEED, AwardType.SAFETY, AwardType.JUDGES, AwardType.ROOKIE_INSPIRATION],
+        2012: [AwardType.SPIRIT, AwardType.GRACIOUS_PROFESSIONALISM, AwardType.IMAGERY, AwardType.HIGHEST_ROOKIE_SEED, AwardType.SAFETY, AwardType.JUDGES, AwardType.ROOKIE_INSPIRATION, AwardType.WEBSITE],
+        2011: [AwardType.SPIRIT, AwardType.GRACIOUS_PROFESSIONALISM, AwardType.IMAGERY, AwardType.HIGHEST_ROOKIE_SEED, AwardType.SAFETY, AwardType.JUDGES, AwardType.ROOKIE_INSPIRATION, AwardType.WEBSITE],
+        2010: [AwardType.SPIRIT, AwardType.GRACIOUS_PROFESSIONALISM, AwardType.IMAGERY, AwardType.HIGHEST_ROOKIE_SEED, AwardType.SAFETY, AwardType.JUDGES, AwardType.ROOKIE_INSPIRATION, AwardType.WEBSITE],
+        2009: [AwardType.SPIRIT, AwardType.GRACIOUS_PROFESSIONALISM, AwardType.IMAGERY, AwardType.JUDGES, AwardType.ROOKIE_INSPIRATION, AwardType.SAFETY, AwardType.WSU_AIM_HIGHER, AwardType.WEBSITE]
+    }

--- a/consts/district_point_values.py
+++ b/consts/district_point_values.py
@@ -27,17 +27,15 @@ class DistrictPointValues(object):
     }
 
     # In years prior to 2015, teams get points for a win/tie in a qualification match
-    MATCH_WIN_DEFAULT = 2
-    MATCH_WIN = {}
-
-    MATCH_TIE_DEFAULT = 1
-    MATCH_TIE = {}
+    MATCH_WIN = 2
+    MATCH_TIE = 1
 
     # Used to determine alliance selection points
     # Captain/First pick get 17-alliance number, second pick gets 17 - draft order
     ALLIANCE_MAX_DEFAULT = 17
 
     # In 2009 - 2013 (except 2010), second pick teams got fewer elim round advancement points as captain/pick 1
+    # TODO many of these events don't have alliance selection data, so we can't factor this in
     ELIM_SECOND_PICK_MULTIPLIER_DEFAULT = 1
     ELIM_SECOND_PICK_MULTIPLIER = {
         2013: 0.8,
@@ -50,7 +48,9 @@ class DistrictPointValues(object):
     # Teams on each round's winning alliance gets points per match won
     # For the 2015 game, these are awarded for participating in a qf/sf match, since there were no wins
     QF_WIN_DEFAULT = 5
-    QF_WIN = {}
+    QF_WIN = {
+        2015: 5.0
+    }
 
     SF_WIN_DEFAULT = 5
     SF_WIN = {
@@ -58,7 +58,9 @@ class DistrictPointValues(object):
     }
 
     F_WIN_DEFAULT = 5
-    F_WIN = {}
+    F_WIN = {
+        2015: 5.0
+    }
 
     # Chairman's Award
     CHAIRMANS_DEFAULT = 10
@@ -70,8 +72,7 @@ class DistrictPointValues(object):
     }
 
     # Engineering Inspiration and Rookie All-Star
-    EI_DEFAULT = 8
-    RAS_DEFAULT = 8
+    EI_AND_RAS_DEFAULT = 8
     OTHER_AWARD_DEFAULT = 5
 
     # Pre-2014 Awards, all worth either 5 or 2 points

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -434,9 +434,6 @@ class DistrictPointsCalcDo(webapp.RequestHandler):
         if event.event_district_enum == DistrictType.NO_DISTRICT:
             self.response.out.write("Can't calculate district points for a non-district event!")
             return
-        if event.year < 2014:
-            self.response.out.write("Can't calculate district points for events before 2014!")  # TODO: implement correct points for pre-2014 districts
-            return
 
         district_points = DistrictHelper.calculate_event_points(event)
 

--- a/helpers/district_helper.py
+++ b/helpers/district_helper.py
@@ -70,9 +70,9 @@ class DistrictHelper(object):
 
         # alliance points
         if event.alliance_selections:
-            selection_points = EventHelper.alliance_selections_to_points(event.alliance_selections)
+            selection_points = EventHelper.alliance_selections_to_points(event.key_name, POINTS_MULTIPLIER, event.alliance_selections)
             for team, points in selection_points.items():
-                district_points['points'][team]['alliance_points'] += points * POINTS_MULTIPLIER
+                district_points['points'][team]['alliance_points'] += points
         else:
             logging.warning("Event {} has no alliance selection district_points!".format(event.key.id()))
 

--- a/helpers/district_helper.py
+++ b/helpers/district_helper.py
@@ -2,14 +2,12 @@ import logging
 import heapq
 import math
 import numpy as np
-from sys import float_info
 
 from collections import defaultdict
 
 from google.appengine.ext import ndb
 
 from consts.award_type import AwardType
-from consts.district_type import DistrictType
 from consts.event_type import EventType
 
 from helpers.event_helper import EventHelper
@@ -26,15 +24,15 @@ class DistrictHelper(object):
     """
     @classmethod
     def inverf(cls, x):
-    	if x > 0:
-    		s = 1
-    	elif x < 0:
-    		s = -1
-    	else:
-    		s = 0
-    	a = 0.147
+        if x > 0:
+            s = 1
+        elif x < 0:
+            s = -1
+        else:
+            s = 0
+        a = 0.147
         y = s * math.sqrt((math.sqrt((((2 / (math.pi * a)) + ((math.log(1 - x**2)) / 2))**2) - ((math.log(1 - x**2)) / a))) - ((2 / (math.pi * a)) + (math.log(1 - x**2)) / 2))
-	return y
+        return y
 
     @classmethod
     def calculate_event_points(cls, event):

--- a/helpers/district_helper.py
+++ b/helpers/district_helper.py
@@ -65,7 +65,8 @@ class DistrictHelper(object):
         single_district_points = district_points.copy()
 
         # match points
-        if event.year == 2015:
+        if event.year >= 2015:
+            # Switched to ranking-based points for 2015 and onward
             cls.calc_rank_based_match_points(event, district_points, match_futures, POINTS_MULTIPLIER)
         else:
             cls.calc_wlt_based_match_points(district_points, match_futures, POINTS_MULTIPLIER)

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -27,13 +27,25 @@ class EventHelper(object):
     Helper class for Events.
     """
     @classmethod
-    def alliance_selections_to_points(self, alliance_selections):
+    def alliance_selections_to_points(self, event_key, multiplier, alliance_selections):
         team_points = {}
-        for n, alliance in enumerate(alliance_selections):
-            n += 1
-            team_points[alliance['picks'][0]] = 17 - n
-            team_points[alliance['picks'][1]] = 17 - n
-            team_points[alliance['picks'][2]] = n
+        if event_key == "2015micmp":
+            # Special case for 2015 Michigan District CMP, due to there being 16 alliances instead of 8
+            # Uses max of 48 points and no multiplier
+            # See 2015 Admin Manual, section 7.4.3.1
+            # http://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/game-and-season-info/archive/2015/AdminManual20150407.pdf
+            for n, alliance in enumerate(alliance_selections):
+                team_points[alliance['picks'][0]] = int(48 - (1.5 * n))
+                team_points[alliance['picks'][1]] = int(48 - (1.5 * n))
+                team_points[alliance['picks'][2]] = int((n + 1) * 1.5)
+                n += 1
+        else:
+            for n, alliance in enumerate(alliance_selections):
+                n += 1
+                team_points[alliance['picks'][0]] = (17 - n) * multiplier
+                team_points[alliance['picks'][1]] = (17 - n) * multiplier
+                team_points[alliance['picks'][2]] = n * multiplier
+
         return team_points
 
     @classmethod


### PR DESCRIPTION
Adds in historical district point calculations. Seems to be mostly
accurate, although we need to import some alliance data to make it
all work. Should be pretty close to accurate (only think I couldn't
do was reduced elim points for 2nd picks).

Also filters out teams that aren't associated with a DistrictTeam, which fixes #1166
We'll also have to run the admin task to build old DistrictTeams for 2009 - 2013

Closes #1060