### PR TITLE
Fixed API Link

### DIFF
--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -1614,7 +1614,7 @@
           </tr>
           <tr>
             <td>Java</td>
-            <td><a href="https://github.com/AdiSai/TheBlueAlliance-Java">TheBlueAlliance-Java</a></td>
+            <td><a href="https://github.com/AdiSai/TheBlueAlliance">TheBlueAlliance</a></td>
           </tr>
           <tr>
             <td>Java</td>


### PR DESCRIPTION
The API changed name, which caused the link to change.