### PR TITLE
Update event API doc to correct description of `official` property.

### DIFF
--- a/templates/apidocs.html
+++ b/templates/apidocs.html
@@ -273,8 +273,7 @@
           </tr>
           <tr>
             <td>official</td>
-            <td>Whether this is a <em>FIRST</em> official event, or an offseaon
-            event.</td>
+            <td>Whether this event used the official FMS.</td>
             <td>true</td>
           </tr>
           <tr>


### PR DESCRIPTION
Per #1607, update the docs to correct the use of `official` as using the official FMS, not being an official event.