### PR TITLE
Switched sides of layout icons and checkmark

### DIFF
--- a/react/gameday2/components/LayoutDrawer.js
+++ b/react/gameday2/components/LayoutDrawer.js
@@ -46,8 +46,8 @@ class LayoutDrawer extends React.Component {
             insetChildren
             onTouchTap={() => this.props.setLayout(i)}
             key={i.toString()}
-            leftIcon={icon}
-            rightIcon={getLayoutSvgIcon(i)}
+            rightIcon={icon}
+            leftIcon={getLayoutSvgIcon(i)}
           />
         )
       }


### PR DESCRIPTION
This helps keep consistency with having content on the left and "controls" on the right of a list item.

Before:

![Imgur](http://i.imgur.com/l5PUFUM.png)

After:

![Imgur](http://i.imgur.com/gDyreYf.png)