### PR TITLE
Fix error with test schedule update notification

### DIFF
--- a/controllers/test_notification_controller.py
+++ b/controllers/test_notification_controller.py
@@ -54,7 +54,7 @@ class TestNotificationController(LoggedInHandler):
         elif type == NotificationType.DISTRICT_POINTS_UPDATED:
             notification = DistrictPointsUpdatedNotification('2014ne')
         elif type == NotificationType.SCHEDULE_UPDATED:
-            notification = ScheduleUpdatedNotification(event)
+            notification = ScheduleUpdatedNotification(event, match)
         elif type == NotificationType.FINAL_RESULTS:
             # Not implemented yet
             pass

--- a/notifications/schedule_updated.py
+++ b/notifications/schedule_updated.py
@@ -6,13 +6,16 @@ from notifications.base_notification import BaseNotification
 
 class ScheduleUpdatedNotification(BaseNotification):
 
-    def __init__(self, event):
+    def __init__(self, event, next_match=None):
         from helpers.match_helper import MatchHelper  # recursive import issues
         self.event = event
         self._event_feed = event.key_name
         self._district_feed = event.event_district_abbrev
-        upcoming = MatchHelper.upcomingMatches(event.matches, 1)
-        self.next_match = upcoming[0] if upcoming[0] else None
+        if not next_match:
+            upcoming = MatchHelper.upcomingMatches(event.matches, 1)
+            self.next_match = upcoming[0] if upcoming and len(upcoming) > 0 else None
+        else:
+            self.next_match = next_match
 
     @property
     def _type(self):


### PR DESCRIPTION
When the event has no more unplayed matches, it broke.

Now, the test page can specify the next match outright

Here's the trace:
```
INFO     2016-03-29 04:32:00,321 test_notification_controller.py:29] Sending for 7
ERROR    2016-03-29 04:32:00,442 main_controller.py:42] list index out of range
Traceback (most recent call last):
  File "/home/phil/google_appengine/lib/webapp2-2.3/webapp2.py", line 1505, in __call__
    rv = self.router.dispatch(request, response)
  File "/home/phil/google_appengine/lib/webapp2-2.3/webapp2.py", line 1253, in default_dispatcher
    return route.handler_adapter(request, response)
  File "/home/phil/google_appengine/lib/webapp2-2.3/webapp2.py", line 1077, in __call__
    return handler.dispatch()
  File "/home/phil/google_appengine/lib/webapp2-2.3/webapp2.py", line 547, in dispatch
    return self.handle_exception(e, self.app.debug)
  File "/home/phil/google_appengine/lib/webapp2-2.3/webapp2.py", line 545, in dispatch
    return method(*args, **kwargs)
  File "/home/phil/Documents/Code/the-blue-alliance/controllers/test_notification_controller.py", line 57, in get
    notification = ScheduleUpdatedNotification(event)
  File "/home/phil/Documents/Code/the-blue-alliance/notifications/schedule_updated.py", line 15, in __init__
    self.next_match = upcoming[0] if upcoming[0] else None
IndexError: list index out of range
```