### PR TITLE
Removes team number from ATC link. Fixes #1407

### DIFF
--- a/templates_jinja2/team_partials/team_info.html
+++ b/templates_jinja2/team_partials/team_info.html
@@ -22,7 +22,7 @@
       <a class="hashtag-link hashtag-youtube" href="http://www.youtube.com/results?search_query=%23frc{{ team.team_number }}+OR+%22team+{{ team.team_number }}%22" target="_blank" title="Search YouTube">YouTube</a> &middot;
       <a class="hashtag-link hashtag-cd" href="http://www.chiefdelphi.com/media/photos/tags/frc{{ team.team_number }}" target="_blank" title="Search Chief Delphi">Chief Delphi</a> &middot;
       <a class="hashtag-link hashtag-flickr" href="http://www.flickr.com/search/?q=%23frc{{ team.team_number }}" target="_blank" title="Search Flickr">Flickr</a><br />
-      <span class="image-atc"></span> <a href="http://atthecontrol.com/{{team.team_number}}">See live data on At The Control</a>
+      <span class="image-atc"></span> <a href="http://atthecontrol.com/">See live data on At The Control</a>
     </p>
 
     {% include "team_partials/team_social_media.html" %}


### PR DESCRIPTION
At The Control no longer allows deep links.
Fixes #1407