### PR TITLE
Set GCM High Priority Messages

### DIFF
--- a/controllers/gcm/gcm.py
+++ b/controllers/gcm/gcm.py
@@ -44,8 +44,9 @@ class GCMMessage:
     collapse_key = None
     delay_while_idle = None
     time_to_live = None
+    priority = None
 
-    def __init__(self, device_tokens, notification, collapse_key=None, delay_while_idle=None, time_to_live=None):
+    def __init__(self, device_tokens, notification, collapse_key=None, delay_while_idle=None, time_to_live=None, priority=None):
         if isinstance(device_tokens, list):
             self.device_tokens = device_tokens
         else:
@@ -55,6 +56,7 @@ class GCMMessage:
         self.collapse_key = collapse_key
         self.delay_while_idle = delay_while_idle
         self.time_to_live = time_to_live
+        self.priority = priority
 
     def __unicode__(self):
         return "%s:%s:%s:%s:%s" % (repr(self.device_tokens), repr(self.notification), repr(self.collapse_key), repr(self.delay_while_idle), repr(self.time_to_live))
@@ -81,6 +83,8 @@ class GCMMessage:
             json_dict['delay_while_idle'] = self.delay_while_idle
         if self.time_to_live:
             json_dict['time_to_live'] = self.time_to_live
+        if self.priority:
+            json_dict['priority'] = self.priority
 
         json_str = json.dumps(json_dict)
         return json_str

--- a/notifications/alliance_selections.py
+++ b/notifications/alliance_selections.py
@@ -5,6 +5,8 @@ from notifications.base_notification import BaseNotification
 
 class AllianceSelectionNotification(BaseNotification):
 
+    _priority = 'high'
+
     def __init__(self, event):
         self.event = event
         self._event_feed = event.key_name

--- a/notifications/awards_updated.py
+++ b/notifications/awards_updated.py
@@ -6,6 +6,8 @@ from notifications.base_notification import BaseNotification
 
 class AwardsUpdatedNotification(BaseNotification):
 
+    _priority = 'high'
+
     def __init__(self, event):
         self.event = event
         self._event_feed = event.key_name

--- a/notifications/base_notification.py
+++ b/notifications/base_notification.py
@@ -37,6 +37,11 @@ class BaseNotification(object):
     # Can be overridden if not
     _push_firebase = True
 
+    # GCM Priority for this message, set to "High" for important pushes
+    # Valid types are 'high' and 'normal'
+    # https://developers.google.com/cloud-messaging/concept-options#setting-the-priority-of-a-message
+    _priority = 'normal'
+
     """
     Class that acts as a basic notification.
     To send a notification, instantiate one and call this method
@@ -105,7 +110,7 @@ class BaseNotification(object):
     def _render_android(self):
         gcm_keys = self.keys[ClientType.OS_ANDROID]
         data = self._build_dict()
-        return GCMMessage(gcm_keys, data)
+        return GCMMessage(gcm_keys, data, priority=self._priority)
 
     def _render_ios(self):
         pass

--- a/notifications/level_starting.py
+++ b/notifications/level_starting.py
@@ -6,6 +6,8 @@ from notifications.base_notification import BaseNotification
 
 class CompLevelStartingNotification(BaseNotification):
 
+    _priority = 'high'
+
     def __init__(self, match, event):
         self.match = match
         self.event = event

--- a/notifications/match_score.py
+++ b/notifications/match_score.py
@@ -5,6 +5,8 @@ from notifications.base_notification import BaseNotification
 
 class MatchScoreNotification(BaseNotification):
 
+    _priority = 'high'
+
     def __init__(self, match):
         self.match = match
         self.event = match.event.get()

--- a/notifications/schedule_updated.py
+++ b/notifications/schedule_updated.py
@@ -6,6 +6,8 @@ from notifications.base_notification import BaseNotification
 
 class ScheduleUpdatedNotification(BaseNotification):
 
+    _priority = 'high'
+
     def __init__(self, event, next_match=None):
         from helpers.match_helper import MatchHelper  # recursive import issues
         self.event = event

--- a/notifications/upcoming_match.py
+++ b/notifications/upcoming_match.py
@@ -7,6 +7,8 @@ from notifications.base_notification import BaseNotification
 
 class UpcomingMatchNotification(BaseNotification):
 
+    _priority = 'high'
+
     def __init__(self, match, event):
         self.match = match
         self.event = event


### PR DESCRIPTION
But only for the commonly used event-result pushes

See the docs: https://developers.google.com/cloud-messaging/concept-options#setting-the-priority-of-a-message

Closes #1462