### PR TITLE
Year last competed shown on team pages

### DIFF
--- a/models/team.py
+++ b/models/team.py
@@ -4,6 +4,7 @@ import re
 from google.appengine.ext import ndb
 from helpers.champ_split_helper import ChampSplitHelper
 
+
 class Team(ndb.Model):
     """
     Teams represent FIRST Robotics Competition teams.

--- a/models/team.py
+++ b/models/team.py
@@ -4,7 +4,6 @@ import re
 from google.appengine.ext import ndb
 from helpers.champ_split_helper import ChampSplitHelper
 
-
 class Team(ndb.Model):
     """
     Teams represent FIRST Robotics Competition teams.

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -28,7 +28,7 @@ class TeamRenderer(object):
         social_media_future = media_query.TeamSocialMediaQuery(team.key.id()).fetch_async()
         robot_future = Robot.get_by_id_async('{}_{}'.format(team.key.id(), year))
         team_districts_future = team_query.TeamDistrictsQuery(team.key.id()).fetch_async()
-        participation_future = team_query.TeamParticipationQuery(team.key.id())._query_async()
+        participation_future = team_query.TeamParticipationQuery(team.key.id()).fetch_async()
 
         events_sorted, matches_by_event_key, awards_by_event_key, valid_years = TeamDetailsDataFetcher.fetch(team, year, return_valid_years=True)
         if not events_sorted:

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -117,6 +117,14 @@ class TeamRenderer(object):
             district_type = DistrictType.abbrevs[district_abbrev]
             district_name = DistrictType.type_names[district_type]
 
+        last_competed = None
+        participation_query = team_query.TeamParticipationQuery(team.key_name)._query_async()
+        participation_years = participation_query.get_result()
+        print participation_years
+        if len(participation_years) > 0:
+            last_competed = max(participation_years)
+        current_year = datetime.date.today().year
+
         handler.template_values.update({
             "is_canonical": is_canonical,
             "team": team,
@@ -135,6 +143,8 @@ class TeamRenderer(object):
             "robot": robot_future.get_result(),
             "district_name": district_name,
             "district_abbrev": district_abbrev,
+            "last_competed": last_competed,
+            "current_year": current_year,
         })
 
         if short_cache:

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -28,6 +28,7 @@ class TeamRenderer(object):
         social_media_future = media_query.TeamSocialMediaQuery(team.key.id()).fetch_async()
         robot_future = Robot.get_by_id_async('{}_{}'.format(team.key.id(), year))
         team_districts_future = team_query.TeamDistrictsQuery(team.key.id()).fetch_async()
+        participation_future = team_query.TeamParticipationQuery(team.key.id())._query_async()
 
         events_sorted, matches_by_event_key, awards_by_event_key, valid_years = TeamDetailsDataFetcher.fetch(team, year, return_valid_years=True)
         if not events_sorted:
@@ -118,9 +119,7 @@ class TeamRenderer(object):
             district_name = DistrictType.type_names[district_type]
 
         last_competed = None
-        participation_query = team_query.TeamParticipationQuery(team.key_name)._query_async()
-        participation_years = participation_query.get_result()
-        print participation_years
+        participation_years = participation_future.get_result()
         if len(participation_years) > 0:
             last_competed = max(participation_years)
         current_year = datetime.date.today().year

--- a/templates_jinja2/team_partials/team_info.html
+++ b/templates_jinja2/team_partials/team_info.html
@@ -15,6 +15,7 @@
       {% if team.location %}<span class="glyphicon glyphicon-map-marker"></span> From <a href="http://maps.google.com/maps?q={{ team.location|urlencode }}" target="_blank">{{ team.location }}</a><br>{% endif %}
       {% if team.name %}<span class="glyphicon glyphicon-info-sign"></span> aka <em>{{ team.name }}</em><br>{% endif %}
       {% if team.rookie_year %}<span class="glyphicon glyphicon-calendar"></span> First competed in {{ team.rookie_year }}<br>{% endif %}
+      {% if last_competed and year != current_year %}Last competed in {{ last_competed }}.{% endif %}
       {% if team.website %}<span class="glyphicon glyphicon-globe"></span> <a href="{{team.website}}" target="_blank">{{ team.website }}</a><br>{% endif %}
       {% if team.championship_location %}<span class="glyphicon glyphicon-flag"></span> Home Championship: {{team.championship_location.2017}}, 2017 | {% if team.championship_location.2017 != team.championship_location.2018 %}, {{team.championship_location.2018}}, 2018{% endif %}+<br>{% endif %}
 


### PR DESCRIPTION
The last year a team competed is shown on team pages directly below the rookie year listing EXCEPT when that year is the current year and the team page is the current year, as requested in #1546.

![image](https://cloud.githubusercontent.com/assets/16950452/17263639/0b053310-55b0-11e6-8f85-74e5d33e94fb.png)
