### PR TITLE
Make database operations in createOrUpdate a single transaction

### DIFF
--- a/helpers/manipulator_base.py
+++ b/helpers/manipulator_base.py
@@ -78,15 +78,21 @@ class ManipulatorBase(object):
                     old_model._affected_references[attr] = old_model._affected_references[attr].union(val)
 
     @classmethod
+    @ndb.transactional
+    def _createOrUpdateDBOperations(cls, new_models, auto_union):
+        models = cls.listify(cls.findOrSpawn(cls.listify(new_models), auto_union=auto_union))
+        models_to_put = [model for model in models if getattr(model, "dirty", False)]
+        ndb.put_multi(models_to_put)
+        return models, models_to_put
+
+    @classmethod
     def createOrUpdate(self, new_models, auto_union=True, run_post_update_hook=True):
         """
         Given a model or list of models, either insert them into the database, or update
         existing models with the same key.
         Once inserted or updated, the model can be marked not dirty.
         """
-        models = self.listify(self.findOrSpawn(self.listify(new_models), auto_union=auto_union))
-        models_to_put = [model for model in models if getattr(model, "dirty", False)]
-        ndb.put_multi(models_to_put)
+        models, models_to_put = self._createOrUpdateDBOperations(new_models, auto_union)
         self._clearCache(models)
         if run_post_update_hook:
             self.runPostUpdateHook(models_to_put)


### PR DESCRIPTION
Reading models, updating it, and writing them back to the DB should be an atomic operation. This typically isn't a problem because we only ever had one thread operating on a given model at a time (e.g. A task in a task queue to update match scores only ever gets touched by that task). However, if someone writes a video to a match via the Trusted API at the exact moment match scores are being updated, there's a tiny chance one of the writes will get overwritten. This fixes that issue.

@gregmarra I'm not spewing BS here, right? Does it make sense to need this? Imagine two concurrent threads that are trying to update different properties of a model. In the old code, imagine if both threads call `createOrUpdate` and execute `findOrSpawn` at the same time, so the retrieved models in both threads are the original model, A. Thread 1 does its merging and results in a updated model A_1. Thread 2 does its merging and results in an updated model A_2. Thread 1 runs `ndb.put_multi` and puts A_1 in the DB. Thread 2 runs `ndb.put_multi` and puts A_2 in the DB. Now the value in the DB is missing the updates from Thread 1.

It's hard to test because as far as I can tell you can't force multiple instances with the dev appserver to get the concurrency issue to rear it's ugly head. If someone can figure it out, it should be pretty easy to force the issue with a well placed `time.sleep()`.

Documentation on Transactions here: https://cloud.google.com/appengine/docs/python/ndb/transactions