### PR TITLE
Updates deploy script to work for other install setups.

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -4,21 +4,28 @@ To use:
 2. Ensure APP_CFG_DIR points to the correct location
 """
 
+import argparse
 import os
 import sys
 
 
-APP_CFG_DIR = '~/Downloads/google_appengine/appcfg.py'
+APP_CFG_DIR = '~/Downloads/google_appengine' # Eugene's Windows
+# APP_CFG_DIR = '/usr/local/bin' # Mac OS symlinks made by GoogleAppEngineLauncher
 
 
-def main(argv):
-    skip_tests = '-s' in argv
+def main():
+    parser = argparse.ArgumentParser(description='Deploy The Blue Alliance app.')
+    parser.add_argument('app_cfg_dir', type=str, default=APP_CFG_DIR,
+                        help='path to folder containing appcfg.py')
+    parser.add_argument('-s', '--skip_tests', action='store_true',
+                        help='Skip running tests. #yolo.')
+    args = parser.parse_args()
 
     os.chdir('../the-blue-alliance-prod')
     os.system('git pull origin master')
 
     test_status = 0
-    if skip_tests:
+    if args.skip_tests:
         print "Skipping tests!"
         os.system('paver make')
     else:
@@ -26,11 +33,11 @@ def main(argv):
 
     if test_status == 0:
         # Update default module and other YAMLs
-        os.system('python ' + APP_CFG_DIR + ' -A tbatv-prod-hrd update .')
+        os.system('python ' + args.app_cfg_dir + '/appcfg.py -A tbatv-prod-hrd update .')
         # Update other modules
-        os.system('python ' + APP_CFG_DIR + ' -A tbatv-prod-hrd update app-backend-tasks.yaml')
+        os.system('python ' + args.app_cfg_dir + '/appcfg.py -A tbatv-prod-hrd update app-backend-tasks.yaml')
     else:
         print "Tests failed! Did not deploy."
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/pavement.py
+++ b/pavement.py
@@ -11,11 +11,17 @@ path = path("./")
 def deploy():
     sh("python deploy.py")
 
+
 @task
 def javascript():
     """Combine Compress Javascript"""
     print("Combining and Compressing Javascript")
     sh("python do_compress.py js")
+
+
+@task
+def jinja2():
+    sh("python compile_jinja2_templates.py")
 
 
 @task
@@ -25,11 +31,6 @@ def less():
     sh("lessc static/css/less_css/tba_style.main.less static/css/less_css/tba_style.main.css")
     sh("lessc static/css/less_css/tba_style.gameday.less static/css/less_css/tba_style.gameday.css")
     sh("python do_compress.py css")
-
-
-@task
-def jinja2():
-    sh("python compile_jinja2_templates.py")
 
 
 @task

--- a/pavement.py
+++ b/pavement.py
@@ -8,8 +8,9 @@ from paver.easy import *
 path = path("./")
 
 @task
-def deploy():
-    sh("python deploy.py")
+@consume_args
+def deploy(args):
+    sh("python deploy.py " + " ".join(args))
 
 
 @task


### PR DESCRIPTION
Accepts an argument to where appcfg.py lives so that people other than Eugene can update prod :)

paver deploy -h for usage instructions.

Test plan:
- Commented out the part that actually deploys
- Ran `paver deploy /usr/local/bin`, verified expected test output, other output
- Ran `paver deploy /usr/local/bin -s`, verified skipped test out, expected other output
- Uncommented the part that actually pushes
- Ran `paver deploy /usr/local/bin`, saw confirmation site deploy
- Visited thebluealliance.com/admin, saw confirmation I was the latest deploy