### PR TITLE
Keyless Eventwizard

### DIFF
--- a/controllers/ajax_controller.py
+++ b/controllers/ajax_controller.py
@@ -4,6 +4,8 @@ import urllib2
 import json
 import time
 
+import datetime
+
 from base_controller import CacheableHandler, LoggedInHandler
 from consts.client_type import ClientType
 from google.appengine.api import memcache
@@ -13,6 +15,7 @@ from google.appengine.ext.webapp import template
 from helpers.model_to_dict import ModelToDict
 from helpers.mytba_helper import MyTBAHelper
 from models.account import Account
+from models.api_auth_access import ApiAuthAccess
 from models.event import Event
 from models.favorite import Favorite
 from models.mobile_client import MobileClient
@@ -304,3 +307,26 @@ class YouTubePlaylistHandler(LoggedInHandler):
             next_page_token = video_result["nextPageToken"]
 
         self.response.out.write(json.dumps(video_ids))
+
+
+class AllowedApiWriteEventsHandler(LoggedInHandler):
+    """
+    Get the events the current user is allowed to edit via the trusted API
+    """
+    def get(self):
+        if not self.user_bundle.user:
+            self.response.out.write(json.dumps([]))
+            return
+
+        now = datetime.datetime.now()
+        auth_tokens = ApiAuthAccess.query(ApiAuthAccess.owner == self.user_bundle.account.key,
+                                          ndb.OR(ApiAuthAccess.expiration == None, ApiAuthAccess.expiration >= now)).fetch()
+        event_keys = []
+        for token in auth_tokens:
+            event_keys.extend(token.event_list)
+
+        events = ndb.get_multi(event_keys)
+        details = {}
+        for event in events:
+            details[event.key_name] =  "{} {}".format(event.year, event.name)
+        self.response.out.write(json.dumps(details))

--- a/controllers/event_wizard_controller.py
+++ b/controllers/event_wizard_controller.py
@@ -15,4 +15,5 @@ class EventWizardHandler(CacheableHandler):
 
     def _render(self, *args, **kw):
         path = os.path.join(os.path.dirname(__file__), "../templates/eventwizard.html")
+
         return template.render(path, self.template_values)

--- a/index.yaml
+++ b/index.yaml
@@ -9,6 +9,17 @@ indexes:
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
 
+- kind: ApiAuthAccess
+  properties:
+  - name: event_list
+  - name: owner
+  - name: expiration
+
+- kind: ApiAuthAccess
+  properties:
+  - name: owner
+  - name: expiration
+
 - kind: Event
   properties:
   - name: __key__

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import tba_config
 
 from controllers.account_controller import AccountEdit, AccountLoginRequired, AccountLogin, AccountLogout, AccountOverview, AccountRegister, MyTBAController, myTBAAddHotMatchesController, MyTBAEventController, MyTBAMatchController, MyTBATeamController
 from controllers.ajax_controller import AccountInfoHandler, AccountRegisterFCMToken, AccountFavoritesHandler, AccountFavoritesAddHandler, AccountFavoritesDeleteHandler, \
-      YouTubePlaylistHandler
+      YouTubePlaylistHandler, AllowedApiWriteEventsHandler
 from controllers.ajax_controller import LiveEventHandler, TypeaheadHandler, WebcastHandler
 from controllers.event_controller import EventList, EventDetail, EventInsights, EventRss
 from controllers.event_wizard_controller import EventWizardHandler
@@ -133,6 +133,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/webhooks/delete', WebhookDelete, 'webhook-delete', strict_slash=True),
       RedirectRoute(r'/webhooks/verify/<client_id:[0-9]+>', WebhookVerify, 'webhook-verify', strict_slash=True),
       RedirectRoute(r'/webhooks/send_verification', WebhookVerificationSend, 'webhook-send-verification', strict_slash=True),
+      RedirectRoute(r'/_/account/apiwrite_events', AllowedApiWriteEventsHandler, 'allowed-apiwrite-events', strict_slash=True),
       RedirectRoute(r'/_/account/info', AccountInfoHandler, 'account-info', strict_slash=True),
       RedirectRoute(r'/_/account/register_fcm_token', AccountRegisterFCMToken, 'account-register-web-client', strict_slash=True),
       RedirectRoute(r'/_/account/favorites/<model_type:[0-9]+>', AccountFavoritesHandler, 'ajax-account-favorites', strict_slash=True),

--- a/static/javascript/tba_js/eventwizard.js
+++ b/static/javascript/tba_js/eventwizard.js
@@ -182,6 +182,17 @@ function playoffMatchAndSet(totalMatchNum, is_octo){
     }
 }
 
+/* Load all valid events for this user */
+var valid_events = [];
+$.get( "/_/account/apiwrite_events", function(data) {
+    valid_events.push('<option value="">Select Event</option>');
+    $.each(JSON.parse(data), function(key, value) {
+        valid_events.push('<option value="'+ key +'">'+ value +'</option>');
+    });
+    valid_events.push('<option value="other">Other</option>');
+    $('#event_key_select').html(valid_events.join(''));
+});
+
 if($('#event_key_select').val() != "other"){
     $('#event_key').hide();
 }

--- a/static/javascript/tba_js/eventwizard.js
+++ b/static/javascript/tba_js/eventwizard.js
@@ -200,9 +200,15 @@ $('#event_key_select').change(function(){
     var eventKey = $(this).val();
     $('#event_key').val(eventKey);
     if(eventKey == "other"){
-        $('#event_key').val("").show()
+        $('#event_key').val("").show();
+        $('#auth-container').show();
+        $('#auth-tools').show();
     }else{
         $('#event_key').hide();
+
+        /* if the user is logged in, they don't need to manually input keys */
+        $('#auth-container').hide();
+        $('#auth-tools').hide();
     }
 
     // clear auth boxes

--- a/templates/eventwizard.html
+++ b/templates/eventwizard.html
@@ -25,7 +25,7 @@
             <input type="text" class="form-control" id="event_key" placeholder="Event Key"/>
           </div>
         </div>
-        <div class="form-group">
+        <div class="form-group" id="auth-tools">
           <label class="col-sm-2 control-label">Auth Tools</label>
           <div class="col-sm-10">
             <button type="button" class="btn btn-default" id="load_auth">Load Auth</button>


### PR DESCRIPTION
Yay!

When a user is logged in:
 - The "Select Event" dropdown in the eventwizard will now be populated with events the user has trusted API tokens for
 - The id/secret boxes will disappear (but they'll still be there for when you manually input an event key)
 - The trusted API now validates that the requested event + current user have auth tokens and will count that as valid (with updated tests)