### PR TITLE
Base District Model

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -7,6 +7,7 @@ import tba_config
 from controllers.admin.admin_api_controller import AdminApiAuthAdd, AdminApiAuthDelete, AdminApiAuthEdit, AdminApiAuthManage
 from controllers.admin.admin_apistatus_controller import AdminApiStatus
 from controllers.admin.admin_authkeys_controller import AdminAuthKeys
+from controllers.admin.admin_district_controller import AdminDistrictList, AdminDistrictEdit
 from controllers.admin.admin_event_controller import AdminEventAddAllianceSelections, AdminEventDeleteTeams, AdminEventAddTeams, AdminEventRemapTeams, AdminEventAddWebcast, AdminEventCreate, AdminEventCreateTest, AdminEventDelete, AdminEventDetail, AdminEventEdit, AdminEventList, \
     AdminAddAllianceBackup
 from controllers.admin.admin_gameday_controller import AdminGamedayDashboard
@@ -35,6 +36,9 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/apistatus', AdminApiStatus),
                                ('/admin/authkeys', AdminAuthKeys),
                                ('/admin/debug', AdminDebugHandler),
+                               ('/admin/districts', AdminDistrictList),
+                               ('/admin/districts/([0-9]*)', AdminDistrictList),
+                               ('/admin/district/edit/(.*)', AdminDistrictEdit),
                                ('/admin/events', AdminEventList),
                                ('/admin/events/([0-9]*)', AdminEventList),
                                ('/admin/event/add_alliance_backup/(.*)', AdminAddAllianceBackup),

--- a/admin_main.py
+++ b/admin_main.py
@@ -7,7 +7,8 @@ import tba_config
 from controllers.admin.admin_api_controller import AdminApiAuthAdd, AdminApiAuthDelete, AdminApiAuthEdit, AdminApiAuthManage
 from controllers.admin.admin_apistatus_controller import AdminApiStatus
 from controllers.admin.admin_authkeys_controller import AdminAuthKeys
-from controllers.admin.admin_district_controller import AdminDistrictList, AdminDistrictEdit
+from controllers.admin.admin_district_controller import AdminDistrictList, AdminDistrictEdit, \
+    AdminDistrictCreate
 from controllers.admin.admin_event_controller import AdminEventAddAllianceSelections, AdminEventDeleteTeams, AdminEventAddTeams, AdminEventRemapTeams, AdminEventAddWebcast, AdminEventCreate, AdminEventCreateTest, AdminEventDelete, AdminEventDetail, AdminEventEdit, AdminEventList, \
     AdminAddAllianceBackup
 from controllers.admin.admin_gameday_controller import AdminGamedayDashboard
@@ -39,6 +40,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/districts', AdminDistrictList),
                                ('/admin/districts/([0-9]*)', AdminDistrictList),
                                ('/admin/district/edit/(.*)', AdminDistrictEdit),
+                               ('/admin/district/create', AdminDistrictCreate),
                                ('/admin/events', AdminEventList),
                                ('/admin/events/([0-9]*)', AdminEventList),
                                ('/admin/event/add_alliance_backup/(.*)', AdminAddAllianceBackup),

--- a/controllers/admin/admin_district_controller.py
+++ b/controllers/admin/admin_district_controller.py
@@ -1,0 +1,66 @@
+import os
+from datetime import datetime
+
+from google.appengine.ext.webapp import template
+
+import tba_config
+from controllers.base_controller import LoggedInHandler
+from helpers.district_manipulator import DistrictManipulator
+from models.district import District
+
+
+class AdminDistrictList(LoggedInHandler):
+    """
+    List all Districts.
+    """
+    VALID_YEARS = range(1992, tba_config.MAX_YEAR + 1)
+
+    def get(self, year=None):
+        self._require_admin()
+
+        if year:
+            year = int(year)
+        else:
+            year = datetime.now().year
+
+        districts = District.query(District.year == year).fetch(10000)
+
+        self.template_values.update({
+            "valid_years": self.VALID_YEARS,
+            "selected_year": year,
+            "districts": districts,
+        })
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/district_list.html')
+        self.response.out.write(template.render(path, self.template_values))
+
+
+class AdminDistrictEdit(LoggedInHandler):
+    """
+    Modify a district
+    """
+
+    def get(self, district_key):
+        self._require_admin()
+
+        district = District.get_by_id(district_key)
+        self.template_values.update({
+            "district": district,
+        })
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/district_edit.html')
+        self.response.out.write(template.render(path, self.template_values))
+
+    def post(self, district_key):
+        self._require_admin()
+
+        district = District(
+            id=District.renderKeyName(self.request.get("year"), self.request.get("abbreviation")),
+            year=int(self.request.get("year")),
+            abbreviation=self.request.get("abbreviation"),
+            display_name=self.request.get("display_name"),
+            elasticsearch_name=self.request.get("elasticsearch_name"),
+        )
+        DistrictManipulator.createOrUpdate(district)
+
+        self.redirect('/admin/districts/' + self.request.get("year"))

--- a/controllers/admin/admin_district_controller.py
+++ b/controllers/admin/admin_district_controller.py
@@ -64,3 +64,14 @@ class AdminDistrictEdit(LoggedInHandler):
         DistrictManipulator.createOrUpdate(district)
 
         self.redirect('/admin/districts/' + self.request.get("year"))
+
+
+class AdminDistrictCreate(LoggedInHandler):
+    """
+    Create an District. POSTs to AdminDistrictEdit.
+    """
+    def get(self):
+        self._require_admin()
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/district_create.html')
+        self.response.out.write(template.render(path, self.template_values))

--- a/database/district_query.py
+++ b/database/district_query.py
@@ -3,6 +3,7 @@ from google.appengine.ext import ndb
 from consts.event_type import EventType
 from database.database_query import DatabaseQuery
 from database.dict_converters.district_converter import DistrictListConverter
+from models.district import District
 from models.event import Event
 
 
@@ -19,3 +20,16 @@ class DistrictListQuery(DatabaseQuery):
             Event.event_type_enum == EventType.DISTRICT_CMP).fetch_async(keys_only=True)
         events = yield ndb.get_multi_async(all_cmp_event_keys)
         raise ndb.Return(events)
+
+
+class DistrictsInYearQuery(DatabaseQuery):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "districts_in_year_{}"  # (year)
+    DICT_CONVERTER = None  # For now (TODO)
+
+    @ndb.tasklet
+    def _query_async(self):
+        year = self._query_args[0]
+        keys_future = yield District.query(District.year == year).fetch_async(keys_only=True)
+        districts = yield ndb.get_multi_async(keys_future)
+        raise ndb.Return(districts)

--- a/database/district_query.py
+++ b/database/district_query.py
@@ -33,3 +33,17 @@ class DistrictsInYearQuery(DatabaseQuery):
         district_keys = yield District.query(District.year == year).fetch_async(keys_only=True)
         districts = yield ndb.get_multi_async(district_keys)
         raise ndb.Return(districts)
+
+
+class DistrictHistoryQuery(DatabaseQuery):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "district_history_{}"  # (abbreviation)
+    DICT_CONVERTER = None  # For now (TODO)
+
+    @ndb.tasklet
+    def _query_async(self):
+        abbreviation = self._query_args[0]
+        district_keys = yield District.query(District.abbreviation == abbreviation).fetch_async(keys_only=True)
+        districts = yield ndb.get_multi_async(district_keys)
+        raise ndb.Return(districts)
+

--- a/database/district_query.py
+++ b/database/district_query.py
@@ -30,6 +30,6 @@ class DistrictsInYearQuery(DatabaseQuery):
     @ndb.tasklet
     def _query_async(self):
         year = self._query_args[0]
-        keys_future = yield District.query(District.year == year).fetch_async(keys_only=True)
-        districts = yield ndb.get_multi_async(keys_future)
+        district_keys = yield District.query(District.year == year).fetch_async(keys_only=True)
+        districts = yield ndb.get_multi_async(district_keys)
         raise ndb.Return(districts)

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -1,4 +1,5 @@
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery
+from database.district_query import DistrictsInYearQuery
 from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
@@ -188,6 +189,10 @@ def districtteam_updated(affected_refs):
 
 
 def district_updated(affected_refs):
-    # TODO
-    return []
+    years = filter(None, affected_refs['year'])
 
+    queries_and_keys = []
+    for year in years:
+        queries_and_keys.append(DistrictsInYearQuery(year))
+
+    return queries_and_keys

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -1,5 +1,5 @@
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery
-from database.district_query import DistrictsInYearQuery
+from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery
 from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
@@ -190,9 +190,13 @@ def districtteam_updated(affected_refs):
 
 def district_updated(affected_refs):
     years = filter(None, affected_refs['year'])
+    district_abbrevs = filter(None, affected_refs['abbreviation'])
 
     queries_and_keys = []
     for year in years:
         queries_and_keys.append(DistrictsInYearQuery(year))
+
+    for abbrev in district_abbrevs:
+        queries_and_keys.append(DistrictHistoryQuery(abbrev))
 
     return queries_and_keys

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -185,3 +185,9 @@ def districtteam_updated(affected_refs):
         queries_and_keys.append(TeamDistrictsQuery(team_key.id()))
 
     return queries_and_keys
+
+
+def district_updated(affected_refs):
+    # TODO
+    return []
+

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -209,9 +209,10 @@ class DatafeedFMSAPI(object):
         else:
             return None
 
+    # Returns a tuple: (list(Event), list(District))
     def getEventList(self, year):
-        events = self._parse(self.FMS_API_EVENT_LIST_URL_PATTERN % (year), FMSAPIEventListParser(year))
-        return events
+        events, districts = self._parse(self.FMS_API_EVENT_LIST_URL_PATTERN % (year), FMSAPIEventListParser(year))
+        return events, districts
 
     # Returns list of tuples (team, districtteam, robot)
     def getEventTeams(self, event_key):

--- a/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -3,6 +3,7 @@ import urlparse
 from google.appengine.ext import ndb
 
 from consts.district_type import DistrictType
+from models.district import District
 from models.district_team import DistrictTeam
 from models.team import Team
 from models.robot import Robot
@@ -56,7 +57,8 @@ class FMSAPITeamDetailsParser(object):
                     id=DistrictTeam.renderKeyName(self.year, districtAbbrev, team.key_name),
                     team=ndb.Key(Team, team.key_name),
                     year=self.year,
-                    district=districtAbbrev
+                    district=districtAbbrev,
+                    district_key=ndb.Key(District, District.renderKeyName(self.year, teamData['districtCode'])),
                 )
 
             robot = None

--- a/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -58,7 +58,7 @@ class FMSAPITeamDetailsParser(object):
                     team=ndb.Key(Team, team.key_name),
                     year=self.year,
                     district=districtAbbrev,
-                    district_key=ndb.Key(District, District.renderKeyName(self.year, teamData['districtCode'])),
+                    district_key=ndb.Key(District, District.renderKeyName(self.year, teamData['districtCode'].lower())),
                 )
 
             robot = None

--- a/helpers/cache_clearer.py
+++ b/helpers/cache_clearer.py
@@ -163,6 +163,16 @@ class CacheClearer(object):
             cls._queries_to_cache_keys_and_controllers(get_affected_queries.robot_updated(affected_refs))
 
     @classmethod
+    def get_district_cache_keys_and_controllers(cls, affected_refs):
+        """
+        Gets cache keys and controllers that reference this district
+        """
+        years = affected_refs['year']
+
+        return cls._get_districtlist_cache_keys_and_controllers(years) + \
+            cls._queries_to_cache_keys_and_controllers(get_affected_queries.district_updated(affected_refs))
+
+    @classmethod
     def get_team_cache_keys_and_controllers(cls, affected_refs):
         """
         Gets cache keys and controllers that references this team

--- a/helpers/district_manipulator.py
+++ b/helpers/district_manipulator.py
@@ -1,0 +1,35 @@
+from helpers.cache_clearer import CacheClearer
+from helpers.manipulator_base import ManipulatorBase
+
+
+class DistrictManipulator(ManipulatorBase):
+    """
+    Handles District database writes
+    """
+
+    @classmethod
+    def getCacheKeysAndControllers(cls, affected_refs):
+        return CacheClearer.get_district_cache_keys_and_controllers(affected_refs)
+
+    @classmethod
+    def updateMerge(self, new_district, old_district, auto_union=True):
+        """
+        Update and return Robots
+        """
+        immutable_attrs = [
+            "year",
+            "abbreviation",
+        ]  # These build key_name, and cannot be changed without deleting the model.
+
+        attrs = [
+            "display_name",
+            "elasticsearch_name",
+        ]
+
+        for attr in attrs:
+            if getattr(new_district, attr) is not None:
+                if getattr(new_district, attr) != getattr(old_district, attr):
+                    setattr(old_district, attr, getattr(new_district, attr))
+                    old_district.dirty = True
+
+        return old_district

--- a/helpers/district_manipulator.py
+++ b/helpers/district_manipulator.py
@@ -50,7 +50,7 @@ class DistrictManipulator(ManipulatorBase):
     @classmethod
     def updateMerge(self, new_district, old_district, auto_union=True):
         """
-        Update and return Robots
+        Update and return Districts
         """
         immutable_attrs = [
             "year",

--- a/helpers/district_manipulator.py
+++ b/helpers/district_manipulator.py
@@ -1,3 +1,6 @@
+import logging
+
+from database.district_query import DistrictHistoryQuery
 from helpers.cache_clearer import CacheClearer
 from helpers.manipulator_base import ManipulatorBase
 from models.district import District
@@ -14,7 +17,7 @@ class DistrictManipulator(ManipulatorBase):
         To run after a district has been updated.
         For new districts, tries to guess the names based on other year's data
         """
-        for (district, is_new) in zip(districts, is_new_list):
+        for (district, is_new, updated_attrs) in zip(districts, is_new_list, updated_attr_list):
             if is_new and (not district.display_name or not district.elasticsearch_name):
                 last_year_key = District.renderKeyName(district.year - 1, district.abbreviation)
                 last_year_district = District.get_by_id(last_year_key)
@@ -28,6 +31,17 @@ class DistrictManipulator(ManipulatorBase):
                         update = True
                     if update:
                         cls.createOrUpdate(district, run_post_update_hook=False)
+
+            if 'display_name' in updated_attrs or 'elasticsearch_name' in updated_attrs:
+                # Set all other instances of this district to have the values
+                all_past_years = DistrictHistoryQuery(district.abbreviation).fetch()
+                to_put = []
+                for other_district in all_past_years:
+                    if other_district.year != district.year:
+                        other_district.display_name = district.display_name
+                        other_district.elasticsearch_name = district.elasticsearch_name
+                        to_put.append(other_district)
+                cls.createOrUpdate(to_put, run_post_update_hook=False)
 
     @classmethod
     def getCacheKeysAndControllers(cls, affected_refs):
@@ -48,10 +62,12 @@ class DistrictManipulator(ManipulatorBase):
             "elasticsearch_name",
         ]
 
+        old_district._updated_attrs = []
         for attr in attrs:
             if getattr(new_district, attr) is not None:
                 if getattr(new_district, attr) != getattr(old_district, attr):
                     setattr(old_district, attr, getattr(new_district, attr))
+                    old_district._updated_attrs.append(attr)
                     old_district.dirty = True
 
         return old_district

--- a/helpers/district_team_manipulator.py
+++ b/helpers/district_team_manipulator.py
@@ -18,6 +18,7 @@ class DistrictTeamManipulator(ManipulatorBase):
         immutable_attrs = [
             "team",
             "district",
+            "district_key",
             "year"
         ]  # These build key_name, and cannot be changed without deleting the model.
 

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -246,7 +246,7 @@ class EventHelper(object):
         return district if district != DistrictType.NO_DISTRICT else DistrictType.abbrevs.get(district_name_str, DistrictType.NO_DISTRICT)
 
     @classmethod
-    def getDistrictFromEventName(cls, event_name):
+    def getDistrictEnumFromEventName(cls, event_name):
         for abbrev, district_type in DistrictType.abbrevs.items():
             if '{} district'.format(abbrev) in event_name.lower():
                 return district_type
@@ -256,6 +256,18 @@ class EventHelper(object):
                 return district_type
 
         return DistrictType.NO_DISTRICT
+
+    @classmethod
+    def getDistrictKeyFromEventName(cls, event_name, year_districts_future):
+        year_districts = year_districts_future.get_result()
+        for district in year_districts:
+            if '{} district'.format(district.abbreviation) in event_name.lower():
+                return district.key
+
+            if district.elasticsearch_name and district.elasticsearch_name in event_name:
+                return district.key
+
+        return None
 
     @classmethod
     def parseEventType(self, event_type_str):

--- a/helpers/event_manipulator.py
+++ b/helpers/event_manipulator.py
@@ -71,6 +71,7 @@ class EventManipulator(ManipulatorBase):
             "event_short",
             "event_type_enum",
             "event_district_enum",
+            "district_key",
             "custom_hashtag",
             "facebook_eid",
             "first_eid",

--- a/models/district.py
+++ b/models/district.py
@@ -19,6 +19,7 @@ class District(ndb.Model):
         # keys must be model properties
         self._affected_references = {
             'year': set(),
+            'abbreviation': set(),
         }
         super(District, self).__init__(*args, **kw)
 

--- a/models/district.py
+++ b/models/district.py
@@ -14,6 +14,14 @@ class District(ndb.Model):
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
 
+    def __init__(self, *args, **kw):
+        # store set of affected references referenced keys for cache clearing
+        # keys must be model properties
+        self._affected_references = {
+            'year': set(),
+        }
+        super(District, self).__init__(*args, **kw)
+
     @property
     def key_name(self):
         return "{}{}".format(self.year, self.abbreviation)

--- a/models/district.py
+++ b/models/district.py
@@ -1,0 +1,24 @@
+from google.appengine.ext import ndb
+
+
+class District(ndb.Model):
+    """
+    One instance of a district in a year. Here, we store info about a district and in-season data
+    (like district rankings)
+    """
+    year = ndb.IntegerProperty()
+    abbreviation = ndb.StringProperty()
+    display_name = ndb.StringProperty()  # This is what we'll show on the TBA site
+    elasticsearch_name = ndb.StringProperty()  # These names are in the event's name as returned by FRC Elasticsearch
+
+    created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
+    updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
+
+    @property
+    def key_name(self):
+        return "{}{}".format(self.year, self.abbreviation)
+
+    @classmethod
+    def renderKeyName(cls, year, district_abbrev):
+        # Like 2016ne or 2016fim
+        return "{}{}".format(year, district_abbrev.lower())

--- a/models/district_team.py
+++ b/models/district_team.py
@@ -35,11 +35,6 @@ class DistrictTeam(ndb.Model):
     def key_name(self):
         return self.renderKeyName(self.year, self.district, self.team.id())
 
-    @property
-    def district_key(self):
-        districtAbbrev = DistrictType.type_abbrevs[self.district]
-        return '{}{}'.format(self.year, districtAbbrev)
-
     @classmethod
     def renderKeyName(self, year, districtEnum, teamKey):
         districtAbbrev = DistrictType.type_abbrevs[districtEnum]

--- a/models/district_team.py
+++ b/models/district_team.py
@@ -1,6 +1,7 @@
 from google.appengine.ext import ndb
 
 from consts.district_type import DistrictType
+from models.district import District
 from models.team import Team
 
 
@@ -14,7 +15,7 @@ class DistrictTeam(ndb.Model):
     team = ndb.KeyProperty(kind=Team)
     year = ndb.IntegerProperty()
     district = ndb.IntegerProperty()  # One of DistrictType constants, DEPRECATED, use district_key
-    district_key = ndb.KeyProperty()
+    district_key = ndb.KeyProperty(kind=District)
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/models/district_team.py
+++ b/models/district_team.py
@@ -13,7 +13,8 @@ class DistrictTeam(ndb.Model):
 
     team = ndb.KeyProperty(kind=Team)
     year = ndb.IntegerProperty()
-    district = ndb.IntegerProperty()  # One of DistrictType constants
+    district = ndb.IntegerProperty()  # One of DistrictType constants, DEPRECATED, use district_key
+    district_key = ndb.KeyProperty()
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/models/event.py
+++ b/models/event.py
@@ -11,6 +11,7 @@ from consts.event_type import EventType
 from consts.ranking_indexes import RankingIndexes
 from context_cache import context_cache
 from helpers.location_helper import LocationHelper
+from models.district import District
 from models.event_details import EventDetails
 from models.location import Location
 
@@ -25,7 +26,8 @@ class Event(ndb.Model):
     short_name = ndb.StringProperty(indexed=False)  # Should not contain "Regional" or "Division", like "Hartford"
     event_short = ndb.StringProperty(required=True, indexed=False)  # Smaller abbreviation like "CT"
     year = ndb.IntegerProperty(required=True)
-    event_district_enum = ndb.IntegerProperty(default=DistrictType.NO_DISTRICT)
+    event_district_enum = ndb.IntegerProperty(default=DistrictType.NO_DISTRICT)  # Deprecated, use district_key instead
+    district_key = ndb.KeyProperty(kind=District)
     start_date = ndb.DateTimeProperty()
     end_date = ndb.DateTimeProperty()
 

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -73,6 +73,8 @@
               <li><a href="/admin/event/create">Create</a></li>
               <li><a href="/admin/offseasons">Scrape USFIRST Offseasons</a></li>
               <li><a href="/admin/offseasons/spreadsheet">Scrape Spreadsheet Offseasons</a></li>
+              <li>Districts</li>
+              <li><a href="/admin/districts">View all</a></li>
               <li>Matches</li>
               <li><a href="/admin/matches">Edit</a></li>
               <li><a href="/admin/match/cleanup">Cleanup</a></li>

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -75,6 +75,7 @@
               <li><a href="/admin/offseasons/spreadsheet">Scrape Spreadsheet Offseasons</a></li>
               <li>Districts</li>
               <li><a href="/admin/districts">View all</a></li>
+              <li><a href="/admin/district/create">Create</a></li>
               <li>Matches</li>
               <li><a href="/admin/matches">Edit</a></li>
               <li><a href="/admin/match/cleanup">Cleanup</a></li>

--- a/templates/admin/district_create.html
+++ b/templates/admin/district_create.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Create District{% endblock %}
+
+{% block content %}
+
+<form action="/admin/district/edit/" method="post">
+    <legend>Create a new district</legend>
+    <table class="table table-striped table-hover table-condensed">
+        <tr>
+            <td>Year</td>
+            <td><input type="text" name="year" value="{{district.year}}"/></td>
+        </tr>
+        <tr>
+            <td>Abbreviation</td>
+            <td><input type="text" name="abbreviation" value="{{district.abbreviation}}"/></td>
+        </tr>
+    </table>
+
+    <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Save District</button>
+    <a href="/admin/districts/{{district.year}}" class="btn btn-default"><span class="glyphicon glyphicon-thumbs-down"></span> Cancel Edit</a>
+</form>
+
+{% endblock %}

--- a/templates/admin/district_edit.html
+++ b/templates/admin/district_edit.html
@@ -27,7 +27,7 @@
         </tr>
     </table>
 
-    <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Save Event</button>
+    <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Save District</button>
     <a href="/admin/districts/{{district.year}}" class="btn btn-default"><span class="glyphicon glyphicon-thumbs-down"></span> Cancel Edit</a>
 </form>
 

--- a/templates/admin/district_edit.html
+++ b/templates/admin/district_edit.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}{{district.key_name}} - Edit{% endblock %}
+
+{% block content %}
+
+<h1>Edit {{ district.key_name }}</h1>
+
+<form action="/admin/district/edit/{{district.key_name}}" method="post">
+    <legend>Edit {{ district.year }} {{ district.abbreviation}}</legend>
+    <table class="table table-striped table-hover table-condensed">
+        <tr>
+            <td>Year</td>
+            <td><input type="text" name="disabled_year" value="{{district.year}}" disabled="disabled" /><input type="hidden" name="year" value="{{district.year}}" /></td>
+        </tr>
+        <tr>
+            <td>Abbreviation</td>
+            <td><input type="text" name="disabled_abbreviation" value="{{district.abbreviation}}" disabled="disabled" /><input type="hidden" name="abbreviation" value="{{district.abbreviation}}" /></td>
+        </tr>
+        <tr>
+            <td>Display Name</td>
+            <td><input type="text" name="display_name" value="{{district.display_name}}" /></td>
+        </tr>
+        <tr>
+            <td>Elasticsearch Name</td>
+            <td><input type="text" name="elasticsearch_name" value="{{district.elasticsearch_name}}" /></td>
+        </tr>
+    </table>
+
+    <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Save Event</button>
+    <a href="/admin/districts/{{district.year}}" class="btn btn-default"><span class="glyphicon glyphicon-thumbs-down"></span> Cancel Edit</a>
+</form>
+
+{% endblock %}

--- a/templates/admin/district_list.html
+++ b/templates/admin/district_list.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block title %}District List{% endblock %}
+
+{% block content %}
+
+<h1>All {{ districts|length }} Districts from {{selected_year}}</h1>
+
+<div class="btn-group">
+  <a class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" href="#">
+    {{selected_year}}
+    <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu tba-dropdown-menu-limited">
+    {% for year in valid_years reversed %}
+      <li><a href="/admin/districts/{{year}}">{{year}}</a></li>
+    {% endfor %}
+  </ul>
+</div>
+
+<table class="table table-striped table-hover">
+    <caption>{{ districts|length }} total districts</caption>
+    <thead>
+        <th>Key</th>
+        <th>Year</th>
+        <th>Abbreviation</th>
+        <th>Display Name</th>
+        <th>Elasticsearch Name</th>
+    </thead>
+
+    {% for district in districts %}
+    <tr>
+        <td><a href="/admin/district/edit/{{district.key_name}}">{{ district.key_name }}</a></td>
+        <td>{{ district.year }}</td>
+        <td>{{ district.abbreviation }}</td>
+        <td>{{ district.display_name }}</td>
+        <td>{{ district.elasticsearch_name }}</td>
+        <td></td>
+    </tr>
+    {% endfor %}
+</table>
+
+{% endblock %}

--- a/templates/datafeeds/fms_event_list_get.html
+++ b/templates/datafeeds/fms_event_list_get.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="row">
     <div class="alert alert-block alert-success">
-        <h4>Got {{events|length}} events</h4>
+        <h4>Got {{events|length}} events in {{ districts|length }} districts</h4>
     </div>
     <table class="table table-condensed table-hover table-striped">
         <thead>
@@ -15,6 +15,7 @@
             <th>state_prov</th>
             <th>country</th>
             <th>start_date</th>
+            <th>district</th>
         </thead>
         {% for event in events %}
         <tr>
@@ -24,6 +25,7 @@
             <td>{{event.state_prov}}</td>
             <td>{{event.country}}</td>
             <td>{{event.start_date}}</td>
+            <td>{{event.district_key}}</td>
         </tr>
         {% endfor %}
     </table>

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -5,7 +5,7 @@ from google.appengine.ext import testbed
 
 from database import get_affected_queries
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery
-from database.district_query import DistrictsInYearQuery
+from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery
 from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
@@ -259,10 +259,13 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
 
     def test_district_updated(self):
         affected_refs = {
-            'year': {2015, 2016}
+            'year': {2015, 2016},
+            'abbreviation': {'ne', 'chs'}
         }
         cache_keys = [q.cache_key for q in get_affected_queries.district_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 2)
+        self.assertEqual(len(cache_keys), 4)
         self.assertTrue(DistrictsInYearQuery(2015).cache_key in cache_keys)
         self.assertTrue(DistrictsInYearQuery(2016).cache_key in cache_keys)
+        self.assertTrue(DistrictHistoryQuery('ne').cache_key in cache_keys)
+        self.assertTrue(DistrictHistoryQuery('chs').cache_key in cache_keys)

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -5,6 +5,7 @@ from google.appengine.ext import testbed
 
 from database import get_affected_queries
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery
+from database.district_query import DistrictsInYearQuery
 from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
@@ -13,7 +14,7 @@ from database.robot_query import TeamRobotsQuery
 from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
 
 from consts.district_type import DistrictType
-
+from models.district import District
 from models.district_team import DistrictTeam
 from models.event import Event
 from models.event_details import EventDetails
@@ -73,6 +74,20 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
 
         self.districtteam_2015fim_frc254.put()
         self.districtteam_2015mar_frc604.put()
+
+        self.district_2015ne = District(
+            id='2015ne',
+            year=2015,
+            abbreviation='ne',
+        )
+
+        self.district_2016chs = District(
+            id='2016chs',
+            year=2016,
+            abbreviation='chs',
+        )
+        self.district_2015ne.put()
+        self.district_2016chs.put()
 
     def tearDown(self):
         self.testbed.deactivate()
@@ -241,3 +256,13 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(DistrictTeamsQuery('2015mar').cache_key in cache_keys)
         self.assertTrue(TeamDistrictsQuery('frc254').cache_key in cache_keys)
         self.assertTrue(TeamDistrictsQuery('frc604').cache_key in cache_keys)
+
+    def test_district_updated(self):
+        affected_refs = {
+            'year': {2015, 2016}
+        }
+        cache_keys = [q.cache_key for q in get_affected_queries.district_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 2)
+        self.assertTrue(DistrictsInYearQuery(2015).cache_key in cache_keys)
+        self.assertTrue(DistrictsInYearQuery(2016).cache_key in cache_keys)

--- a/tests/test_first_elasticsearch_event_list_parser.py
+++ b/tests/test_first_elasticsearch_event_list_parser.py
@@ -9,6 +9,7 @@ from google.appengine.ext import testbed
 
 from consts.district_type import DistrictType
 from consts.event_type import EventType
+from models.district import District
 from models.event import Event
 
 
@@ -19,6 +20,14 @@ class TestFIRSTElasticSearchEventListParser(unittest2.TestCase):
         self.testbed.init_datastore_v3_stub()
         self.testbed.init_memcache_stub()
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+        self.ne_district = District(
+            id='2015ne',
+            abbreviation='ne',
+            year=2015,
+            elasticsearch_name='NE FIRST'
+        )
+        self.ne_district.put()
 
     def tearDown(self):
         self.testbed.deactivate()
@@ -77,6 +86,7 @@ class TestFIRSTElasticSearchEventListParser(unittest2.TestCase):
                     self.assertEquals(event.year, 2015)
                     self.assertEquals(event.event_type_enum, EventType.DISTRICT)
                     self.assertEquals(event.event_district_enum, DistrictType.NEW_ENGLAND)
+                    self.assertEqual(event.district_key, self.ne_district.key)
                     self.assertEquals(event.first_eid, '13443')
                     self.assertEquals(event.website, 'http://www.nefirst.org/')
 
@@ -101,5 +111,6 @@ class TestFIRSTElasticSearchEventListParser(unittest2.TestCase):
                     self.assertEquals(event.year, 2015)
                     self.assertEquals(event.event_type_enum, EventType.DISTRICT_CMP)
                     self.assertEquals(event.event_district_enum, DistrictType.NEW_ENGLAND)
+                    self.assertEqual(event.district_key, self.ne_district.key)
                     self.assertEquals(event.first_eid, '13423')
                     self.assertEquals(event.website, 'http:///www.nefirst.org/')

--- a/tests/test_fms_api_team_parser.py
+++ b/tests/test_fms_api_team_parser.py
@@ -8,6 +8,7 @@ from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
 from consts.district_type import DistrictType
+from models.district import District
 from models.district_team import DistrictTeam
 from models.robot import Robot
 from models.team import Team
@@ -49,6 +50,7 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertEqual(districtTeam.key_name, "2015ne_frc1124")
             self.assertEqual(districtTeam.team.id(), "frc1124")
             self.assertEqual(districtTeam.district, DistrictType.abbrevs['ne'])
+            self.assertEqual(districtTeam.district_key, ndb.Key(District, '2015ne'))
 
             # Test the Robot model we get back
             self.assertNotEqual(robot, None)


### PR DESCRIPTION
This is backend improvement towards apiv3 (a place to store district rankings).

Store one `District` model per year/region. This also gives us a persistent place to store stuff. Will deprecate the `DistrictType` constants and manage everything from the admin panel instead (this is more scalable).

This pull provides the base model and automated creation from the FMS Datafeed. The constants we'll need to parse event names that come back from elasticsearch need to be manually input. However, the code will keep the constants from the previous year, if it exists.

Migration path after merge:
1. Run some script that backfills these based on existing DCMPs and auto-fills the names from the existing constants file
2. Remove constants file, deprecate `Event.district_type_enum` and `DistrictTeam.district` and use the key links instead for rendering.
3. Profit