### PR TITLE
Show old Rankings page for some events

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -179,7 +179,11 @@
       <div class="row">
         <div class="col-sm-8 col-sm-offset-2 col-md-offset-2 col-lg-offset-2">
           {% if event.official %}
-            <p>Data from <a href="http://frc-events.firstinspires.org/{{event.year}}/{{event.event_short}}/rankings" target="_blank"> <em>FIRST</em>'s event page</a>.</p>
+            {% if event.year > 2014 %}
+              <p>Data from <a href="http://frc-events.firstinspires.org/{{event.year}}/{{event.event_short}}/rankings" target="_blank"> <em>FIRST</em>'s event page</a>.</p>
+            {% else %}
+              <p>Data from <a href="http://www2.usfirst.org/{{event.year}}comp/events/{{event.event_short}}/rankings.html" target="_blank"> <em>FIRST</em>'s event page</a>.</p>
+            {% endif %}
           {% endif %}
           <table class="table table-striped table-condensed table-center tablesorter" id="rankingsTable">
             <thead>


### PR DESCRIPTION
For events 2014 and before, there's no data on
frc-events.firstinspires.org, so we can fall back to showing the old
data