### PR TITLE
Open external links in new tab

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -45,7 +45,7 @@
           {% endif %}
         {% endif %}
         {% if event.website %}<br><span class="glyphicon glyphicon-globe"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
-        {% if event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="http://www.firstinspires.org/team-event-search/event?id={{ event.first_eid }} target="_blank">firstinspires.org</a>{% endif %}
+        {% if event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="http://www.firstinspires.org/team-event-search/event?id={{ event.first_eid }}" target="_blank">firstinspires.org</a>{% endif %}
         {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank">RSVP on Facebook</a><br>{% endif %}
       </p>
 

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -39,14 +39,14 @@
         {% if event.location or event.venue_address %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
           {% if event.venue_address %}
-            <a href="http://maps.google.com/maps?q={{ event.venue_address|urlencode }}">{{ event.venue_or_venue_from_address }}</a>{% if event.location %} in {{event.location}}{% endif %}
+            <a href="http://maps.google.com/maps?q={{ event.venue_address|urlencode }}" target="_blank">{{ event.venue_or_venue_from_address }}</a>{% if event.location %} in {{event.location}}{% endif %}
           {% else %}
-            <a href="http://maps.google.com/maps?q={{ event.location|urlencode }}">{{event.location}}</a>
+            <a href="http://maps.google.com/maps?q={{ event.location|urlencode }}" target="_blank">{{event.location}}</a>
           {% endif %}
         {% endif %}
-        {% if event.website %}<br><span class="glyphicon glyphicon-globe"></span> <a href="{{ event.website }}" title="{{ event.name }}">{{ event.website }}</a>{% endif %}
-        {% if event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="http://www.firstinspires.org/team-event-search/event?id={{ event.first_eid }}">firstinspires.org</a>{% endif %}
-        {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event">RSVP on Facebook</a><br>{% endif %}
+        {% if event.website %}<br><span class="glyphicon glyphicon-globe"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
+        {% if event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="http://www.firstinspires.org/team-event-search/event?id={{ event.first_eid }} target="_blank">firstinspires.org</a>{% endif %}
+        {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank">RSVP on Facebook</a><br>{% endif %}
       </p>
 
       <p><strong>#{{ event.hashtag }}</strong> <small><a href="/hashtags" rel="tooltip" title="What are hashtags?">?</a></small> - Search

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -69,7 +69,7 @@
               <div class="col-sm-4">
                 <h3><a href="/event/{{ comp.event.key_name }}">{{ comp.event.name }}</a></h3>
                 <p>
-                  {% if comp.event.location %}<span class="glyphicon glyphicon-map-marker"></span> in <a href="http://maps.google.com/maps?q={{ comp.event.location }}">{{ comp.event.location }}</a><br />{% endif %}
+                  {% if comp.event.location %}<span class="glyphicon glyphicon-map-marker"></span> in <a href="http://maps.google.com/maps?q={{ comp.event.location }}" target="_blank">{{ comp.event.location }}</a><br />{% endif %}
                   {% if comp.event.start_date %}<span class="glyphicon glyphicon-calendar"></span> {{ comp.event.start_date|strftime("%B %d") }}{% if comp.event.start_date != comp.event.end_date %} - {{ comp.event.end_date|strftime("%B %d") }}{% endif %}, {{ comp.event.end_date|strftime("%Y") }}{% endif %}
                 </p>
 

--- a/templates_jinja2/team_partials/team_info.html
+++ b/templates_jinja2/team_partials/team_info.html
@@ -9,7 +9,7 @@
 <div class="row">
   <div class="col-sm-7">
     <p>
-      {% if team.location %}<span class="glyphicon glyphicon-map-marker"></span> from <a href="http://maps.google.com/maps?q={{ team.location|urlencode }}">{{ team.location }}</a><br>{% endif %}
+      {% if team.location %}<span class="glyphicon glyphicon-map-marker"></span> from <a href="http://maps.google.com/maps?q={{ team.location|urlencode }}" target="_blank">{{ team.location }}</a><br>{% endif %}
       {% if team.name %}<span class="glyphicon glyphicon-info-sign"></span> aka <em>{{ team.name }}</em><br>{% endif %}
       {% if team.rookie_year %}<span class="glyphicon glyphicon-calendar"></span> first competed in {{ team.rookie_year }}<br>{% endif %}
       {% if team.website %}<span class="glyphicon glyphicon-globe"></span> <a href="{{team.website}}" target="_blank">{{ team.website }}</a>{% endif %}


### PR DESCRIPTION
Some links to external sites, like team websites and all the hashtag searches, already open in new tabs. This PR adds consistency by opening all external links (or at least the ones I found by poking around the site for a bit) in new tabs.

If I missed any links, let me know and I'll add them to this PR.

First contribution to the website, woo!