### PR TITLE
Consolidate Media Templates

### DIFF
--- a/controllers/suggestions/suggest_social_media_review_controller.py
+++ b/controllers/suggestions/suggest_social_media_review_controller.py
@@ -8,6 +8,7 @@ from google.appengine.ext import ndb
 from consts.media_type import MediaType
 from controllers.suggestions.suggestions_review_base_controller import SuggestionsReviewBaseController
 from helpers.media_manipulator import MediaManipulator
+from helpers.suggestions.media_creator import MediaCreator
 from models.media import Media
 from models.suggestion import Suggestion
 from template_engine import jinja2_engine
@@ -55,9 +56,6 @@ class SuggestSocialMediaReviewController(SuggestionsReviewBaseController):
         # Async get
         suggestion_future = Suggestion.get_by_id_async(accept_key)
 
-        # Setup
-        to_replace_id = self.request.POST.get('replace-preferred-{}'.format(accept_key), None)
-
         # Resolve async Futures
         suggestion = suggestion_future.get_result()
 
@@ -68,17 +66,8 @@ class SuggestSocialMediaReviewController(SuggestionsReviewBaseController):
         team_reference = Media.create_reference(
             suggestion.contents['reference_type'],
             suggestion.contents['reference_key'])
-        media_type_enum = suggestion.contents['media_type_enum']
 
-        media = Media(
-            id=Media.render_key_name(suggestion.contents['media_type_enum'], suggestion.contents['foreign_key']),
-            foreign_key=suggestion.contents['foreign_key'],
-            media_type_enum=media_type_enum,
-            details_json=suggestion.contents.get('details_json', None),
-            private_details_json=suggestion.contents.get('private_details_json', None),
-            year=int(suggestion.contents['year']) if not suggestion.contents.get('is_social', False) else None,
-            references=[team_reference],
-        )
+        media = MediaCreator.create_media(suggestion, team_reference)
 
         # Mark Suggestion as accepted
         suggestion.review_state = Suggestion.REVIEW_ACCEPTED

--- a/controllers/suggestions/suggest_team_media_review_controller.py
+++ b/controllers/suggestions/suggest_team_media_review_controller.py
@@ -8,6 +8,7 @@ from google.appengine.ext import ndb
 from consts.media_type import MediaType
 from controllers.suggestions.suggestions_review_base_controller import SuggestionsReviewBaseController
 from helpers.media_manipulator import MediaManipulator
+from helpers.suggestions.media_creator import MediaCreator
 from models.media import Media
 from models.suggestion import Suggestion
 from template_engine import jinja2_engine
@@ -105,16 +106,7 @@ class SuggestTeamMediaReviewController(SuggestionsReviewBaseController):
         if media_type_enum in MediaType.image_types and ('preferred::{}'.format(suggestion.key.id()) in preferred_keys or to_replace_id):
             preferred_references = [team_reference]
 
-        media = Media(
-            id=Media.render_key_name(suggestion.contents['media_type_enum'], suggestion.contents['foreign_key']),
-            foreign_key=suggestion.contents['foreign_key'],
-            media_type_enum=media_type_enum,
-            details_json=suggestion.contents.get('details_json', None),
-            private_details_json=suggestion.contents.get('private_details_json', None),
-            year=int(suggestion.contents['year']) if not suggestion.contents.get('is_social', False) else None,
-            references=[team_reference],
-            preferred_references=preferred_references,
-        )
+        media = MediaCreator.create_media(suggestion, team_reference, preferred_references)
 
         # Mark Suggestion as accepted
         suggestion.review_state = Suggestion.REVIEW_ACCEPTED

--- a/helpers/suggestions/media_creator.py
+++ b/helpers/suggestions/media_creator.py
@@ -1,0 +1,21 @@
+from models.media import Media
+
+
+class MediaCreator(object):
+    """
+    Used to create a Media object from an accepted Suggestion
+    """
+
+    @classmethod
+    def create_media(cls, suggestion, team_reference, preferred_references=[]):
+        media_type_enum = suggestion.contents['media_type_enum']
+        return Media(
+            id=Media.render_key_name(media_type_enum, suggestion.contents['foreign_key']),
+            foreign_key=suggestion.contents['foreign_key'],
+            media_type_enum=media_type_enum,
+            details_json=suggestion.contents.get('details_json', None),
+            private_details_json=suggestion.contents.get('private_details_json', None),
+            year=int(suggestion.contents['year']) if not suggestion.contents.get('is_social', False) else None,
+            references=[team_reference],
+            preferred_references=preferred_references,
+        )

--- a/models/suggestion.py
+++ b/models/suggestion.py
@@ -2,7 +2,9 @@ import json
 
 from google.appengine.ext import ndb
 
+from helpers.suggestions.media_creator import MediaCreator
 from models.account import Account
+from models.media import Media
 
 
 class Suggestion(ndb.Model):
@@ -44,6 +46,13 @@ class Suggestion(ndb.Model):
     def contents(self, contents):
         self._contents = contents
         self.contents_json = json.dumps(self._contents)
+
+    @property
+    def candidate_media(self):
+        team_reference = Media.create_reference(
+            self.contents['reference_type'],
+            self.contents['reference_key'])
+        return MediaCreator.create_media(self, team_reference)
 
     @property
     def youtube_video(self):

--- a/templates_jinja2/media_partials/media_display_partial.html
+++ b/templates_jinja2/media_partials/media_display_partial.html
@@ -1,9 +1,10 @@
 {% if media.media_type_enum == 1 %}
+    <!-- CD Photo Thread -->
     {% include "media_partials/cdphotothread_partial.html" %}
-{% endif %}
-{% if media.media_type_enum == 0 %}
+{% elif media.media_type_enum == 0 %}
+    <!-- YouTube Video -->
     {% include "media_partials/youtube_partial.html" %}
-{% endif %}
-{% if media.media_type_enum == 2 %}
+{% elif media.media_type_enum == 2 %}
+    <!-- Imgur Image -->
     {% include "media_partials/imgur_partial.html" %}
 {% endif %}

--- a/templates_jinja2/media_partials/media_display_partial.html
+++ b/templates_jinja2/media_partials/media_display_partial.html
@@ -1,0 +1,9 @@
+{% if media.media_type_enum == 1 %}
+    {% include "media_partials/cdphotothread_partial.html" %}
+{% endif %}
+{% if media.media_type_enum == 0 %}
+    {% include "media_partials/youtube_partial.html" %}
+{% endif %}
+{% if media.media_type_enum == 2 %}
+    {% include "media_partials/imgur_partial.html" %}
+{% endif %}

--- a/templates_jinja2/media_partials/social_media_macros.html
+++ b/templates_jinja2/media_partials/social_media_macros.html
@@ -11,3 +11,41 @@
 {% endif %}
 {{ media.foreign_key }}</a>
 {% endmacro %}
+
+{% macro social_media_card(suggestion) %}
+    {% if suggestion.contents.media_type_enum == 3 %}
+        <!-- Facebook profile -->
+        <div class="fb-page"
+             data-href="https://www.facebook.com/{{ suggestion.contents.foreign_key }}"
+             data-hide-cover="false" data-show-facepile="false" data-show-posts="false"
+             data-width="500">
+            <div class="fb-xfbml-parse-ignore">
+                <blockquote cite="https://www.facebook.com/{{ suggestion.contents.foreign_key }}"><a
+                        href="https://www.facebook.com/">Facebook
+                    Profile: {{ suggestion.contents.foreign_key }}</a></blockquote>
+            </div>
+        </div>
+    {% elif suggestion.contents.media_type_enum == 4 %}
+        <!-- Twitter profile -->
+        <a class="twitter-timeline" href="https://twitter.com/{{ suggestion.contents.foreign_key }}"
+           data-widget-id="715993204777172992"
+           data-screen-name="{{ suggestion.contents.foreign_key }}">Tweets by
+            @{{ suggestion.contents.foreign_key }}</a>
+        <script>!function (d, s, id) {
+            var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https';
+            if (!d.getElementById(id)) {
+                js = d.createElement(s);
+                js.id = id;
+                js.src = p + "://platform.twitter.com/widgets.js";
+                fjs.parentNode.insertBefore(js, fjs);
+            }
+        }(document, "script", "twitter-wjs");</script>
+    {% elif suggestion.contents.media_type_enum == 5 %}
+        <!-- YouTube profile -->
+        {{ suggestion.contents.site_name }}:
+        <a href="{{ suggestion.contents.profile_url }}">{{ suggestion.contents.foreign_key }}</a>
+    {% elif suggestion.contents.media_type_enum == 6 %}
+        <!-- GitHub profile -->
+        <div class="github-card" data-user="{{ suggestion.contents.foreign_key }}"></div>
+    {% endif %}
+{% endmacro %}

--- a/templates_jinja2/media_partials/social_partial.html
+++ b/templates_jinja2/media_partials/social_partial.html
@@ -1,3 +1,0 @@
-<div>
-    <p>{{ media.type_name }}: <a href="{{ media.social_profile_url }}" target="_blank">{{ media.foreign_key }}</a></p>
-</div>

--- a/templates_jinja2/suggest_team_media_review_list.html
+++ b/templates_jinja2/suggest_team_media_review_list.html
@@ -78,19 +78,8 @@
                   </div>
                   <div class="col-xs-5 fitvids">
                       <p><strong><a href="/team/{{reference.team_number}}/{{suggestion.contents.year}}" target="_blank">Team {{reference.team_number}}{% if reference.nickname %} - {{reference.nickname}}{% endif %} ({{suggestion.contents.year}})</a></strong></p>
-                      {% if suggestion.contents.media_type_enum == 1 %}
-                        <a href="http://www.chiefdelphi.com/media/photos/{{suggestion.contents.foreign_key}}" target="_blank">
-                          <img class="img-thumbnail" src="http://www.chiefdelphi.com/media/img/{{suggestion.details.thumbnail}}" style="max-height: 200px;">
-                        </a>
-                      {% endif %}
-                      {% if suggestion.contents.media_type_enum == 0 %}
-                        <iframe width="320" height="180" src="https://www.youtube.com/embed/{{suggestion.contents.foreign_key}}" frameborder="0" allowfullscreen></iframe>
-                      {% endif %}
-                      {% if suggestion.contents.media_type_enum == 2 %}
-                        <a href="http://imgur.com/{{suggestion.contents.foreign_key}}" target="_blank">
-                          <img class="img-thumbnail" src="http://i.imgur.com/{{suggestion.contents.foreign_key}}m.jpg" style="max-height: 200px;">
-                        </a>
-                      {% endif %}
+                      {% set media = suggestion.candidate_media -%}
+                      {% include "media_partials/media_display_partial.html" %}
                   </div>
                   <div class="col-xs-3">
                     {% if preferred %}

--- a/templates_jinja2/suggest_team_social_media.html
+++ b/templates_jinja2/suggest_team_social_media.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import 'media_partials/social_media_macros.html' as smm %}
 
 {% block title %}The Blue Alliance - Add Team Social Media{% endblock %}
 
@@ -88,7 +89,7 @@
                 <h4>Existing Social Media Accounts</h4>
                 <ul>
                 {% for media in social_medias %}
-                  <li>{% include "media_partials/social_partial.html" %}</li>
+                  <li>{{smm.social_media_icon_link(media)}}</li>
                 {% endfor %}
                 </ul>
               {% else %}

--- a/templates_jinja2/suggest_team_social_review.html
+++ b/templates_jinja2/suggest_team_social_review.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import 'media_partials/social_media_macros.html' as smm %}
 
 {% block title %}Pending Suggestions{% endblock %}
 
@@ -36,25 +37,8 @@
                     </label>
                   </div>
                   <div class="col-xs-5 fitvids">
-                      <p><strong><a href="/team/{{reference.team_number}}/{{suggestion.contents.year}}" target="_blank">Team {{reference.team_number}}{% if reference.nickname %} - {{reference.nickname}}{% endif %}</a></strong></p>
-                      {% if suggestion.contents.media_type_enum == 3 %}
-                        <!-- Facebook profile -->
-                        <div class="fb-page" data-href="https://www.facebook.com/{{ suggestion.contents.foreign_key }}" data-hide-cover="false" data-show-facepile="false" data-show-posts="false" data-width="500"><div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/{{ suggestion.contents.foreign_key }}"><a href="https://www.facebook.com/">Facebook Profile: {{ suggestion.contents.foreign_key }}</a></blockquote></div></div>
-                      {% endif %}
-                      {% if suggestion.contents.media_type_enum == 4 %}
-                        <!-- Twitter profile -->
-                        <a class="twitter-timeline"  href="https://twitter.com/{{ suggestion.contents.foreign_key }}" data-widget-id="715993204777172992" data-screen-name="{{ suggestion.contents.foreign_key }}">Tweets by @{{ suggestion.contents.foreign_key }}</a>
-                        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-                      {% endif %}
-                      {% if suggestion.contents.media_type_enum == 5 %}
-                        <!-- YouTube profile -->
-                        {{ suggestion.contents.site_name }}: <a href="{{ suggestion.contents.profile_url }}">{{ suggestion.contents.foreign_key }}</a>
-                      {% endif %}
-                      {% if suggestion.contents.media_type_enum == 6 %}
-                        <!-- GitHub profile -->
-                        <div class="github-card" data-user="{{ suggestion.contents.foreign_key }}"></div>
-                      {% endif %}
-
+                      <p><strong><a href="/team/{{reference.team_number}}/{{suggestion.contents.year}}" target="_blank">Team {{reference.team_number}}{% if reference.nickname %} - {{reference.nickname}}{% endif %} ({{suggestion.contents.year}})</a></strong></p>
+                      {{smm.social_media_card(suggestion)}}
                   </div>
                   <div class="col-xs-2">
                       <ul>

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -144,11 +144,7 @@
               {% if image_medias %}
                 {% for media in image_medias %}
                   <div class="col-xs-6 col-sm-3">
-                  {% if media.media_type_enum == 1 %}
-                    {% include "media_partials/cdphotothread_partial.html" %}
-                  {% else %} {% if media.media_type_enum == 2 %}
-                    {% include "media_partials/imgur_partial.html" %}
-                  {% endif %} {% endif %}
+                    {% include "media_partials/media_display_partial.html" %}
                   </div>
                 {% endfor %}
               {% else %}
@@ -163,7 +159,7 @@
               {% if medias_by_slugname.youtube %}
                 {% for media in medias_by_slugname.youtube %}
                   <div class="col-xs-12 col-md-6 fitvids">
-                  {% include "media_partials/youtube_partial.html" %}
+                  {% include "media_partials/media_display_partial.html" %}
                   </div>
                 {% endfor %}
               {% else %}


### PR DESCRIPTION
Try and simplify showing medias by reusing more templates.

Now, the suggestion queue and team detail pages share a template for the full size embed. Hopefully it should reduce code copy/paste