### PR TITLE
Predict Upcoming Match Times

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -67,3 +67,7 @@ cron:
 - description: Update live events
   url: /tasks/do/update_live_events
   schedule: every 1 hours
+
+- description: Predict Match Times
+  url: /tasks/enqueue/predict_match_times
+  schedule: event 1 minutes

--- a/cron_main.py
+++ b/cron_main.py
@@ -10,7 +10,8 @@ from controllers.datafeed_controller import TbaVideosGet, TbaVideosEnqueue
 from controllers.datafeed_controller import FMSAPIAwardsEnqueue, FMSAPIEventAlliancesEnqueue, FMSAPIEventRankingsEnqueue, FMSAPIMatchesEnqueue
 from controllers.datafeed_controller import FMSAPIAwardsGet, FMSAPIEventAlliancesGet, FMSAPIEventRankingsGet, FMSAPIMatchesGet
 
-from controllers.cron_controller import DistrictPointsCalcEnqueue, DistrictPointsCalcDo
+from controllers.cron_controller import DistrictPointsCalcEnqueue, DistrictPointsCalcDo, \
+    MatchTimePredictionsEnqueue, MatchTimePredictionsDo
 from controllers.cron_controller import DistrictRankingsCalcEnqueue, DistrictRankingsCalcDo
 from controllers.cron_controller import EventTeamStatusCalcEnqueue, EventTeamStatusCalcDo
 from controllers.cron_controller import EventShortNameCalcEnqueue, EventShortNameCalcDo
@@ -58,6 +59,8 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/math/do/eventteam_repair', EventTeamRepairDo),
                                ('/tasks/math/do/eventteam_update/(.*)', EventTeamUpdate),
                                ('/tasks/math/do/final_matches_repair/([0-9]*)', FinalMatchesRepairDo),
+                               ('/tasks/math/enqueue/predict_match_times', MatchTimePredictionsEnqueue),
+                               ('/tasks/math/do/predict_match_times/(.*)', MatchTimePredictionsDo),
                                ('/tasks/notifications/upcoming_match', UpcomingNotificationDo),
                                ('/tasks/admin/enqueue/clear_mobile_duplicates', AdminMobileClearEnqueue),
                                ('/tasks/admin/clear_mobile_duplicates', AdminMobileClear),

--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -1,0 +1,99 @@
+import datetime
+import time
+import pytz
+from pytz import timezone
+import numpy as np
+
+from helpers.match_manipulator import MatchManipulator
+
+
+class MatchTimePredictionHelper(object):
+
+    @classmethod
+    def as_local(cls, time, timezone):
+        return pytz.utc.localize(datetime.datetime.utcfromtimestamp(time)).astimezone(timezone)
+
+    @classmethod
+    def timestamp(cls, d):
+        return time.mktime(d.timetuple())
+
+    @classmethod
+    def compute_average_cycle_time(cls, played_matches, next_unplayed, timezone):
+        """
+        Compute the average cycle time of the given matches, but only for the current day
+        :param played_matches: The matches for this event that have been played
+        :param next_unplayed: The next match to be played
+        :param timezone: The timezone object, for computing local times
+        :return: The average cycle time, in seconds, or None if not enough info
+        """
+        cycles = []
+
+        # Sort matches by when they were actually played
+        # This should account for out of order replays messing with the computations
+        played_matches.sort(lambda x: x.actual_time)
+
+        # Next match start time (in local time)
+        next_match_start = cls.as_local(next_unplayed.time, timezone)
+
+        # Find the first played match of the same day as the next match to be played
+        start_of_day = None
+        for i in range(0, len(played_matches)):
+            scheduled_time = cls.as_local(played_matches[i].time, timezone)
+            if scheduled_time.day == next_match_start.day:
+                start_of_day = i
+                break
+
+        if start_of_day is None:
+            return None
+
+        # Compute cycle times for matches on this day
+        for i in range(start_of_day + 1, len(played_matches)):
+            cycle = cls.timestamp(played_matches[i].actual_time) - cls.timestamp(played_matches[i - 1].actual_time)
+
+            # Discard (with 0 weight) outlier cycles that take too long (>150% of the schedule)
+            # We want to bias our average to be low, so we don't "overshoot" our predictions
+            # So we simply discard outliers instead of letting them skew the average
+            # Additionally, discard matches with breaks (like lunch) in between. We find those
+            # when we see a scheduled time between matches larger than 15 minutes
+            scheduled_cycle = cls.timestamp(played_matches[i].time) - cls.timestamp(played_matches[i - 1].time)
+            if scheduled_cycle < 15 * 60 or cycle <= scheduled_cycle * 1.25:
+                # Bias the times towards the schedule
+                cycle = (0.7 * cycle) + (0.3 * scheduled_cycle)
+                cycles.append(cycle)
+
+        return np.percentile(cycles, 30) if cycles else None
+
+    @classmethod
+    def predict_future_matches(cls, played_matches, unplayed_matches, timezone):
+        """
+        Add match time predictions for future matches
+        """
+        last_match = played_matches[-1] if played_matches else None
+        next_match = unplayed_matches[0] if unplayed_matches else None
+
+        last_match_day = cls.as_local(last_match.time, timezone).day if last_match else None
+        average_cycle_time = cls.compute_average_cycle_time(played_matches, next_match, timezone)
+        last = last_match
+
+        # Only predict up to 10 matches in the future on the same day
+        for i in range(0, min(10, len(unplayed_matches))):
+            match = unplayed_matches[i]
+            scheduled_time = cls.as_local(match.time, timezone)
+            if scheduled_time.day != last_match_day and last_match_day is not None:
+                # Stop, once we exhaust all unplayed matches on this day
+                break
+
+            # For the first iteration, base the predictions off the newest known actual start time
+            # Otherwise, use the predicted start time of the previously processed match
+            last_predicted = last_match.actual_time if i == 0 else last.predicted_time
+            if last_predicted and average_cycle_time:
+                predicted = last_predicted + datetime.timedelta(seconds=average_cycle_time)
+            else:
+                predicted = match.time
+
+            # Never predict a match to happen more than 2 minutes ahead of schedule
+            earliest_possible = match.time + datetime.timedelta(minutes=-2)
+            match.predicted_time = max(predicted, earliest_possible)
+            last = match
+
+        MatchManipulator.createOrUpdate(unplayed_matches)

--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -56,7 +56,7 @@ class MatchTimePredictionHelper(object):
             # Additionally, discard matches with breaks (like lunch) in between. We find those
             # when we see a scheduled time between matches larger than 15 minutes
             scheduled_cycle = cls.timestamp(played_matches[i].time) - cls.timestamp(played_matches[i - 1].time)
-            if scheduled_cycle < 15 * 60 and cycle <= scheduled_cycle * 1.25:
+            if scheduled_cycle < 15 * 60 and cycle <= scheduled_cycle * 1.5:
                 # Bias the times towards the schedule
                 cycle = (0.7 * cycle) + (0.3 * scheduled_cycle)
                 cycles.append(cycle)

--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -56,7 +56,7 @@ class MatchTimePredictionHelper(object):
             # Additionally, discard matches with breaks (like lunch) in between. We find those
             # when we see a scheduled time between matches larger than 15 minutes
             scheduled_cycle = cls.timestamp(played_matches[i].time) - cls.timestamp(played_matches[i - 1].time)
-            if scheduled_cycle < 15 * 60 or cycle <= scheduled_cycle * 1.25:
+            if scheduled_cycle < 15 * 60 and cycle <= scheduled_cycle * 1.25:
                 # Bias the times towards the schedule
                 cycle = (0.7 * cycle) + (0.3 * scheduled_cycle)
                 cycles.append(cycle)

--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -92,8 +92,9 @@ class MatchTimePredictionHelper(object):
                 predicted = match.time
 
             # Never predict a match to happen more than 2 minutes ahead of schedule
+            now = datetime.datetime.now(timezone)
             earliest_possible = match.time + datetime.timedelta(minutes=-2)
-            match.predicted_time = max(predicted, earliest_possible)
+            match.predicted_time = max(predicted, earliest_possible, now)
             last = match
 
         MatchManipulator.createOrUpdate(unplayed_matches)

--- a/models/match.py
+++ b/models/match.py
@@ -82,6 +82,7 @@ class Match(ndb.Model):
     time = ndb.DateTimeProperty()  # UTC time of scheduled start
     time_string = ndb.StringProperty(indexed=False)  # the time as displayed on FIRST's site (event's local time)
     actual_time = ndb.DateTimeProperty()  # UTC time of match actual start
+    predicted_time = ndb.DateTimeProperty()  # UTC time of when we predict the match will start
     youtube_videos = ndb.StringProperty(repeated=True)  # list of Youtube IDs
     tba_videos = ndb.StringProperty(repeated=True)  # list of filetypes a TBA video exists for
     push_sent = ndb.BooleanProperty()  # has an upcoming match notification been sent for this match? None counts as False


### PR DESCRIPTION
Adds a cronjob that calculates predicted times for the next 10 matches at each currently live event. The algorithms works like so:

1. Compute Cycle Time
   - This is the 30% percentile of all cycle times (biased 70/30 towards the schedule) from the same day, discarding outliers.

2. Assuming that cycle time, start with the last know match start time and predict the times for the next 10 matches.

Some data:
This was an event that ran ahead of schedule, for the most part:
![2016ytr](https://cloud.githubusercontent.com/assets/2754863/23321192/5ad73d9c-faac-11e6-9b76-914e4a2b3fef.png)

This was an event that was very behind, for the most part:
![2016nyny](https://cloud.githubusercontent.com/assets/2754863/23321193/5ad76376-faac-11e6-8d2d-f01666521c26.png)

This was an event that was all over the place:
![2016necmp](https://cloud.githubusercontent.com/assets/2754863/23321191/5ad5ef5a-faac-11e6-86cf-b9d6fbd200b5.png)

Overall, the predicted times are rarely more than 3 minutes late when the event is running faster than anticipated and are always more (usually very) accurate for other cases.
