### PR TITLE
Fixed GD2 crash caused by Redux devtools not being present

### DIFF
--- a/react/gameday2/gameday2.js
+++ b/react/gameday2/gameday2.js
@@ -14,7 +14,7 @@ const webcastData = $.parseJSON($('#webcasts_json').text())
 
 let store = createStore(gamedayReducer, compose(
   applyMiddleware(thunk),
-  window.devToolsExtension && window.devToolsExtension()
+  window.devToolsExtension ? window.devToolsExtension() : f => f
 ))
 
 ReactDOM.render(


### PR DESCRIPTION
If the Redux devtools extension wasn't installed, an undefined object would be inserted in the Redux middleware chain, which made things break. This PR properly handles the case where said extension isn't present.