### PR TITLE
New rankings format

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -17,7 +17,7 @@ from controllers.admin.admin_award_controller import AdminAwardDashboard, AdminA
 from controllers.admin.admin_match_controller import AdminVideosAdd, AdminMatchCleanup, AdminMatchDashboard, AdminMatchDelete, AdminMatchDetail, AdminMatchAdd, AdminMatchEdit
 from controllers.admin.admin_media_controller import AdminMediaDashboard, AdminMediaDeleteReference, AdminMediaMakePreferred, AdminMediaRemovePreferred, AdminMediaAdd
 from controllers.admin.admin_memcache_controller import AdminMemcacheMain
-from controllers.admin.admin_migration_controller import AdminMigration, AdminMigrationCreateEventDetails
+from controllers.admin.admin_migration_controller import AdminMigration, AdminMigrationCreateEventDetails, AdminMigrationRankings
 from controllers.admin.admin_mobile_controller import AdminMobile, AdminBroadcast, AdminMobileWebhooks
 from controllers.admin.admin_offseason_scraper_controller import AdminOffseasonScraperController
 from controllers.admin.admin_offseason_spreadsheet_controller import AdminOffseasonSpreadsheetController
@@ -72,6 +72,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/memcache', AdminMemcacheMain),
                                ('/admin/migration', AdminMigration),
                                ('/admin/migration/create_event_details', AdminMigrationCreateEventDetails),
+                               ('/admin/migration/migrate_rankings/([0-9]*)', AdminMigrationRankings),
                                ('/admin/offseasons', AdminOffseasonScraperController),
                                ('/admin/offseasons/spreadsheet', AdminOffseasonSpreadsheetController),
                                ('/admin/sitevars', AdminSitevarList),

--- a/controllers/admin/admin_migration_controller.py
+++ b/controllers/admin/admin_migration_controller.py
@@ -8,6 +8,7 @@ from controllers.base_controller import LoggedInHandler
 from models.event import Event
 from models.event_details import EventDetails
 from helpers.event_details_manipulator import EventDetailsManipulator
+from helpers.rankings_helper import RankingsHelper
 
 
 def create_event_details(event_key):
@@ -34,5 +35,21 @@ class AdminMigrationCreateEventDetails(LoggedInHandler):
     self._require_admin()
     for event_key in Event.query().fetch(keys_only=True):
       deferred.defer(create_event_details, event_key.id(), _queue="admin")
+
+    self.response.out.write("DONE")
+
+
+class AdminMigrationRankings(LoggedInHandler):
+  def get(self, year):
+    self._require_admin()
+
+    event_keys = Event.query(Event.year==int(year)).fetch(keys_only=True)
+    event_details = ndb.get_multi([ndb.Key(EventDetails, key.id()) for key in event_keys])
+    updated = []
+    for event_detail in event_details:
+      if event_detail:
+        event_detail.rankings2 = RankingsHelper.convert_rankings(event_detail)
+        updated.append(event_detail)
+    EventDetailsManipulator.createOrUpdate(updated)
 
     self.response.out.write("DONE")

--- a/controllers/admin/admin_migration_controller.py
+++ b/controllers/admin/admin_migration_controller.py
@@ -48,6 +48,7 @@ class AdminMigrationRankings(LoggedInHandler):
     updated = []
     for event_detail in event_details:
       if event_detail:
+        logging.info(event_detail.key.id())
         event_detail.rankings2 = RankingsHelper.convert_rankings(event_detail)
         updated.append(event_detail)
     EventDetailsManipulator.createOrUpdate(updated)

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -193,11 +193,12 @@ class FMSAPIEventRankingsGet(webapp.RequestHandler):
     def get(self, event_key):
         df = DatafeedFMSAPI('v2.0')
 
-        rankings = df.getEventRankings(event_key)
+        rankings, rankings2 = df.getEventRankings(event_key)
 
         event_details = EventDetails(
             id=event_key,
-            rankings=rankings
+            rankings=rankings,
+            rankings2=rankings2
         )
         EventDetailsManipulator.createOrUpdate(event_details)
 

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -15,7 +15,7 @@ from models.sitevar import Sitevar
 from parsers.fms_api.fms_api_awards_parser import FMSAPIAwardsParser
 from parsers.fms_api.fms_api_event_alliances_parser import FMSAPIEventAlliancesParser
 from parsers.fms_api.fms_api_event_list_parser import FMSAPIEventListParser
-from parsers.fms_api.fms_api_event_rankings_parser import FMSAPIEventRankingsParser
+from parsers.fms_api.fms_api_event_rankings_parser import FMSAPIEventRankingsParser, FMSAPIEventRankings2Parser
 from parsers.fms_api.fms_api_match_parser import FMSAPIHybridScheduleParser, FMSAPIMatchDetailsParser
 from parsers.fms_api.fms_api_team_details_parser import FMSAPITeamDetailsParser
 
@@ -198,7 +198,8 @@ class DatafeedFMSAPI(object):
         event_short = event_key[4:]
 
         rankings = self._parse(self.FMS_API_EVENT_RANKINGS_URL_PATTERN % (year, self._get_event_short(event_short)), FMSAPIEventRankingsParser(year))
-        return rankings
+        rankings2 = self._parse(self.FMS_API_EVENT_RANKINGS_URL_PATTERN % (year, self._get_event_short(event_short)), FMSAPIEventRankings2Parser(year))
+        return rankings, rankings2
 
     def getTeamDetails(self, year, team_key):
         team_number = team_key[3:]  # everything after 'frc'

--- a/datafeeds/parsers/fms_api/fms_api_event_rankings_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_event_rankings_parser.py
@@ -1,3 +1,6 @@
+from helpers.rankings_helper import RankingsHelper
+
+
 class FMSAPIEventRankingsParser(object):
     def __init__(self, year):
         self.year = year
@@ -42,3 +45,26 @@ class FMSAPIEventRankingsParser(object):
                 team['matchesPlayed']])
 
         return rankings if len(rankings) > 1 else None
+
+
+class FMSAPIEventRankings2Parser(object):
+    def __init__(self, year):
+        self.year = year
+
+    def parse(self, response):
+        rankings = []
+        for team in response['Rankings']:
+            count = 1
+            order_name = 'sortOrder{}'.format(count)
+            sort_orders = []
+            while order_name in team:
+                sort_orders.append(team[order_name])
+                count += 1
+                order_name = 'sortOrder{}'.format(count)
+
+            rankings.append(RankingsHelper.build_ranking(
+                self.year, team['rank'], 'frc{}'.format(team['teamNumber']),
+                team['wins'], team['losses'], team['ties'],
+                team['qualAverage'], team['matchesPlayed'], team['dq'], sort_orders))
+
+        return rankings

--- a/helpers/event_details_manipulator.py
+++ b/helpers/event_details_manipulator.py
@@ -57,6 +57,7 @@ class EventDetailsManipulator(ManipulatorBase):
             'matchstats',
             'predictions',
             'rankings',
+            'rankings2',
         ]
 
         old_event_details._updated_attrs = []

--- a/helpers/rankings_helper.py
+++ b/helpers/rankings_helper.py
@@ -1,0 +1,90 @@
+from consts.ranking_indexes import RankingIndexes
+from models.event_details import EventDetails
+
+
+class RankingsHelper(object):
+    SORT_ORDERS = {
+        2016: [2, 3, 4, 5, 6],
+        2015: [2, 5, 3, 4, 7, 6],
+        2014: [2, 3, 4, 5, 6],
+        2013: [2, 3, 4, 5],
+        2012: [2, 3, 4, 5],
+        2011: [6, 7],
+        2010: [3, 4, 5],
+        2009: [6, 7, 8],
+        2008: [6, 7, 8],
+        2007: [6, 7, 8],
+    }
+
+    @classmethod
+    def migrate_rankings(cls, event_key):
+        """
+        Converts event_details.rankings to event_details.rankings2
+        """
+        event_details = EventDetails.get_by_id(event_key)
+        year = event_details.year
+        if event_key == '2015mttd':  # 2015mttd played the 2014 game
+            year = 2014
+
+        # Look up indexes
+        mp_index = RankingIndexes.MATCHES_PLAYED.get(year)
+        if mp_index is None:
+            return
+        ranking_index = RankingIndexes.RECORD_INDEXES.get(year)
+        dq_index = None
+
+        # Overwrite indexes in case thing are different
+        for i, name in enumerate(event_details.rankings[0]):
+            name = name.lower()
+            if name == 'played':
+                mp_index = i
+            if name == 'dq':
+                dq_index = i
+
+        sort_order_indices = cls.SORT_ORDERS[year]
+      # Special case for offseasons with different ordering
+        if year == 2015 and event_details.rankings[0][3].lower() == 'coopertition':
+            sort_order_indices = [2, 3, 5, 4, 6, 7]
+
+        rankings2 = []
+        for row in event_details.rankings[1:]:
+            if ranking_index is None:
+                record = None
+            elif type(ranking_index) == tuple:
+                record = {
+                    'wins': int(row[ranking_index[0]]),
+                    'losses': int(row[ranking_index[1]]),
+                    'ties': int(row[ranking_index[2]])
+                }
+            else:
+                wins, losses, ties = row[ranking_index].split('-')
+                record = {
+                    'wins': int(wins),
+                    'losses': int(losses),
+                    'ties': int(ties)
+                }
+
+            if dq_index is None:
+                dq = 0
+            else:
+                dq = int(row[dq_index])
+
+            if year == 2015:
+                qual_average = row[RankingIndexes.CUMULATIVE_RANKING_SCORE.get(year)]
+            else:
+                qual_average = None
+
+            sort_orders = [float(row[index]) for index in sort_order_indices]
+
+            ranking = {
+                'rank': int(row[0]),
+                'team_key': 'frc{}'.format(row[1]),
+                'record': record,  # None if record doesn't affect rank (e.g. 2010, 2015)
+                'qual_average': qual_average,  # None if qual_average doesn't affect rank (all years except 2015)
+                'matches_played': row[mp_index],
+                'dq': dq,
+                'sort_orders': sort_orders,
+            }
+            rankings2.append(ranking)
+
+        return rankings2

--- a/helpers/rankings_helper.py
+++ b/helpers/rankings_helper.py
@@ -47,13 +47,15 @@ class RankingsHelper(object):
             }
 
     @classmethod
-    def migrate_rankings(cls, event_key):
+    def convert_rankings(cls, event_details):
         """
         Converts event_details.rankings to event_details.rankings2
         """
-        event_details = EventDetails.get_by_id(event_key)
+        if not event_details.rankings:
+            return None
+
         year = event_details.year
-        if event_key == '2015mttd':  # 2015mttd played the 2014 game
+        if event_details.key.id() == '2015mttd':  # 2015mttd played the 2014 game
             year = 2014
 
         # Look up indexes

--- a/models/event_details.py
+++ b/models/event_details.py
@@ -12,6 +12,7 @@ class EventDetails(ndb.Model):
     matchstats = ndb.JsonProperty()  # for OPR, DPR, CCWM, etc.
     predictions = ndb.JsonProperty()
     rankings = ndb.JsonProperty()
+    rankings2 = ndb.JsonProperty()
 
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True)
@@ -26,3 +27,7 @@ class EventDetails(ndb.Model):
 
     def key_name(self):
         return self.key.id()
+
+    @property
+    def year(self):
+        return int(self.key.id()[:4])


### PR DESCRIPTION
Saves `EventDetails.rankings` to `EventDetails.rankings2`. Continues to write to both from the FRC API for now. This new format should be more future-proof and easier to use.