### PR TITLE
Fix suggestions select all by moving javascript.

### DIFF
--- a/templates/suggest_match_video_review_list.html
+++ b/templates/suggest_match_video_review_list.html
@@ -20,21 +20,6 @@
                 </div>
             </div><br>
 
-            <script>
-            $("#accept_all_button").click(function() {
-                $('.accept').prop('checked', true);
-                $('.reject').prop('checked', false);
-            });
-            $("#reject_all_button").click(function() {
-                $('.accept').prop('checked', false);
-                $('.reject').prop('checked', true);
-            });
-            $("#deselect_all_button").click(function() {
-                $('.accept').prop('checked', false);
-                $('.reject').prop('checked', false);
-            });
-            </script>
-
             {% for suggestion in suggestions %}
             <div class="row">
                 <div class="well">
@@ -71,5 +56,21 @@
         </div>
     </form>
 </div>
+{% endblock %}
 
+{% block inline_javascript %}
+<script>
+$("#accept_all_button").click(function() {
+    $('.accept').prop('checked', true);
+    $('.reject').prop('checked', false);
+});
+$("#reject_all_button").click(function() {
+    $('.accept').prop('checked', false);
+    $('.reject').prop('checked', true);
+});
+$("#deselect_all_button").click(function() {
+    $('.accept').prop('checked', false);
+    $('.reject').prop('checked', false);
+});
+</script>
 {% endblock %}

--- a/templates/suggest_team_media_review_list.html
+++ b/templates/suggest_team_media_review_list.html
@@ -40,21 +40,6 @@
               </div>
           </div><br>
 
-          <script>
-          $("#accept_all_button").click(function() {
-              $('.accept').prop('checked', true);
-              $('.reject').prop('checked', false);
-          });
-          $("#reject_all_button").click(function() {
-              $('.accept').prop('checked', false);
-              $('.reject').prop('checked', true);
-          });
-          $("#deselect_all_button").click(function() {
-              $('.accept').prop('checked', false);
-              $('.reject').prop('checked', false);
-          });
-          </script>
-
           {% for suggestion, reference in suggestions_and_references %}
           <div class="row">
               <div class="well">
@@ -99,5 +84,21 @@
       </div>
   </form>
 </div>
+{% endblock %}
 
+{% block inline_javascript %}
+<script>
+$("#accept_all_button").click(function() {
+    $('.accept').prop('checked', true);
+    $('.reject').prop('checked', false);
+});
+$("#reject_all_button").click(function() {
+    $('.accept').prop('checked', false);
+    $('.reject').prop('checked', true);
+});
+$("#deselect_all_button").click(function() {
+    $('.accept').prop('checked', false);
+    $('.reject').prop('checked', false);
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
Fixes #1328.
Moves inline javascript to execute after jquery loads.

Test Plan:
- Create test suggestions.
- Visit suggestion approval pages.
- Click 'select all' button.
- Verify all check boxes become checked.