### PR TITLE
Add admin bar to make tasks easier

### DIFF
--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -13,6 +13,7 @@ from google.appengine.api import memcache
 import tba_config
 
 from helpers.user_bundle import UserBundle
+from template_engine import jinja2_engine
 
 
 class CacheableHandler(webapp2.RequestHandler):
@@ -27,6 +28,8 @@ class CacheableHandler(webapp2.RequestHandler):
         super(CacheableHandler, self).__init__(*args, **kw)
         self._cache_expiration = 0
         self._last_modified = None  # A datetime object
+        self._user_bundle = UserBundle()
+        self._is_admin = self._user_bundle.is_current_user_admin
         if not hasattr(self, '_partial_cache_key'):
             self._partial_cache_key = self.CACHE_KEY_FORMAT
         self.template_values = {}
@@ -48,16 +51,24 @@ class CacheableHandler(webapp2.RequestHandler):
             cls.CACHE_VERSION,
             tba_config.CONFIG["static_resource_version"])
 
+    def _add_admin_bar(self, html):
+        if self._is_admin:
+            self.template_values["cache_key"] = self.cache_key
+            self.template_values["user_bundle"] = self._user_bundle
+            admin_bar = jinja2_engine.render('admin_bar.html', self.template_values)
+            return html.replace('<!-- Admin Bar -->', admin_bar)
+        else:
+            return html
+
     def get(self, *args, **kw):
         cached_response = self._read_cache()
 
         if cached_response is None:
             self._set_cache_header_length(self.CACHE_HEADER_LENGTH)
-            self.template_values["cache_key"] = self.cache_key
             self.template_values["render_time"] = datetime.datetime.now()
             rendered = self._render(*args, **kw)
             if self._has_been_modified_since(self._last_modified):
-                self.response.out.write(rendered)
+                self.response.out.write(self._add_admin_bar(rendered))
                 self._write_cache(self.response)
                 return
             else:
@@ -66,7 +77,7 @@ class CacheableHandler(webapp2.RequestHandler):
             self.response.headers.update(cached_response.headers)
             del self.response.headers['Content-Length']  # Content-Length gets set automatically
             if self._has_been_modified_since(self._last_modified):
-                self.response.out.write(cached_response.body)
+                self.response.out.write(self._add_admin_bar(cached_response.body))
                 return
             else:
                 return None
@@ -98,7 +109,7 @@ class CacheableHandler(webapp2.RequestHandler):
             return response
 
     def _write_cache(self, response):
-        if tba_config.CONFIG["memcache"]:
+        if tba_config.CONFIG["memcache"] and not self._is_admin:
             compressed = zlib.compress(cPickle.dumps((response, self._last_modified)))
             memcache.set(self.cache_key, compressed, self._cache_expiration)
 
@@ -114,8 +125,9 @@ class CacheableHandler(webapp2.RequestHandler):
             logging.error("Cache-Control max-age is not integer: {}".format(seconds))
             return
 
-        self.response.headers['Cache-Control'] = "public, max-age=%d" % max(seconds, 61)  # needs to be at least 61 seconds to work
-        self.response.headers['Pragma'] = 'Public'
+        if not self._is_admin:
+            self.response.headers['Cache-Control'] = "public, max-age=%d" % max(seconds, 61)  # needs to be at least 61 seconds to work
+            self.response.headers['Pragma'] = 'Public'
 
 
 class LoggedInHandler(webapp2.RequestHandler):

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--cache_key {{cache_key}}-->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -156,6 +155,8 @@
     </div>
   </div>
 </div>
+
+<!-- Admin Bar -->
 
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>

--- a/templates_jinja2/admin_bar.html
+++ b/templates_jinja2/admin_bar.html
@@ -1,0 +1,9 @@
+<nav class="navbar navbar-inverse navbar-fixed-bottom">
+  <div class="container">
+    <p class="navbar-text">Admin logged in as {{ user_bundle.account.display_name }}</p>
+    <form class="form-inline" action="/admin/memcache" method="post">
+      <input name="memcache_key" value="{{cache_key}}" type="hidden" />
+      <button class="btn btn-default navbar-btn" type="submit"><span class="glyphicon glyphicon-trash"></span> Clear Page Cache</button>
+    </form>
+  </div>
+</nav>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--cache_key {{cache_key}}-->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -156,6 +155,8 @@
     </div>
   </div>
 </div>
+
+<!-- Admin Bar -->
 
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>


### PR DESCRIPTION
Adds a bar to the bottom of all pages if the user is logged in as an admin. This bar currently allows for easier cache clearing of the page, but can be extended to do more.

If the user is an admin, none of generated HTML is cached in either memcache or edge cache. Adding the admin bar makes used of existing memcache by find/replacing an HTML comment.

I'm confident that the current setup doesn't improperly leak the admin bar to non admins (in the worst case, the button they click will still prompt for login). However, the bar may not show up for admins if the page already exists in edge cache (I'm not sure), but through experience and [this documentation](https://cloud.google.com/appengine/docs/python/how-requests-are-handled#cache-control_expires_and_vary), it seems like GAE never sets cache headers if the user is an admin so it probably won't be a problem.

![image](https://cloud.githubusercontent.com/assets/1421884/18658473/671ffb36-7ed1-11e6-81fd-39f6a38bcca9.png)
