### PR TITLE
myTBA on Navbar & Cleanup Login Flow

### DIFF
--- a/controllers/account_controller.py
+++ b/controllers/account_controller.py
@@ -136,6 +136,9 @@ class AccountRegister(LoggedInHandler):
 
 class AccountLogin(LoggedInHandler):
     def get(self):
+        if self.user_bundle.user:
+            self.redirect('/account', abort=True)
+
         redirect = self.request.get('redirect')
         if redirect:
             url = self._get_login_url(redirect)

--- a/controllers/account_controller.py
+++ b/controllers/account_controller.py
@@ -99,11 +99,7 @@ class AccountEdit(LoggedInHandler):
 
 class AccountRegister(LoggedInHandler):
     def get(self):
-        redirect = self.request.get('redirect')
-        if redirect:
-            self._require_login(redirect)
-        else:
-            self._require_login()
+        self._require_login()
 
         # Redirects if already registered
         if self.user_bundle.account.registered:
@@ -112,7 +108,7 @@ class AccountRegister(LoggedInHandler):
             else:
                 self.redirect('/account', abort=True)
 
-        self.template_values['redirect'] = redirect
+        self.template_values['redirect'] = self.request.get('redirect')
         self.response.out.write(jinja2_engine.render('account_register.html', self.template_values))
 
     def post(self):
@@ -150,8 +146,7 @@ class AccountLogin(LoggedInHandler):
 
 class AccountLoginRequired(LoggedInHandler):
     def get(self):
-        redirect = self.request.get('redirect')
-        self.template_values['redirect'] = redirect
+        self.template_values['redirect'] = self.request.get('redirect')
         self.response.out.write(jinja2_engine.render('account_login_required.html', self.template_values))
 
 

--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -144,7 +144,9 @@ class LoggedInHandler(webapp2.RequestHandler):
 
     def _require_login(self, redirect_url=None):
         if not self.user_bundle.user:
-            if redirect_url is None:
+            if not redirect_url:
+                redirect_url = self.request.get('redirect')
+            if not redirect_url:
                 redirect_url = self.request.url
             return self.redirect(
                 '/account/login_required?redirect={}'.format(redirect_url),
@@ -164,7 +166,9 @@ class LoggedInHandler(webapp2.RequestHandler):
 
     def _require_registration(self, redirect_url=None):
         if not self.user_bundle.account.registered:
-            if redirect_url is None:
+            if not redirect_url:
+                redirect_url = self.request.get('redirect')
+            if not redirect_url:
                 redirect_url = self.request.url
             return self.redirect(
                 '/account/register?redirect={}'.format(redirect_url),

--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -134,15 +134,20 @@ class LoggedInHandler(webapp2.RequestHandler):
         self.response.headers['Expires'] = '0'
         self.response.headers['Vary'] = 'Accept-Encoding'
 
+    def _get_login_url(self, target_url):
+        return self.user_bundle.create_login_url(target_url)
+
     def _require_admin(self):
         self._require_login()
         if not self.user_bundle.is_current_user_admin:
             return self.redirect(self.user_bundle.login_url, abort=True)
 
-    def _require_login(self, target_url="/"):
+    def _require_login(self, redirect_url=None):
         if not self.user_bundle.user:
+            if redirect_url is None:
+                redirect_url = self.request.url
             return self.redirect(
-                self.user_bundle.create_login_url(target_url),
+                '/account/login_required?redirect={}'.format(redirect_url),
                 abort=True
             )
 
@@ -157,9 +162,11 @@ class LoggedInHandler(webapp2.RequestHandler):
                 abort=True
             )
 
-    def _require_registration(self, target_url="/"):
+    def _require_registration(self, redirect_url=None):
         if not self.user_bundle.account.registered:
+            if redirect_url is None:
+                redirect_url = self.request.url
             return self.redirect(
-                target_url,
+                '/account/register?redirect={}'.format(redirect_url),
                 abort=True
             )

--- a/controllers/mytba_controller.py
+++ b/controllers/mytba_controller.py
@@ -15,7 +15,7 @@ from models.team import Team
 
 class MyTBALiveController(LoggedInHandler):
     def get(self):
-        self._require_login('/account/register')
+        self._require_login('/mytba')
         self._require_registration('/account/register')
 
         user = self.user_bundle.account.key

--- a/controllers/mytba_controller.py
+++ b/controllers/mytba_controller.py
@@ -15,8 +15,8 @@ from models.team import Team
 
 class MyTBALiveController(LoggedInHandler):
     def get(self):
-        self._require_login('/mytba')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         user = self.user_bundle.account.key
         team_favorites_future = Favorite.query(Favorite.model_type == ModelType.TEAM, ancestor=user).fetch_async()

--- a/controllers/notification_controller.py
+++ b/controllers/notification_controller.py
@@ -14,8 +14,8 @@ class UserNotificationBroadcast(LoggedInHandler):
     """
 
     def post(self):
-        self._require_login('/account/register')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         # Check to make sure that they aren't trying to edit another user
         current_user_account_id = self.user_bundle.account.key.id()

--- a/controllers/suggestions/suggest_event_webcast_controller.py
+++ b/controllers/suggestions/suggest_event_webcast_controller.py
@@ -13,7 +13,7 @@ class SuggestEventWebcastController(LoggedInHandler):
     """
 
     def get(self):
-        self._require_login("/suggest/event/webcast?event=%s" % self.request.get("event_key"))
+        self._require_login()
 
         if not self.request.get("event_key"):
             self.redirect("/", abort=True)

--- a/controllers/suggestions/suggest_match_video_controller.py
+++ b/controllers/suggestions/suggest_match_video_controller.py
@@ -17,7 +17,7 @@ class SuggestMatchVideoController(LoggedInHandler):
     """
 
     def get(self):
-        self._require_login("/suggest/match/video?match=%s" % self.request.get("match_key"))
+        self._require_login()
 
         if not self.request.get("match_key"):
             self.redirect("/", abort=True)
@@ -55,7 +55,7 @@ class SuggestMatchVideoPlaylistController(LoggedInHandler):
     Allow users to suggest a playlist of YouTube videos for matches
     """
     def get(self):
-        self._require_login("/suggest/event/video?event_key={}".format(self.request.get("event_key")))
+        self._require_login()
 
         if not self.request.get("event_key"):
             self.redirect("/", abort=True)

--- a/controllers/suggestions/suggest_team_media_controller.py
+++ b/controllers/suggestions/suggest_team_media_controller.py
@@ -22,7 +22,7 @@ class SuggestTeamMediaController(LoggedInHandler):
         team_key = self.request.get("team_key")
         year_str = self.request.get("year")
 
-        self._require_login("/suggest/team/media?team_key=%s&year=%s" % (team_key, year_str))
+        self._require_login()
 
         if not team_key or not year_str:
             self.redirect("/", abort=True)

--- a/controllers/webhook_controller.py
+++ b/controllers/webhook_controller.py
@@ -14,15 +14,15 @@ from models.mobile_client import MobileClient
 
 class WebhookAdd(LoggedInHandler):
     def get(self):
-        self._require_login('/account/register')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         path = os.path.join(os.path.dirname(__file__), '../templates/webhook_add.html')
         self.response.out.write(template.render(path, self.template_values))
 
     def post(self):
-        self._require_login('/account/register')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         # Check to make sure that they aren't trying to edit another user
         current_user_account_id = self.user_bundle.account.key.id()
@@ -56,8 +56,8 @@ class WebhookAdd(LoggedInHandler):
 
 class WebhookDelete(LoggedInHandler):
     def post(self):
-        self._require_login('/account/register')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         # Check to make sure that they aren't trying to edit another user
         current_user_account_id = self.user_bundle.account.key.id()
@@ -73,8 +73,8 @@ class WebhookDelete(LoggedInHandler):
 
 class WebhookVerify(LoggedInHandler):
     def get(self, client_id):
-        self._require_login('/account/register')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         self.template_values['client_id'] = client_id
         self.template_values['error'] = self.request.get('error')
@@ -83,8 +83,8 @@ class WebhookVerify(LoggedInHandler):
         self.response.out.write(template.render(path, self.template_values))
 
     def post(self, client_id):
-        self._require_login('/account/register')
-        self._require_registration('/account/register')
+        self._require_login()
+        self._require_registration()
 
         # Check to make sure the user isn't trying to impersonate another
         current_user_account_id = self.user_bundle.account.key.id()
@@ -108,8 +108,8 @@ class WebhookVerify(LoggedInHandler):
 
 class WebhookVerificationSend(LoggedInHandler):
     def post(self):
-        self._require_login('/account_register')
-        self._require_registration('/account_register')
+        self._require_login()
+        self._require_registration()
 
         current_user_account_id = self.user_bundle.account.key.id()
         target_account_id = self.request.get('account_id')

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from webapp2_extras.routes import RedirectRoute
 
 import tba_config
 
-from controllers.account_controller import AccountEdit, AccountLogout, AccountOverview, AccountRegister, MyTBAController, MyTBAEventController, MyTBATeamController
+from controllers.account_controller import AccountEdit, AccountLoginRequired, AccountLogin, AccountLogout, AccountOverview, AccountRegister, MyTBAController, MyTBAEventController, MyTBATeamController
 from controllers.ajax_controller import AccountFavoritesHandler, AccountFavoritesAddHandler, AccountFavoritesDeleteHandler, \
       YouTubePlaylistHandler
 from controllers.ajax_controller import LiveEventHandler, TypeaheadHandler, WebcastHandler
@@ -59,6 +59,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/account', AccountOverview, 'account-overview', strict_slash=True),
       RedirectRoute(r'/account/edit', AccountEdit, 'account-edit', strict_slash=True),
       RedirectRoute(r'/account/register', AccountRegister, 'account-register', strict_slash=True),
+      RedirectRoute(r'/account/login_required', AccountLoginRequired, 'account-login-required', strict_slash=True),
       RedirectRoute(r'/account/mytba', MyTBAController, 'account-mytba', strict_slash=True),
       RedirectRoute(r'/account/mytba/event/<event_key>', MyTBAEventController, 'account-mytba-event', strict_slash=True),
       RedirectRoute(r'/account/mytba/team/<team_number:[0-9]+>', MyTBATeamController, 'account-mytba-team', strict_slash=True),
@@ -78,6 +79,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/hashtags', HashtagsHandler, 'hashtags', strict_slash=True),
       RedirectRoute(r'/insights/<year:[0-9]+>', InsightsDetail, 'insights-detail', strict_slash=True),
       RedirectRoute(r'/insights', InsightsOverview, 'insights', strict_slash=True),
+      RedirectRoute(r'/login', AccountLogin, 'account-login', strict_slash=True),
       RedirectRoute(r'/logout', AccountLogout, 'account-logout', strict_slash=True),
       RedirectRoute(r'/match/<match_key>', MatchDetail, 'match-detail', strict_slash=True),
       RedirectRoute(r'/matchinput', MatchInputHandler, 'match-input', strict_slash=True),

--- a/static/javascript/tba_js/gameday_mytba.js
+++ b/static/javascript/tba_js/gameday_mytba.js
@@ -1,7 +1,7 @@
 $(function() {
     // Setup redirect after login
     $('#mytba-login').click(function() {
-      window.location.href = '/account?redirect=' + escape(document.URL.replace(document.location.origin, ""));
+      window.location.href = '/login?redirect=' + escape(document.URL.replace(document.location.origin, ""));
     });
 
     updateFavoritesList();  // Setup

--- a/static/javascript/tba_js/tba_favorites.js
+++ b/static/javascript/tba_js/tba_favorites.js
@@ -182,7 +182,7 @@ function addSpinner(el) {
 $(document).ready(function(){
   // Setup redirect after login
   $('#mytba-login').click(function() {
-    window.location.href = '/account?redirect=' + escape(document.URL.replace(document.location.origin, ""));
+    window.location.href = '/login?redirect=' + escape(document.URL.replace(document.location.origin, ""));
   });
 
   setupFavAddClick();

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,8 +49,8 @@
 
     <ul class="nav navbar-nav tba-navbar-nav">
       <li class="tba-nav-persistent {% block mytba_active %}{% endblock %}"><a href="/mytba"><span><span class="glyphicon glyphicon-star"></span> MyTBA</span></a></li>
-      <li class="tba-nav-persistent {% block teams_active %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
       <li class="tba-nav-persistent {% block events_active %}{% endblock %}"><a href="/events"><span><span class="glyphicon glyphicon-calendar"></span> Events</span></a></li>
+      <li class="tba-nav-persistent hidden-xs {% block teams_active %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
       <li class="tba-nav-persistent hidden-xs {% block insights_active %}{% endblock %}"><a href="/insights"><span><span class="glyphicon glyphicon-align-left"></span> Insights</span></a></li>
       <li class="tba-nav-persistent hidden-xs"><a href="/gameday"><span><span class="glyphicon glyphicon-facetime-video"></span> GameDay</span></a></li>
       <li class="tba-nav-persistent hidden-xs hidden-sm dropdown">
@@ -63,6 +63,7 @@
 
     <div class="navbar-collapse collapse tba-navbar-collapse tba-collapse navbar-responsive-collapse">
       <ul class="nav navbar-nav">
+        <li class="visible-xs {% block teams_active_collapsed %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
         <li class="visible-xs {% block insights_active_collapsed %}{% endblock %}"><a href="/insights"><span><span class="glyphicon glyphicon-align-left"></span> Insights</span></a></li>
         <li class="visible-xs"><a href="/gameday"><span><span class="glyphicon glyphicon-facetime-video"></span> GameDay</span></a></li>
         <li class="visible-xs visible-sm"><a href="/account"><span class="glyphicon glyphicon-cog"></span> Account</a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,6 +48,7 @@
     <a class="navbar-brand tba-navbar-brand hidden-lg" href="/">TBA</a>
 
     <ul class="nav navbar-nav tba-navbar-nav">
+      <li class="tba-nav-persistent {% block mytba_active %}{% endblock %}"><a href="/mytba"><span><span class="glyphicon glyphicon-star"></span> MyTBA</span></a></li>
       <li class="tba-nav-persistent {% block teams_active %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
       <li class="tba-nav-persistent {% block events_active %}{% endblock %}"><a href="/events"><span><span class="glyphicon glyphicon-calendar"></span> Events</span></a></li>
       <li class="tba-nav-persistent hidden-xs {% block insights_active %}{% endblock %}"><a href="/insights"><span><span class="glyphicon glyphicon-align-left"></span> Insights</span></a></li>

--- a/templates/index_lhc.html
+++ b/templates/index_lhc.html
@@ -7,8 +7,8 @@
 </form>
 <br>
 <div class="btn-group btn-group-block-2">
-  <a class="btn btn-primary btn-lg" href="/teams"><span class="glyphicon glyphicon-user"></span> Teams</a>
   <a class="btn btn-primary btn-lg" href="/events"><span class="glyphicon glyphicon-calendar"></span> Events</a>
+  <a class="btn btn-primary btn-lg" href="/teams"><span class="glyphicon glyphicon-user"></span> Teams</a>
 </div>
 <div class="hidden-xs">
   <br>

--- a/templates/mytba_live.html
+++ b/templates/mytba_live.html
@@ -4,6 +4,8 @@
 
 {% block meta_description %}View how your favorite teams are doing.{% endblock %}
 
+{% block mytba_active %}active{% endblock %}
+
 {% block content %}
 <div class="container">
   <div class="row">

--- a/templates/team_list.html
+++ b/templates/team_list.html
@@ -12,6 +12,7 @@
 {% endblock %}
 
 {% block teams_active %}active{% endblock %}
+{% block teams_active_collapsed %}active{% endblock %}
 
 {% block content %}
 <div class="container">

--- a/templates_jinja2/account_login_required.html
+++ b/templates_jinja2/account_login_required.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}The Blue Alliance - Login Required{% endblock %}
+
+{% block meta_description %}Login Required{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-sm-8 col-sm-offset-2">
+      <h1>Please log in to your TBA Account</h1>
+
+
+      <div class="row">
+        <div class="col-md-6">
+          <p>Your account settings will be accessible both on <a href="/">www.thebluealliance.com</a> and our <a href="https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient" target="_blank">Android app</a>.</p>
+        </div>
+        <div class="col-md-6">
+          <a href="/login{% if redirect %}?redirect={{redirect|safe}}{% endif %}" class="btn btn-success btn-block" role="button">Take me to the login page!</a>
+          <a href="javascript:history.back()" class="btn btn-default btn-block" role="button">No thanks, take me back.</a>
+        </div>
+      </div>
+
+      <hr>
+
+      <h3>myTBA</h3>
+      <p>Signing in enables myTBA, which lets you customize your experience when using The Blue Alliance.</p>
+      <p><strong><span class="glyphicon glyphicon-star"></span> Favorites</strong> are used for personalized content and quick access.</p>
+      <p><strong><span class="glyphicon glyphicon-bell"></span> Subscriptions</strong> are used for push notifications.</p>
+
+      <hr>
+
+      <h3>Content Submission</h3>
+      <p>When logged in, you can help contribute by submitting match videos, team photos, and more for review. Once approved,
+      they will be available for everyone to see. In the future, we hope to have a leaderboard to show our top contributors!</p>
+
+      <hr>
+
+      <h3>About Google Accounts</h3>
+      <p>The Blue Alliance uses <a href="https://myaccount.google.com" target="_blank">Google Accounts</a> to handle our login.
+      Only your email address is shared with us and it will always be kept private.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates_jinja2/account_register.html
+++ b/templates_jinja2/account_register.html
@@ -10,7 +10,7 @@
     <div class="col-md-8 col-md-offset-2">
       <h1>Greetings, {{user_bundle.user.nickname()}}!</h1>
       <p>Fill out this short form to finish signing up for a TBA account.</p>
-      <form class="account_signup_form" action="/account/register" method="post">
+      <form class="account_signup_form" action="/account/register{% if redirect %}?redirect={{redirect}}{% endif %}" method="post">
         <table class="table table-striped">
           <tbody>
             <tr>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -49,8 +49,8 @@
 
     <ul class="nav navbar-nav tba-navbar-nav">
       <li class="tba-nav-persistent {% block mytba_active %}{% endblock %}"><a href="/mytba"><span><span class="glyphicon glyphicon-star"></span> MyTBA</span></a></li>
-      <li class="tba-nav-persistent {% block teams_active %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
       <li class="tba-nav-persistent {% block events_active %}{% endblock %}"><a href="/events"><span><span class="glyphicon glyphicon-calendar"></span> Events</span></a></li>
+      <li class="tba-nav-persistent hidden-xs {% block teams_active %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
       <li class="tba-nav-persistent hidden-xs {% block insights_active %}{% endblock %}"><a href="/insights"><span><span class="glyphicon glyphicon-align-left"></span> Insights</span></a></li>
       <li class="tba-nav-persistent hidden-xs"><a href="/gameday"><span><span class="glyphicon glyphicon-facetime-video"></span> GameDay</span></a></li>
       <li class="tba-nav-persistent hidden-xs hidden-sm dropdown">
@@ -63,6 +63,7 @@
 
     <div class="navbar-collapse collapse tba-navbar-collapse tba-collapse navbar-responsive-collapse">
       <ul class="nav navbar-nav">
+        <li class="visible-xs {% block teams_active_collapsed %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
         <li class="visible-xs {% block insights_active_collapsed %}{% endblock %}"><a href="/insights"><span><span class="glyphicon glyphicon-align-left"></span> Insights</span></a></li>
         <li class="visible-xs"><a href="/gameday"><span><span class="glyphicon glyphicon-facetime-video"></span> GameDay</span></a></li>
         <li class="visible-xs visible-sm"><a href="/account"><span class="glyphicon glyphicon-cog"></span> Account</a></li>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -48,6 +48,7 @@
     <a class="navbar-brand tba-navbar-brand hidden-lg" href="/">TBA</a>
 
     <ul class="nav navbar-nav tba-navbar-nav">
+      <li class="tba-nav-persistent {% block mytba_active %}{% endblock %}"><a href="/mytba"><span><span class="glyphicon glyphicon-star"></span> MyTBA</span></a></li>
       <li class="tba-nav-persistent {% block teams_active %}{% endblock %}"><a href="/teams"><span><span class="glyphicon glyphicon-user"></span> Teams</span></a></li>
       <li class="tba-nav-persistent {% block events_active %}{% endblock %}"><a href="/events"><span><span class="glyphicon glyphicon-calendar"></span> Events</span></a></li>
       <li class="tba-nav-persistent hidden-xs {% block insights_active %}{% endblock %}"><a href="/insights"><span><span class="glyphicon glyphicon-align-left"></span> Insights</span></a></li>


### PR DESCRIPTION
Don't merge until we have a better empty landing page for `/mytba` or Champs starts (since it won't be empty then.)

Instead of kicking a user straight to the Google login page when visiting a page that requires login, we now show the following page:
![image](https://cloud.githubusercontent.com/assets/1421884/14695551/20edd582-0741-11e6-86ed-6bddb5ee0804.png)

Also did a bunch of refactoring so that 
`self._require_login()` and `self._require_registration()` are much more intuitive to use.