### PR TITLE
Suggestion home

### DIFF
--- a/controllers/admin/admin_main_controller.py
+++ b/controllers/admin/admin_main_controller.py
@@ -29,9 +29,10 @@ class AdminMain(LoggedInHandler):
         users = Account.query().order(-Account.created).fetch(5)
         self.template_values['users'] = users
 
-        self.template_values['video_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "match")
-        self.template_values['webcast_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event")
-        self.template_values['media_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media")
+        self.template_values['suggestions'] = dict()
+        self.template_values['suggestions']['match'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "match")
+        self.template_values['suggestions']['event'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event")
+        self.template_values['suggestions']['media'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media")
 
         # version info
         try:

--- a/controllers/admin/admin_main_controller.py
+++ b/controllers/admin/admin_main_controller.py
@@ -10,6 +10,7 @@ from google.appengine.ext.webapp import template
 
 from controllers.base_controller import LoggedInHandler
 from database.database_query import DatabaseQuery
+from helpers.suggestions.suggestion_fetcher import SuggestionFetcher
 from models.account import Account
 from models.suggestion import Suggestion
 
@@ -28,21 +29,9 @@ class AdminMain(LoggedInHandler):
         users = Account.query().order(-Account.created).fetch(5)
         self.template_values['users'] = users
 
-        # Retrieves the number of pending suggestions
-        video_suggestions = Suggestion.query().filter(
-            Suggestion.review_state == Suggestion.REVIEW_PENDING).filter(
-            Suggestion.target_model == "match").count()
-        self.template_values['video_suggestions'] = video_suggestions
-
-        webcast_suggestions = Suggestion.query().filter(
-            Suggestion.review_state == Suggestion.REVIEW_PENDING).filter(
-            Suggestion.target_model == "event").count()
-        self.template_values['webcast_suggestions'] = webcast_suggestions
-
-        media_suggestions = Suggestion.query().filter(
-            Suggestion.review_state == Suggestion.REVIEW_PENDING).filter(
-            Suggestion.target_model == "media").count()
-        self.template_values['media_suggestions'] = media_suggestions
+        self.template_values['video_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "match")
+        self.template_values['webcast_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event")
+        self.template_values['media_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media")
 
         # version info
         try:

--- a/controllers/suggestions/suggest_event_webcast_review_controller.py
+++ b/controllers/suggestions/suggest_event_webcast_review_controller.py
@@ -58,7 +58,7 @@ class SuggestEventWebcastReviewController(SuggestionsReviewBaseController):
 
             suggestion.review_state = Suggestion.REVIEW_ACCEPTED
             suggestion.reviewer = self.user_bundle.account.key
-            suggestion.reviewer_at = datetime.datetime.now()
+            suggestion.reviewed_at = datetime.datetime.now()
             suggestion.put()
 
             self.redirect("/suggest/event/webcast/review?success=accept&event_key=%s" % event.key.id())
@@ -69,7 +69,7 @@ class SuggestEventWebcastReviewController(SuggestionsReviewBaseController):
 
             suggestion.review_state = Suggestion.REVIEW_REJECTED
             suggestion.reviewer = self.user_bundle.account.key
-            suggestion.reviewer_at = datetime.datetime.now()
+            suggestion.reviewed_at = datetime.datetime.now()
             suggestion.put()
 
             self.redirect("/suggest/event/webcast/review?success=reject")
@@ -84,7 +84,7 @@ class SuggestEventWebcastReviewController(SuggestionsReviewBaseController):
                 event_key = suggestion.target_key
                 suggestion.review_state = Suggestion.REVIEW_REJECTED
                 suggestion.reviewer = self.user_bundle.account.key
-                suggestion.reviewer_at = datetime.datetime.now()
+                suggestion.reviewed_at = datetime.datetime.now()
                 suggestion.put()
 
             self.redirect("/suggest/event/webcast/review?success=reject_all&event_key=%s" % event_key)

--- a/controllers/suggestions/suggest_match_video_review_controller.py
+++ b/controllers/suggestions/suggest_match_video_review_controller.py
@@ -45,7 +45,7 @@ class SuggestMatchVideoReviewController(SuggestionsReviewBaseController):
             if suggestion.key.id() in reject_keys:
                 suggestion.review_state = Suggestion.REVIEW_REJECTED
             suggestion.reviewer = self.user_bundle.account.key
-            suggestion.reviewer_at = datetime.datetime.now()
+            suggestion.reviewed_at = datetime.datetime.now()
 
         ndb.put_multi(all_suggestions)
 

--- a/controllers/suggestions/suggest_review_home.py
+++ b/controllers/suggestions/suggest_review_home.py
@@ -1,1 +1,0 @@
-suggest_review_home.py

--- a/controllers/suggestions/suggest_review_home.py
+++ b/controllers/suggestions/suggest_review_home.py
@@ -1,0 +1,1 @@
+suggest_review_home.py

--- a/controllers/suggestions/suggest_review_home_controller.py
+++ b/controllers/suggestions/suggest_review_home_controller.py
@@ -1,0 +1,18 @@
+import os
+
+from google.appengine.ext.webapp import template
+
+from controllers.suggestions.suggestions_review_base_controller import SuggestionsReviewBaseController
+from helpers.suggestions.suggestion_fetcher import SuggestionFetcher
+from models.suggestion import Suggestion
+
+
+class SuggestReviewHomeController(SuggestionsReviewBaseController):
+    """The main view for a data reviewer to see the state of pending suggestions."""
+    def get(self):
+        self.template_values['video_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "match")
+        self.template_values['webcast_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event")
+        self.template_values['media_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media")
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/suggest_review_home.html')
+        self.response.out.write(template.render(path, self.template_values))

--- a/controllers/suggestions/suggest_review_home_controller.py
+++ b/controllers/suggestions/suggest_review_home_controller.py
@@ -10,9 +10,10 @@ from models.suggestion import Suggestion
 class SuggestReviewHomeController(SuggestionsReviewBaseController):
     """The main view for a data reviewer to see the state of pending suggestions."""
     def get(self):
-        self.template_values['video_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "match")
-        self.template_values['webcast_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event")
-        self.template_values['media_suggestions'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media")
+        self.template_values['suggestions'] = dict()
+        self.template_values['suggestions']['match'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "match")
+        self.template_values['suggestions']['event'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event")
+        self.template_values['suggestions']['media'] = SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media")
 
         path = os.path.join(os.path.dirname(__file__), '../../templates/suggest_review_home.html')
         self.response.out.write(template.render(path, self.template_values))

--- a/controllers/suggestions/suggest_team_media_review_controller.py
+++ b/controllers/suggestions/suggest_team_media_review_controller.py
@@ -74,7 +74,7 @@ class SuggestTeamMediaReviewController(SuggestionsReviewBaseController):
             if suggestion.key.id() in reject_keys:
                 suggestion.review_state = Suggestion.REVIEW_REJECTED
             suggestion.reviewer = self.user_bundle.account.key
-            suggestion.reviewer_at = datetime.datetime.now()
+            suggestion.reviewed_at = datetime.datetime.now()
 
         ndb.put_multi(all_suggestions)
 

--- a/helpers/suggestions/suggestion_fetcher.py
+++ b/helpers/suggestions/suggestion_fetcher.py
@@ -1,0 +1,11 @@
+from google.appengine.ext import ndb
+
+from models.suggestion import Suggestion
+
+class SuggestionFetcher(object):
+    @classmethod
+    def count(self, review_state, suggestion_type):
+        """Return the count of suggestions of a particular type with a particular state."""
+        return Suggestion.query().filter(
+            Suggestion.review_state == review_state).filter(
+            Suggestion.target_model == suggestion_type).count()

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from controllers.suggestions.suggest_match_video_controller import SuggestMatchV
 from controllers.suggestions.suggest_match_video_review_controller import SuggestMatchVideoReviewController
 from controllers.suggestions.suggest_event_webcast_controller import SuggestEventWebcastController
 from controllers.suggestions.suggest_event_webcast_review_controller import SuggestEventWebcastReviewController
+from controllers.suggestions.suggest_review_home_controller import SuggestReviewHomeController
 from controllers.suggestions.suggest_team_media_controller import SuggestTeamMediaController
 from controllers.suggestions.suggest_team_media_review_controller import SuggestTeamMediaReviewController
 from controllers.test_notification_controller import TestNotificationController
@@ -83,6 +84,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/suggest/event/webcast/review', SuggestEventWebcastReviewController, 'suggest-event-webcast-review', strict_slash=True),
       RedirectRoute(r'/suggest/match/video', SuggestMatchVideoController, 'suggest-match-video', strict_slash=True),
       RedirectRoute(r'/suggest/match/video/review', SuggestMatchVideoReviewController, 'suggest-match-video-review', strict_slash=True),
+      RedirectRoute(r'/suggest/review', SuggestReviewHomeController, 'suggest-review-home', strict_slash=True),
       RedirectRoute(r'/suggest/team/media', SuggestTeamMediaController, 'suggest-team-media', strict_slash=True),
       RedirectRoute(r'/suggest/team/media/review', SuggestTeamMediaReviewController, 'suggest-team-media-review', strict_slash=True),
       RedirectRoute(r'/team/<team_number:[0-9]+>', TeamCanonical, 'team-canonical', strict_slash=True),

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -152,26 +152,7 @@ $(function () {
             </div>
             <div class="panel-body">
                 <div class="row">
-                    <ul class="nav nav-pills nav-stacked">
-                        <li>
-                            <a href="/suggest/match/video/review">
-                                <span class="badge pull-right">{{video_suggestions}}</span>
-                                Video Suggestions
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/suggest/event/webcast/review">
-                                <span class="badge pull-right">{{webcast_suggestions}}</span>
-                                Webcast Suggestions
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/suggest/team/media/review">
-                                <span class="badge pull-right">{{media_suggestions}}</span>
-                                Media Suggestions
-                            </a>
-                        </li>
-                    </ul>
+                    {% include "partials/pending_suggestion_rows_partial.html" %}
                 </div>
                 <div class="row">
                     <div id="graphdatabasequery" style="width: 100%; height: 400px;"></div>

--- a/templates/admin/partials/pending_suggestion_rows_partial.html
+++ b/templates/admin/partials/pending_suggestion_rows_partial.html
@@ -1,20 +1,20 @@
 <ul class="nav nav-pills nav-stacked">
     <li>
         <a href="/suggest/match/video/review">
-            <span class="badge pull-right">{{video_suggestions}}</span>
-            Video Suggestions
+            <span class="badge pull-right">{{suggestions.match}}</span>
+            Match Video Suggestions
         </a>
     </li>
     <li>
         <a href="/suggest/event/webcast/review">
-            <span class="badge pull-right">{{webcast_suggestions}}</span>
-            Webcast Suggestions
+            <span class="badge pull-right">{{suggestions.event}}</span>
+            Event Webcast Suggestions
         </a>
     </li>
     <li>
         <a href="/suggest/team/media/review">
-            <span class="badge pull-right">{{media_suggestions}}</span>
-            Media Suggestions
+            <span class="badge pull-right">{{suggestions.media}}</span>
+            Team Media Suggestions
         </a>
     </li>
 </ul>

--- a/templates/admin/partials/pending_suggestion_rows_partial.html
+++ b/templates/admin/partials/pending_suggestion_rows_partial.html
@@ -1,0 +1,20 @@
+<ul class="nav nav-pills nav-stacked">
+    <li>
+        <a href="/suggest/match/video/review">
+            <span class="badge pull-right">{{video_suggestions}}</span>
+            Video Suggestions
+        </a>
+    </li>
+    <li>
+        <a href="/suggest/event/webcast/review">
+            <span class="badge pull-right">{{webcast_suggestions}}</span>
+            Webcast Suggestions
+        </a>
+    </li>
+    <li>
+        <a href="/suggest/team/media/review">
+            <span class="badge pull-right">{{media_suggestions}}</span>
+            Media Suggestions
+        </a>
+    </li>
+</ul>

--- a/templates/suggest_event_webcast_review_list.html
+++ b/templates/suggest_event_webcast_review_list.html
@@ -5,6 +5,10 @@
 {% block content %}
 <div class="container">
 
+    <ol class="breadcrumb">
+        <li><a href="/suggest/review">Suggestions</a></li>
+        <li class="active">Webcasts</li>
+    </ol>
     <h1>{{ suggestion_sets|length }} Pending Webcast Suggestions</h1>
 
     <form action="/suggest/event/webcast/review" method="post">

--- a/templates/suggest_match_video_review_list.html
+++ b/templates/suggest_match_video_review_list.html
@@ -5,6 +5,10 @@
 {% block content %}
 <div class="container">
 
+    <ol class="breadcrumb">
+        <li><a href="/suggest/review">Suggestions</a></li>
+        <li class="active">Match Videos</li>
+    </ol>
     <h1>{{ suggestions|length }} Pending Match Video Suggestions</h1>
 
     <form action="/suggest/match/video/review" method="post">

--- a/templates/suggest_review_home.html
+++ b/templates/suggest_review_home.html
@@ -9,26 +9,7 @@
 
     <div class="row">
         <div class="col-xs-6">
-            <ul class="nav nav-pills nav-stacked">
-                <li>
-                    <a href="/suggest/match/video/review">
-                        <span class="badge pull-right">{{video_suggestions}}</span>
-                        Video Suggestions
-                    </a>
-                </li>
-                <li>
-                    <a href="/suggest/event/webcast/review">
-                        <span class="badge pull-right">{{webcast_suggestions}}</span>
-                        Webcast Suggestions
-                    </a>
-                </li>
-                <li>
-                    <a href="/suggest/team/media/review">
-                        <span class="badge pull-right">{{media_suggestions}}</span>
-                        Media Suggestions
-                    </a>
-                </li>
-            </ul>
+            {% include "admin/partials/pending_suggestion_rows_partial.html" %}
         </div>
     </div>
 

--- a/templates/suggest_review_home.html
+++ b/templates/suggest_review_home.html
@@ -6,6 +6,7 @@
 <div class="container">
 
     <h1>Review Pending Suggestions</h1>
+    <p>Thanks for helping us get more data!</p>
 
     <div class="row">
         <div class="col-xs-6">

--- a/templates/suggest_review_home.html
+++ b/templates/suggest_review_home.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Pending Suggestions{% endblock %}
+
+{% block content %}
+<div class="container">
+
+    <h1>Review Pending Suggestions</h1>
+
+    <div class="row">
+        <div class="col-xs-6">
+            <ul class="nav nav-pills nav-stacked">
+                <li>
+                    <a href="/suggest/match/video/review">
+                        <span class="badge pull-right">{{video_suggestions}}</span>
+                        Video Suggestions
+                    </a>
+                </li>
+                <li>
+                    <a href="/suggest/event/webcast/review">
+                        <span class="badge pull-right">{{webcast_suggestions}}</span>
+                        Webcast Suggestions
+                    </a>
+                </li>
+                <li>
+                    <a href="/suggest/team/media/review">
+                        <span class="badge pull-right">{{media_suggestions}}</span>
+                        Media Suggestions
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/templates/suggest_team_media_review_list.html
+++ b/templates/suggest_team_media_review_list.html
@@ -5,6 +5,10 @@
 {% block content %}
 <div class="container">
 
+  <ol class="breadcrumb">
+    <li><a href="/suggest/review">Suggestions</a></li>
+    <li class="active">Team Medias</li>
+  </ol>
   <h1>{{ suggestions_and_references|length }} Pending Team Media Suggestions</h1>
 
   <h2>Video Approval Guidelines</h2>

--- a/tests/test_suggestion_fetcher.py
+++ b/tests/test_suggestion_fetcher.py
@@ -8,7 +8,7 @@ from models.suggestion import Suggestion
 from helpers.suggestions.suggestion_fetcher import SuggestionFetcher
 
 
-class TestEventTeamRepairer(unittest2.TestCase):
+class TestSuggestionFetcher(unittest2.TestCase):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()

--- a/tests/test_suggestion_fetcher.py
+++ b/tests/test_suggestion_fetcher.py
@@ -1,0 +1,31 @@
+import unittest2
+
+from google.appengine.ext import testbed
+
+from models.account import Account
+from models.suggestion import Suggestion
+
+from helpers.suggestions.suggestion_fetcher import SuggestionFetcher
+
+
+class TestEventTeamRepairer(unittest2.TestCase):
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+
+        account = Account.get_or_insert(
+            "123",
+            email="user@example.com",
+            registered=True).put()
+
+        suggestion = Suggestion(
+            author=account,
+            review_state=Suggestion.REVIEW_PENDING,
+            target_key="2012cmp",
+            target_model="event").put()
+
+    def testCount(self):
+        self.assertEqual(SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "event"), 1)
+        self.assertEqual(SuggestionFetcher.count(Suggestion.REVIEW_PENDING, "media"), 0)


### PR DESCRIPTION
1. Creates a `SuggestionFetcher` helper class to avoid duplicating code between controllers.
2. Creates `SuggestHomeReviewController` to create a standalone page to review suggestions for people with the `MUTATE_DATA` permission who can't check the /admin/ page.
3. Refactor pending suggestion partial out into separate partial.

Problem I ran into: Couldn't put this partial above the admin directory, because the admin template can't reference "up a directory". Maybe Jinja2 templates can fix this? Didn't need to fix it for this.