### PR TITLE
Show Similar Offseason Events on Review Page

### DIFF
--- a/templates_jinja2/suggest_offseason_event_review_list.html
+++ b/templates_jinja2/suggest_offseason_event_review_list.html
@@ -9,7 +9,7 @@
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Offseason Events</li>
   </ol>
-  <h1>{{ events|length }} Pending Event Suggestions</h1>
+  <h1>{{ events_and_ids|length }} Pending Event Suggestions</h1>
 
   {% if success == "accept" %}
   <div class="row">
@@ -50,8 +50,16 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      {% for suggestion_id, event in events_and_ids %}
+      {% for suggestion_id, event, similar in events_and_ids %}
         <div class="well">
+          <h4>Similar Events</h4>
+          <ul>
+          {% for other_event in similar %}
+            <li><a href="/event/{{ other_event.key_name }}" target="_blank">[{{ other_event.event_short }}] {{ other_event.name }}</a></li>
+          {% else %}
+            <li>No similar events found</li>
+          {% endfor %}
+          </ul>
           {% include "event_partials/suggest_event_info.html" %}
         </div>
       {% else %}


### PR DESCRIPTION
It shows events with the same start and end date, I figure that will be enough, since we never have too many events on the same day.

![screenshot from 2016-05-21 11-01-45](https://cloud.githubusercontent.com/assets/2754863/15449204/ec2aa502-1f44-11e6-9b91-d1f8e27c7051.png)
![screenshot from 2016-05-21 11-04-26](https://cloud.githubusercontent.com/assets/2754863/15449205/ec2e4fc2-1f44-11e6-9008-53683f3a1b68.png)
