### PR TITLE
Add event timezone to API

### DIFF
--- a/controllers/api/api_event_controller.py
+++ b/controllers/api/api_event_controller.py
@@ -19,7 +19,7 @@ from models.event import Event
 
 class ApiEventController(ApiBaseController):
     CACHE_KEY_FORMAT = "apiv2_event_controller_{}"  # (event_key)
-    CACHE_VERSION = 4
+    CACHE_VERSION = 5
     CACHE_HEADER_LENGTH = 61
 
     def __init__(self, *args, **kw):

--- a/helpers/model_to_dict.py
+++ b/helpers/model_to_dict.py
@@ -52,6 +52,7 @@ class ModelToDict(object):
         event_dict["official"] = event.official
         event_dict["facebook_eid"] = event.facebook_eid
         event_dict["website"] = event.website
+        event_dict["timezone"] = event.timezone_id
 
         if event.alliance_selections:
             event_dict["alliances"] = event.alliance_selections

--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -253,6 +253,11 @@
             <td>Long Beach Arena\n300 East Ocean Blvd\nLong Beach, CA 90802\nUSA</td>
           </tr>
           <tr>
+            <td>timezone</td>
+            <td>Timezone name, as found in the <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database</a></td>
+            <td>America/New_York</td>
+          </tr>
+          <tr>
             <td>website</td>
             <td>The event's website, if any.</td>
             <td>http://www.firstsv.org</td>

--- a/tests/test_apiv2_event_controller.py
+++ b/tests/test_apiv2_event_controller.py
@@ -49,6 +49,7 @@ class TestEventApiController(unittest2.TestCase):
                 location='Clemson, SC',
                 venue="Long Beach Arena",
                 venue_address="Long Beach Arena\r\n300 East Ocean Blvd\r\nLong Beach, CA 90802\r\nUSA",
+                timezone_id="America/New_York",
                 start_date=datetime(2010, 03, 24),
                 webcast_json="[{\"type\": \"twitch\", \"channel\": \"frcgamesense\"}]",
                 alliance_selections_json="[ {\"declines\": [], \"picks\": [\"frc971\", \"frc254\", \"frc1662\"]},"+
@@ -83,6 +84,7 @@ class TestEventApiController(unittest2.TestCase):
         self.assertEqual(event["webcast"], json.loads(self.event.webcast_json))
         self.assertEqual(event["alliances"], json.loads(self.event.alliance_selections_json))
         self.assertEqual(event["website"], self.event.website)
+        self.assertEqual(event["timezone"], self.event.timezone_id)
 
     def testEventApi(self):
         response = self.testapp.get('/2010sc', headers={"X-TBA-App-Id": "tba-tests:event-controller-test:v01"})


### PR DESCRIPTION
Exposes event timezone string (like "America/New_York") in the API event
model.

Fixes #1444