### PR TITLE
Add Admin Panel for API Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Run a local dev server
   * Visit, say, [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=0), [localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000](http://localhost:8088/tasks/get/usfirst_teams_tpids/2015?skip=1000), ...
   * Also visit [localhost:8088/tasks/enqueue/usfirst_event_details/2015](http://localhost:8088/tasks/enqueue/usfirst_event_details/2015), [2014](http://localhost:8088/tasks/enqueue/usfirst_event_details/2014), ...
   * Once you have events for a certain year, you can visit [localhost:8088/tasks/enqueue/csv_restore_events/2015](http://localhost:8088/tasks/enqueue/csv_restore_events/2015), [2014](http://localhost:8088/tasks/enqueue/csv_restore_events/2014), ... etc. to get data from [github.com/the-blue-alliance/the-blue-alliance-data](https://github.com/the-blue-alliance/the-blue-alliance-data) instead of hitting up usfirst.org lots of times.
+  * If you want to test development using the offical FMS API, you can request API keys [here](https://usfirst.collab.net/sf/projects/first_community_developers/). Once you have your keys, you can input them in [the admin panel](http://localhost:8088/admin/authkeys)
 5. Ignore these warnings in the local dev server:
   * `pytz is required to calculate future run times for cron jobs with timezones` (The pytz library is in the source tree and works fine.)
 

--- a/admin_main.py
+++ b/admin_main.py
@@ -6,6 +6,7 @@ import tba_config
 
 from controllers.admin.admin_api_controller import AdminApiAuthAdd, AdminApiAuthDelete, AdminApiAuthEdit, AdminApiAuthManage
 from controllers.admin.admin_apistatus_controller import AdminApiStatus
+from controllers.admin.admin_authkeys_controller import AdminAuthKeys
 from controllers.admin.admin_event_controller import AdminEventAddAllianceSelections, AdminEventAddTeams, AdminEventRemapTeams, AdminEventAddWebcast, AdminEventCreate, AdminEventCreateTest, AdminEventDelete, AdminEventDetail, AdminEventEdit, AdminEventList
 from controllers.admin.admin_main_controller import AdminDebugHandler, AdminMain, AdminTasksHandler
 from controllers.admin.admin_award_controller import AdminAwardDashboard, AdminAwardEdit, AdminAwardAdd
@@ -27,6 +28,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/api_auth/edit/(.*)', AdminApiAuthEdit),
                                ('/admin/api_auth/manage', AdminApiAuthManage),
                                ('/admin/apistatus', AdminApiStatus),
+                               ('/admin/authkeys', AdminAuthKeys),
                                ('/admin/debug', AdminDebugHandler),
                                ('/admin/events', AdminEventList),
                                ('/admin/events/([0-9]*)', AdminEventList),

--- a/controllers/admin/admin_authkeys_controller.py
+++ b/controllers/admin/admin_authkeys_controller.py
@@ -1,0 +1,67 @@
+import json
+import os
+
+from google.appengine.ext import ndb
+from google.appengine.ext.webapp import template
+
+from controllers.base_controller import LoggedInHandler
+from models.sitevar import Sitevar
+
+
+class AdminAuthKeys(LoggedInHandler):
+    """
+    A place to see all the connected API keys
+    """
+    def get(self):
+        self._require_admin()
+        google_secrets = Sitevar.get_by_id('google.secrets')
+        firebase_secrets = Sitevar.get_by_id('firebase.secrets')
+        fmsapi_secrets = Sitevar.get_by_id('fmsapi.secrets')
+        mobile_clientIds = Sitevar.get_by_id('mobile.clientIds')
+        gcm_serverKey = Sitevar.get_by_id('gcm.serverKey')
+
+        fmsapi_keys = fmsapi_secrets.contents if fmsapi_secrets else {}
+        clientIds = mobile_clientIds.contents if mobile_clientIds else {}
+        self.template_values.update({
+            'google_secret': google_secrets.contents.get('api_key', "") if google_secrets else "",
+            'firebase_secret': firebase_secrets.contents.get('FIREBASE_SECRET', "") if firebase_secrets else "",
+            'fmsapi_user': fmsapi_keys.get('username', ''),
+            'fmsapi_secret': fmsapi_keys.get('authkey', ''),
+            'web_client_id': clientIds.get('web', ''),
+            'android_client_id': clientIds.get('android', ''),
+            'gcm_key': gcm_serverKey.contents if gcm_serverKey else "",
+        })
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/authkeys.html')
+        self.response.out.write(template.render(path, self.template_values))
+
+    def post(self):
+        self._require_admin()
+
+        google_secrets = Sitevar.get_or_insert('google.secrets')
+        firebase_secrets = Sitevar.get_or_insert('firebase.secrets')
+        fmsapi_secrets = Sitevar.get_or_insert('fmsapi.secrets')
+        mobile_clientIds = Sitevar.get_or_insert('mobile.clientIds')
+        gcm_serverKey = Sitevar.get_or_insert('gcm.serverKey')
+
+        google_key = self.request.get("google_secret")
+        firebase_key = self.request.get("firebase_secret")
+        fmsapi_user = self.request.get("fmsapi_user")
+        fmsapi_secret = self.request.get("fmsapi_secret")
+        web_client_id = self.request.get("web_client_id")
+        android_client_id = self.request.get("android_client_id")
+        gcm_key = self.request.get("gcm_key")
+
+        google_secrets.contents = {'api_key': google_key}
+        firebase_secrets.contents = {'FIREBASE_SECRET': firebase_key}
+        fmsapi_secrets.contents = {'username': fmsapi_user, 'authkey': fmsapi_secret}
+        mobile_clientIds.contents = {'web': web_client_id, 'android': android_client_id}
+        gcm_serverKey.contents = gcm_key
+
+        google_secrets.put()
+        firebase_secrets.put()
+        fmsapi_secrets.put()
+        mobile_clientIds.put()
+        gcm_serverKey.put()
+
+        self.redirect('/admin/authkeys')

--- a/controllers/admin/admin_authkeys_controller.py
+++ b/controllers/admin/admin_authkeys_controller.py
@@ -14,14 +14,14 @@ class AdminAuthKeys(LoggedInHandler):
     """
     def get(self):
         self._require_admin()
-        google_secrets = Sitevar.get_by_id('google.secrets')
-        firebase_secrets = Sitevar.get_by_id('firebase.secrets')
-        fmsapi_secrets = Sitevar.get_by_id('fmsapi.secrets')
-        mobile_clientIds = Sitevar.get_by_id('mobile.clientIds')
-        gcm_serverKey = Sitevar.get_by_id('gcm.serverKey')
+        google_secrets = Sitevar.get_or_insert('google.secrets')
+        firebase_secrets = Sitevar.get_or_insert('firebase.secrets')
+        fmsapi_secrets = Sitevar.get_or_insert('fmsapi.secrets')
+        mobile_clientIds = Sitevar.get_or_insert('mobile.clientIds')
+        gcm_serverKey = Sitevar.get_or_insert('gcm.serverKey')
 
-        fmsapi_keys = fmsapi_secrets.contents if fmsapi_secrets else {}
-        clientIds = mobile_clientIds.contents if mobile_clientIds else {}
+        fmsapi_keys = fmsapi_secrets.contents if fmsapi_secrets and isinstance(fmsapi_secrets.contents, dict) else {}
+        clientIds = mobile_clientIds.contents if mobile_clientIds and isinstance(mobile_clientIds.contents, dict) else {}
         self.template_values.update({
             'google_secret': google_secrets.contents.get('api_key', "") if google_secrets else "",
             'firebase_secret': firebase_secrets.contents.get('FIREBASE_SECRET', "") if firebase_secrets else "",
@@ -29,7 +29,7 @@ class AdminAuthKeys(LoggedInHandler):
             'fmsapi_secret': fmsapi_keys.get('authkey', ''),
             'web_client_id': clientIds.get('web', ''),
             'android_client_id': clientIds.get('android', ''),
-            'gcm_key': gcm_serverKey.contents if gcm_serverKey else "",
+            'gcm_key': gcm_serverKey.contents.get("gcm_key", "") if gcm_serverKey else "",
         })
 
         path = os.path.join(os.path.dirname(__file__), '../../templates/admin/authkeys.html')
@@ -56,7 +56,7 @@ class AdminAuthKeys(LoggedInHandler):
         firebase_secrets.contents = {'FIREBASE_SECRET': firebase_key}
         fmsapi_secrets.contents = {'username': fmsapi_user, 'authkey': fmsapi_secret}
         mobile_clientIds.contents = {'web': web_client_id, 'android': android_client_id}
-        gcm_serverKey.contents = gcm_key
+        gcm_serverKey.contents = {'gcm_key': gcm_key}
 
         google_secrets.put()
         firebase_secrets.put()

--- a/controllers/gcm/gcm.py
+++ b/controllers/gcm/gcm.py
@@ -106,7 +106,7 @@ class GCMConnection:
         self.SERVER_KEY = Sitevar.get_by_id('gcm.serverKey')
         if self.SERVER_KEY is None:
             raise Exception("Missing sitevar: gcm.serverKey. Can't send GCM messages.")
-        self.GCM_CONFIG = {'gcm_api_key': self.SERVER_KEY.contents}
+        self.GCM_CONFIG = {'gcm_api_key': self.SERVER_KEY.contents['gcm_key']}
         self.GOOGLE_LOGIN_URL = 'https://www.google.com/accounts/ClientLogin'
         # Can't use https on localhost due to Google cert bug
         self.GOOGLE_GCM_SEND_URL = 'https://android.apis.google.com/gcm/send'

--- a/controllers/gcm/gcm.py
+++ b/controllers/gcm/gcm.py
@@ -106,8 +106,7 @@ class GCMConnection:
         self.SERVER_KEY = Sitevar.get_by_id('gcm.serverKey')
         if self.SERVER_KEY is None:
             raise Exception("Missing sitevar: gcm.serverKey. Can't send GCM messages.")
-        logging.info("GCM KEY: "+str(self.SERVER_KEY.values_json))
-        self.GCM_CONFIG = {'gcm_api_key': str(self.SERVER_KEY.values_json) }
+        self.GCM_CONFIG = {'gcm_api_key': self.SERVER_KEY.contents}
         self.GOOGLE_LOGIN_URL = 'https://www.google.com/accounts/ClientLogin'
         # Can't use https on localhost due to Google cert bug
         self.GOOGLE_GCM_SEND_URL = 'https://android.apis.google.com/gcm/send'

--- a/mobile_main.py
+++ b/mobile_main.py
@@ -25,16 +25,21 @@ from models.mobile_api_messages import BaseResponse, FavoriteCollection, Favorit
 from models.mobile_client import MobileClient
 from models.suggestion import Suggestion
 
-client_id_sitevar = Sitevar.get_by_id('appengine.webClientId')
-if client_id_sitevar is None:
-    raise Exception("Sitevar appengine.webClientId is undefined. Can't process incoming requests")
-WEB_CLIENT_ID = str(client_id_sitevar.values_json)
-ANDROID_AUDIENCE = WEB_CLIENT_ID
+WEB_CLIENT_ID = ""
+ANDROID_AUDIENCE = ""
+ANDROID_CLIENT_ID = ""
 
-android_id_sitevar = Sitevar.get_by_id('android.clientId')
-if android_id_sitevar is None:
-    raise Exception("Sitevar android.clientId is undefined. Can't process incoming requests")
-ANDROID_CLIENT_ID = str(android_id_sitevar.values_json)
+client_ids_sitevar = Sitevar.get_or_insert('mobile.clientIds')
+if isinstance(client_ids_sitevar.contents, dict):
+    WEB_CLIENT_ID = client_ids_sitevar.contents.get("web", "")
+    ANDROID_AUDIENCE = WEB_CLIENT_ID
+    ANDROID_CLIENT_ID = client_ids_sitevar.contents.get("android", "")
+
+if not WEB_CLIENT_ID:
+    logging.error("Web client ID is not set, see /admin/authkeys")
+
+if not ANDROID_CLIENT_ID:
+    logging.error("Android client ID is not set, see /admin/authkeys")
 
 # To enable iOS access to the API, add another variable for the iOS client ID
 

--- a/models/sitevar.py
+++ b/models/sitevar.py
@@ -15,7 +15,7 @@ class Sitevar(ndb.Model):
     manually edited by site administrators in the admin console.
     """
     description = ndb.StringProperty(indexed=False)
-    values_json = ndb.StringProperty(indexed=False)  # a json blob
+    values_json = ndb.StringProperty(indexed=False, default="{}")  # a json blob
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/templates/admin/authkeys.html
+++ b/templates/admin/authkeys.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}API Keys{% endblock %}
+
+{% block content %}
+
+<h1>Third Party API Keys</h1>
+<p>Here you can manage all of the tokens for third party APIs used by TBA</p>
+
+<form method="post">
+<table class="table table-striped">
+  <tr><th>Google</th></tr>
+  <tr><td>API Key</td><td><input name="google_secret" value="{{google_secret}}" class="form-control"/></td></tr>
+
+  <tr><th>Firebase</th></tr>
+  <tr><td>API Key</td><td><input name="firebase_secret" value="{{firebase_secret}}" class="form-control"/></td></tr>
+
+  <tr><th>FMS API</th></tr>
+  <tr><td>Username</td><td><input name="fmsapi_user" value="{{fmsapi_user}}" class="form-control"/></td></tr>
+  <tr><td>Auth Key</td><td><input name="fmsapi_secret" value="{{fmsapi_secret}}" class="form-control"/></td></tr>
+
+  <tr><th>Mobile Apps</th></tr>
+  <tr><td>GCM Key</td><td><input name="gcm_key" value="{{gcm_key}}" class="form-control"/></td></tr>
+  <tr><td>Web Client ID</td><td><input name="web_client_id" value="{{web_client_id}}" class="form-control"/></td></tr>
+  <tr><td>Android Client ID</td><td><input name="android_client_id" value="{{android_client_id}}" class="form-control"/></td></tr>
+</table>
+
+<button type="submit" class="btn btn-info"><span class="glyphicon glyphicon-thumbs-up"></span> Update</button>
+
+</form>
+
+{% endblock %}

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -102,6 +102,7 @@
               <li><a href="/admin/tasks">Task Launcher</a></li>
               <li><a href="/admin/mobile">Mobile Clients</a></li>
               <li><a href="/admin/apistatus">API Status</a></li>
+              <li><a href="/admin/authkeys">Third Party API Keys</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
So it's easy to keep track/add them.

This also consolidates/cleans up some of the Sitevars in use for myTBA related things, although there are a few migration steps (below).
1. Change the value in `gcm.serverKey`: make the current content the value in a dict with key "gcm_key"
2. Copy/paste the values from `appEngine.webClientId` and `android.clientId` into the panel and submit (those should be the only ones to default unfilled)
3. You can now delete the two sitevars above, they were migrated to a dict in `mobile.clientIds`