### PR TITLE
Defer loading of chat sidebar until it is opened for the first time

### DIFF
--- a/react/gameday2/components/ChatSidebar.js
+++ b/react/gameday2/components/ChatSidebar.js
@@ -6,22 +6,31 @@ const ChatSidebar = (props) => {
     hidden: !props.enabled,
     'chat-sidebar': true,
   })
-  return (
-    <div className={classes}>
-      <iframe
-        frameBorder="0"
-        scrolling="no"
-        id="chat_embed"
-        src="http://twitch.tv/chat/embed?channel=tbagameday&amp;popout_chat=true"
-        height="100%"
-        width="100%"
-      />
-    </div>
-  )
+
+  let content
+  if (props.hasBeenVisible) {
+    content = (
+      <div className={classes}>
+        <iframe
+          frameBorder="0"
+          scrolling="no"
+          id="chat_embed"
+          src="http://twitch.tv/chat/embed?channel=tbagameday&amp;popout_chat=true"
+          height="100%"
+          width="100%"
+        />
+      </div>
+    )
+  } else {
+    content = (<div />)
+  }
+
+  return content
 }
 
 ChatSidebar.propTypes = {
   enabled: PropTypes.bool,
+  hasBeenVisible: PropTypes.bool,
 }
 
 export default ChatSidebar

--- a/react/gameday2/containers/ChatSidebarContainer.js
+++ b/react/gameday2/containers/ChatSidebarContainer.js
@@ -3,6 +3,7 @@ import ChatSidebar from '../components/ChatSidebar'
 
 const mapStateToProps = (state) => ({
   enabled: state.visibility.chatSidebar,
+  hasBeenVisible: state.visibility.chatSidebarHasBeenVisible,
 })
 
 export default connect(mapStateToProps, null)(ChatSidebar)

--- a/react/gameday2/reducers/__tests__/visibility.test.js
+++ b/react/gameday2/reducers/__tests__/visibility.test.js
@@ -6,6 +6,7 @@ describe('visibility reducer', () => {
     const expectedState = {
       hashtagSidebar: false,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: false,
       tickerSidebar: false,
     }
     expect(visibility(undefined, {})).toEqual(expectedState)
@@ -15,11 +16,13 @@ describe('visibility reducer', () => {
     const initialState = {
       hashtagSidebar: false,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: false,
       tickerSidebar: false,
     }
     const expectedState = {
       hashtagSidebar: false,
       chatSidebar: true,
+      chatSidebarHasBeenVisible: true,
       tickerSidebar: false,
     }
     const action = {
@@ -32,11 +35,13 @@ describe('visibility reducer', () => {
     const initialState = {
       hashtagSidebar: false,
       chatSidebar: true,
+      chatSidebarHasBeenVisible: true,
       tickerSidebar: false,
     }
     const expectedState = {
       hashtagSidebar: false,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: true,
       tickerSidebar: false,
     }
     const action = {
@@ -49,11 +54,13 @@ describe('visibility reducer', () => {
     const initialState = {
       hashtagSidebar: false,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: false,
       tickerSidebar: false,
     }
     const expectedState = {
       hashtagSidebar: true,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: false,
       tickerSidebar: false,
     }
     const action = {
@@ -66,11 +73,13 @@ describe('visibility reducer', () => {
     const initialState = {
       hashtagSidebar: true,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: false,
       tickerSidebar: false,
     }
     const expectedState = {
       hashtagSidebar: false,
       chatSidebar: false,
+      chatSidebarHasBeenVisible: false,
       tickerSidebar: false,
     }
     const action = {

--- a/react/gameday2/reducers/visibility.js
+++ b/react/gameday2/reducers/visibility.js
@@ -5,12 +5,17 @@ import { TOGGLE_CHAT_SIDEBAR_VISIBILITY, TOGGLE_HASHTAG_SIDEBAR_VISIBILITY } fro
 const defaultState = {
   hashtagSidebar: false,
   chatSidebar: false,
+  chatSidebarHasBeenVisible: false,
   tickerSidebar: false,
 }
 
-const toggleChatSidebarVisibility = (state) => (Object.assign({}, state, {
-  chatSidebar: !state.chatSidebar,
-}))
+const toggleChatSidebarVisibility = (state) => {
+  const hasBeenVisible = (state.chatSidebarHasBeenVisible || !state.chatSidebar)
+  return Object.assign({}, state, {
+    chatSidebar: !state.chatSidebar,
+    chatSidebarHasBeenVisible: hasBeenVisible,
+  })
+}
 
 const toggleHashtagSidebarVisibility = (state) => (Object.assign({}, state, {
   hashtagSidebar: !state.hashtagSidebar,

--- a/react/gameday2/sidebars.less
+++ b/react/gameday2/sidebars.less
@@ -6,6 +6,7 @@
   right: 0;
   width: @chat-sidebar-width;
   height: 100%;
+  background: #EFEEF1
 }
 
 .hashtag-sidebar {


### PR DESCRIPTION
This makes Gameday perform better when the site is first loading. The embed kicks off an absolutely insane number of network requests, and I've noticed some (subjective) lags when the page loads. I need to learn how to do proper profiling of websites...

It looks like the twitch embed is broken on prod GD2 because it's being requested over http, not https. I'll fix that next.