### PR TITLE
Adds match offset column to rankings if event.within_a_day

### DIFF
--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -174,16 +174,27 @@ class EventDetail(CacheableHandler):
         # rankings processing for ranking score per match
         full_rankings = event.rankings
         rankings_enhanced = event.rankings_enhanced
+        ranking_disclaimer = ""
         if rankings_enhanced is not None:
+            # Ranking disclaimer formatted to handle singular vs plural
+            ranking_disclaimer = "<p><b>*</b>%s calculated for your convenience by The Blue Alliance using data provided by <i>FIRST</i> and %s not official.</p>"
             rp_index = RankingIndexes.CUMULATIVE_RANKING_SCORE[event.year]
             ranking_criterion_name = full_rankings[0][rp_index]
-            full_rankings[0].append(ranking_criterion_name + "/Match*")    
-            if rankings_enhanced:
-                for row in full_rankings[1:]:
-                    team = row[1]
-                    if team in rankings_enhanced:
-                        rp_per_match = rankings_enhanced[team]['ranking_score_per_match']
-                        row.append(rp_per_match)
+            full_rankings[0].append(ranking_criterion_name + "/Match*")
+            if rankings_enhanced["match_offset"] is not None:
+                full_rankings[0].append("# Played Offset*")
+                ranking_disclaimer = ranking_disclaimer % ("These columns are", "are")
+            else:
+                ranking_disclaimer = ranking_disclaimer % ("This column is", "is")
+            for row in full_rankings[1:]:
+                team = row[1]
+                if rankings_enhanced["ranking_score_per_match"] is not None:
+                    rp_per_match = rankings_enhanced['ranking_score_per_match'][team]
+                    row.append(rp_per_match)
+                if rankings_enhanced["match_offset"] is not None:
+                    match_offset = rankings_enhanced["match_offset"][team]
+                    row.append(match_offset)
+
 
 
         self.template_values.update({
@@ -205,6 +216,7 @@ class EventDetail(CacheableHandler):
             "event_insights_qual": event_insights['qual'] if event_insights else None,
             "event_insights_playoff": event_insights['playoff'] if event_insights else None,
             "event_insights_template": event_insights_template,
+            "ranking_disclaimer": ranking_disclaimer,
         })
 
         if event.within_a_day:

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -211,7 +211,7 @@
               {% endfor %}
             </tbody>
           </table>
-          {% if event.year >= 2007 and event.year != 2015 %}<p><b>*</b>This column is calculated for your convenience by The Blue Alliance using data provided by <i>FIRST</i> and is not official.</p>{% endif %}
+          {% if event.year >= 2007 and event.year != 2015 %}<p>{{ ranking_disclaimer | safe }}</p>{% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #1572. There is now an additional column for events that are within a day, showing the the maximum number of matches played played minus the number of matches that team has played
![image](https://cloud.githubusercontent.com/assets/16950452/17239708/32313d48-5534-11e6-9cc1-d41b2a2158b0.png)


Since values will be either -1 or 0 for all teams, I decided to see what it would look like with text values:
![image](https://cloud.githubusercontent.com/assets/16950452/17239672/f7515208-5533-11e6-8125-ef97c71b35bb.png)
I personally like this better, though I have not pushed it. If we go with this, what should I make the column heading?