### PR TITLE
Manage Deployments With gcloud Utility

### DIFF
--- a/app-backend-tasks-b2.yaml
+++ b/app-backend-tasks-b2.yaml
@@ -1,6 +1,4 @@
-application: tbatv-dev-hrd
-module: backend-tasks-b2
-version: 1-1
+service: backend-tasks-b2
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/app-backend-tasks.yaml
+++ b/app-backend-tasks.yaml
@@ -1,6 +1,4 @@
-application: tbatv-dev-hrd
-module: backend-tasks
-version: 1-1
+service: backend-tasks
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,3 @@
-application: tbatv-dev-hrd
-version: 1-3
 runtime: python27
 api_version: 1
 threadsafe: false

--- a/app_shared.yaml
+++ b/app_shared.yaml
@@ -17,6 +17,7 @@ skip_files:
 - tests/*
 - utils/*
 - react/*
+- node_modules/*
 
 # specific files
 - .gitignore

--- a/deploy.py
+++ b/deploy.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument('--project', default='tbatv-prod-hrd', help="App Engine project to deploy")
     parser.add_argument('--yolo', action="store_true", help="Do not wait for travis builds to succeed #yolo", default=False)
     parser.add_argument('--config', help="gcloud configuration profile to use", default="")
-    parser.add_argument('--version', help="Version for app engine modules", default="1-3")
+    parser.add_argument('--version', help="Version for app engine modules", default="prod")
     parser.add_argument('--modules', help="Modules to deploy, comma separated, as yaml spec files in this directory", default="")
     parser.add_argument('--skip-cron', action="store_true", help="Do not deploy cron.yaml", default=False)
     args = parser.parse_args()
@@ -58,7 +58,7 @@ def main():
     if test_status == 0:
         print "Deploying..."
         os.system("gcloud version")
-        cmd = ["gcloud", "app", "deploy", "--project", args.project]
+        cmd = ["gcloud", "app", "deploy", "--verbosity", "info", "--project", args.project]
         if args.config:
             cmd.extend(["--configuration", args.config])
         if args.version:

--- a/deploy.py
+++ b/deploy.py
@@ -19,7 +19,7 @@ def main():
     parser.add_argument('--project', default='tbatv-prod-hrd', help="App Engine project to deploy")
     parser.add_argument('--yolo', action="store_true", help="Do not wait for travis builds to succeed #yolo", default=False)
     parser.add_argument('--config', help="gcloud configuration profile to use", default="")
-    parser.add_argument('--version', help="Version for app engine modules", default="prod")
+    parser.add_argument('--version', help="Version for app engine modules", default="prod-1")
     parser.add_argument('--modules', help="Modules to deploy, comma separated, as yaml spec files in this directory", default="")
     parser.add_argument('--skip-cron', action="store_true", help="Do not deploy cron.yaml", default=False)
     args = parser.parse_args()

--- a/deploy.py
+++ b/deploy.py
@@ -3,6 +3,8 @@ To use:
 1. Clone a production copy of TBA in the same directory as the development copy by running: `git clone git@github.com:the-blue-alliance/the-blue-alliance.git the-blue-alliance-prod`
 2. Ensure you have gcloud available and in your PATH (https://cloud.google.com/sdk/gcloud/)
 3. If you want to allow travis support, be sure you have the official client installed and in your PATH (https://github.com/travis-ci/travis.rb)
+
+NOTE: if your deployments are slow, try exporting the environment variable CLOUDSDK_APP_USE_GSUTIL=1 to use a different approach
 """
 
 import argparse

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,5 +1,3 @@
-application: tbatv-dev-hrd
-
 dispatch:
 # Send low-frequency long-running tasks to backend module
 - url: "*/backend-tasks/*"

--- a/pavement.py
+++ b/pavement.py
@@ -11,19 +11,25 @@ path = path("./")
 
 @task
 @cmdopts([
-    optparse.make_option("-d", "--sdk", help="Path to GAE SDK", default=None),
     optparse.make_option("-p", "--project", help="App Engine project to deploy", default="tbatv-prod-hrd"),
-    optparse.make_option("--reauth", action="store_true", help="Prompt for re-auth during all GAE commands", default=False),
     optparse.make_option("--yolo", action="store_true", help="Do not wait for the travis build to succeed #yolo", default=False),
+    optparse.make_option("--config", help="gcloud SDK configuration profile to use", default=""),
+    optparse.make_option("--version", help="App engine version to deploy", default=""),
+    optparse.make_option("--modules", help="Comma separated names of module yaml files to deploy", default=""),
+    optparse.make_option("--skip-cron", action="store_true", help="Do not deploy cron.yaml", default=False),
 ])
 def deploy(options):
     args = ["python", "deploy.py", "--project", options.deploy.project]
-    if options.deploy.sdk:
-        args.extend(["--app_cfg_dir", options.deploy.sdk])
-    if options.deploy.reauth:
-        args.append("--reauth")
     if options.deploy.yolo:
         args.append("--yolo")
+    if options.deploy.config:
+        args.extend(["--config", options.deploy.config])
+    if options.deploy.version:
+        args.extend(["--version", options.deploy.version])
+    if options.deploy.modules:
+        args.extend(["--modules", options.deploy.modules])
+    if options.skip_cron:
+        args.append("--skip-cron")
     print "Running {}".format(subprocess.list2cmdline(args))
     subprocess.call(args)
 


### PR DESCRIPTION
[`gcloud`](https://cloud.google.com/sdk/gcloud/reference/) is the evolution of `appcfg.py` (which is deprecated). This pull moves our deployment pipeline to use the newer command and hopefully fixes @fangeugene's deployment issues. Heads up to @gregmarra as well

It requires some changes to the module yaml files, notably you no longer provide the version and application name values (those are instead passed at the `gcloud` command line). I made the default version to be `prod`, keeping in mind that the continuous deployment stuff I'm working on in parallel will use the version `contbuild`. 

This also adds some other various options to `paver deploy` for increased flexibility.

Also, note that if your deployments are slow, try exporting the environment variable `CLOUDSDK_APP_USE_GSUTIL` to  be `1` to use a different code path