### PR TITLE
Update API to include event insights

### DIFF
--- a/controllers/api/api_event_controller.py
+++ b/controllers/api/api_event_controller.py
@@ -92,7 +92,7 @@ class ApiEventMatchesController(ApiEventController):
 
 class ApiEventStatsController(ApiEventController):
     CACHE_KEY_FORMAT = "apiv2_event_stats_controller_{}"  # (event_key)
-    CACHE_VERSION = 0
+    CACHE_VERSION = 1
     CACHE_HEADER_LENGTH = 61
 
     def __init__(self, *args, **kw):

--- a/controllers/api/api_event_controller.py
+++ b/controllers/api/api_event_controller.py
@@ -11,6 +11,7 @@ from database.event_query import EventListQuery
 
 from helpers.award_helper import AwardHelper
 from helpers.district_helper import DistrictHelper
+from helpers.event_insights_helper import EventInsightsHelper
 from helpers.model_to_dict import ModelToDict
 
 from models.event import Event
@@ -104,7 +105,16 @@ class ApiEventStatsController(ApiEventController):
     def _render(self, event_key):
         self._set_event(event_key)
 
-        return json.dumps(Event.get_by_id(event_key).matchstats)
+        stats = {}
+        matchstats = self.event.matchstats
+        if matchstats:
+            stats.update(matchstats)
+
+        year_specific = EventInsightsHelper.calculate_event_insights(self.event.matches, self.event.year)
+        if year_specific:
+            stats['year_specific'] = year_specific
+
+        return json.dumps(stats)
 
 
 class ApiEventRankingsController(ApiEventController):


### PR DESCRIPTION
Result looks like this (doesn't include opr/dpr/ccwm since they weren't calculated on this instance)
```
{
  "year_specific": {
    "C_SallyPort": [
      1,
      14,
      7.142857142857143
    ],
    "scales": [
      3,
      66,
      4.545454545454546
    ],
    "captures": [
      0,
      22,
      0
    ],
    "challenges": [
      23,
      66,
      34.84848484848485
    ],
    "A_Portcullis": [
      0,
      2,
      0
    ],
    "D_RockWall": [
      10,
      15,
      66.66666666666667
    ],
    "LowBar": [
      12,
      22,
      54.54545454545455
    ],
    "average_high_goals": 1.9090909090909092,
    "C_Drawbridge": [
      1,
      8,
      12.5
    ],
    "B_Moat": [
      8,
      12,
      66.66666666666667
    ],
    "breaches": [
      4,
      22,
      18.181818181818183
    ],
    "average_boulder_score": 11.090909090909092,
    "NotSpecified": [
      1,
      2,
      50
    ],
    "A_ChevalDeFrise": [
      4,
      18,
      22.22222222222222
    ],
    "average_low_goals": 1.4545454545454546,
    "average_score": 45.68181818181818,
    "average_win_score": 59.18181818181818,
    "B_Ramparts": [
      6,
      10,
      60
    ],
    "average_win_margin": 27,
    "average_foul_score": 4.545454545454546,
    "average_auto_score": 19.818181818181817,
    "average_crossing_score": 41.36363636363637,
    "D_RoughTerrain": [
      6,
      7,
      85.71428571428571
    ],
    "high_score": [
      97,
      "2016scmb_qm3",
      "Q3"
    ],
    "average_tower_score": 14.545454545454545
  }
}
```