### PR TITLE
[GD2] Implemented remaining streaming providers

### DIFF
--- a/controllers/gameday_controller.py
+++ b/controllers/gameday_controller.py
@@ -161,4 +161,4 @@ class GamedayRedirectHandler(webapp2.RequestHandler):
         for i, webcast in enumerate(event.webcast):
             params += "&view_{}={}-{}".format(i, webcast['key_name'], i+1)
 
-        return param
+        return params

--- a/controllers/gameday_controller.py
+++ b/controllers/gameday_controller.py
@@ -161,4 +161,4 @@ class GamedayRedirectHandler(webapp2.RequestHandler):
         for i, webcast in enumerate(event.webcast):
             params += "&view_{}={}-{}".format(i, webcast['key_name'], i+1)
 
-        return params
+        return param

--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -1,8 +1,6 @@
 import React, { PropTypes } from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
-import EmbedUstream from './EmbedUstream'
-import EmbedYoutube from './EmbedYoutube'
-import EmbedTwitch from './EmbedTwitch'
+import WebcastEmbed from './WebcastEmbed'
 import VideoCellToolbarContainer from '../containers/VideoCellToolbarContainer'
 import WebcastSelectionOverlayDialogContainer from '../containers/WebcastSelectionOverlayDialogContainer'
 import SwapPositionOverlayDialogContainer from '../containers/SwapPositionOverlayDialogContainer'
@@ -56,22 +54,6 @@ export default class VideoCell extends React.Component {
     })
 
     if (this.props.webcast) {
-      let cellEmbed
-      switch (this.props.webcast.type) {
-        case 'ustream':
-          cellEmbed = (<EmbedUstream webcast={this.props.webcast} />)
-          break
-        case 'youtube':
-          cellEmbed = (<EmbedYoutube webcast={this.props.webcast} />)
-          break
-        case 'twitch':
-          cellEmbed = (<EmbedTwitch webcast={this.props.webcast} />)
-          break
-        default:
-          cellEmbed = ''
-          break
-      }
-
       const toolbarStyle = {
         position: 'absolute',
         bottom: 0,
@@ -83,7 +65,7 @@ export default class VideoCell extends React.Component {
         <div
           style={cellStyle}
         >
-          {cellEmbed}
+          <WebcastEmbed webcast={this.props.webcast} />
           <VideoCellToolbarContainer
             style={toolbarStyle}
             webcast={this.props.webcast}

--- a/react/gameday2/components/WebcastEmbed.js
+++ b/react/gameday2/components/WebcastEmbed.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 import EmbedUstream from './embeds/EmbedUstream'
 import EmbedYoutube from './embeds/EmbedYoutube'
 import EmbedTwitch from './embeds/EmbedTwitch'

--- a/react/gameday2/components/WebcastEmbed.js
+++ b/react/gameday2/components/WebcastEmbed.js
@@ -1,0 +1,52 @@
+import React, { PropTypes } from 'react'
+import EmbedUstream from './embeds/EmbedUstream'
+import EmbedYoutube from './embeds/EmbedYoutube'
+import EmbedTwitch from './embeds/EmbedTwitch'
+import EmbedLivestream from './embeds/EmbedLivestream'
+import EmbedIframe from './embeds/EmbedIframe'
+import EmbedHtml5 from './embeds/EmbedHtml5'
+import EmbedDacast from './embeds/EmbedDacast'
+import EmbedRtmp from './embeds/EmbedRtmp'
+import EmbedNotSupported from './embeds/EmbedNotSupported'
+import { webcastPropType } from '../utils/webcastUtils'
+
+export default class WebcastEmbed extends React.Component {
+  static propTypes = {
+    webcast: webcastPropType,
+  }
+
+  render() {
+    let cellEmbed
+    switch (this.props.webcast.type) {
+      case 'ustream':
+        cellEmbed = (<EmbedUstream webcast={this.props.webcast} />)
+        break
+      case 'youtube':
+        cellEmbed = (<EmbedYoutube webcast={this.props.webcast} />)
+        break
+      case 'twitch':
+        cellEmbed = (<EmbedTwitch webcast={this.props.webcast} />)
+        break
+      case 'livestream':
+        cellEmbed = (<EmbedLivestream webcast={this.props.webcast} />)
+        break
+      case 'iframe':
+        cellEmbed = (<EmbedIframe webcast={this.props.webcast} />)
+        break
+      case 'html5':
+        cellEmbed = (<EmbedHtml5 webcast={this.props.webcast} />)
+        break
+      case 'dacast':
+        cellEmbed = (<EmbedDacast webcast={this.props.webcast} />)
+        break
+      case 'rtmp':
+        cellEmbed = (<EmbedRtmp webcast={this.props.webcast} />)
+        break
+      default:
+        cellEmbed = (<EmbedNotSupported />)
+        break
+    }
+
+    return cellEmbed
+  }
+}

--- a/react/gameday2/components/embeds/EmbedDacast.js
+++ b/react/gameday2/components/embeds/EmbedDacast.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { webcastPropType } from '../../utils/webcastUtils'
+
+const EmbedDacast = (props) => {
+  const channel = props.webcast.channel
+  const file = props.webcast.file
+  const iframeSrc = `https://static.viewer.dacast.com/b/${channel}/c/{file}`
+  return (
+    <iframe
+      src={iframeSrc}
+      width="100%"
+      height="100%"
+      frameborder="0"
+      scrolling="no"
+    />
+  )
+}
+
+EmbedDacast.propTypes = {
+  webcast: webcastPropType.isRequired,
+}
+
+export default EmbedDacast

--- a/react/gameday2/components/embeds/EmbedDacast.js
+++ b/react/gameday2/components/embeds/EmbedDacast.js
@@ -4,13 +4,13 @@ import { webcastPropType } from '../../utils/webcastUtils'
 const EmbedDacast = (props) => {
   const channel = props.webcast.channel
   const file = props.webcast.file
-  const iframeSrc = `https://static.viewer.dacast.com/b/${channel}/c/{file}`
+  const iframeSrc = `https://static.viewer.dacast.com/b/${channel}/c/${file}`
   return (
     <iframe
       src={iframeSrc}
       width="100%"
       height="100%"
-      frameborder="0"
+      frameBorder="0"
       scrolling="no"
     />
   )

--- a/react/gameday2/components/embeds/EmbedHtml5.js
+++ b/react/gameday2/components/embeds/EmbedHtml5.js
@@ -1,40 +1,28 @@
 import React from 'react'
 import { webcastPropType } from '../../utils/webcastUtils'
 
-const EmbedHtml5 = (props) => {
-  const flashVars = JSON.stringify({
-    plugins: {
-      flashls: {
-        url: '/flowplayer/flashlsFlowPlayer.swf',
-        hls_maxbufferlength: 20
-      }
-    },
-    clip: {
-      live: true,
-      url: `${props.webcast.channel}`,
-      provider: 'flashls',
-      urlResolvers: 'flashls',
-      scaling: 'fit'
-    }
-  })
-  const flashVarsConfig = `config=${flashVars}`
-  return (
-    <object
-      width="100%"
-      height="100%"
-      data="/flowplayer/flowplayer-3.2.18.swf"
-      type="application/x-shockwave-flash"
-    >
-      <param name="flashvars" value={flashVarsConfig} />
-      <param name="movie" value="/flowplayer/flowplayer-3.2.18.swf" />
-      <param name="allowfullscreen" value="true" />
-      <param name="bgcolor" value="222222" />
-    </object>
-  )
-}
+export default class EmbedHtml5 extends React.Component {
+  static propTypes = {
+    webcast: webcastPropType.isRequired,
+  }
 
-EmbedHtml5.propTypes = {
-  webcast: webcastPropType.isRequired,
-}
+  componentDidMount() {
+    videojs(this.props.webcast.id, {
+      width: '100%',
+      height: '100%',
+      autoplay: true,
+    })
+  }
 
-export default EmbedHtml5
+  render() {
+    return (
+      <video
+        controls
+        id={this.props.webcast.id}
+        className="video-js vjs-default-skin"
+      >
+        <source src={this.props.webcast.channel} type="application/x-mpegurl" />
+      </video>
+    )
+  }
+}

--- a/react/gameday2/components/embeds/EmbedHtml5.js
+++ b/react/gameday2/components/embeds/EmbedHtml5.js
@@ -1,3 +1,4 @@
+/* global videojs */
 import React from 'react'
 import { webcastPropType } from '../../utils/webcastUtils'
 

--- a/react/gameday2/components/embeds/EmbedHtml5.js
+++ b/react/gameday2/components/embeds/EmbedHtml5.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { webcastPropType } from '../../utils/webcastUtils'
+
+const EmbedHtml5 = (props) => {
+  const flashVars = JSON.stringify({
+    plugins: {
+      flashls: {
+        url: '/flowplayer/flashlsFlowPlayer.swf',
+        hls_maxbufferlength: 20
+      }
+    },
+    clip: {
+      live: true,
+      url: `${props.webcast.channel}`,
+      provider: 'flashls',
+      urlResolvers: 'flashls',
+      scaling: 'fit'
+    }
+  })
+  const flashVarsConfig = `config=${flashVars}`
+  return (
+    <object
+      width="100%"
+      height="100%"
+      data="/flowplayer/flowplayer-3.2.18.swf"
+      type="application/x-shockwave-flash"
+    >
+      <param name="flashvars" value={flashVarsConfig} />
+      <param name="movie" value="/flowplayer/flowplayer-3.2.18.swf" />
+      <param name="allowfullscreen" value="true" />
+      <param name="bgcolor" value="222222" />
+    </object>
+  )
+}
+
+EmbedHtml5.propTypes = {
+  webcast: webcastPropType.isRequired,
+}
+
+export default EmbedHtml5

--- a/react/gameday2/components/embeds/EmbedIframe.js
+++ b/react/gameday2/components/embeds/EmbedIframe.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { webcastPropType } from '../../utils/webcastUtils'
+
+const EmbedIframe = (props) => {
+  const divStyle = {
+    width: '100%',
+    height: '100%',
+  }
+
+  let iframeMarkup = props.webcast.channel
+  iframeMarkup = iframeMarkup.replace(/&lt;/, '<')
+  iframeMarkup = iframeMarkup.replace(/&gt;/, '>')
+  const markup = {
+    __html: iframeMarkup,
+  }
+
+  console.log(markup)
+
+  const elem = (
+    <div
+      style={divStyle}
+      dangerouslySetInnerHTML={markup}
+    />
+  )
+
+  return elem
+}
+
+EmbedIframe.propTypes = {
+  webcast: webcastPropType.isRequired,
+}
+
+export default EmbedIframe

--- a/react/gameday2/components/embeds/EmbedIframe.js
+++ b/react/gameday2/components/embeds/EmbedIframe.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react'
 import { webcastPropType } from '../../utils/webcastUtils'
 
@@ -13,8 +14,6 @@ const EmbedIframe = (props) => {
   const markup = {
     __html: iframeMarkup,
   }
-
-  console.log(markup)
 
   const elem = (
     <div

--- a/react/gameday2/components/embeds/EmbedLivestream.js
+++ b/react/gameday2/components/embeds/EmbedLivestream.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { webcastPropType } from '../../utils/webcastUtils'
+
+const EmbedLivestream = (props) => {
+  const channel = props.webcast.channel
+  const file = props.webcast.file
+  const iframeSrc = `https://new.livestream.com/accounts/${channel}/events/${file}/player?width=640&height=360&autoPlay=true&mute=false`
+  return (
+    <iframe
+      src={iframeSrc}
+      frameBorder="0"
+      scrolling="no"
+      height="100%"
+      width="100%"
+    />
+  )
+}
+
+EmbedLivestream.propTypes = {
+  webcast: webcastPropType.isRequired,
+}
+
+export default EmbedLivestream

--- a/react/gameday2/components/embeds/EmbedNotSupported.js
+++ b/react/gameday2/components/embeds/EmbedNotSupported.js
@@ -7,7 +7,7 @@ const EmbedNotSupported = () => {
   }
 
   const textStyles = {
-    color: '#ffffff'
+    color: '#ffffff',
   }
 
   return (

--- a/react/gameday2/components/embeds/EmbedNotSupported.js
+++ b/react/gameday2/components/embeds/EmbedNotSupported.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+const EmbedNotSupported = () => {
+  const containerStyles = {
+    margin: 20,
+    textAlign: 'center',
+  }
+
+  const textStyles = {
+    color: '#ffffff'
+  }
+
+  return (
+    <div style={containerStyles}>
+      <p style={textStyles}>This webcast is not supported.</p>
+    </div>
+  )
+}
+
+export default EmbedNotSupported

--- a/react/gameday2/components/embeds/EmbedRtmp.js
+++ b/react/gameday2/components/embeds/EmbedRtmp.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { webcastPropType } from '../../utils/webcastUtils'
+
+const EmbedRtmp = (props) => {
+  const channel = props.webcast.channel
+  const file = props.webcast.file
+  const flashVars = `file=${file}&streamer=rtmp://${channel}&autostart=true&provider=rtmp`
+  return (
+    <object
+      width="100%"
+      height="100%"
+      data="/jwplayer/player.swf"
+      type="application/x-shockwave-flash"
+      >
+      <param name="flashvars" value={flashVars} />
+      <param name="allowfullscreen" value="true" />
+      <param name="background" value="transparent" />
+      <param name="wmode" value="transparent" />
+    </object>
+  )
+}
+
+EmbedRtmp.propTypes = {
+  webcast: webcastPropType.isRequired,
+}
+
+export default EmbedRtmp

--- a/react/gameday2/components/embeds/EmbedRtmp.js
+++ b/react/gameday2/components/embeds/EmbedRtmp.js
@@ -1,27 +1,29 @@
 import React from 'react'
 import { webcastPropType } from '../../utils/webcastUtils'
 
-const EmbedRtmp = (props) => {
-  const channel = props.webcast.channel
-  const file = props.webcast.file
-  const flashVars = `file=${file}&streamer=rtmp://${channel}&autostart=true&provider=rtmp`
-  return (
-    <object
-      width="100%"
-      height="100%"
-      data="/jwplayer/player.swf"
-      type="application/x-shockwave-flash"
+export default class EmbedHtml5 extends React.Component {
+  static propTypes = {
+    webcast: webcastPropType.isRequired,
+  }
+
+  componentDidMount() {
+    videojs(this.props.webcast.id, {
+      width: '100%',
+      height: '100%',
+      autoplay: true,
+    })
+  }
+
+  render() {
+    const src = `rtmp://${this.props.webcast.channel}&${this.props.webcast.file}`
+    return (
+      <video
+        controls
+        id={this.props.webcast.id}
+        className="video-js vjs-default-skin"
       >
-      <param name="flashvars" value={flashVars} />
-      <param name="allowfullscreen" value="true" />
-      <param name="background" value="transparent" />
-      <param name="wmode" value="transparent" />
-    </object>
-  )
+        <source src={src} type="rtmp/mp4" />
+      </video>
+    )
+  }
 }
-
-EmbedRtmp.propTypes = {
-  webcast: webcastPropType.isRequired,
-}
-
-export default EmbedRtmp

--- a/react/gameday2/components/embeds/EmbedRtmp.js
+++ b/react/gameday2/components/embeds/EmbedRtmp.js
@@ -1,3 +1,4 @@
+/* global videojs */
 import React from 'react'
 import { webcastPropType } from '../../utils/webcastUtils'
 

--- a/react/gameday2/components/embeds/EmbedTwitch.js
+++ b/react/gameday2/components/embeds/EmbedTwitch.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { webcastPropType } from '../utils/webcastUtils'
+import { webcastPropType } from '../../utils/webcastUtils'
 
 const EmbedTwitch = (props) => {
   const channel = props.webcast.channel

--- a/react/gameday2/components/embeds/EmbedUstream.js
+++ b/react/gameday2/components/embeds/EmbedUstream.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { webcastPropType } from '../utils/webcastUtils'
+import { webcastPropType } from '../../utils/webcastUtils'
 
 const EmbedUstream = (props) => {
   const channel = props.webcast.channel

--- a/react/gameday2/components/embeds/EmbedYoutube.js
+++ b/react/gameday2/components/embeds/EmbedYoutube.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { webcastPropType } from '../utils/webcastUtils'
+import { webcastPropType } from '../../utils/webcastUtils'
 
 const EmbedYoutube = (props) => {
   const src = `//www.youtube.com/embed/${props.webcast.channel}`

--- a/react/gameday2/gameday2.less
+++ b/react/gameday2/gameday2.less
@@ -1,6 +1,7 @@
 @import "normalize.less";
 @import "sidebars.less";
 @import "nowebcasts.less";
+@import "videojs.less";
 
 @navbar-height: 50px;
 

--- a/react/gameday2/reducers/webcastsById.js
+++ b/react/gameday2/reducers/webcastsById.js
@@ -18,6 +18,7 @@ const getWebcastsFromRawWebcasts = (webcasts) => {
       name: webcast.name,
       type: webcast.type,
       channel: webcast.channel,
+      file: webcast.file,
       sortOrder: index,
     }
   })
@@ -37,6 +38,7 @@ const getWebcastsFromRawWebcasts = (webcasts) => {
         name,
         type: webcast.type,
         channel: webcast.channel,
+        file: webcast.file,
       }
     })
   })

--- a/react/gameday2/videojs.less
+++ b/react/gameday2/videojs.less
@@ -1,0 +1,5 @@
+// Fixes inability of video.js to stretch to fill a container
+.video-js {
+  width: 100% !important;
+  height: 100% !important;
+}

--- a/templates/admin/partials/webcast_add_form_partial.html
+++ b/templates/admin/partials/webcast_add_form_partial.html
@@ -3,7 +3,6 @@
         <td>Type</td>
         <td><select name="webcast_type">
             <option value="livestream">livestream</option>
-            <option value="mms">mms</option>
             <option value="rtmp">rtmp</option>
             <option value="twitch">twitch</option>
             <option value="ustream">ustream</option>

--- a/templates/admin/partials/webcast_type_select.html
+++ b/templates/admin/partials/webcast_type_select.html
@@ -1,7 +1,6 @@
 <select name="webcast_type">
     <option value="">Select Type</option>
     <option value="livestream"{% if webcast.type == "livestream"%} selected{% endif %}>livestream</option>
-    <option value="mms"{% if webcast.type == "mms" %} selected{% endif %}>mms</option>
     <option value="rtmp"{% if webcast.type == "rtmp" %} selected{% endif %}>rtmp</option>
     <option value="twitch"{% if webcast.type == "twitch" %} selected{% endif %}>twitch</option>
     <option value="ustream"{% if webcast.type == "ustream" %} selected{% endif %}>ustream</option>

--- a/templates/gameday2.html
+++ b/templates/gameday2.html
@@ -3,8 +3,9 @@
 {% block title %}GameDay - The Blue Alliance{% endblock %}
 
 {% block main_style %}
-    <link rel="stylesheet" href="/css/gameday2.min.css" type="text/css" />
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+  <link rel="stylesheet" href="/css/gameday2.min.css" type="text/css" />
+  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+  <link href="http://vjs.zencdn.net/5.8.8/video-js.css" rel="stylesheet">
 {% endblock %}
 {% block font_awesome_css %}{% endblock %}
 {% block featherlight_css %}{% endblock %}
@@ -34,7 +35,9 @@
 {% block login_modal %}{% endblock %}
 
 {% block main_javascript %}
-    <script type="text/javascript" src="javascript/gameday2.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/5.10.2/video.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls/3.0.2/videojs-contrib-hls.js"></script>
+  <script type="text/javascript" src="javascript/gameday2.min.js"></script>
 {% endblock %}
 
 {% block ganalytics_timer %}

--- a/templates/gameday2.html
+++ b/templates/gameday2.html
@@ -24,7 +24,7 @@
 
 {% block content %}
   <div id="content"></div>
-  <div style="display: none;" id="webcasts_json">{{ webcasts_json|safe }}</div>
+  <div style="display: none;" id="webcasts_json">{{ webcasts_json }}</div>
 {% endblock %}
 
 {% block admin_bar %}{% endblock %}


### PR DESCRIPTION
More work on the march towards feature parity with GD1!

* Adds streaming support for HTML5 (HLS), Livestream, Iframe, Dacast, and RTMP streams
* Migrated HLS and RTMP streams to both use [video.js](http://videojs.com/)
* Removed support for MMS streams
* Added a nice "webcast not supported" message to handle the case where we accidentally set a bad type in the sitevar

Iframes were kind of weird to get working: I either ended up with weird double-escaping if I use the `safe` keyword in the template file, or escaped html entities without it. I ended up going with the latter and just regex-replacing the escaped entities on the client. @fangeugene want to see if you can figure this one out?