### PR TITLE
Remove deprecated Event properties now in EventDetails

### DIFF
--- a/controllers/admin/admin_event_controller.py
+++ b/controllers/admin/admin_event_controller.py
@@ -40,13 +40,6 @@ class AdminEventAddAllianceSelections(LoggedInHandler):
         alliance_selections_csv = self.request.get('alliance_selections_csv')
         alliance_selections = CSVAllianceSelectionsParser.parse(alliance_selections_csv)
 
-        if alliance_selections and event.alliance_selections != alliance_selections:
-            event.alliance_selections_json = json.dumps(alliance_selections)
-            event._alliance_selections = None
-            event.dirty = True
-
-        EventManipulator.createOrUpdate(event)
-
         event_details = EventDetails(
             id=event_key,
             alliance_selections=alliance_selections
@@ -309,8 +302,6 @@ class AdminEventEdit(LoggedInHandler):
             facebook_eid=self.request.get("facebook_eid"),
             custom_hashtag=self.request.get("custom_hashtag"),
             webcast_json=self.request.get("webcast_json"),
-            alliance_selections_json=self.request.get("alliance_selections_json"),
-            rankings_json=self.request.get("rankings_json"),
         )
         event = EventManipulator.createOrUpdate(event)
 

--- a/controllers/api/api_trusted_controller.py
+++ b/controllers/api/api_trusted_controller.py
@@ -32,7 +32,7 @@ from models.team import Team
 
 class ApiTrustedEventAllianceSelectionsUpdate(ApiTrustedBaseController):
     """
-    Overwrites an event's alliance_selections_json with new data
+    Overwrites an event_detail's alliance_selections with new data
     """
     REQUIRED_AUTH_TYPES = {AuthType.EVENT_ALLIANCES}
 
@@ -40,8 +40,6 @@ class ApiTrustedEventAllianceSelectionsUpdate(ApiTrustedBaseController):
         alliance_selections = JSONAllianceSelectionsParser.parse(request.body)
 
         event = Event.get_by_id(event_key)
-        event.alliance_selections_json = json.dumps(alliance_selections)
-        EventManipulator.createOrUpdate(event)
 
         event_details = EventDetails(
             id=event_key,
@@ -172,7 +170,7 @@ class ApiTrustedEventMatchesDeleteAll(ApiTrustedBaseController):
 
 class ApiTrustedEventRankingsUpdate(ApiTrustedBaseController):
     """
-    Overwrites an event's rankings_json with new data
+    Overwrites an event_detail's rankings with new data
     """
     REQUIRED_AUTH_TYPES = {AuthType.EVENT_RANKINGS}
 
@@ -180,8 +178,6 @@ class ApiTrustedEventRankingsUpdate(ApiTrustedBaseController):
         rankings = JSONRankingsParser.parse(request.body)
 
         event = Event.get_by_id(event_key)
-        event.rankings_json = json.dumps(rankings)
-        EventManipulator.createOrUpdate(event)
 
         event_details = EventDetails(
             id=event_key,

--- a/controllers/backup_controller.py
+++ b/controllers/backup_controller.py
@@ -172,11 +172,6 @@ class TbaCSVRestoreEventDo(webapp.RequestHandler):
         else:
             data = result.content.replace('frc', '')
             alliance_selections = CSVAllianceSelectionsParser.parse(data)
-            if alliance_selections and event.alliance_selections != alliance_selections:
-                event.alliance_selections_json = json.dumps(alliance_selections)
-                event._alliance_selections = None
-                event.dirty = True
-            EventManipulator.createOrUpdate(event)
 
             event_details = EventDetails(
                 id=event_key,
@@ -241,11 +236,6 @@ class TbaCSVRestoreEventDo(webapp.RequestHandler):
         else:
             # convert into expected input format
             rankings = list(csv.reader(StringIO.StringIO(result.content), delimiter=','))
-            if rankings and event.rankings != rankings:
-                event.rankings_json = json.dumps(rankings)
-                event._rankings = None
-                event.dirty = True
-            EventManipulator.createOrUpdate(event)
 
             event_details = EventDetails(
                 id=event_key,

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -161,9 +161,6 @@ class EventMatchstatsDo(webapp.RequestHandler):
             matchstats_dict['ranking_prediction_stats'] = ranking_prediction_stats
 
         if any([v != {} for v in matchstats_dict.values()]):
-            event.matchstats_json = json.dumps(matchstats_dict)
-            EventManipulator.createOrUpdate(event)
-
             event_details = EventDetails(
                 id=event_key,
                 matchstats=matchstats_dict
@@ -460,9 +457,6 @@ class DistrictPointsCalcDo(webapp.RequestHandler):
             return
 
         district_points = DistrictHelper.calculate_event_points(event)
-
-        event.district_points_json = json.dumps(district_points)
-        EventManipulator.createOrUpdate(event)
 
         event_details = EventDetails(
             id=event_key,

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -144,12 +144,6 @@ class FMSAPIEventAlliancesGet(webapp.RequestHandler):
         event = Event.get_by_id(event_key)
 
         alliance_selections = df.getEventAlliances(event_key)
-        if alliance_selections and event.alliance_selections != alliance_selections:
-            event.alliance_selections_json = json.dumps(alliance_selections)
-            event._alliance_selections = None
-            event.dirty = True
-
-        EventManipulator.createOrUpdate(event)
 
         event_details = EventDetails(
             id=event_key,
@@ -158,7 +152,7 @@ class FMSAPIEventAlliancesGet(webapp.RequestHandler):
         EventDetailsManipulator.createOrUpdate(event_details)
 
         template_values = {'alliance_selections': alliance_selections,
-                           'event_name': event.key_name}
+                           'event_name': event_details.key.id()}
 
         if 'X-Appengine-Taskname' not in self.request.headers:  # Only write out if not in taskqueue
             path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_event_alliances_get.html')
@@ -201,13 +195,6 @@ class FMSAPIEventRankingsGet(webapp.RequestHandler):
 
         rankings = df.getEventRankings(event_key)
 
-        event = Event.get_by_id(event_key)
-        if rankings and event.rankings_json != json.dumps(rankings):
-            event.rankings_json = json.dumps(rankings)
-            event.dirty = True
-
-        EventManipulator.createOrUpdate(event)
-
         event_details = EventDetails(
             id=event_key,
             rankings=rankings
@@ -215,7 +202,7 @@ class FMSAPIEventRankingsGet(webapp.RequestHandler):
         EventDetailsManipulator.createOrUpdate(event_details)
 
         template_values = {'rankings': rankings,
-                           'event_name': event.key_name}
+                           'event_name': event_details.key.id()}
 
         if 'X-Appengine-Taskname' not in self.request.headers:  # Only write out if not in taskqueue
             path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_event_rankings_get.html')

--- a/helpers/event_manipulator.py
+++ b/helpers/event_manipulator.py
@@ -43,8 +43,6 @@ class EventManipulator(ManipulatorBase):
         the "old" event that are null in the "new" event.
         """
         attrs = [
-            "alliance_selections_json",
-            "district_points_json",
             "end_date",
             "event_short",
             "event_type_enum",
@@ -58,8 +56,6 @@ class EventManipulator(ManipulatorBase):
             "timezone_id",
             "name",
             "official",
-            "matchstats_json",
-            "rankings_json",
             "short_name",
             "start_date",
             "venue",
@@ -74,10 +70,6 @@ class EventManipulator(ManipulatorBase):
         old_event._updated_attrs = []
 
         for attr in attrs:
-            # Special case for rankings. Don't merge bad data.
-            if attr == 'rankings_json':
-                if new_event.rankings and len(new_event.rankings) <= 1:
-                    continue
             if getattr(new_event, attr) is not None:
                 if getattr(new_event, attr) != getattr(old_event, attr):
                     setattr(old_event, attr, getattr(new_event, attr))

--- a/models/event.py
+++ b/models/event.py
@@ -40,13 +40,6 @@ class Event(ndb.Model):
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
 
-    # The following properties are deprecated. TODO: Remove entirely
-    matchstats_json = ndb.TextProperty(indexed=False)  # for OPR, DPR, CCWM, etc.
-    rankings_json = ndb.TextProperty(indexed=False)
-    alliance_selections_json = ndb.TextProperty(indexed=False)  # Formatted as: [{'picks': [captain, pick1, pick2, 'frc123', ...], 'declines':[decline1, decline2, ...] }, {'picks': [], 'declines': []}, ... ]
-    district_points_json = ndb.TextProperty(indexed=False)
-    # End deprecated properties
-
     def __init__(self, *args, **kw):
         # store set of affected references referenced keys for cache clearing
         # keys must be model properties

--- a/templates/admin/event_edit.html
+++ b/templates/admin/event_edit.html
@@ -94,11 +94,11 @@
         </tr>
         <tr>
             <td>Alliances</td>
-            <td><textarea name="alliance_selections_json" >{{event.alliance_selections_json}}</textarea></td>
+            <td><textarea name="alliance_selections_json" >{{event.alliance_selections}}</textarea></td>
         </tr>
         <tr>
             <td>Rankings</td>
-            <td><textarea name="rankings_json" >{{event.rankings_json}}</textarea></td>
+            <td><textarea name="rankings_json" >{{event.rankings}}</textarea></td>
         </tr>
     </table>
 


### PR DESCRIPTION
Merge after #1593

This PR:
- [x] Removes writing EventDetails properties to Events
- [x] Removes unused Event properties

After everything is working, need to:
- Delete migrated entries from Event models
- Clear database query caches