### PR TITLE
Improve deployment pipeline

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -2,41 +2,67 @@
 To use:
 1. Clone a production copy of TBA in the same directory as the development copy by running: `git clone git@github.com:the-blue-alliance/the-blue-alliance.git the-blue-alliance-prod`
 2. Ensure APP_CFG_DIR points to the correct location
+3. If you want to allow travis support, be sure you have the official client installed and in your PATH (https://github.com/travis-ci/travis.rb)
 """
 
 import argparse
 import os
 import sys
+import subprocess
+import re
 
 
-APP_CFG_DIR = '~/Downloads/google_appengine' # Eugene's Windows
+APP_CFG_DIR = '~/Downloads/google_appengine'  # Eugene's Windows
 # APP_CFG_DIR = '/usr/local/bin' # Mac OS symlinks made by GoogleAppEngineLauncher
 
 
 def main():
     parser = argparse.ArgumentParser(description='Deploy The Blue Alliance app.')
-    parser.add_argument('app_cfg_dir', type=str, default=APP_CFG_DIR,
+    parser.add_argument('--app_cfg_dir', type=str, default=APP_CFG_DIR,
                         help='path to folder containing appcfg.py')
-    parser.add_argument('-s', '--skip_tests', action='store_true',
-                        help='Skip running tests. #yolo.')
+    parser.add_argument('--project', default='tbatv-prod-hrd', help="App Engine project to deploy")
+    parser.add_argument('--reauth', action="store_true", help="Prompt for reauth during GAE commands", default=False)
+    parser.add_argument('--yolo', action="store_true", help="Do not wait for travis builds to succeed #yolo", default=False)
     args = parser.parse_args()
 
     os.chdir('../the-blue-alliance-prod')
     os.system('git pull origin master')
 
     test_status = 0
-    if args.skip_tests:
+    if args.yolo:
         print "Skipping tests!"
+        print "Welcome to clowntown..."
         os.system('paver make')
     else:
         test_status = os.system('paver preflight')
+        print "Verifying travis build for branch master"
+        status = "created"
+        duration = ""
+        while status == "created" or status == "started":
+            try:
+                info = subprocess.check_output(["travis", "show", "master"])
+            except subprocess.CalledProcessError:
+                try:
+                    input("Error getting travis status. Press Enter to continue...")
+                except SyntaxError:
+                    pass
+            regex = re.search(".*State:[ \t]+((\w)*)\n", info)
+            status = regex.group(1)
+            regex = re.search(".*Duration:[ \t]+(([\w\d ])*)", info)
+            duration = regex.group(1) if regex else None
+            print "Build Status: {}, duration: {}".format(status, duration)
+            if status == "passed":
+                break
+            elif status == "failed" or status == "errored":
+                test_status = 1
+                break
+            time.sleep(30)
 
     if test_status == 0:
-        # Update default module and other YAMLs
-        os.system('python ' + args.app_cfg_dir + '/appcfg.py -A tbatv-prod-hrd update .')
-        # Update other modules
-        os.system('python ' + args.app_cfg_dir + '/appcfg.py -A tbatv-prod-hrd update app-backend-tasks.yaml')
-        os.system('python ' + args.app_cfg_dir + '/appcfg.py -A tbatv-prod-hrd update app-backend-tasks-b2.yaml')
+        other_args = "--no_cookies" if args.reauth else ""
+        modules = [".", "app-backend-tasks.yaml", "app-backend-tasks-b2.yaml"]
+        for module in modules:
+            os.system("python {}/appcfg.py {} -A {} update {}".format(args.app_cfg_dir, other_args, args.project, module))
     else:
         print "Tests failed! Did not deploy."
 

--- a/pavement.py
+++ b/pavement.py
@@ -3,15 +3,29 @@
 import subprocess
 import json
 import time
+import optparse
 from paver.easy import *
 
 path = path("./")
 
 
 @task
-@consume_args
-def deploy(args):
-    sh("python deploy.py " + " ".join(args))
+@cmdopts([
+    optparse.make_option("-d", "--sdk", help="Path to GAE SDK", default=None),
+    optparse.make_option("-p", "--project", help="App Engine project to deploy", default="tbatv-prod-hrd"),
+    optparse.make_option("--reauth", action="store_true", help="Prompt for re-auth during all GAE commands", default=False),
+    optparse.make_option("--yolo", action="store_true", help="Do not wait for the travis build to succeed #yolo", default=False),
+])
+def deploy(options):
+    args = ["python", "deploy.py", "--project", options.deploy.project]
+    if options.deploy.sdk:
+        args.extend(["--app_cfg_dir", options.deploy.sdk])
+    if options.deploy.reauth:
+        args.append("--reauth")
+    if options.deploy.yolo:
+        args.append("--yolo")
+    print "Running {}".format(subprocess.list2cmdline(args))
+    subprocess.call(args)
 
 
 @task


### PR DESCRIPTION
This addresses some of the issues raised in #1568. Specifically:
 - takes the target app engine module as a parameter
 - allows setting a `--reauth` flag so you can choose which account to use
   when deploying
 - by default checks for the travis build to have succeeded before
   deploying. Bypass with `--yolo`

For example, I can deploy tba.lopreiato.me with `paver deploy -d
~/google_appengine -p tba-dev-phil`

Closes #1568