### PR TITLE
Support gapps-managed YouTube profiles

### DIFF
--- a/consts/media_type.py
+++ b/consts/media_type.py
@@ -33,6 +33,6 @@ class MediaType(object):
     profile_urls = {  # Format with foreign_key
         FACEBOOK_PROFILE: 'https://www.facebook.com/{}',
         TWITTER_PROFILE: 'https://twitter.com/{}',
-        YOUTUBE_CHANNEL: 'https://www.youtube.com/user/{}',
+        YOUTUBE_CHANNEL: 'https://www.youtube.com/{}',
         GITHUB_PROFILE: 'https://github.com/{}',
     }

--- a/helpers/media_helper.py
+++ b/helpers/media_helper.py
@@ -51,7 +51,9 @@ class MediaParser(object):
     FOREIGN_KEY_PATTERNS = {
         MediaType.FACEBOOK_PROFILE: [(r".*facebook.com\/(.*)(\/(.*))?", 1)],
         MediaType.TWITTER_PROFILE: [(r".*twitter.com\/(.*)(\/(.*))?", 1)],
-        MediaType.YOUTUBE_CHANNEL: [(r".*youtube.com\/user\/(.*)(\/(.*))?", 1), (r".*youtube.com\/(.*)(\/(.*))?", 1)],
+        MediaType.YOUTUBE_CHANNEL: [(r".*youtube.com\/user\/(.*)(\/(.*))?", 1),
+                                    (r".*youtube.com\/c\/(.*)(\/(.*))?", 1),
+                                    (r".*youtube.com\/(.*)(\/(.*))?", 1)],
         MediaType.GITHUB_PROFILE: [(r".*github.com\/(.*)(\/(.*))?", 1)],
         MediaType.YOUTUBE_VIDEO: [(r".*youtu\.be\/(.*)", 1), (r".*v=([a-zA-Z0-9_-]*)", 1)],
         MediaType.IMGUR: [(r".*imgur.com\/(\w+)\/?\Z", 1), (r".*imgur.com\/(\w+)\.\w+\Z", 1)],
@@ -63,6 +65,7 @@ class MediaParser(object):
         ('facebook.com/', MediaType.FACEBOOK_PROFILE),
         ('twitter.com/', MediaType.TWITTER_PROFILE),
         ('youtube.com/user', MediaType.YOUTUBE_CHANNEL),
+        ('youtube.com/c/', MediaType.YOUTUBE_CHANNEL),
         ('github.com/', MediaType.GITHUB_PROFILE),
         ('chiefdelphi.com/media/photos/', MediaType.CD_PHOTO_THREAD),
         ('youtube.com/watch', MediaType.YOUTUBE_VIDEO),

--- a/tests/test_media_url_parse.py
+++ b/tests/test_media_url_parse.py
@@ -70,19 +70,26 @@ class TestMediaUrlParser(unittest2.TestCase):
         self.assertEqual(result['profile_url'], 'https://twitter.com/team1124')
 
     def test_youtube_profile_parse(self):
-        result = MediaParser.partial_media_dict_from_url("https://www.youtube.com/user/Uberbots1124")
+        result = MediaParser.partial_media_dict_from_url("https://www.youtube.com/Uberbots1124")
         self.assertEqual(result['media_type_enum'], MediaType.YOUTUBE_CHANNEL)
         self.assertEqual(result['is_social'], True)
         self.assertEqual(result['foreign_key'], 'uberbots1124')
         self.assertEqual(result['site_name'], MediaType.type_names[MediaType.YOUTUBE_CHANNEL])
-        self.assertEqual(result['profile_url'], 'https://www.youtube.com/user/uberbots1124')
+        self.assertEqual(result['profile_url'], 'https://www.youtube.com/uberbots1124')
 
         short_result = MediaParser.partial_media_dict_from_url("https://www.youtube.com/Uberbots1124")
         self.assertEqual(short_result['media_type_enum'], MediaType.YOUTUBE_CHANNEL)
         self.assertEqual(short_result['is_social'], True)
         self.assertEqual(short_result['foreign_key'], 'uberbots1124')
         self.assertEqual(short_result['site_name'], MediaType.type_names[MediaType.YOUTUBE_CHANNEL])
-        self.assertEqual(short_result['profile_url'], 'https://www.youtube.com/user/uberbots1124')
+        self.assertEqual(short_result['profile_url'], 'https://www.youtube.com/uberbots1124')
+
+        gapps_result = MediaParser.partial_media_dict_from_url("https://www.youtube.com/c/tnt3102org")
+        self.assertEqual(gapps_result['media_type_enum'], MediaType.YOUTUBE_CHANNEL)
+        self.assertEqual(gapps_result['is_social'], True)
+        self.assertEqual(gapps_result['foreign_key'], 'tnt3102org')
+        self.assertEqual(gapps_result['site_name'], MediaType.type_names[MediaType.YOUTUBE_CHANNEL])
+        self.assertEqual(gapps_result['profile_url'], 'https://www.youtube.com/tnt3102org')
 
     def test_github_profile_parse(self):
         result = MediaParser.partial_media_dict_from_url("https://github.com/frc1124")


### PR DESCRIPTION
Those urls are formed like yt.com/c/whatever. Now, TBA doesn't assume a user/ url suffix and lets youtube handle the proper redirects.

I can't come up with a case where things break because we changed the profile display url format.

Fixes #1542