### PR TITLE
Embed video for highest scoring match if available

### DIFF
--- a/helpers/insights_helper.py
+++ b/helpers/insights_helper.py
@@ -102,7 +102,9 @@ class InsightsHelper(object):
                 'verbose_name': match.verbose_name,
                 'event_name': event.name,
                 'alliances': match.alliances,
-                'winning_alliance': match.winning_alliance
+                'winning_alliance': match.winning_alliance,
+                'tba_video': match.tba_video,
+                'youtube_videos_formatted': match.youtube_videos_formatted
                 }
 
     @classmethod

--- a/templates_jinja2/insights_details.html
+++ b/templates_jinja2/insights_details.html
@@ -23,10 +23,10 @@
         {{mtm.single_match_table(match, force_played=True)}}
         {% if match.tba_video %}
           {% include "video_partials/tbavideo_player.html" %}
-        {% endif %}
-        {% for youtube_video in match.youtube_videos_formatted %}
+        {% elif match.youtube_videos_formatted %}
+          {% set youtube_video = match.youtube_videos_formatted.0 %}
           {% include "video_partials/youtube_video_player.html" %}
-        {% endfor %}
+        {% endif %}
       </div>
       {% endfor %}
     </div>

--- a/templates_jinja2/insights_details.html
+++ b/templates_jinja2/insights_details.html
@@ -21,6 +21,12 @@
       <h4><a href="/match/{{match.key_name}}">{{ match.event_name }} <small>{{ match.verbose_name }}</small></a></h4>
       <div class="col-xs-8 col-xs-offset-2">
         {{mtm.single_match_table(match, force_played=True)}}
+        {% if match.tba_video %}
+          {% include "video_partials/tbavideo_player.html" %}
+        {% endif %}
+        {% for youtube_video in match.youtube_videos_formatted %}
+          {% include "video_partials/youtube_video_player.html" %}
+        {% endfor %}
       </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
This embeds the video(s) for the highest scoring match on the insights page for each year if it is available as described in #383. Should I also do this to the insights on the landing page?