### PR TITLE
Close admin cache bar

### DIFF
--- a/templates_jinja2/admin_bar.html
+++ b/templates_jinja2/admin_bar.html
@@ -5,7 +5,7 @@
       <input name="memcache_key" value="{{cache_key}}" type="hidden" />
       <button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-trash"></span> Clear Page Cache</button>
     </form>
-    <button type="button" class="btn btn-default navbar-btn navbar-right" onclick="if($){$('#admin-bar').remove()}">
+    <button type="button" class="btn btn-default navbar-btn navbar-right" onclick="var c=document.getElementById('admin-bar');c.parentNode.removeChild(c);">
       <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
     </button>
   </div>

--- a/templates_jinja2/admin_bar.html
+++ b/templates_jinja2/admin_bar.html
@@ -1,9 +1,12 @@
-<nav class="navbar navbar-inverse navbar-fixed-bottom">
+<nav class="navbar navbar-inverse navbar-fixed-bottom" id="admin-bar">
   <div class="container">
     <p class="navbar-text">Admin logged in as {{ user_bundle.account.display_name }}</p>
-    <form class="form-inline" action="/admin/memcache" method="post">
+    <form class="navbar-form navbar-left" action="/admin/memcache" method="post">
       <input name="memcache_key" value="{{cache_key}}" type="hidden" />
-      <button class="btn btn-default navbar-btn" type="submit"><span class="glyphicon glyphicon-trash"></span> Clear Page Cache</button>
+      <button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-trash"></span> Clear Page Cache</button>
     </form>
+    <button type="button" class="btn btn-default navbar-btn navbar-right" onclick="if($){$('#admin-bar').remove()}">
+      <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+    </button>
   </div>
 </nav>


### PR DESCRIPTION
The admin bar with the "clear cache" button can block player controls in Gameday. This adds a "close" button with some inline javascript that will remove the bar from the DOM.