### PR TITLE
Fix the link to the FIRST event page

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -174,7 +174,9 @@
     <div class="tab-pane" id="rankings">
       <div class="row">
         <div class="col-sm-8 col-sm-offset-2 col-md-offset-2 col-lg-offset-2">
-          <p>Data from <a href="http://www2.usfirst.org/{{event.year}}comp/events/{{event.event_short}}/rankings.html" target="_blank"> <em>FIRST</em>'s event page</a>.</p>
+          {% if event.official %}
+            <p>Data from <a href="http://frc-events.firstinspires.org/{{event.year}}/{{event.event_short}}/rankings" target="_blank"> <em>FIRST</em>'s event page</a>.</p>
+          {% endif %}
           <table class="table table-striped table-condensed table-center tablesorter" id="rankingsTable">
             <thead>
               <tr>


### PR DESCRIPTION
Done on the github web editor, so sorry if the formatting comes out weird. Also stops the link from showing up for non-official events.

This may not work for Championship divisions, which seems to use a brand new identifier, i.e. `http://frc-events.firstinspires.org/2016/ARCHIMEDES`. Not sure I have a good enough handle on TBAs codebase to decide what to do here.

Fixes #1417 and #1224