### PR TITLE
Prevent team media review page from scrolling to top

### DIFF
--- a/templates_jinja2/suggest_team_media_review_list.html
+++ b/templates_jinja2/suggest_team_media_review_list.html
@@ -148,15 +148,18 @@
 
 {% block inline_javascript %}
 <script>
-$("#accept_all_button").click(function() {
+$("#accept_all_button").click(function(e) {
+    e.preventDefault();
     $('.accept').prop('checked', true);
     $('.reject').prop('checked', false);
 });
-$("#reject_all_button").click(function() {
+$("#reject_all_button").click(function(e) {
+    e.preventDefault();
     $('.accept').prop('checked', false);
     $('.reject').prop('checked', true);
 });
-$("#deselect_all_button").click(function() {
+$("#deselect_all_button").click(function(e) {
+    e.preventDefault();
     $('.accept').prop('checked', false);
     $('.reject').prop('checked', false);
 });


### PR DESCRIPTION
The "accept all"/"reject all"/"deselect all" buttons use `href="#"`, which scrolls the page to the top when the element is clicked. This changes the javascript click handlers to prevent that default action.