### PR TITLE
Show when pages are rendered

### DIFF
--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -1,5 +1,6 @@
 import cPickle
 import logging
+import time
 import webapp2
 import zlib
 
@@ -52,6 +53,7 @@ class CacheableHandler(webapp2.RequestHandler):
         if cached_response is None:
             self._set_cache_header_length(self.CACHE_HEADER_LENGTH)
             self.template_values["cache_key"] = self.cache_key
+            self.template_values["render_time"] = time.strftime('%b %d %Y at %l:%M%p %Z')
             rendered = self._render(*args, **kw)
             if self._has_been_modified_since(self._last_modified):
                 self.response.out.write(rendered)

--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -53,7 +53,7 @@ class CacheableHandler(webapp2.RequestHandler):
         if cached_response is None:
             self._set_cache_header_length(self.CACHE_HEADER_LENGTH)
             self.template_values["cache_key"] = self.cache_key
-            self.template_values["render_time"] = time.strftime('%b %d %Y at %l:%M%p %Z')
+            self.template_values["render_time"] = time.strftime('%b. %d, %Y at %l:%M%p %Z')
             rendered = self._render(*args, **kw)
             if self._has_been_modified_since(self._last_modified):
                 self.response.out.write(rendered)

--- a/templates/base.html
+++ b/templates/base.html
@@ -108,6 +108,11 @@
 
       <hr>
 
+      {% if render_time %}
+      <div>
+          <p>This page was generated on {{ render_time }}</p>
+      </div>
+      {% endif %}
       <div>The Blue Alliance is <a href="https://github.com/the-blue-alliance/the-blue-alliance/">open source</a>. Help improve it!</div>
       <div>
         <a href="/about">about</a> -

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -108,6 +108,11 @@
 
       <hr>
 
+      {% if render_time %}
+      <div>
+          <p>This page was generated at {{ render_time }}</p>
+      </div>
+      {% endif %}
       <div>The Blue Alliance is <a href="https://github.com/the-blue-alliance/the-blue-alliance/">open source</a>. Help improve it!</div>
       <div>
         <a href="/about">about</a> -

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -110,7 +110,7 @@
 
       {% if render_time %}
       <div>
-          <p>This page was generated at {{ render_time }}</p>
+          <p>This page was generated on {{ render_time }}</p>
       </div>
       {% endif %}
       <div>The Blue Alliance is <a href="https://github.com/the-blue-alliance/the-blue-alliance/">open source</a>. Help improve it!</div>


### PR DESCRIPTION
To help avoid some cache-based confusion (we just admit to stale data)
Suggested by @gregmarra in #1468

![screenshot from 2016-04-11 22-55-44](https://cloud.githubusercontent.com/assets/2754863/14448686/e46e9f24-0038-11e6-86ab-c0cb17a5b11f.png)