### PR TITLE
FAB for marking a team as Favorite

### DIFF
--- a/static/css/less_css/less/tba/tba_base.less
+++ b/static/css/less_css/less/tba/tba_base.less
@@ -52,15 +52,6 @@ body {
   margin-bottom: 15px;
 }
 
-.scroll-up {
-  .btn();
-  .btn-default();
-  font-size: 12px;
-  position: fixed;
-  right: 10px;
-  bottom: 10px;
-}
-
 .tba-match-time-utc, .tba-verbose-date-utc, .tba-verbose-time-utc {
   display: none;
 }

--- a/static/css/less_css/less/tba/tba_base.less
+++ b/static/css/less_css/less/tba/tba_base.less
@@ -73,6 +73,24 @@ body {
   display: none;
 }
 
+#fixed-alert-container {
+  position: fixed;
+  top: 20px;
+  left: 0px;
+  right: 0px;
+  margin-right: auto;
+  margin-left: auto;
+  width: 80%;
+  max-width: 500px;
+  z-index: 10000;
+  pointer-events: none;
+
+  .alert {
+    z-index: 10100;
+    pointer-events: auto;
+  }
+}
+
 .tba-fab {
   position: fixed;
   right: 30px;

--- a/static/css/less_css/less/tba/tba_base.less
+++ b/static/css/less_css/less/tba/tba_base.less
@@ -72,3 +72,39 @@ body {
 .reView {
   display: none;
 }
+
+.tba-fab {
+  position: fixed;
+  right: 30px;
+  bottom: 30px;
+  @media (max-width: @screen-sm-max) {
+    right: 15px;
+    bottom: 15px;
+  }
+
+  width: 60px;
+  height: 60px;
+  border-radius: 100%;
+  border: none;
+  outline: none;
+  font-size: 22px;
+  box-shadow:  0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  transition: 0.2s;
+  background: @TBAyellow;
+  background-color: @TBAyellow;
+  color: #ffffff;
+  z-index: 10000;
+
+  .glyphicon {  // Slightly hacky
+    line-height: 1.5;
+    margin-left: 2px;
+  }
+
+  .favorite {
+    display: none;
+  }
+}
+
+.tba-fab:hover {
+  box-shadow:  0 6px 12px rgba(0,0,0,0.16), 0 6px 12px rgba(0,0,0,0.23);
+}

--- a/static/css/less_css/less/tba/tba_variables.less
+++ b/static/css/less_css/less/tba/tba_variables.less
@@ -14,3 +14,7 @@
 // TBA Purples
 // -------------------------
 @TBApurpleDarker:  #220022;
+// TBA Yellows
+// -------------------------
+@TBAyellow:        #ffd600;
+@TBAyellowDark:    #e6c100;

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -1,10 +1,6 @@
 var favoriteTeamsCookieName = "tba-favorite-teams";
 
-function updateFavoriteTeams() {
-  updateFavoriteTeams(null, null);
-}
-
-function updateFavoriteTeams(teamKey, action) {
+function updateFavoriteTeams(teamKey, action, skipDelay) {
   /*
   Updates Favorites locally and on the server and
   updates the page to reflect these changes
@@ -22,7 +18,7 @@ function updateFavoriteTeams(teamKey, action) {
         data: {'model_key': teamKey, 'model_type': 1},
         success: function(data, textStatus, xhr) {
           addLocalFavoriteTeam(teamKey);
-          updateFavoriteTeams();
+          updateFavoriteTeams(null, null, false);
         },
         error: function(xhr, textStatus, errorThrown) {
           if (xhr.status == 401) {
@@ -30,7 +26,7 @@ function updateFavoriteTeams(teamKey, action) {
           } else {
             $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
           }
-          updateFavoriteTeams();
+          updateFavoriteTeams(null, null, false);
         }
       });
     } else if (action == 'delete') {
@@ -41,7 +37,7 @@ function updateFavoriteTeams(teamKey, action) {
         data: {'model_key': teamKey, 'model_type': 1},
         success: function(data, textStatus, xhr) {
           deleteLocalFavoriteTeam(teamKey);
-          updateFavoriteTeams();
+          updateFavoriteTeams(null, null, false);
         },
         error: function(xhr, textStatus, errorThrown) {
           if (xhr.status == 401) {
@@ -49,7 +45,7 @@ function updateFavoriteTeams(teamKey, action) {
           } else {
             $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to delete favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
           }
-          updateFavoriteTeams();
+          updateFavoriteTeams(null, null, false);
         }
       });
     }
@@ -65,15 +61,15 @@ function updateFavoriteTeams(teamKey, action) {
             favoriteTeams[favorites[key]['model_key']] = true;
           }
           setLocalFavoriteTeams(favoriteTeams);
-          updatePageFavoriteTeams(favoriteTeams);
+          updatePageFavoriteTeams(favoriteTeams, skipDelay);
         },
         error: function(xhr, textStatus, errorThrown) {
           setLocalFavoriteTeams(null);
-          updatePageFavoriteTeams({});
+          updatePageFavoriteTeams({}, skipDelay);
         }
       });
     } else {
-      updatePageFavoriteTeams(storedFavoriteTeams);
+      updatePageFavoriteTeams(storedFavoriteTeams, skipDelay);
     }
   }
 }
@@ -108,10 +104,14 @@ function deleteLocalFavoriteTeam(teamKey) {
   }
 }
 
-function updatePageFavoriteTeams(favoriteTeams) {
+function updatePageFavoriteTeams(favoriteTeams, skipDelay) {
   updateMatchFavoriteTeams(favoriteTeams);
   updateTeamlistFavoriteTeams(favoriteTeams);
-  setTimeout(function() {updateTeamFABFavoriteTeams(favoriteTeams)}, 3000);
+  if (skipDelay) {
+    updateTeamFABFavoriteTeams(favoriteTeams);
+  } else {
+    setTimeout(function() {updateTeamFABFavoriteTeams(favoriteTeams)}, 3000);
+  }
 }
 
 function updateMatchFavoriteTeams(favoriteTeams) {
@@ -166,7 +166,7 @@ function setupFavAddClick() {
 
     console.log("CLICK ADD");
     console.log($(this).attr("data-team"));
-    updateFavoriteTeams($(this).attr("data-team"), 'add')
+    updateFavoriteTeams($(this).attr("data-team"), 'add', false);
   });
 }
 
@@ -179,12 +179,12 @@ function setupFavDeleteClick() {
 
     console.log("CLICK DELETE");
     console.log($(this).attr("data-team"));
-    updateFavoriteTeams($(this).attr("data-team"), 'delete')
+    updateFavoriteTeams($(this).attr("data-team"), 'delete', false);
   });
 }
 
 function addSpinner(el) {
-  el.append("<i class='fa fa-refresh fa-spin'/>");
+  el.append("<i class='fa fa-refresh fa-spin'></i>");
   el.prop("disabled", true);
 }
 
@@ -196,5 +196,5 @@ $(document).ready(function(){
 
   console.log(getLocalFavoriteTeams());
   setupFavAddClick();
-  updateFavoriteTeams();
+  updateFavoriteTeams(null, null, true);
 });

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -25,7 +25,8 @@ function updateFavoriteTeams(teamKey, action) {
           updateFavoriteTeams();
         },
         error: function(xhr, textStatus, errorThrown) {
-          $('#mytba-alert-container').append('<div class="alert alert-warning alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          updateFavoriteTeams();
         }
       });
     } else if (action == 'delete') {
@@ -39,7 +40,8 @@ function updateFavoriteTeams(teamKey, action) {
           updateFavoriteTeams();
         },
         error: function(xhr, textStatus, errorThrown) {
-          $('#mytba-alert-container').append('<div class="alert alert-warning alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to delete favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          updateFavoriteTeams();
         }
       });
     }

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -11,7 +11,6 @@ function updateFavoriteTeams(teamKey, action, skipDelay) {
 
   if (teamKey != null) {
     if (action == 'add') {
-      console.log("REMOTE ADD");
       $.ajax({
         type: 'POST',
         url: '/_/account/favorites/add',
@@ -30,7 +29,6 @@ function updateFavoriteTeams(teamKey, action, skipDelay) {
         }
       });
     } else if (action == 'delete') {
-      console.log("REMOTE DELETE");
       $.ajax({
         type: 'POST',
         url: '/_/account/favorites/delete',
@@ -87,20 +85,16 @@ function setLocalFavoriteTeams(favoriteTeams) {
 function addLocalFavoriteTeam(teamKey) {
   var storedFavoriteTeams = getLocalFavoriteTeams();
   if (storedFavoriteTeams != null) {
-    console.log("Adding: " + teamKey);
     storedFavoriteTeams[teamKey] = true;
     setLocalFavoriteTeams(storedFavoriteTeams);
-    console.log(storedFavoriteTeams);
   }
 }
 
 function deleteLocalFavoriteTeam(teamKey) {
   var storedFavoriteTeams = getLocalFavoriteTeams();
   if (storedFavoriteTeams != null && teamKey in storedFavoriteTeams) {
-    console.log("Deleting: " + teamKey);
     delete storedFavoriteTeams[teamKey];
     setLocalFavoriteTeams(storedFavoriteTeams);
-    console.log(storedFavoriteTeams);
   }
 }
 
@@ -164,8 +158,6 @@ function setupFavAddClick() {
     $(this).find(".not-favorite").hide();
     addSpinner($(this));
 
-    console.log("CLICK ADD");
-    console.log($(this).attr("data-team"));
     updateFavoriteTeams($(this).attr("data-team"), 'add', false);
   });
 }
@@ -177,8 +169,6 @@ function setupFavDeleteClick() {
     $(this).find(".favorite").hide();
     addSpinner($(this));
 
-    console.log("CLICK DELETE");
-    console.log($(this).attr("data-team"));
     updateFavoriteTeams($(this).attr("data-team"), 'delete', false);
   });
 }
@@ -194,7 +184,6 @@ $(document).ready(function(){
     window.location.href = '/account?redirect=' + escape(document.URL.replace(document.location.origin, ""));
   });
 
-  console.log(getLocalFavoriteTeams());
   setupFavAddClick();
   updateFavoriteTeams(null, null, true);
 });

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -1,68 +1,170 @@
-function getFavoriteTeams() {
-  var cookieName = "tba-favorite-teams";
-  var storedFavoriteTeams = $.cookie(cookieName);
+var favoriteTeamsCookieName = "tba-favorite-teams2";
 
-  console.log(storedFavoriteTeams);
+function updateFavoriteTeams() {
+  updateFavoriteTeams(null, null);
+}
 
-  if (storedFavoriteTeams == null) {
-    // Set cookie expiration
-    var date = new Date();
-    date.setTime(date.getTime() + (5 * 60 * 1000));  // 5 minutes
+function updateFavoriteTeams(teamKey, action) {
+  /*
+  Updates Favorites locally and on the server and
+  updates the page to reflect these changes
+  teamKey: like "frc254" or null
+  action: "add" or "delete" or null (doesn't do anything if teamKey is null)
+  */
+  var storedFavoriteTeams = getLocalFavoriteTeams();
 
-    $.ajax({
-      type: 'GET',
-      dataType: 'json',
-      url: '/_/account/favorites/1',
-      success: function(favorites, textStatus, xhr) {
-        var favoriteTeams = {};
-        for (var key in favorites) {
-          favoriteTeams[favorites[key]['model_key']] = true;
+  if (teamKey != null) {
+    if (action == 'add') {
+      console.log("REMOTE ADD");
+      $.ajax({
+        type: 'POST',
+        url: '/_/account/favorites/add',
+        data: {'model_key': teamKey, 'model_type': 1},
+        success: function(data, textStatus, xhr) {
+          addLocalFavoriteTeam(teamKey);
+          updateFavoriteTeams();
+        },
+        error: function(xhr, textStatus, errorThrown) {
+          $('#mytba-alert-container').append('<div class="alert alert-warning alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
         }
-        $.cookie(cookieName, JSON.stringify(favoriteTeams), { expires: date });
-
-        updateFavorites(favoriteTeams);
-      },
-      error: function(xhr, textStatus, errorThrown) {
-        $.cookie(cookieName, JSON.stringify({}), { expires: date });
-      }
-    });
+      });
+    } else if (action == 'delete') {
+      console.log("REMOTE DELETE");
+      $.ajax({
+        type: 'POST',
+        url: '/_/account/favorites/delete',
+        data: {'model_key': teamKey, 'model_type': 1},
+        success: function(data, textStatus, xhr) {
+          deleteLocalFavoriteTeam(teamKey);
+          updateFavoriteTeams();
+        },
+        error: function(xhr, textStatus, errorThrown) {
+          $('#mytba-alert-container').append('<div class="alert alert-warning alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+        }
+      });
+    }
   } else {
-    updateFavorites(JSON.parse(storedFavoriteTeams));
+    if (storedFavoriteTeams == null) {
+      $.ajax({
+        type: 'GET',
+        dataType: 'json',
+        url: '/_/account/favorites/1',
+        success: function(favorites, textStatus, xhr) {
+          var favoriteTeams = {};
+          for (var key in favorites) {
+            favoriteTeams[favorites[key]['model_key']] = true;
+          }
+          setLocalFavoriteTeams(favoriteTeams);
+          updatePageFavoriteTeams(favoriteTeams);
+        },
+        error: function(xhr, textStatus, errorThrown) {
+          setLocalFavoriteTeams({});
+        }
+      });
+    } else {
+      updatePageFavoriteTeams(storedFavoriteTeams);
+    }
   }
 }
 
-function updateFavorites(favoriteTeams) {
-  updateMatchFavorites(favoriteTeams);
-  updateTeamlistFavorites(favoriteTeams);
-  updateTeamFABFavorites(favoriteTeams);
+function getLocalFavoriteTeams() {
+  return JSON.parse($.cookie(favoriteTeamsCookieName));
 }
 
-function updateMatchFavorites(favoriteTeams) {
+function setLocalFavoriteTeams(favoriteTeams) {
+  var date = new Date();
+  date.setTime(date.getTime() + (5 * 60 * 1000));  // Set 5 minutes cookie expiration
+  // $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), { expires: date });
+}
+
+function addLocalFavoriteTeam(teamKey) {
+  var storedFavoriteTeams = getLocalFavoriteTeams();
+  if (storedFavoriteTeams != null) {
+    console.log("Adding: " + teamKey);
+    storedFavoriteTeams[teamKey] = true;
+    setLocalFavoriteTeams(storedFavoriteTeams);
+    console.log(storedFavoriteTeams);
+  }
+}
+
+function deleteLocalFavoriteTeam(teamKey) {
+  var storedFavoriteTeams = getLocalFavoriteTeams();
+  if (storedFavoriteTeams != null && teamKey in storedFavoriteTeams) {
+    console.log("Deleting: " + teamKey);
+    delete storedFavoriteTeams[teamKey];
+    setLocalFavoriteTeams(storedFavoriteTeams);
+    console.log(storedFavoriteTeams);
+  }
+}
+
+function updatePageFavoriteTeams(favoriteTeams) {
+  updateMatchFavoriteTeams(favoriteTeams);
+  updateTeamlistFavoriteTeams(favoriteTeams);
+  updateTeamFABFavoriteTeams(favoriteTeams);
+}
+
+function updateMatchFavoriteTeams(favoriteTeams) {
+  // Reset all stars
+  $(".favorite-match-icon").each(function() {
+    $(this).hide();
+  });
+
   $(".favorite-team-dot").each(function() {
     if ($(this).attr("data-team") in favoriteTeams) {
       $(this).show();  // Dot
       $(this).closest('tr').find('.favorite-match-icon').show();  // Star
+    } else {
+      $(this).hide();  // Dot
     }
   });
 }
 
-function updateTeamlistFavorites(favoriteTeams) {
+function updateTeamlistFavoriteTeams(favoriteTeams) {
   $(".favorite-team-icon").each(function() {
     if ($(this).attr("data-team") in favoriteTeams) {
       $(this).show();
+    } else {
+      $(this).hide();
     }
   });
 }
 
-function updateTeamFABFavorites(favoriteTeams) {
+function updateTeamFABFavoriteTeams(favoriteTeams) {
   $(".tba-fab-team").each(function() {
     if ($(this).attr("data-team") in favoriteTeams) {
       $(this).find(".favorite").show();
       $(this).find(".not-favorite").hide();
+      setupFavDeleteClick();
+    } else {
+      $(this).find(".favorite").hide();
+      $(this).find(".not-favorite").show();
+      setupFavAddClick();
     }
   });
 }
 
+function setupFavAddClick() {
+  $(".tba-fab-team").off("click");  // make sure only one click handler is attached at a time
+  $(".tba-fab-team").click(function() {
+    $(".tba-fab-team").off("click");
+    console.log("CLICK ADD");
+    console.log($(this).attr("data-team"));
+    updateFavoriteTeams($(this).attr("data-team"), 'add')
+  });
+}
+
+function setupFavDeleteClick() {
+  $(".tba-fab-team").off("click");  // make sure only one click handler is attached at a time
+  $(".tba-fab-team").click(function() {
+    $(".tba-fab-team").off("click");
+    console.log("CLICK DELETE");
+    console.log($(this).attr("data-team"));
+    updateFavoriteTeams($(this).attr("data-team"), 'delete')
+  });
+}
+
 $(document).ready(function(){
-  getFavoriteTeams();
+  console.log(getLocalFavoriteTeams());
+  setupFavAddClick();
+  updateFavoriteTeams();
 });

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -85,7 +85,7 @@ function getLocalFavoriteTeams() {
 function setLocalFavoriteTeams(favoriteTeams) {
   var date = new Date();
   date.setTime(date.getTime() + (1 * 60 * 1000));  // Set 5 minutes cookie expiration
-  $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), { expires: date });
+  // $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), {expires: date, path: '/'});
 }
 
 function addLocalFavoriteTeam(teamKey) {

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -30,9 +30,11 @@ function getFavoriteTeams() {
     updateFavorites(JSON.parse(storedFavoriteTeams));
   }
 }
+
 function updateFavorites(favoriteTeams) {
   updateMatchFavorites(favoriteTeams);
   updateTeamlistFavorites(favoriteTeams);
+  updateTeamFABFavorites(favoriteTeams);
 }
 
 function updateMatchFavorites(favoriteTeams) {
@@ -48,6 +50,15 @@ function updateTeamlistFavorites(favoriteTeams) {
   $(".favorite-team-icon").each(function() {
     if ($(this).attr("data-team") in favoriteTeams) {
       $(this).show();
+    }
+  });
+}
+
+function updateTeamFABFavorites(favoriteTeams) {
+  $(".tba-fab-team").each(function() {
+    if ($(this).attr("data-team") in favoriteTeams) {
+      $(this).find(".favorite").show();
+      $(this).find(".not-favorite").hide();
     }
   });
 }

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -25,7 +25,11 @@ function updateFavoriteTeams(teamKey, action) {
           updateFavoriteTeams();
         },
         error: function(xhr, textStatus, errorThrown) {
-          $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          if (xhr.status == 401) {
+            $('#login-modal').modal('show');
+          } else {
+            $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to add favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          }
           updateFavoriteTeams();
         }
       });
@@ -40,7 +44,11 @@ function updateFavoriteTeams(teamKey, action) {
           updateFavoriteTeams();
         },
         error: function(xhr, textStatus, errorThrown) {
-          $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to delete favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          if (xhr.status == 401) {
+            $('#login-modal').modal('show');
+          } else {
+            $('#fixed-alert-container').append('<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Oops! Failed to delete favorite.</strong><br>Something went wrong on our end. Please try again later.</div>');
+          }
           updateFavoriteTeams();
         }
       });
@@ -60,7 +68,8 @@ function updateFavoriteTeams(teamKey, action) {
           updatePageFavoriteTeams(favoriteTeams);
         },
         error: function(xhr, textStatus, errorThrown) {
-          setLocalFavoriteTeams({});
+          setLocalFavoriteTeams(null);
+          updatePageFavoriteTeams({});
         }
       });
     } else {
@@ -75,8 +84,8 @@ function getLocalFavoriteTeams() {
 
 function setLocalFavoriteTeams(favoriteTeams) {
   var date = new Date();
-  date.setTime(date.getTime() + (5 * 60 * 1000));  // Set 5 minutes cookie expiration
-  // $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), { expires: date });
+  date.setTime(date.getTime() + (1 * 60 * 1000));  // Set 5 minutes cookie expiration
+  $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), { expires: date });
 }
 
 function addLocalFavoriteTeam(teamKey) {
@@ -180,6 +189,11 @@ function addSpinner(el) {
 }
 
 $(document).ready(function(){
+  // Setup redirect after login
+  $('#mytba-login').click(function() {
+    window.location.href = '/account?redirect=' + escape(document.URL.replace(document.location.origin, ""));
+  });
+
   console.log(getLocalFavoriteTeams());
   setupFavAddClick();
   updateFavoriteTeams();

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -114,7 +114,8 @@ function updateMatchFavoriteTeams(favoriteTeams) {
   $(".favorite-team-dot").each(function() {
     if ($(this).attr("data-team") in favoriteTeams) {
       $(this).show();  // Dot
-      $(this).closest('tr').find('.favorite-match-icon').show();  // Star
+      var match_key = $(this).attr("data-match");
+      $('.favorite-match-icon-' + match_key).show();  // Star
     } else {
       $(this).hide();  // Dot
     }

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -102,7 +102,7 @@ function deleteLocalFavoriteTeam(teamKey) {
 function updatePageFavoriteTeams(favoriteTeams) {
   updateMatchFavoriteTeams(favoriteTeams);
   updateTeamlistFavoriteTeams(favoriteTeams);
-  updateTeamFABFavoriteTeams(favoriteTeams);
+  setTimeout(function() {updateTeamFABFavoriteTeams(favoriteTeams)}, 3000);
 }
 
 function updateMatchFavoriteTeams(favoriteTeams) {
@@ -133,13 +133,13 @@ function updateTeamlistFavoriteTeams(favoriteTeams) {
 
 function updateTeamFABFavoriteTeams(favoriteTeams) {
   $(".tba-fab-team").each(function() {
+    $(this).find(".fa-spin").remove();
+    $(this).prop("disabled", false);
     if ($(this).attr("data-team") in favoriteTeams) {
-      $(this).find(".fa-spin").remove();
       $(this).find(".not-favorite").hide();
       $(this).find(".favorite").show();
       setupFavDeleteClick();
     } else {
-      $(this).find(".fa-spin").remove();
       $(this).find(".favorite").hide();
       $(this).find(".not-favorite").show();
       setupFavAddClick();
@@ -175,6 +175,7 @@ function setupFavDeleteClick() {
 
 function addSpinner(el) {
   el.append("<i class='fa fa-refresh fa-spin'/>");
+  el.prop("disabled", true);
 }
 
 $(document).ready(function(){

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -62,7 +62,6 @@ function updateFavoriteTeams(teamKey, action, skipDelay) {
           updatePageFavoriteTeams(favoriteTeams, skipDelay);
         },
         error: function(xhr, textStatus, errorThrown) {
-          setLocalFavoriteTeams(null);
           updatePageFavoriteTeams({}, skipDelay);
         }
       });
@@ -78,8 +77,8 @@ function getLocalFavoriteTeams() {
 
 function setLocalFavoriteTeams(favoriteTeams) {
   var date = new Date();
-  date.setTime(date.getTime() + (1 * 60 * 1000));  // Set 5 minutes cookie expiration
-  // $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), {expires: date, path: '/'});
+  date.setTime(date.getTime() + (5 * 60 * 1000));  // Set 5 minutes cookie expiration
+  $.cookie(favoriteTeamsCookieName, JSON.stringify(favoriteTeams), {expires: date, path: '/'});
 }
 
 function addLocalFavoriteTeam(teamKey) {

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -1,4 +1,4 @@
-var favoriteTeamsCookieName = "tba-favorite-teams2";
+var favoriteTeamsCookieName = "tba-favorite-teams";
 
 function updateFavoriteTeams() {
   updateFavoriteTeams(null, null);
@@ -132,10 +132,12 @@ function updateTeamlistFavoriteTeams(favoriteTeams) {
 function updateTeamFABFavoriteTeams(favoriteTeams) {
   $(".tba-fab-team").each(function() {
     if ($(this).attr("data-team") in favoriteTeams) {
-      $(this).find(".favorite").show();
+      $(this).find(".fa-spin").remove();
       $(this).find(".not-favorite").hide();
+      $(this).find(".favorite").show();
       setupFavDeleteClick();
     } else {
+      $(this).find(".fa-spin").remove();
       $(this).find(".favorite").hide();
       $(this).find(".not-favorite").show();
       setupFavAddClick();
@@ -147,6 +149,9 @@ function setupFavAddClick() {
   $(".tba-fab-team").off("click");  // make sure only one click handler is attached at a time
   $(".tba-fab-team").click(function() {
     $(".tba-fab-team").off("click");
+    $(this).find(".not-favorite").hide();
+    addSpinner($(this));
+
     console.log("CLICK ADD");
     console.log($(this).attr("data-team"));
     updateFavoriteTeams($(this).attr("data-team"), 'add')
@@ -157,10 +162,17 @@ function setupFavDeleteClick() {
   $(".tba-fab-team").off("click");  // make sure only one click handler is attached at a time
   $(".tba-fab-team").click(function() {
     $(".tba-fab-team").off("click");
+    $(this).find(".favorite").hide();
+    addSpinner($(this));
+
     console.log("CLICK DELETE");
     console.log($(this).attr("data-team"));
     updateFavoriteTeams($(this).attr("data-team"), 'delete')
   });
+}
+
+function addSpinner(el) {
+  el.append("<i class='fa fa-refresh fa-spin'/>");
 }
 
 $(document).ready(function(){

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,8 @@
 
 <div id="fb-root"></div>
 
+<div id="fixed-alert-container"></div>
+
 {% block navbar %}
 <div class="navbar navbar-default navbar-fixed-top">
   <div class="container">

--- a/templates/base.html
+++ b/templates/base.html
@@ -127,8 +127,6 @@
 </div>
 {% endblock %}
 
-<a class="scroll-up visible-xs smooth-scroll" href="#"><span class="glyphicon glyphicon-arrow-up"></span></a>
-
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -127,6 +127,28 @@
 </div>
 {% endblock %}
 
+<!-- Login Modal -->
+<div id="login-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 class="text-center">Follow your favorite teams with myTBA</h3>
+      </div>
+      <div class="modal-body">
+        <p>myTBA lets you customize your experience when using The Blue Alliance.</p>
+        <p><strong><span class="glyphicon glyphicon-star"></span> Favorites</strong> are used for personalized content and quick access.</p>
+        <p><strong><span class="glyphicon glyphicon-bell"></span> Subscriptions</strong> are used for push notifications.</p>
+        <hr>
+        <p>Your settings will be accessible both on <a href="/" target="_blank">www.thebluealliance.com</a> and our <a href="https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient" target="_blank">Android app</a>.</p>
+        <p>Sign in with your Google Account to start using myTBA!</p>
+        <br>
+        <button id="mytba-login" type="button" class="btn btn-success btn-lg btn-block" data-dismiss="modal">Yes, I'm in!</button>
+        <button type="button" class="btn btn-danger btn-lg btn-block" data-dismiss="modal">No thanks.</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js"></script>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -29,6 +29,8 @@
 
 <div id="fb-root"></div>
 
+<div id="fixed-alert-container"></div>
+
 {% block navbar %}
 <div class="navbar navbar-default navbar-fixed-top">
   <div class="container">

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -127,8 +127,6 @@
 </div>
 {% endblock %}
 
-<a class="scroll-up visible-xs smooth-scroll" href="#"><span class="glyphicon glyphicon-arrow-up"></span></a>
-
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js"></script>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -127,6 +127,28 @@
 </div>
 {% endblock %}
 
+<!-- Login Modal -->
+<div id="login-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 class="text-center">Follow your favorite teams with myTBA</h3>
+      </div>
+      <div class="modal-body">
+        <p>myTBA lets you customize your experience when using The Blue Alliance.</p>
+        <p><strong><span class="glyphicon glyphicon-star"></span> Favorites</strong> are used for personalized content and quick access.</p>
+        <p><strong><span class="glyphicon glyphicon-bell"></span> Subscriptions</strong> are used for push notifications.</p>
+        <hr>
+        <p>Your settings will be accessible both on <a href="/" target="_blank">www.thebluealliance.com</a> and our <a href="https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient" target="_blank">Android app</a>.</p>
+        <p>Sign in with your Google Account to start using myTBA!</p>
+        <br>
+        <button id="mytba-login" type="button" class="btn btn-success btn-lg btn-block" data-dismiss="modal">Yes, I'm in!</button>
+        <button type="button" class="btn btn-danger btn-lg btn-block" data-dismiss="modal">No thanks.</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js"></script>

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -15,7 +15,7 @@
 {% macro match_name_td(match, compact=False) %}
 <td{% if compact %} rowspan="2"{% endif %}>
   <div class="match-name-container">
-    <div class="favorite-match-icon">
+    <div class="favorite-match-icon favorite-match-icon-{{match.key.id()}}">
         <span class="favorite-match-icon-spacer"></span>
         <span class="glyphicon glyphicon-star" rel="tooltip" title="A Favorited team is in this match!"></span>
     </div>
@@ -47,7 +47,7 @@
   {% endif %}
 {% endif %}
 <td colspan="{{colspan}}" class="{{alliance_color}}{% if match.winning_alliance == alliance_color %} winner{% endif %}{% if cur_team_key and cur_team_key == team_key %} current-team{% endif %}">
-  <svg class="favorite-team-dot" data-team="{{team_key}}" rel="tooltip" title="You have Favorited this team!">
+  <svg class="favorite-team-dot" data-team="{{team_key}}" data-match="{{match.key.id()}}" rel="tooltip" title="You have Favorited this team!">
     <circle cx="2.5" cy="2.5" r="2.5"/>
   </svg>
   <a href="/team/{{team_key|digits}}/{{match.year}}">{{ team_key|strip_frc }}</a>

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -10,6 +10,11 @@
 {% endblock %}
 
 {% block content %}
+<button class="tba-fab tba-fab-team" data-team="{{team.key.id()}}">
+  <span class="glyphicon glyphicon-star favorite"></span>
+  <span class="glyphicon glyphicon-star-empty not-favorite"></span>
+</button>
+
 <div class="container">
   <div class="row">
     <div class="col-sm-3 col-lg-2">


### PR DESCRIPTION
Currently only for Team pages, but is designed with modularity in mind to be used for other pages as well as replace GameDay's current myTBA login prompts. Only Favs (and not Subs) for now because it was way simpler and we don't make use of Subs on the website right now anyways.


Logged out:
![image](https://cloud.githubusercontent.com/assets/1421884/13834979/f4d136ac-ebc9-11e5-85a1-72f9b8dbb4f4.png)

After clicking the FAB (if logged out):
![image](https://cloud.githubusercontent.com/assets/1421884/13834981/ff6a3f78-ebc9-11e5-83ac-267f0fe4acf1.png)

After logging in:
![image](https://cloud.githubusercontent.com/assets/1421884/13834985/0fad4ce0-ebca-11e5-875f-861a950029ae.png)

Clicking the FAB send an AJAX request to the server and updates the local list of Favorites stored in a cookie:
![image](https://cloud.githubusercontent.com/assets/1421884/13835029/7d4ff0c2-ebca-11e5-9116-e7c95dbbc7c7.png)

After Favoriting:
![image](https://cloud.githubusercontent.com/assets/1421884/13835055/a9a5edd4-ebca-11e5-8783-378c95e85282.png)

If server 500's when trying to add or delete a favorite:
![image](https://cloud.githubusercontent.com/assets/1421884/13835078/e0687b52-ebca-11e5-8d5d-92737465cca8.png)
