### PR TITLE
Fixed typo: 'offset' was referenced instead of 'match_offset'

### DIFF
--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -188,7 +188,7 @@ class EventDetail(CacheableHandler):
                 if rankings_enhanced["match_offset"] is not None:
                     match_offset = rankings_enhanced["match_offset"][team]
                     if match_offset != 0:
-                        row[matches_index] = "{} ({})".format(row[matches_index], offset)
+                        row[matches_index] = "{} ({})".format(row[matches_index], match_offset)
 
 
 


### PR DESCRIPTION
Very minor typo that broke match_offset functionality. I didn't test between changing the string format method and pushing, so the typo went undetected.