### PR TITLE
Admin Panel Interface for Registration Days

### DIFF
--- a/controllers/admin/admin_cron_controller.py
+++ b/controllers/admin/admin_cron_controller.py
@@ -238,7 +238,7 @@ class AdminPostEventTasksDo(LoggedInHandler):
 
 
 class AdminRegistrationDayEnqueue(LoggedInHandler):
-    def get(self, date_string, event_year, interval):
+    def post(self):
         """
         Configures scheduling a registration day in advance
         This will enqueue the requested year's event details task every X minutes
@@ -248,7 +248,10 @@ class AdminRegistrationDayEnqueue(LoggedInHandler):
         :param interval: How many minutes between fetches
         """
         self._require_admin()
-        logging.info(date_string)
+        date_string = self.request.get("date_string")
+        event_year = self.request.get("event_year")
+        interval = self.request.get("interval")
+
         start = datetime.strptime(date_string, "%Y-%m-%d")
         event_year = int(event_year)
         interval = int(interval)

--- a/controllers/admin/admin_cron_controller.py
+++ b/controllers/admin/admin_cron_controller.py
@@ -254,13 +254,18 @@ class AdminRegistrationDayEnqueue(LoggedInHandler):
         interval = int(interval)
 
         # Enqueue the tasks
+        now = datetime.now()
         for i in xrange(0, 24*60, interval):
             # 24*60 is number of minutes per day
+            task_eta = start + timedelta(minutes=i)
+            if task_eta < now:
+                # Don't enqueue tasks in the past
+                continue
             taskqueue.add(
                 queue_name='datafeed',
                 target='backend-tasks',
                 url='/backend-tasks/get/event_list/{}'.format(event_year),
-                eta=start + timedelta(minutes=i),
+                eta=task_eta,
                 method='GET'
             )
 

--- a/cron_main.py
+++ b/cron_main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import webapp2
-from webapp2_extras.routes import RedirectRoute
 
 import tba_config
 
@@ -55,6 +54,6 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/admin/clear_old_subs', AdminSubsClear),
                                ('/tasks/admin/enqueue/clear_old_webhooks', AdminWebhooksClearEnqueue),
                                ('/tasks/admin/clear_old_webhooks', AdminWebhooksClear),
-                               RedirectRoute(r'/tasks/admin/enqueue/registration_day/<date_string>/<event_year>/<interval>', AdminRegistrationDayEnqueue),
+                               ('/tasks/admin/enqueue/registration_day', AdminRegistrationDayEnqueue),
                                ],
                               debug=tba_config.DEBUG)

--- a/cron_main.py
+++ b/cron_main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import webapp2
+from webapp2_extras.routes import RedirectRoute
 
 import tba_config
 
@@ -18,7 +19,7 @@ from controllers.cron_controller import FinalMatchesRepairDo
 from controllers.cron_controller import UpcomingNotificationDo
 
 from controllers.admin.admin_cron_controller import AdminMobileClearEnqueue, AdminMobileClear, AdminSubsClearEnqueue, AdminSubsClear, \
-    AdminWebhooksClearEnqueue, AdminWebhooksClear
+    AdminWebhooksClearEnqueue, AdminWebhooksClear, AdminRegistrationDayEnqueue
 
 app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackupEventsEnqueue),
                                ('/tasks/enqueue/csv_backup_events/([0-9]*)', TbaCSVBackupEventsEnqueue),
@@ -54,5 +55,6 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/admin/clear_old_subs', AdminSubsClear),
                                ('/tasks/admin/enqueue/clear_old_webhooks', AdminWebhooksClearEnqueue),
                                ('/tasks/admin/clear_old_webhooks', AdminWebhooksClear),
+                               RedirectRoute(r'/tasks/admin/enqueue/registration_day/<date_string>/<event_year>/<interval>', AdminRegistrationDayEnqueue),
                                ],
                               debug=tba_config.DEBUG)

--- a/templates/admin/tasks.html
+++ b/templates/admin/tasks.html
@@ -57,6 +57,32 @@
 </div>
 
 <hr>
+<h4>Special Registration Days</h4>
+<div class="row">
+    <div class="col-xs-4">
+        <form class="form-inline">
+            <div class="input-group">
+                <span class="help-block">Registration Date</span>
+                <input class="form-control" id="enqueue_registration_date" type="text" placeholder="2016-10-17">
+                <span class="help-block">Event Year to Enqueue</span>
+                <input class="form-control" id="enqueue_registration_year" type="text" placeholder="2017">
+                <span class="help-block">Scrape Interval (minutes)</span>
+                <input class="form-control" id="enqueue_registration_interval" type="text" placeholder="30">
+            </div>
+            <span class="input-group-btn" id="enqueue_registration_submit">
+                  <button class="btn btn-warning" type="button">Go <span class="glyphicon glyphicon-fast-forward"></span></button>
+            </span>
+        </form>
+        <script>
+        $("#enqueue_registration_submit").click(function() {
+            window.location = "/tasks/admin/enqueue/registration_day/" + $("#enqueue_registration_date").val() + "/"
+                            + $("#enqueue_registration_year").val() + "/" + $("#enqueue_registration_interval").val();
+        });
+        </script>
+    </div>
+</div>
+
+<hr>
 <h4>TbaVideos</h4>
 <p>Scrape videos.thebluealliance.com to update hosted video file index</p>
 <div class="row">

--- a/templates/admin/tasks.html
+++ b/templates/admin/tasks.html
@@ -60,25 +60,19 @@
 <h4>Special Registration Days</h4>
 <div class="row">
     <div class="col-xs-4">
-        <form class="form-inline">
+        <form class="form-inline" action="/tasks/admin/enqueue/registration_day" method="post">
             <div class="input-group">
                 <span class="help-block">Registration Date</span>
-                <input class="form-control" id="enqueue_registration_date" type="text" placeholder="2016-10-17">
+                <input class="form-control" id="enqueue_registration_date" name="date_string" type="text" placeholder="2016-10-17">
                 <span class="help-block">Event Year to Enqueue</span>
-                <input class="form-control" id="enqueue_registration_year" type="text" placeholder="2017">
+                <input class="form-control" id="enqueue_registration_year" name="event_year" type="text" placeholder="2017">
                 <span class="help-block">Scrape Interval (minutes)</span>
-                <input class="form-control" id="enqueue_registration_interval" type="text" placeholder="30">
+                <input class="form-control" id="enqueue_registration_interval" name="interval" type="text" placeholder="30">
             </div>
             <span class="input-group-btn" id="enqueue_registration_submit">
-                  <button class="btn btn-warning" type="button">Go <span class="glyphicon glyphicon-fast-forward"></span></button>
+                  <button class="btn btn-warning" type="submit">Go <span class="glyphicon glyphicon-fast-forward"></span></button>
             </span>
         </form>
-        <script>
-        $("#enqueue_registration_submit").click(function() {
-            window.location = "/tasks/admin/enqueue/registration_day/" + $("#enqueue_registration_date").val() + "/"
-                            + $("#enqueue_registration_year").val() + "/" + $("#enqueue_registration_interval").val();
-        });
-        </script>
     </div>
 </div>
 


### PR DESCRIPTION
This allows us to schedule event details scraping in advance for registration days. Adds a box on `/admin/tasks/` to do it for you.

This will schedule `/backend-tasks/get/event_list/<year>` every `<interval>` minutes for the day specified. It will also set the "turbo mode" sitevar to reduce caches matching `.*<year>.*` to 61 seconds until the end of that day (starting now).

![screenshot from 2016-10-17 17-50-21](https://cloud.githubusercontent.com/assets/2754863/19456988/36c14072-9492-11e6-8c95-d28fd22f2cca.png)

Fixes https://github.com/the-blue-alliance/the-blue-alliance/issues/1622