### PR TITLE
Improved predictions for 2017

### DIFF
--- a/controllers/account_controller.py
+++ b/controllers/account_controller.py
@@ -331,8 +331,8 @@ class myTBAAddHotMatchesController(LoggedInHandler):
             ancestor=self.user_bundle.account.key).fetch_async(projection=[Subscription.model_key])
 
         matches = []
-        if event.matchstats and 'match_predictions' in event.matchstats:
-            match_predictions = event.matchstats['match_predictions']
+        if event.details and event.details.predictions:
+            match_predictions = event.details.predictions['match_predictions']
             max_hotness = 0
             min_hotness = float('inf')
             for match in event.matches:

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -210,8 +210,10 @@ class EventMatchstatsEnqueue(webapp.RequestHandler):
         else:
             events = Event.query(Event.year == int(when)).fetch(500)
 
+        EventHelper.sort_events(events)
         for event in events:
             taskqueue.add(
+                queue_name='run-in-order',  # Because predictions depend on past events
                 url='/tasks/math/do/event_matchstats/' + event.key_name,
                 method='GET')
 

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -169,13 +169,13 @@ class EventMatchstatsDo(webapp.RequestHandler):
         if event.year == 2016:
             organized_matches = MatchHelper.organizeMatches(event.matches)
             match_predictions, match_prediction_stats = PredictionHelper.get_match_predictions(organized_matches['qm'])
-            ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
+            # ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
 
             predictions_dict = {
                 'match_predictions': match_predictions,
                 'match_prediction_stats': match_prediction_stats,
-                'ranking_predictions': ranking_predictions,
-                'ranking_prediction_stats': ranking_prediction_stats
+                # 'ranking_predictions': ranking_predictions,
+                # 'ranking_prediction_stats': ranking_prediction_stats
             }
 
         event_insights = EventInsightsHelper.calculate_event_insights(event.matches, event.year)

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -167,9 +167,9 @@ class EventMatchstatsDo(webapp.RequestHandler):
 
         predictions_dict = None
         if event.year >= 2016:
-            organized_matches = MatchHelper.organizeMatches(event.matches)
-            match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(organized_matches['qm'])
-            ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
+            sorted_matches = MatchHelper.play_order_sort_matches(event.matches)
+            match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(sorted_matches)
+            ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(sorted_matches, match_predictions['qual'])
 
             predictions_dict = {
                 'match_predictions': match_predictions,

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -166,17 +166,17 @@ class EventMatchstatsDo(webapp.RequestHandler):
             matchstats_dict = None
 
         predictions_dict = None
-        if event.year == 2016:
+        if event.year >= 2016:
             organized_matches = MatchHelper.organizeMatches(event.matches)
             match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(organized_matches['qm'])
-            ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
+            # ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
 
             predictions_dict = {
                 'match_predictions': match_predictions,
                 'match_prediction_stats': match_prediction_stats,
                 'stat_mean_vars': stat_mean_vars,
-                'ranking_predictions': ranking_predictions,
-                'ranking_prediction_stats': ranking_prediction_stats
+                # 'ranking_predictions': ranking_predictions,
+                # 'ranking_prediction_stats': ranking_prediction_stats
             }
 
         event_insights = EventInsightsHelper.calculate_event_insights(event.matches, event.year)

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -169,14 +169,14 @@ class EventMatchstatsDo(webapp.RequestHandler):
         if event.year == 2016:
             organized_matches = MatchHelper.organizeMatches(event.matches)
             match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(organized_matches['qm'])
-            # ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
+            ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
 
             predictions_dict = {
                 'match_predictions': match_predictions,
                 'match_prediction_stats': match_prediction_stats,
                 'stat_mean_vars': stat_mean_vars,
-                # 'ranking_predictions': ranking_predictions,
-                # 'ranking_prediction_stats': ranking_prediction_stats
+                'ranking_predictions': ranking_predictions,
+                'ranking_prediction_stats': ranking_prediction_stats
             }
 
         event_insights = EventInsightsHelper.calculate_event_insights(event.matches, event.year)

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -169,14 +169,14 @@ class EventMatchstatsDo(webapp.RequestHandler):
         if event.year >= 2016:
             organized_matches = MatchHelper.organizeMatches(event.matches)
             match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(organized_matches['qm'])
-            # ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
+            ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
 
             predictions_dict = {
                 'match_predictions': match_predictions,
                 'match_prediction_stats': match_prediction_stats,
                 'stat_mean_vars': stat_mean_vars,
-                # 'ranking_predictions': ranking_predictions,
-                # 'ranking_prediction_stats': ranking_prediction_stats
+                'ranking_predictions': ranking_predictions,
+                'ranking_prediction_stats': ranking_prediction_stats
             }
 
         event_insights = EventInsightsHelper.calculate_event_insights(event.matches, event.year)

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -168,12 +168,13 @@ class EventMatchstatsDo(webapp.RequestHandler):
         predictions_dict = None
         if event.year == 2016:
             organized_matches = MatchHelper.organizeMatches(event.matches)
-            match_predictions, match_prediction_stats = PredictionHelper.get_match_predictions(organized_matches['qm'])
+            match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(organized_matches['qm'])
             # ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(organized_matches['qm'], match_predictions)
 
             predictions_dict = {
                 'match_predictions': match_predictions,
                 'match_prediction_stats': match_prediction_stats,
+                'stat_mean_vars': stat_mean_vars,
                 # 'ranking_predictions': ranking_predictions,
                 # 'ranking_prediction_stats': ranking_prediction_stats
             }

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -289,9 +289,16 @@ class EventInsights(CacheableHandler):
                 ))
 
         # Add actual scores to predictions
+        distribution_info = {}
         for match in matches['qm']:
-            match_predictions[match.key.id()]['red']['actual_score'] = match.alliances['red']['score']
-            match_predictions[match.key.id()]['blue']['actual_score'] = match.alliances['blue']['score']
+            distribution_info[match.key.id()] = {
+                'red_actual_score': match.alliances['red']['score'],
+                'blue_actual_score': match.alliances['blue']['score'],
+                'red_mean': match_predictions[match.key.id()]['red']['score'],
+                'blue_mean': match_predictions[match.key.id()]['blue']['score'],
+                'red_var': match_predictions[match.key.id()]['red']['score_var'],
+                'blue_var': match_predictions[match.key.id()]['blue']['score_var'],
+            }
 
         last_played_match_num = None
         if ranking_prediction_stats:
@@ -304,7 +311,7 @@ class EventInsights(CacheableHandler):
             "matches": matches,
             "fake_matches": fake_matches,
             "match_predictions": match_predictions,
-            "match_predictions_json": json.dumps(match_predictions),
+            "distribution_info_json": json.dumps(distribution_info),
             "match_prediction_stats": match_prediction_stats,
             "ranking_predictions": ranking_predictions,
             "ranking_prediction_stats": ranking_prediction_stats,

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -240,10 +240,13 @@ class EventInsights(CacheableHandler):
     def _render(self, event_key):
         event = Event.get_by_id(event_key)
 
-        if not event or event.year != 2016:
+        if not event or event.year < 2016:
             self.abort(404)
 
         event.get_matches_async()
+
+        if not event.details.predictions:
+            self.abort(404)
 
         match_predictions = event.details.predictions.get('match_predictions', None)
         match_prediction_stats = event.details.predictions.get('match_prediction_stats', None)

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -285,6 +285,11 @@ class EventInsights(CacheableHandler):
                     alliances_json=json.dumps(alliances),
                 ))
 
+        # Add actual scores to predictions
+        for match in matches['qm']:
+            match_predictions[match.key.id()]['red']['actual_score'] = match.alliances['red']['score']
+            match_predictions[match.key.id()]['blue']['actual_score'] = match.alliances['blue']['score']
+
         last_played_match_num = None
         if ranking_prediction_stats:
             last_played_match_key = ranking_prediction_stats.get('last_played_match', None)
@@ -296,6 +301,7 @@ class EventInsights(CacheableHandler):
             "matches": matches,
             "fake_matches": fake_matches,
             "match_predictions": match_predictions,
+            "match_predictions_json": json.dumps(match_predictions),
             "match_prediction_stats": match_prediction_stats,
             "ranking_predictions": ranking_predictions,
             "ranking_prediction_stats": ranking_prediction_stats,

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -240,13 +240,10 @@ class EventInsights(CacheableHandler):
     def _render(self, event_key):
         event = Event.get_by_id(event_key)
 
-        if not event or event.year < 2016:
+        if not event or event.year < 2016 or not event.details.predictions:
             self.abort(404)
 
         event.get_matches_async()
-
-        if not event.details.predictions:
-            self.abort(404)
 
         match_predictions = event.details.predictions.get('match_predictions', None)
         match_prediction_stats = event.details.predictions.get('match_prediction_stats', None)

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -290,14 +290,16 @@ class EventInsights(CacheableHandler):
 
         # Add actual scores to predictions
         distribution_info = {}
-        for match in matches['qm']:
-            distribution_info[match.key.id()] = {
-                'red_actual_score': match.alliances['red']['score'],
-                'blue_actual_score': match.alliances['blue']['score'],
-                'red_mean': match_predictions[match.key.id()]['red']['score'],
-                'blue_mean': match_predictions[match.key.id()]['blue']['score'],
-                'red_var': match_predictions[match.key.id()]['red']['score_var'],
-                'blue_var': match_predictions[match.key.id()]['blue']['score_var'],
+        for comp_level in Match.COMP_LEVELS:
+            level = 'qual' if comp_level == 'qm' else 'playoff'
+            for match in matches[comp_level]:
+                distribution_info[match.key.id()] = {
+                    'red_actual_score': match.alliances['red']['score'],
+                    'blue_actual_score': match.alliances['blue']['score'],
+                    'red_mean': match_predictions[level][match.key.id()]['red']['score'],
+                    'blue_mean': match_predictions[level][match.key.id()]['blue']['score'],
+                    'red_var': match_predictions[level][match.key.id()]['red']['score_var'],
+                    'blue_var': match_predictions[level][match.key.id()]['blue']['score_var'],
             }
 
         last_played_match_num = None

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -294,6 +294,7 @@ class EventInsights(CacheableHandler):
             level = 'qual' if comp_level == 'qm' else 'playoff'
             for match in matches[comp_level]:
                 distribution_info[match.key.id()] = {
+                    'level': level,
                     'red_actual_score': match.alliances['red']['score'],
                     'blue_actual_score': match.alliances['blue']['score'],
                     'red_mean': match_predictions[level][match.key.id()]['red']['score'],

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -260,7 +260,7 @@ class EventInsights(CacheableHandler):
         # If no matches but there are match predictions, create fake matches
         # For cases where FIRST doesn't allow posting of match schedule
         fake_matches = False
-        if not matches['qm'] and match_predictions:
+        if not matches['qm'] and match_predictions['qual']:
             fake_matches = True
             for i in xrange(len(match_predictions.keys())):
                 match_number = i + 1

--- a/helpers/matchstats_helper.py
+++ b/helpers/matchstats_helper.py
@@ -154,13 +154,13 @@ class MatchstatsHelper(object):
 
         stats = {'oprs': oprs_dict, 'dprs': dprs_dict, 'ccwms': ccwms_dict}
 
-        if year == 2016:
-            # First ranking tiebreaker
-            stats['2016autoPointsOPR'] = cls.calc_stat(matches, team_list, team_id_map, Minv, '2016autoPointsOPR')
+        # if year == 2016:
+        #     # First ranking tiebreaker
+        #     stats['2016autoPointsOPR'] = cls.calc_stat(matches, team_list, team_id_map, Minv, '2016autoPointsOPR')
 
-            # For RP calculation
-            stats['2016crossingsOPR'] = cls.calc_stat(matches, team_list, team_id_map, Minv, '2016crossingsOPR')
-            stats['2016bouldersOPR'] = cls.calc_stat(matches, team_list, team_id_map, Minv, '2016bouldersOPR')
+        #     # For RP calculation
+        #     stats['2016crossingsOPR'] = cls.calc_stat(matches, team_list, team_id_map, Minv, '2016crossingsOPR')
+        #     stats['2016bouldersOPR'] = cls.calc_stat(matches, team_list, team_id_map, Minv, '2016bouldersOPR')
 
         return stats
 

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -473,12 +473,12 @@ class PredictionHelper(object):
                             else:
                                 brier_sums['gears'] += pow(prediction[color]['prob_gears'] - 0, 2)
 
-                brier_scores = {}
-                for stat, brier_sum in brier_sums.items():
-                    if stat == 'score':
-                        brier_scores['win_loss'] = brier_sum / played_matches
-                    else:
-                        brier_scores[stat] = brier_sum / (2 * played_matches)
+            brier_scores = {}
+            for stat, brier_sum in brier_sums.items():
+                if stat == 'score':
+                    brier_scores['win_loss'] = brier_sum / played_matches
+                else:
+                    brier_scores[stat] = brier_sum / (2 * played_matches)
 
             prediction_stats[level] = {
                 'wl_accuracy': None if played_matches == 0 else 100 * float(correct_predictions) / played_matches,

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -326,38 +326,6 @@ class PredictionHelper(object):
         event_key = matches[0].event
         event = event_key.get()
 
-        # # Setup
-        # team_list, team_id_map = cls._build_team_mapping(matches)
-        # # last_event_stats = MatchstatsHelper.get_last_event_stats(team_list, event_key)
-
-        # # Setup matrices
-        # m = len(matches)
-        # t = len(team_list)
-        # Ar = np.zeros((m, t))
-        # Ab = np.zeros((m, t))
-        # Mr_mean = np.zeros((m, 1))
-        # Mb_mean = np.zeros((m, 1))
-        # Mr_var = np.zeros((m, 1))
-        # Mb_var = np.zeros((m, 1))
-
-        # init_stats_sums = defaultdict(int)
-        # init_stats_totals = defaultdict(int)
-        # for _, stats in last_event_stats.items():
-        #     for stat, stat_value in stats.items():
-        #         init_stats_sums[stat] += stat_value
-        #         init_stats_totals[stat] += 1
-
-        # init_stats_default = defaultdict(int)
-        # for stat, stat_sum in init_stats_sums.items():
-        #     init_stats_default[stat] = float(stat_sum) / init_stats_totals[stat]
-
-        # relevant_stats = [
-        #     'oprs',
-        #     '2016autoPointsOPR',
-        #     '2016crossingsOPR',
-        #     '2016bouldersOPR'
-        # ]
-
         # Make predictions before each match
         predictions = {}
         played_matches = 0
@@ -425,33 +393,6 @@ class PredictionHelper(object):
                     brier_scores[stat] = brier_sum / played_matches
                 else:
                     brier_scores[stat] = brier_sum / (2 * played_matches)
-
-            # # Update init_stats
-            # if match.has_been_played and match.score_breakdown:
-            #     for alliance_color in ['red', 'blue']:
-            #         stats_sum['score'] += match.alliances[alliance_color]['score']
-
-            #         for stat in relevant_stats:
-            #             if stat == '2016autoPointsOPR':
-            #                 init_stats_default[stat] += match.score_breakdown[alliance_color]['autoPoints']
-            #             elif stat == '2016bouldersOPR':
-            #                 init_stats_default[stat] += (
-            #                     match.score_breakdown[alliance_color].get('autoBouldersLow', 0) +
-            #                     match.score_breakdown[alliance_color].get('autoBouldersHigh', 0) +
-            #                     match.score_breakdown[alliance_color].get('teleopBouldersLow', 0) +
-            #                     match.score_breakdown[alliance_color].get('teleopBouldersHigh', 0))
-            #             elif stat == '2016crossingsOPR':
-            #                 init_stats_default[stat] += (
-            #                     match.score_breakdown[alliance_color].get('position1crossings', 0) +
-            #                     match.score_breakdown[alliance_color].get('position2crossings', 0) +
-            #                     match.score_breakdown[alliance_color].get('position3crossings', 0) +
-            #                     match.score_breakdown[alliance_color].get('position4crossings', 0) +
-            #                     match.score_breakdown[alliance_color].get('position5crossings', 0))
-
-            # init_stats_default['oprs'] = float(stats_sum['score']) / (i + 1) / 6  # Initialize with 1/3 of average scores (2 alliances per match)
-            # for stat in relevant_stats:
-            #     if stat != 'oprs':
-            #         init_stats_default[stat] = float(stats_sum[stat]) / (i + 1) / 6  # Initialize with 1/3 of average scores (2 alliances per match)
 
         prediction_stats = {
             'wl_accuracy': None if played_matches == 0 else 100 * float(correct_predictions) / played_matches,

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -26,6 +26,7 @@ class ContributionCalculator(object):
         self._Mmean = np.zeros((2*m, 1))  # Means
         self._Mvar = np.zeros((2*m, 1))  # Variances
 
+        # For finding event averages for initialization
         self._mean_sums = []
         self._var_sums = []
 
@@ -78,18 +79,21 @@ class ContributionCalculator(object):
         all_team_means = {}  # TODO
         for team in self._team_list:
             mean = self._default_mean
-            if team not in all_team_means:
-                if all_team_means:
-                    mean = np.mean([ato[-1] for ato in all_team_means.values()])
-                elif self._mean_sums:
-                    mean = np.mean(self._mean_sums) / 3
-            else:
+            if team in all_team_means:
+                # Use team's past means
                 weight_sum = 0
                 for j, o in enumerate(reversed(all_team_means[team])):
                     weight = pow(0.1, j)
                     opr += weight * o
                     weight_sum += weight
                 mean /= weight_sum
+            else:
+                if all_team_means:
+                    # Use averages from other past teams
+                    mean = np.mean([ato[-1] for ato in all_team_means.values()])
+                elif self._mean_sums:
+                    # Use averages from this event
+                    mean = np.mean(self._mean_sums) / 3
 
             self._Oe[self._team_id_map[team]] = mean
             self._diags[self._team_id_map[team]] = 3  # TODO
@@ -105,12 +109,8 @@ class ContributionCalculator(object):
         all_team_vars = {}  # TODO
         for team in self._team_list:
             var = self._default_var
-            if team not in all_team_vars:
-                if all_team_vars:
-                    var = np.mean([ato[-1] for ato in all_team_vars.values()])
-                elif self._var_sums:
-                    var = np.mean(self._var_sums) / 3
-            else:
+            if team in all_team_vars:
+                # Use team's past variances
                 var = 0
                 weight_sum = 0
                 for j, o in enumerate(reversed(all_team_vars[team])):
@@ -118,6 +118,13 @@ class ContributionCalculator(object):
                     var += weight * o
                     weight_sum += weight
                 var /= weight_sum
+            else:
+                if all_team_vars:
+                    # Use averages from other past teams
+                    var = np.mean([ato[-1] for ato in all_team_vars.values()])
+                elif self._var_sums:
+                    # Use averages from this event
+                    var = np.mean(self._var_sums) / 3
 
             self._Oe[self._team_id_map[team]] = var
             self._diags[self._team_id_map[team]] = 3  # TODO

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -82,8 +82,10 @@ class ContributionCalculator(object):
                     # event.details is backed by in-context cache
                     predictions = event.details.predictions
                     if predictions and 'stat_mean_vars' in predictions:
-                        past_stats_mean[team].append(predictions['stat_mean_vars'][self._stat]['mean'][team])
-                        past_stats_var[team].append(predictions['stat_mean_vars'][self._stat]['var'][team])
+                        if team in predictions['stat_mean_vars'][self._stat]['mean']:
+                            past_stats_mean[team].append(predictions['stat_mean_vars'][self._stat]['mean'][team])
+                        if team in predictions['stat_mean_vars'][self._stat]['var']:
+                            past_stats_var[team].append(predictions['stat_mean_vars'][self._stat]['var'][team])
 
         return past_stats_mean, past_stats_var
 
@@ -107,6 +109,7 @@ class ContributionCalculator(object):
             mean = self._default_mean
             if team in self._past_stats_mean:
                 # Use team's past means
+                mean = 0
                 weight_sum = 0
                 for j, o in enumerate(reversed(self._past_stats_mean[team])):
                     weight = pow(0.1, j)
@@ -328,7 +331,7 @@ class PredictionHelper(object):
     @classmethod
     def get_match_predictions(cls, matches):
         if not matches:
-            return None, None
+            return None, None, None
 
         event_key = matches[0].event
         event = event_key.get()

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -10,7 +10,7 @@ from helpers.matchstats_helper import MatchstatsHelper
 class ContributionCalculator(object):
     def __init__(self, matches, stat, default_mean, default_var):
         """
-        stat: 'score' or a specific breakdown like '2016autoPoints'
+        stat: 'score' or a specific breakdown like 'auto_points' or 'boulders'
         """
         self._matches = matches
         self._stat = stat
@@ -364,7 +364,7 @@ class PredictionHelper(object):
             brier_scores = {}
             for stat, brier_sum in brier_sums.items():
                 if stat == 'score':
-                    brier_scores[stat] = brier_sum / played_matches
+                    brier_scores['win_loss'] = brier_sum / played_matches
                 else:
                     brier_scores[stat] = brier_sum / (2 * played_matches)
 

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -489,8 +489,8 @@ class PredictionHelper(object):
                     for team in match.alliances[alliance_color]['teams']:
                         num_played[team] += 1
 
-                sampled_breach = {}
-                sampled_capture = {}
+                sampled_rp1 = {}
+                sampled_rp2 = {}
                 sampled_tiebreaker = {}
                 # Get actual results or sampled results, depending if match has been played
                 if match.has_been_played:
@@ -499,9 +499,14 @@ class PredictionHelper(object):
                     last_played_match = match.key.id()
                     sampled_winner = match.winning_alliance
                     for alliance_color in ['red', 'blue']:
-                        sampled_breach[alliance_color] = match.score_breakdown[alliance_color]['teleopDefensesBreached']
-                        sampled_capture[alliance_color] = match.score_breakdown[alliance_color]['teleopTowerCaptured']
-                        sampled_tiebreaker[alliance_color] = match.score_breakdown[alliance_color]['autoPoints']
+                        if match.year == 2016:
+                            sampled_rp1[alliance_color] = match.score_breakdown[alliance_color]['teleopDefensesBreached']
+                            sampled_rp2[alliance_color] = match.score_breakdown[alliance_color]['teleopTowerCaptured']
+                            sampled_tiebreaker[alliance_color] = match.score_breakdown[alliance_color]['autoPoints']
+                        elif match.year == 2017:
+                            sampled_rp1[alliance_color] = match.score_breakdown[alliance_color]['kPaRankingPointAchieved']
+                            sampled_rp2[alliance_color] = match.score_breakdown[alliance_color]['rotorRankingPointAchieved']
+                            sampled_tiebreaker[alliance_color] = match.score_breakdown[alliance_color]['totalPoints']
                 else:
                     prediction = match_predictions[match.key.id()]
                     if np.random.uniform(high=1) < prediction['prob']:
@@ -513,18 +518,23 @@ class PredictionHelper(object):
                             sampled_winner = 'red'
 
                     for alliance_color in ['red', 'blue']:
-                        sampled_breach[alliance_color] = np.random.uniform(high=1) < prediction[alliance_color]['prob_breach']
-                        sampled_capture[alliance_color] = np.random.uniform(high=1) < prediction[alliance_color]['prob_capture']
-                        sampled_tiebreaker[alliance_color] = prediction[alliance_color]['auto_points']
+                        if match.year == 2016:
+                            sampled_rp1[alliance_color] = np.random.uniform(high=1) < prediction[alliance_color]['prob_breach']
+                            sampled_rp2[alliance_color] = np.random.uniform(high=1) < prediction[alliance_color]['prob_capture']
+                            sampled_tiebreaker[alliance_color] = prediction[alliance_color]['auto_points']
+                        elif match.year == 2017:
+                            sampled_rp1[alliance_color] = np.random.uniform(high=1) < prediction[alliance_color]['prob_pressure']
+                            sampled_rp2[alliance_color] = np.random.uniform(high=1) < prediction[alliance_color]['prob_gears']
+                            sampled_tiebreaker[alliance_color] = prediction[alliance_color]['score']
 
                 # Using match results, update RP and tiebreaker
                 for alliance_color in ['red', 'blue']:
                     for team in match.alliances[alliance_color]['teams']:
                         if team in surrogate_teams and num_played[team] == 3:
                             continue
-                        if sampled_breach[alliance_color]:
+                        if sampled_rp1[alliance_color]:
                             team_ranking_points[team] += 1
-                        if sampled_capture[alliance_color]:
+                        if sampled_rp2[alliance_color]:
                             team_ranking_points[team] += 1
                         team_rank_tiebreaker[team] += sampled_tiebreaker[alliance_color]
 

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -550,6 +550,10 @@ class PredictionHelper(object):
                             continue
                         team_ranking_points[team] += 2
 
+                    sampled_loser = 'red' if sampled_winner == 'blue' else 'blue'
+                    for team in match.alliances[sampled_loser]['teams']:
+                        team_ranking_points[team] += 0
+
             # Compute ranks for this sample
             sample_rankings = sorted(team_ranking_points.items(), key=lambda x: -team_rank_tiebreaker[x[0]])  # Sort by tiebreaker.
             sample_rankings = sorted(sample_rankings, key=lambda x: -x[1])  # Sort by RP. Sort is stable.

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -84,10 +84,10 @@ class ContributionCalculator(object):
                     # event.details is backed by in-context cache
                     predictions = event.details.predictions
                     if predictions and 'stat_mean_vars' in predictions:
-                        if team in predictions['stat_mean_vars'][self._stat]['mean']:
-                            past_stats_mean[team].append(predictions['stat_mean_vars'][self._stat]['mean'][team])
-                        if team in predictions['stat_mean_vars'][self._stat]['var']:
-                            past_stats_var[team].append(predictions['stat_mean_vars'][self._stat]['var'][team])
+                        if team in predictions['stat_mean_vars']['qual'][self._stat]['mean']:
+                            past_stats_mean[team].append(predictions['stat_mean_vars']['qual'][self._stat]['mean'][team])
+                        if team in predictions['stat_mean_vars']['qual'][self._stat]['var']:
+                            past_stats_var[team].append(predictions['stat_mean_vars']['qual'][self._stat]['var'][team])
 
         return past_stats_mean, past_stats_var
 

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -458,9 +458,6 @@ class PredictionHelper(object):
 
     @classmethod
     def get_ranking_predictions(cls, matches, match_predictions, n=1000):
-        """
-        Only works for 2016
-        """
         if not matches:
             return None, None
 

--- a/helpers/prediction_helper.py
+++ b/helpers/prediction_helper.py
@@ -213,7 +213,7 @@ class ContributionCalculator(object):
             self._Mvar[2*i+1] = best_var_sum
             self._var_sums.append(best_var_sum)
 
-        return self._means, self._vars
+        return {'mean': self._means, 'var': self._vars}
 
 
 class PredictionHelper(object):
@@ -229,9 +229,9 @@ class PredictionHelper(object):
         }
         for color in ['red', 'blue']:
             for team in match.alliances[color]['teams']:
-                for stat, (mean, var) in stat_mean_vars.items():
-                    team_mean = mean[team]
-                    team_var = var[team]
+                for stat, mean_var in stat_mean_vars.items():
+                    team_mean = mean_var['mean'][team]
+                    team_var = mean_var['var'][team]
 
                     # Crossing OPR usually underestimates. hacky fix to make numbers more believable
                     if stat == 'crossings':
@@ -376,7 +376,7 @@ class PredictionHelper(object):
             'brier_scores': brier_scores,
         }
 
-        return predictions, prediction_stats
+        return predictions, prediction_stats, stat_mean_vars
 
     @classmethod
     def get_ranking_predictions(cls, matches, match_predictions, n=1000):

--- a/queue.yaml
+++ b/queue.yaml
@@ -31,3 +31,7 @@ queue:
 
 - name: admin
   rate: 5/s
+
+- name: run-in-order
+  max_concurrent_requests: 1
+  rate: 5/s

--- a/templates/predictions.html
+++ b/templates/predictions.html
@@ -15,9 +15,14 @@
       and prove us wrong!</p>
 
       <h2>Match Predictions</h2>
-      <p>Match result predictions use ixOPR, a slight variant of
-      <a href="/opr">OPR</a>, to attempt to extrapolate the final match score
-      based on a team's estimated point contribution to an alliance.</p>
+      <p>Match result predictions attempts to estimate the mean and variance of
+      a team's contribution to the alliance final score. Means are estimated by
+      solving for the minimum mean squared error
+      (<a href="https://en.wikipedia.org/wiki/Minimum_mean_square_error">MMSE</a>)
+      solution to the standard <a href="/opr">OPR</a> equations. Final match
+      score is predicted by summing each team's mean contribution. The actual
+      score is then compared to the predicted score to calculate a team's
+      variance which is used to inform future predictions.</p>
 
       <h2>Event Ranking Predictions</h2>
       <p>Rankings are predicted using the <a href="https://en.wikipedia.org/wiki/Monte_Carlo_method" target="_blank">Monte Carlo</a>

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -45,7 +45,7 @@
           {% if match_prediction_stats.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.wl_accuracy|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.wl_accuracy_75|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
-          {% if match_prediction_stats.brier_scores.score %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.score}}</p>{% endif %}
+          {% if match_prediction_stats.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.win_loss}}</p>{% endif %}
           {% if match_prediction_stats.brier_scores.breach %}<p><strong>Breach Brier score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>{% endif %}
           {% if match_prediction_stats.brier_scores.capture %}<p><strong>Capture Brier score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>{% endif %}
 

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -45,9 +45,9 @@
           {% if match_prediction_stats.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.wl_accuracy|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.wl_accuracy_75|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
-          {% if match_prediction_stats.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.win_loss}}</p>{% endif %}
 
           <!--
+          {% if match_prediction_stats.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.win_loss}}</p>{% endif %}
           {% if event.year == 2016 %}
             <p><strong>Breach Brier Score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>
             <p><strong>Capture Brier Score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -38,7 +38,7 @@
         {% if matches.qm %}
         <div class="col-xs-12">
           <h3>Qualification Match Predictions (<a href="/predictions">?</a>)</h3>
-          <p>Remember, ranking predictions are JUST FOR FUN! Please do not be discouraged by our predictions -- they are almost certainly wrong.</p>
+          <p>Remember, match predictions are JUST FOR FUN! Please do not be discouraged by our predictions -- they are almost certainly wrong.</p>
           {% if fake_matches %}
           <p>Note: Match teams are not shown because <em>FIRST</em> does not allow the re-hosting of the preliminary match schedule. Sorry for the inconvenience.</p>
           {% endif %}

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -234,7 +234,6 @@
             },
             scales: {
                 xAxes: [{
-                    // display: false,
                     type: 'linear',
                     position: 'bottom',
                     gridLines: {
@@ -263,8 +262,7 @@
     });
   });
 
-  //taken from Jason Davies science library
-  // https://github.com/jasondavies/science.js/
+  // taken from https://github.com/jasondavies/science.js/
   function gaussian(x, mean, sig) {
     var gaussianConstant = 1 / Math.sqrt(2 * Math.PI),
       x = (x - mean) / sig;

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -129,13 +129,14 @@
   var predictions = JSON.parse($('#predictionsJson').html());
   Chart.defaults.global.legend.display = false;
   Chart.defaults.global.maintainAspectRatio = false;
+  Chart.defaults.global.tooltips = false;
 
   $('.score_chart').each(function() {
     var ctx = document.getElementById(this.id).getContext('2d');
     var matchKey = $(this).attr('data-match-key');
 
-    var numPoints = 20;
-    var tailScale = 8;
+    var numPoints = 10;
+    var tailScale = 7;
 
     var redMean = predictions[matchKey]['red']['score'];
     var redSig = Math.sqrt(predictions[matchKey]['red']['score_var']);
@@ -159,7 +160,7 @@
       })
     }
 
-    var lineHeight = Math.max(gaussian(redMean, redMean, redSig), gaussian(blueMean, blueMean, blueSig));
+    // var lineHeight = Math.max(gaussian(redMean, redMean, redSig), gaussian(blueMean, blueMean, blueSig));
 
     var scatterChart = new Chart(ctx, {
         type: 'line',
@@ -171,7 +172,7 @@
                   y: 0
                 },{
                   x: predictions[matchKey]['red']['actual_score'],
-                  y: lineHeight
+                  y: 0.06
                 }],
                 borderColor: "rgba(255,0,0,1)"
             },
@@ -181,7 +182,7 @@
                   y: 0
                 },{
                   x: predictions[matchKey]['blue']['actual_score'],
-                  y: lineHeight
+                  y: 0.06
                 }],
                 borderColor: "rgba(0,0,255,1)"
             },
@@ -204,14 +205,23 @@
                     gridLines: {
                         display: false,
                     },
+                    ticks: {
+                      min: 0,
+                      max: 200
+                    }
                 }],
                 yAxes: [{
-                    display: false
+                    display: false,
+                    ticks: {
+                      min: 0,
+                      max: 0.07
+                    }
                 }]
             },
             elements: {
               point: {
-                radius: 0
+                radius: 0,
+                hoverRadius: 0
               }
             }
         }

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -36,7 +36,6 @@
     <div class="tab-pane active" id="qual-match-predictions">
       {% if match_predictions.qual %}
       <div class="row">
-        {% if matches.qm %}
         <div class="col-xs-12">
           <h3>Qualification Match Predictions (<a href="/predictions">?</a>)</h3>
           <p>Remember, match predictions are JUST FOR FUN! Please do not be discouraged by our predictions -- they are almost certainly wrong.</p>
@@ -60,7 +59,6 @@
 
           {{mtm.qual_match_prediction_table(matches, match_predictions.qual, fake_matches, event.year)}}
         </div>
-        {% endif %}
       </div>
       {% else %}
       <div class="row">
@@ -131,7 +129,6 @@
     <div class="tab-pane" id="playoff-match-predictions">
       {% if match_predictions.playoff %}
       <div class="row">
-        {% if matches.qm %}
         <div class="col-xs-12">
           <h3>Playoff Match Predictions (<a href="/predictions">?</a>)</h3>
           <p>Remember, match predictions are JUST FOR FUN! Please do not be discouraged by our predictions -- they are almost certainly wrong.</p>
@@ -155,7 +152,6 @@
 
           {{mtm.playoff_match_prediction_table(matches, match_predictions.playoff, fake_matches, event.year)}}
         </div>
-        {% endif %}
       </div>
       {% else %}
       <div class="row">

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -173,24 +173,55 @@
   Chart.defaults.global.maintainAspectRatio = false;
   Chart.defaults.global.tooltips = false;
 
-  var maxScore = 0;
-  var lineHeight = 0;
+  var minQualScore = Infinity;
+  var maxQualScore = 0;
+  var qualLineHeight = 0;
+  var minPlayoffScore = Infinity;
+  var maxPlayoffScore = 0;
+  var playoffLineHeight = 0;
   for (var key in predictions) {
-    maxScore = Math.max(maxScore, predictions[key]['red_actual_score']);
-    maxScore = Math.max(maxScore, predictions[key]['blue_actual_score']);
-    lineHeight = Math.max(lineHeight,
-      Math.max(gaussian(predictions[key]['red_mean'],
-                        predictions[key]['red_mean'],
-                        Math.sqrt(predictions[key]['red_var'])),
-               gaussian(predictions[key]['blue_mean'],
-                        predictions[key]['blue_mean'],
-                        Math.sqrt(predictions[key]['blue_var']))));
+    var redScore = predictions[key]['red_actual_score'];
+    var blueScore = predictions[key]['blue_actual_score'];
+
+    if (predictions[key].level == 'qual') {
+      if (redScore != -1 && blueScore != -1) {
+        minQualScore = Math.min(minQualScore, redScore);
+        minQualScore = Math.min(minQualScore, blueScore);
+        maxQualScore = Math.max(maxQualScore, redScore);
+        maxQualScore = Math.max(maxQualScore, blueScore);
+      }
+      qualLineHeight = Math.max(qualLineHeight,
+        Math.max(gaussian(predictions[key]['red_mean'],
+                          predictions[key]['red_mean'],
+                          Math.sqrt(predictions[key]['red_var'])),
+                 gaussian(predictions[key]['blue_mean'],
+                          predictions[key]['blue_mean'],
+                          Math.sqrt(predictions[key]['blue_var']))));
+    } else {
+      if (redScore != -1 && blueScore != -1) {
+        minPlayoffScore = Math.min(minPlayoffScore, redScore);
+        minPlayoffScore = Math.min(minPlayoffScore, blueScore);
+        maxPlayoffScore = Math.max(maxPlayoffScore, redScore);
+        maxPlayoffScore = Math.max(maxPlayoffScore, blueScore);
+      }
+      playoffLineHeight = Math.max(playoffLineHeight,
+        Math.max(gaussian(predictions[key]['red_mean'],
+                          predictions[key]['red_mean'],
+                          Math.sqrt(predictions[key]['red_var'])),
+                 gaussian(predictions[key]['blue_mean'],
+                          predictions[key]['blue_mean'],
+                          Math.sqrt(predictions[key]['blue_var']))));
+    }
   }
-  var xMax = maxScore - (maxScore % 50) + 50;
+  var xMinQual = minQualScore - (minQualScore % 50);
+  var xMaxQual = maxQualScore - (maxQualScore % 50) + 50;
+  var xMinPlayoff = minPlayoffScore - (minPlayoffScore % 50);
+  var xMaxPlayoff = maxPlayoffScore - (maxPlayoffScore % 50) + 50;
 
   $('.score_chart').each(function() {
     var ctx = document.getElementById(this.id).getContext('2d');
     var matchKey = $(this).attr('data-match-key');
+    var isQual = predictions[matchKey].level == 'qual';
 
     var numPoints = 10;
     var tailScale = 7;
@@ -228,7 +259,7 @@
           y: 0
         },{
           x: redScore,
-          y: lineHeight
+          y: isQual ? qualLineHeight : playoffLineHeight
         }],
         borderColor: "rgba(255,0,0,0.8)",
         borderWidth: 2
@@ -239,7 +270,7 @@
           y: 0
         },{
           x: blueScore,
-          y: lineHeight
+          y: isQual ? qualLineHeight : playoffLineHeight
         }],
         borderColor: "rgba(0,0,255,0.8)",
         borderWidth: 2
@@ -277,15 +308,15 @@
                         display: false,
                     },
                     ticks: {
-                      min: 0,
-                      max: xMax,
+                      min: isQual? xMinQual : xMinPlayoff,
+                      max: isQual? xMaxQual : xMaxPlayoff,
                     }
                 }],
                 yAxes: [{
                     display: false,
                     ticks: {
                       min: 0,
-                      max: lineHeight * 1.1,
+                      max: isQual? qualLineHeight * 1.1 : playoffLineHeight * 1.1,
                     }
                 }]
             },

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -179,7 +179,8 @@
                   x: predictions[matchKey]['red']['actual_score'],
                   y: 0.06
                 }],
-                borderColor: "rgba(255,0,0,1)"
+                borderColor: "rgba(255,0,0,0.8)",
+                borderWidth: 2
             },
             {
                 data: [{
@@ -189,7 +190,8 @@
                   x: predictions[matchKey]['blue']['actual_score'],
                   y: 0.06
                 }],
-                borderColor: "rgba(0,0,255,1)"
+                borderColor: "rgba(0,0,255,0.8)",
+                borderWidth: 2
             },
             {
                 data: redDist,

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -198,6 +198,9 @@
             ]
         },
         options: {
+            animation: {
+              duration: 0
+            },
             scales: {
                 xAxes: [{
                     type: 'linear',

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -121,3 +121,109 @@
   </div>
 </div>
 {% endblock %}
+
+{% block inline_javascript %}
+<script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+<script id="predictionsJson" type="application/json">{{match_predictions_json|safe}}</script>
+<script>
+  var predictions = JSON.parse($('#predictionsJson').html());
+  Chart.defaults.global.legend.display = false;
+  Chart.defaults.global.maintainAspectRatio = false;
+
+  $('.score_chart').each(function() {
+    var ctx = document.getElementById(this.id).getContext('2d');
+    var matchKey = $(this).attr('data-match-key');
+
+    var numPoints = 20;
+    var tailScale = 8;
+
+    var redMean = predictions[matchKey]['red']['score'];
+    var redSig = Math.sqrt(predictions[matchKey]['red']['score_var']);
+    var redDist = [];
+    for (var i=-numPoints/2; i<=numPoints/2; i++) {
+      x = redMean + redSig * i * tailScale / numPoints;
+      redDist.push({
+        x: x,
+        y: gaussian(x, redMean, redSig)
+      })
+    }
+
+    var blueMean = predictions[matchKey]['blue']['score'];
+    var blueSig = Math.sqrt(predictions[matchKey]['blue']['score_var']);
+    var blueDist = [];
+    for (var i=-numPoints/2; i<=numPoints/2; i++) {
+      x = blueMean + blueSig * i * tailScale / numPoints;
+      blueDist.push({
+        x: x,
+        y: gaussian(x, blueMean, blueSig)
+      })
+    }
+
+    var lineHeight = Math.max(gaussian(redMean, redMean, redSig), gaussian(blueMean, blueMean, blueSig));
+
+    var scatterChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            datasets: [
+            {
+                data: [{
+                  x: predictions[matchKey]['red']['actual_score'],
+                  y: 0
+                },{
+                  x: predictions[matchKey]['red']['actual_score'],
+                  y: lineHeight
+                }],
+                borderColor: "rgba(255,0,0,1)"
+            },
+            {
+                data: [{
+                  x: predictions[matchKey]['blue']['actual_score'],
+                  y: 0
+                },{
+                  x: predictions[matchKey]['blue']['actual_score'],
+                  y: lineHeight
+                }],
+                borderColor: "rgba(0,0,255,1)"
+            },
+            {
+                data: redDist,
+                backgroundColor: "rgba(255,111,111,0.4)"
+            },
+            {
+                data: blueDist,
+                backgroundColor: "rgba(111,111,255,0.4)"
+            }
+
+            ]
+        },
+        options: {
+            scales: {
+                xAxes: [{
+                    type: 'linear',
+                    position: 'bottom',
+                    gridLines: {
+                        display: false,
+                    },
+                }],
+                yAxes: [{
+                    display: false
+                }]
+            },
+            elements: {
+              point: {
+                radius: 0
+              }
+            }
+        }
+    });
+  });
+
+  //taken from Jason Davies science library
+  // https://github.com/jasondavies/science.js/
+  function gaussian(x, mean, sig) {
+    var gaussianConstant = 1 / Math.sqrt(2 * Math.PI),
+      x = (x - mean) / sig;
+      return gaussianConstant * Math.exp(-.5 * x * x) / sig;
+  };
+</script>
+{% endblock %}

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -47,6 +47,7 @@
           {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
           {% if match_prediction_stats.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.win_loss}}</p>{% endif %}
 
+          <!--
           {% if event.year == 2016 %}
             <p><strong>Breach Brier Score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>
             <p><strong>Capture Brier Score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>
@@ -54,6 +55,7 @@
             <p><strong>Pressure Brier Score:</strong> {{match_prediction_stats.brier_scores.pressure}}</p>
             <p><strong>Rotors Brier Score:</strong> {{match_prediction_stats.brier_scores.gears}}</p>
           {% endif %}
+          -->
 
 
           {{mtm.qual_match_prediction_table(matches, match_predictions, fake_matches, event.year)}}

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -45,6 +45,7 @@
           {% if match_prediction_stats.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.wl_accuracy|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.wl_accuracy_75|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
+          {% if match_prediction_stats.brier_score %}<p><strong>Brier score:</strong> {{match_prediction_stats.brier_score}}</p>{% endif %}
           {{mtm.qual_match_prediction_table(matches, match_predictions, fake_matches)}}
         </div>
         {% endif %}

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -45,7 +45,11 @@
           {% if match_prediction_stats.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.wl_accuracy|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.wl_accuracy_75|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
-          {% if match_prediction_stats.brier_score %}<p><strong>Brier score:</strong> {{match_prediction_stats.brier_score}}</p>{% endif %}
+          {% if match_prediction_stats.brier_scores.score %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.score}}</p>{% endif %}
+          {% if match_prediction_stats.brier_scores.breach %}<p><strong>Breach Brier score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>{% endif %}
+          {% if match_prediction_stats.brier_scores.capture %}<p><strong>Capture Brier score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>{% endif %}
+
+
           {{mtm.qual_match_prediction_table(matches, match_predictions, fake_matches)}}
         </div>
         {% endif %}

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -25,15 +25,16 @@
   <div class="row">
     <div class="col-sm-12">
       <ul class="nav nav-tabs">
-        <li class="active"><a href="#match-predictions" data-toggle="tab">Qual Match Predictions</a></li>
+        <li class="active"><a href="#qual-match-predictions" data-toggle="tab">Qual Match Predictions</a></li>
         <li><a href="#ranking-predictions" data-toggle="tab">Ranking Predictions</a></li>
+        <li><a href="#playoff-match-predictions" data-toggle="tab">Playoff Match Predictions</a></li>
       </ul>
     </div>
   </div>
 
   <div class="tab-content">
-    <div class="tab-pane active" id="match-predictions">
-      {% if match_predictions %}
+    <div class="tab-pane active" id="qual-match-predictions">
+      {% if match_predictions.qual %}
       <div class="row">
         {% if matches.qm %}
         <div class="col-xs-12">
@@ -42,30 +43,29 @@
           {% if fake_matches %}
           <p>Note: Match teams are not shown because <em>FIRST</em> does not allow the re-hosting of the preliminary match schedule. Sorry for the inconvenience.</p>
           {% endif %}
-          {% if match_prediction_stats.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.wl_accuracy|round|int}}%</p>{% endif %}
-          {% if match_prediction_stats.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.wl_accuracy_75|round|int}}%</p>{% endif %}
-          {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
+          {% if match_prediction_stats.qual.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.qual.wl_accuracy|round|int}}%</p>{% endif %}
+          {% if match_prediction_stats.qual.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.qual.wl_accuracy_75|round|int}}%</p>{% endif %}
+          {% if match_prediction_stats.qual.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.qual.err_mean|round(1)}}</p>{% endif %}
 
           <!--
-          {% if match_prediction_stats.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.win_loss}}</p>{% endif %}
+          {% if match_prediction_stats.qual.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.qual.brier_scores.win_loss}}</p>{% endif %}
           {% if event.year == 2016 %}
-            <p><strong>Breach Brier Score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>
-            <p><strong>Capture Brier Score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>
+            <p><strong>Breach Brier Score:</strong> {{match_prediction_stats.qual.brier_scores.breach}}</p>
+            <p><strong>Capture Brier Score:</strong> {{match_prediction_stats.qual.brier_scores.capture}}</p>
           {% elif event.year == 2017 %}
-            <p><strong>Pressure Brier Score:</strong> {{match_prediction_stats.brier_scores.pressure}}</p>
-            <p><strong>Rotors Brier Score:</strong> {{match_prediction_stats.brier_scores.gears}}</p>
+            <p><strong>Pressure Brier Score:</strong> {{match_prediction_stats.qual.brier_scores.pressure}}</p>
+            <p><strong>Rotors Brier Score:</strong> {{match_prediction_stats.qual.brier_scores.gears}}</p>
           {% endif %}
           -->
 
-
-          {{mtm.qual_match_prediction_table(matches, match_predictions, fake_matches, event.year)}}
+          {{mtm.qual_match_prediction_table(matches, match_predictions.qual, fake_matches, event.year)}}
         </div>
         {% endif %}
       </div>
       {% else %}
       <div class="row">
         <div class="col-xs-12">
-          <p>No match predictions available. Check back later!</p>
+          <p>No qual match predictions available. Check back later!</p>
         </div>
       </div>
       {% endif %}
@@ -112,6 +112,7 @@
                   <td>{{avg_rp|round(1)}}</td>
                   <td>{{max_rp}}</td>
                   <td>{{min_rp}}</td>
+                </tr>
                 {% endfor %}
               </tbody>
             </table>
@@ -122,6 +123,44 @@
       <div class="row">
         <div class="col-xs-12">
           <p>No ranking predictions available. Check back later!</p>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="tab-pane" id="playoff-match-predictions">
+      {% if match_predictions.playoff %}
+      <div class="row">
+        {% if matches.qm %}
+        <div class="col-xs-12">
+          <h3>Playoff Match Predictions (<a href="/predictions">?</a>)</h3>
+          <p>Remember, match predictions are JUST FOR FUN! Please do not be discouraged by our predictions -- they are almost certainly wrong.</p>
+          {% if fake_matches %}
+          <p>Note: Match teams are not shown because <em>FIRST</em> does not allow the re-hosting of the preliminary match schedule. Sorry for the inconvenience.</p>
+          {% endif %}
+          {% if match_prediction_stats.playoff.wl_accuracy %}<p><strong>Win/Loss prediction accuracy:</strong> {{match_prediction_stats.playoff.wl_accuracy|round|int}}%</p>{% endif %}
+          {% if match_prediction_stats.playoff.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.playoff.wl_accuracy_75|round|int}}%</p>{% endif %}
+          {% if match_prediction_stats.playoff.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.playoff.err_mean|round(1)}}</p>{% endif %}
+
+          <!--
+          {% if match_prediction_stats.playoff.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.playoff.brier_scores.win_loss}}</p>{% endif %}
+          {% if event.year == 2016 %}
+            <p><strong>Breach Brier Score:</strong> {{match_prediction_stats.playoff.brier_scores.breach}}</p>
+            <p><strong>Capture Brier Score:</strong> {{match_prediction_stats.playoff.brier_scores.capture}}</p>
+          {% elif event.year == 2017 %}
+            <p><strong>Pressure Brier Score:</strong> {{match_prediction_stats.playoff.brier_scores.pressure}}</p>
+            <p><strong>Rotors Brier Score:</strong> {{match_prediction_stats.playoff.brier_scores.gears}}</p>
+          {% endif %}
+          -->
+
+          {{mtm.playoff_match_prediction_table(matches, match_predictions.playoff, fake_matches, event.year)}}
+        </div>
+        {% endif %}
+      </div>
+      {% else %}
+      <div class="row">
+        <div class="col-xs-12">
+          <p>No playoff match predictions available. Check back later!</p>
         </div>
       </div>
       {% endif %}

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -131,10 +131,25 @@
 {% block inline_javascript %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
 <script>
-  var predictions = {{match_predictions_json|safe}};
+  var predictions = {{distribution_info_json|safe}};  // Kind of hacky
   Chart.defaults.global.legend.display = false;
   Chart.defaults.global.maintainAspectRatio = false;
   Chart.defaults.global.tooltips = false;
+
+  var maxScore = 0;
+  var lineHeight = 0;
+  for (var key in predictions) {
+    maxScore = Math.max(maxScore, predictions[key]['red_actual_score']);
+    maxScore = Math.max(maxScore, predictions[key]['blue_actual_score']);
+    lineHeight = Math.max(lineHeight,
+      Math.max(gaussian(predictions[key]['red_mean'],
+                        predictions[key]['red_mean'],
+                        Math.sqrt(predictions[key]['red_var'])),
+               gaussian(predictions[key]['blue_mean'],
+                        predictions[key]['blue_mean'],
+                        Math.sqrt(predictions[key]['blue_var']))));
+  }
+  var xMax = maxScore - (maxScore % 50) + 50;
 
   $('.score_chart').each(function() {
     var ctx = document.getElementById(this.id).getContext('2d');
@@ -143,8 +158,8 @@
     var numPoints = 10;
     var tailScale = 7;
 
-    var redMean = predictions[matchKey]['red']['score'];
-    var redSig = Math.sqrt(predictions[matchKey]['red']['score_var']);
+    var redMean = predictions[matchKey]['red_mean'];
+    var redSig = Math.sqrt(predictions[matchKey]['red_var']);
     var redDist = [];
     for (var i=-numPoints/2; i<=numPoints/2; i++) {
       x = redMean + redSig * i * tailScale / numPoints;
@@ -154,8 +169,8 @@
       })
     }
 
-    var blueMean = predictions[matchKey]['blue']['score'];
-    var blueSig = Math.sqrt(predictions[matchKey]['blue']['score_var']);
+    var blueMean = predictions[matchKey]['blue_mean'];
+    var blueSig = Math.sqrt(predictions[matchKey]['blue_var']);
     var blueDist = [];
     for (var i=-numPoints/2; i<=numPoints/2; i++) {
       x = blueMean + blueSig * i * tailScale / numPoints;
@@ -165,63 +180,61 @@
       })
     }
 
-    // var lineHeight = Math.max(gaussian(redMean, redMean, redSig), gaussian(blueMean, blueMean, blueSig));
+    var redScore = predictions[matchKey]['red_actual_score'];
+    var blueScore = predictions[matchKey]['blue_actual_score'];
+
+    var datasets;
+    if (redScore != -1 && blueScore != -1) {
+      datasets = [{
+        data: [{
+          x: redScore,
+          y: 0
+        },{
+          x: redScore,
+          y: lineHeight
+        }],
+        borderColor: "rgba(255,0,0,0.8)",
+        borderWidth: 2
+      },
+      {
+        data: [{
+          x: blueScore,
+          y: 0
+        },{
+          x: blueScore,
+          y: lineHeight
+        }],
+        borderColor: "rgba(0,0,255,0.8)",
+        borderWidth: 2
+      }]
+    } else {
+      datasets = [];
+    }
+    datasets.push({
+      data: redDist,
+      backgroundColor: "rgba(255,111,111,0.4)",
+      borderColor: "rgba(255,0,0,0.4)",
+      borderWidth: 1,
+    });
+    datasets.push({
+      data: blueDist,
+      backgroundColor: "rgba(111,111,255,0.4)",
+      borderColor: "rgba(0,0,255,0.4)",
+      borderWidth: 1,
+    });
 
     var scatterChart = new Chart(ctx, {
         type: 'line',
         data: {
-            datasets: [
-            {
-                data: [{
-                  x: predictions[matchKey]['red']['actual_score'],
-                  y: 0
-                },{
-                  x: predictions[matchKey]['red']['actual_score'],
-                  y: 0.06
-                }],
-                borderColor: "rgba(255,0,0,0.8)",
-                borderWidth: 2
-            },
-            {
-                data: [{
-                  x: predictions[matchKey]['blue']['actual_score'],
-                  y: 0
-                },{
-                  x: predictions[matchKey]['blue']['actual_score'],
-                  y: 0.06
-                }],
-                borderColor: "rgba(0,0,255,0.8)",
-                borderWidth: 2
-            },
-            {
-                data: redDist,
-                backgroundColor: "rgba(255,111,111,0.4)"
-            },
-            {
-                data: blueDist,
-                backgroundColor: "rgba(111,111,255,0.4)"
-            }
-
-            ]
+            datasets: datasets
         },
         options: {
             animation: {
               duration: 0,
-              onComplete: function () {
-                // Draw tiny scale
-                var ctx = this.chart.ctx;
-                ctx.font = Chart.helpers.fontString(Chart.defaults.global.defaultFontFamily, 'normal', Chart.defaults.global.defaultFontFamily);
-                ctx.textBaseline = 'bottom';
-                ctx.fillStyle = '#000';
-                ctx.textAlign = 'left';
-                ctx.fillText("0", 0, 50);
-                ctx.textAlign = 'right';
-                ctx.fillText("200", 150, 50);
-              }
             },
             scales: {
                 xAxes: [{
-                    display: false,
+                    // display: false,
                     type: 'linear',
                     position: 'bottom',
                     gridLines: {
@@ -229,14 +242,14 @@
                     },
                     ticks: {
                       min: 0,
-                      max: 200,
+                      max: xMax,
                     }
                 }],
                 yAxes: [{
                     display: false,
                     ticks: {
                       min: 0,
-                      max: 0.07,
+                      max: lineHeight * 1.1,
                     }
                 }]
             },

--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -46,11 +46,17 @@
           {% if match_prediction_stats.wl_accuracy_75 %}<p><strong>Win/Loss prediction accuracy (>75% confidence):</strong> {{match_prediction_stats.wl_accuracy_75|round|int}}%</p>{% endif %}
           {% if match_prediction_stats.err_mean %}<p><strong>Match score prediction average error:</strong> {{match_prediction_stats.err_mean|round(1)}}</p>{% endif %}
           {% if match_prediction_stats.brier_scores.win_loss %}<p><strong>Win/Loss Brier Score:</strong> {{match_prediction_stats.brier_scores.win_loss}}</p>{% endif %}
-          {% if match_prediction_stats.brier_scores.breach %}<p><strong>Breach Brier score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>{% endif %}
-          {% if match_prediction_stats.brier_scores.capture %}<p><strong>Capture Brier score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>{% endif %}
+
+          {% if event.year == 2016 %}
+            <p><strong>Breach Brier Score:</strong> {{match_prediction_stats.brier_scores.breach}}</p>
+            <p><strong>Capture Brier Score:</strong> {{match_prediction_stats.brier_scores.capture}}</p>
+          {% elif event.year == 2017 %}
+            <p><strong>Pressure Brier Score:</strong> {{match_prediction_stats.brier_scores.pressure}}</p>
+            <p><strong>Rotors Brier Score:</strong> {{match_prediction_stats.brier_scores.gears}}</p>
+          {% endif %}
 
 
-          {{mtm.qual_match_prediction_table(matches, match_predictions, fake_matches)}}
+          {{mtm.qual_match_prediction_table(matches, match_predictions, fake_matches, event.year)}}
         </div>
         {% endif %}
       </div>
@@ -124,9 +130,8 @@
 
 {% block inline_javascript %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
-<script id="predictionsJson" type="application/json">{{match_predictions_json|safe}}</script>
 <script>
-  var predictions = JSON.parse($('#predictionsJson').html());
+  var predictions = {{match_predictions_json|safe}};
   Chart.defaults.global.legend.display = false;
   Chart.defaults.global.maintainAspectRatio = false;
   Chart.defaults.global.tooltips = false;
@@ -199,10 +204,22 @@
         },
         options: {
             animation: {
-              duration: 0
+              duration: 0,
+              onComplete: function () {
+                // Draw tiny scale
+                var ctx = this.chart.ctx;
+                ctx.font = Chart.helpers.fontString(Chart.defaults.global.defaultFontFamily, 'normal', Chart.defaults.global.defaultFontFamily);
+                ctx.textBaseline = 'bottom';
+                ctx.fillStyle = '#000';
+                ctx.textAlign = 'left';
+                ctx.fillText("0", 0, 50);
+                ctx.textAlign = 'right';
+                ctx.fillText("200", 150, 50);
+              }
             },
             scales: {
                 xAxes: [{
+                    display: false,
                     type: 'linear',
                     position: 'bottom',
                     gridLines: {
@@ -210,14 +227,14 @@
                     },
                     ticks: {
                       min: 0,
-                      max: 200
+                      max: 200,
                     }
                 }],
                 yAxes: [{
                     display: false,
                     ticks: {
                       min: 0,
-                      max: 0.07
+                      max: 0.07,
                     }
                 }]
             },

--- a/templates_jinja2/match_partials/match_predictions_table_header.html
+++ b/templates_jinja2/match_partials/match_predictions_table_header.html
@@ -4,7 +4,13 @@
   <th colspan="6">Red Alliance</th>
   <th colspan="6">Blue Alliance</th>
   <th colspan="2">Scores:<br>Actual<br><em>(Predicted)</em></th>
-  <th colspan="2">Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em></th>
+  <th colspan="2">
+    {% if year == 2016 %}
+      Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em>
+    {% elif year == 2017 %}
+      Pressure / Rotors:<br>Actual<br><em>(Predicted Probability)</em>
+    {% endif %}
+  </th>
   <th>Win/Loss<br>Prediction<br>Confidence</th>
   <th>Win/Loss<br>Prediction<br>Correct</th>
 </tr>
@@ -14,7 +20,13 @@
   <th rowspan="2">Match</th>
   <th colspan="12">Red Alliance</th>
   <th rowspan="2" colspan="2">Scores:<br>Actual<br><em>(Predicted)</em></th>
-  <th rowspan="2">Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em></th>
+  <th rowspan="2">
+    {% if year == 2016 %}
+      Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em>
+    {% elif year == 2017 %}
+      Pressure / Rotors:<br>Actual<br><em>(Predicted Probability)</em>
+    {% endif %}
+  </th>
   <th rowspan="2">Win/Loss<br>Prediction<br>Confidence</th>
   <th rowspan="2">Win/Loss<br>Prediction<br>Correct</th>
 </tr>

--- a/templates_jinja2/match_partials/match_predictions_table_header.html
+++ b/templates_jinja2/match_partials/match_predictions_table_header.html
@@ -2,7 +2,6 @@
   <th rowspan="2">Match</th>
   <th colspan="12">Red Alliance</th>
   <th rowspan="2" colspan="2">Scores:<br>Actual<br><em>(Predicted)</em></th>
-  <th rowspan="2">Actual Score vs. Predicted Distribution</th>
   <th rowspan="2">
     {% if year == 2016 %}
       Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em>
@@ -10,6 +9,7 @@
       Pressure / Rotors:<br>Actual<br><em>(Predicted Probability)</em>
     {% endif %}
   </th>
+  <th rowspan="2">Actual Score vs. Predicted Distribution</th>
   <th rowspan="2">Win/Loss<br>Prediction<br>Probability</th>
   <th rowspan="2">Win/Loss<br>Prediction<br>Correct</th>
 </tr>

--- a/templates_jinja2/match_partials/match_predictions_table_header.html
+++ b/templates_jinja2/match_partials/match_predictions_table_header.html
@@ -1,25 +1,8 @@
-<tr class="key visible-lg">
-  <th><span class="glyphicon glyphicon-play-circle" rel="tooltip" title="Matches with the play icon have videos to watch"></span></th>
-  <th>Match</th>
-  <th colspan="6">Red Alliance</th>
-  <th colspan="6">Blue Alliance</th>
-  <th colspan="2">Scores:<br>Actual<br><em>(Predicted)</em></th>
-  <th colspan="2">
-    {% if year == 2016 %}
-      Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em>
-    {% elif year == 2017 %}
-      Pressure / Rotors:<br>Actual<br><em>(Predicted Probability)</em>
-    {% endif %}
-  </th>
-  <th>Win/Loss<br>Prediction<br>Confidence</th>
-  <th>Win/Loss<br>Prediction<br>Correct</th>
-</tr>
-
-<tr class="key hidden-lg">
-  <th rowspan="2"><span class="glyphicon glyphicon-play-circle" title="Matches with the play icon have videos to watch"></span></th>
+<tr class="key">
   <th rowspan="2">Match</th>
   <th colspan="12">Red Alliance</th>
   <th rowspan="2" colspan="2">Scores:<br>Actual<br><em>(Predicted)</em></th>
+  <th rowspan="2">Actual Score vs. Predicted Distribution</th>
   <th rowspan="2">
     {% if year == 2016 %}
       Breach / Capture:<br>Actual<br><em>(Predicted Probability)</em>
@@ -27,7 +10,7 @@
       Pressure / Rotors:<br>Actual<br><em>(Predicted Probability)</em>
     {% endif %}
   </th>
-  <th rowspan="2">Win/Loss<br>Prediction<br>Confidence</th>
+  <th rowspan="2">Win/Loss<br>Prediction<br>Probability</th>
   <th rowspan="2">Win/Loss<br>Prediction<br>Correct</th>
 </tr>
 <tr class="key hidden-lg">

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -132,11 +132,10 @@
 
 {% macro correct_prediction_td(match, predictions, compact=False) %}
 <td{% if compact %} rowspan="2"{% endif %}>
-  <div style="width: 150px; height: 50px;"><canvas id="chart_{{match.key.id()}}" class="score_chart" data-match-key="{{match.key.id()}}"></canvas></div>
-<!--   {#{% if match.has_been_played %}
+  {% if match.has_been_played %}
     {% if match.winning_alliance == predictions.get(match.key.id()).winning_alliance %}<span class="glyphicon glyphicon-ok"></span>{% endif %}
   {% else %}
     <strong>?</strong>
-  {% endif %}#} -->
+  {% endif %}
 </td>
 {% endmacro %}

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -100,15 +100,15 @@
   {% else %}
     ?
   {% endif %}
-  <br><em>{{predictions.get(match.key.id()).get(alliance_color).prob_breach|round|int}}% / {{predictions.get(match.key.id()).get(alliance_color).prob_capture|round|int}}%</em>
+  <br><em>{{(predictions.get(match.key.id()).get(alliance_color).prob_breach*100)|round|int}}% / {{(predictions.get(match.key.id()).get(alliance_color).prob_capture*200)|round|int}}%</em>
 </td>
 {% endmacro %}
 
 {% macro prob_td(match, predictions, compact=False) %}
 <td{% if compact %} rowspan="2"{% endif %}>
   <div class="progress" style="margin: 0px;">
-    <div class="progress-bar {% if predictions.get(match.key.id()).prob < 65 %}progress-bar-danger{% elif predictions.get(match.key.id()).prob < 80 %}progress-bar-warning{% else %}progress-bar-success{% endif %}" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{predictions.get(match.key.id()).prob|round|int}}%;">
-      {{predictions.get(match.key.id()).prob|round|int}}%
+    <div class="progress-bar {% if predictions.get(match.key.id()).prob < 0.65 %}progress-bar-danger{% elif predictions.get(match.key.id()).prob < 0.80 %}progress-bar-warning{% else %}progress-bar-success{% endif %}" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{(predictions.get(match.key.id()).prob*100)|round|int}}%;">
+      {{(predictions.get(match.key.id()).prob*100)|round|int}}%
     </div>
   </div>
 </td>

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -116,10 +116,11 @@
 
 {% macro correct_prediction_td(match, predictions, compact=False) %}
 <td{% if compact %} rowspan="2"{% endif %}>
-  {% if match.has_been_played %}
+  <div style="width: 100%; height: 100px;"><canvas id="chart_{{match.key.id()}}" class="score_chart" data-match-key="{{match.key.id()}}"></canvas></div>
+<!--   {#{% if match.has_been_played %}
     {% if match.winning_alliance == predictions.get(match.key.id()).winning_alliance %}<span class="glyphicon glyphicon-ok"></span>{% endif %}
   {% else %}
     <strong>?</strong>
-  {% endif %}
+  {% endif %}#} -->
 </td>
 {% endmacro %}

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -100,7 +100,7 @@
   {% else %}
     ?
   {% endif %}
-  <br><em>{{(predictions.get(match.key.id()).get(alliance_color).prob_breach*100)|round|int}}% / {{(predictions.get(match.key.id()).get(alliance_color).prob_capture*200)|round|int}}%</em>
+  <br><em>{{(predictions.get(match.key.id()).get(alliance_color).prob_breach*100)|round|int}}% / {{(predictions.get(match.key.id()).get(alliance_color).prob_capture*100)|round|int}}%</em>
 </td>
 {% endmacro %}
 

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -120,8 +120,8 @@
 </td>
 {% endmacro %}
 
-{% macro prob_td(match, predictions, compact=False) %}
-<td{% if compact %} rowspan="2"{% endif %}>
+{% macro prob_td(match, predictions) %}
+<td rowspan="2">
   <div class="progress" style="margin: 0px;">
     <div class="progress-bar {% if predictions.get(match.key.id()).prob < 0.65 %}progress-bar-danger{% elif predictions.get(match.key.id()).prob < 0.80 %}progress-bar-warning{% else %}progress-bar-success{% endif %}" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{(predictions.get(match.key.id()).prob*100)|round|int}}%;">
       {{(predictions.get(match.key.id()).prob*100)|round|int}}%
@@ -130,8 +130,8 @@
 </td>
 {% endmacro %}
 
-{% macro correct_prediction_td(match, predictions, compact=False) %}
-<td{% if compact %} rowspan="2"{% endif %}>
+{% macro correct_prediction_td(match, predictions) %}
+<td rowspan="2">
   {% if match.has_been_played %}
     {% if match.winning_alliance == predictions.get(match.key.id()).winning_alliance %}<span class="glyphicon glyphicon-ok"></span>{% endif %}
   {% else %}

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -86,7 +86,7 @@
 
 {% macro breach_prob_td(match, alliance_color, predictions) %}
 <td class="{{alliance_color}}">
-  {% if match.has_been_played and match.score_breakdown %}
+  {% if match.year == 2016 and match.has_been_played and match.score_breakdown %}
     {% if "teleopDefensesBreached" in match.score_breakdown.get(alliance_color) and
     match.score_breakdown.get(alliance_color).teleopDefensesBreached and
     "teleopTowerCaptured" in match.score_breakdown.get(alliance_color) and
@@ -97,10 +97,26 @@
       {% elif "teleopTowerCaptured" in match.score_breakdown.get(alliance_color) and match.score_breakdown.get(alliance_color).teleopTowerCaptured %}C
       {% else %}--{% endif %}
     {% endif %}
+  {% elif match.year == 2017 and match.has_been_played and match.score_breakdown %}
+    {% if "kPaRankingPointAchieved" in match.score_breakdown.get(alliance_color) and
+    match.score_breakdown.get(alliance_color).kPaRankingPointAchieved and
+    "teleopTowerCaptured" in match.score_breakdown.get(alliance_color) and
+    match.score_breakdown.get(alliance_color).teleopTowerCaptured %}
+    P / R
+    {% else %}
+      {% if "rotorRankingPointAchieved" in match.score_breakdown.get(alliance_color) and match.score_breakdown.get(alliance_color).rotorRankingPointAchieved %}P
+      {% elif "teleopTowerCaptured" in match.score_breakdown.get(alliance_color) and match.score_breakdown.get(alliance_color).teleopTowerCaptured %}R
+      {% else %}--{% endif %}
+    {% endif %}
   {% else %}
     ?
   {% endif %}
-  <br><em>{{(predictions.get(match.key.id()).get(alliance_color).prob_breach*100)|round|int}}% / {{(predictions.get(match.key.id()).get(alliance_color).prob_capture*100)|round|int}}%</em>
+  <br>
+  {% if match.year == 2016 %}
+  <em>{{(predictions.get(match.key.id()).get(alliance_color).prob_breach*100)|round|int}}% / {{(predictions.get(match.key.id()).get(alliance_color).prob_capture*100)|round|int}}%</em>
+  {% elif match.year == 2017 %}
+  <em>{{(predictions.get(match.key.id()).get(alliance_color).prob_pressure*100)|round|int}}% / {{(predictions.get(match.key.id()).get(alliance_color).prob_gears*100)|round|int}}%</em>
+  {% endif %}
 </td>
 {% endmacro %}
 
@@ -116,7 +132,7 @@
 
 {% macro correct_prediction_td(match, predictions, compact=False) %}
 <td{% if compact %} rowspan="2"{% endif %}>
-  <div style="width: 100%; height: 100px;"><canvas id="chart_{{match.key.id()}}" class="score_chart" data-match-key="{{match.key.id()}}"></canvas></div>
+  <div style="width: 150px; height: 50px;"><canvas id="chart_{{match.key.id()}}" class="score_chart" data-match-key="{{match.key.id()}}"></canvas></div>
 <!--   {#{% if match.has_been_played %}
     {% if match.winning_alliance == predictions.get(match.key.id()).winning_alliance %}<span class="glyphicon glyphicon-ok"></span>{% endif %}
   {% else %}

--- a/templates_jinja2/match_partials/match_table_macros.html
+++ b/templates_jinja2/match_partials/match_table_macros.html
@@ -58,6 +58,49 @@
 </table>
 {% endmacro %}
 
+{% macro playoff_match_prediction_table(matches, predictions, fake_matches, year) %}
+<table class="match-table">
+  <thead>
+    {% include "match_partials/match_predictions_table_header.html" %}
+  </thead>
+
+  <tbody>
+    {% if matches.ef %}
+      <tr class="key">
+        <th colspan="19">Eighth-Finals</th>
+      </tr>
+      {% for match in matches.ef %}
+        {{mtrm.match_prediction_row_tr(match, predictions, fake_matches=fake_matches)}}
+      {% endfor %}
+    {% endif %}
+    {% if matches.qf %}
+      <tr class="key">
+        <th colspan="19">Quarterfinals</th>
+      </tr>
+      {% for match in matches.qf %}
+        {{mtrm.match_prediction_row_tr(match, predictions, fake_matches=fake_matches)}}
+      {% endfor %}
+    {% endif %}
+    {% if matches.sf %}
+      <tr class="key">
+        <th colspan="19">Semifinals</th>
+      </tr>
+      {% for match in matches.sf %}
+        {{mtrm.match_prediction_row_tr(match, predictions, fake_matches=fake_matches)}}
+      {% endfor %}
+    {% endif %}
+    {% if matches.f %}
+      <tr class="key">
+        <th colspan="19">Finals</th>
+      </tr>
+      {% for match in matches.f %}
+        {{mtrm.match_prediction_row_tr(match, predictions, fake_matches=fake_matches)}}
+      {% endfor %}
+    {% endif %}
+  </tbody>
+</table>
+{% endmacro %}
+
 {% macro elim_match_table(matches, cur_team_key=None) %}
 <table class="match-table">
   <thead>

--- a/templates_jinja2/match_partials/match_table_macros.html
+++ b/templates_jinja2/match_partials/match_table_macros.html
@@ -39,7 +39,7 @@
 </table>
 {% endmacro %}
 
-{% macro qual_match_prediction_table(matches, predictions, fake_matches) %}
+{% macro qual_match_prediction_table(matches, predictions, fake_matches, year) %}
 <table class="match-table">
   <thead>
     {% include "match_partials/match_predictions_table_header.html" %}

--- a/templates_jinja2/match_partials/match_table_macros.html
+++ b/templates_jinja2/match_partials/match_table_macros.html
@@ -48,10 +48,10 @@
   <tbody>
     {% if matches.qm %}
       <tr class="key">
-        <th colspan="20">Qualifications</th>
+        <th colspan="19">Qualifications</th>
       </tr>
       {% for match in matches.qm %}
-        {{mtrm.match_row_tr(match, predictions=predictions, fake_matches=fake_matches)}}
+        {{mtrm.match_prediction_row_tr(match, predictions, fake_matches=fake_matches)}}
       {% endfor %}
     {% endif %}
   </tbody>

--- a/templates_jinja2/match_partials/match_table_row_macros.html
+++ b/templates_jinja2/match_partials/match_table_row_macros.html
@@ -60,15 +60,14 @@
   {% endfor %}
 
   {{mtcm.match_score_td(match, 'red', None, compact=True, predictions=predictions)}}
+  {{mtcm.breach_prob_td(match, 'red', predictions)}}
   <td rowspan="2" style="width: 300px;">
     <div style="width: 300px; height: 90px;">
       <canvas id="chart_{{match.key.id()}}" class="score_chart" data-match-key="{{match.key.id()}}"></canvas>
     </div>
   </td>
-
-  {{mtcm.breach_prob_td(match, 'red', predictions)}}
-  {{mtcm.prob_td(match, predictions, compact=True)}}
-  {{mtcm.correct_prediction_td(match, predictions, compact=True)}}
+  {{mtcm.prob_td(match, predictions)}}
+  {{mtcm.correct_prediction_td(match, predictions)}}
 </tr>
 <tr>
   {% for team_key in match.alliances.blue.teams %}

--- a/templates_jinja2/match_partials/match_table_row_macros.html
+++ b/templates_jinja2/match_partials/match_table_row_macros.html
@@ -1,6 +1,6 @@
 {% import "match_partials/match_table_cell_macros.html" as mtcm %}
 
-{% macro match_row_tr(match, cur_team_key, upcoming=False, predictions=None, fake_matches=False) %}
+{% macro match_row_tr(match, cur_team_key, upcoming=False, fake_matches=False) %}
 <tr class="visible-lg">
   {% if upcoming %}
     {{mtcm.match_time_td(match)}}
@@ -18,15 +18,8 @@
   {% endfor %}
 
   {% if not upcoming %}
-    {{mtcm.match_score_td(match, 'red', cur_team_key, predictions=predictions)}}
-    {{mtcm.match_score_td(match, 'blue', cur_team_key, predictions=predictions)}}
-  {% endif %}
-
-  {% if predictions %}
-    {{mtcm.breach_prob_td(match, 'red', predictions)}}
-    {{mtcm.breach_prob_td(match, 'blue', predictions)}}
-    {{mtcm.prob_td(match, predictions)}}
-    {{mtcm.correct_prediction_td(match, predictions)}}
+    {{mtcm.match_score_td(match, 'red', cur_team_key)}}
+    {{mtcm.match_score_td(match, 'blue', cur_team_key)}}
   {% endif %}
 </tr>
 
@@ -44,13 +37,7 @@
   {% endfor %}
 
   {% if not upcoming %}
-  {{mtcm.match_score_td(match, 'red', cur_team_key, compact=True, predictions=predictions)}}
-  {% endif %}
-
-  {% if predictions %}
-    {{mtcm.breach_prob_td(match, 'red', predictions)}}
-    {{mtcm.prob_td(match, predictions, compact=True)}}
-    {{mtcm.correct_prediction_td(match, predictions, compact=True)}}
+  {{mtcm.match_score_td(match, 'red', cur_team_key, compact=True)}}
   {% endif %}
 </tr>
 <tr class="hidden-lg">
@@ -59,7 +46,37 @@
   {% endfor %}
 
   {% if not upcoming %}
-  {{mtcm.match_score_td(match, 'blue', cur_team_key, compact=True, predictions=predictions)}}
+  {{mtcm.match_score_td(match, 'blue', cur_team_key, compact=True)}}
+  {% endif %}
+</tr>
+{% endmacro %}
+
+{% macro match_prediction_row_tr(match, predictions, fake_matches=False) %}
+<tr>
+  {{mtcm.match_name_td(match, compact=True, fake_matches=fake_matches)}}
+
+  {% for team_key in match.alliances.red.teams %}
+    {{mtcm.match_team_td(match, 'red', team_key, None, compact=True, fake_matches=fake_matches)}}
+  {% endfor %}
+
+  {{mtcm.match_score_td(match, 'red', None, compact=True, predictions=predictions)}}
+  <td rowspan="2" style="width: 300px;">
+    <div style="width: 300px; height: 90px;">
+      <canvas id="chart_{{match.key.id()}}" class="score_chart" data-match-key="{{match.key.id()}}"></canvas>
+    </div>
+  </td>
+
+  {{mtcm.breach_prob_td(match, 'red', predictions)}}
+  {{mtcm.prob_td(match, predictions, compact=True)}}
+  {{mtcm.correct_prediction_td(match, predictions, compact=True)}}
+</tr>
+<tr>
+  {% for team_key in match.alliances.blue.teams %}
+    {{mtcm.match_team_td(match, 'blue', team_key, None, compact=True, fake_matches=fake_matches)}}
+  {% endfor %}
+
+  {% if not upcoming %}
+  {{mtcm.match_score_td(match, 'blue', None, compact=True, predictions=predictions)}}
   {% endif %}
 
   {% if predictions %}
@@ -67,7 +84,6 @@
   {% endif %}
 </tr>
 {% endmacro %}
-
 
 {% macro match_row_tr_hot(match) %}
 <tr>

--- a/tests/test_event_controller.py
+++ b/tests/test_event_controller.py
@@ -88,13 +88,13 @@ class TestEventController(unittest2.TestCase):
 
         self.event1_details = EventDetails(
             id=self.event1.key.id(),
-            predictions={"ranking_prediction_stats": None, "match_predictions": None, "ranking_predictions": None, "match_prediction_stats": None}
+            predictions={"ranking_prediction_stats": {'qual': None, 'playoff': None}, "match_predictions": {'qual': None, 'playoff': None}, "ranking_predictions": None, "match_prediction_stats": {'qual': None, 'playoff': None}}
         )
         self.event1_details.put()
 
         self.event2_details = EventDetails(
             id=self.event2.key.id(),
-            predictions={"ranking_prediction_stats": None, "match_predictions": None, "ranking_predictions": None, "match_prediction_stats": None}
+            predictions={"ranking_prediction_stats": {'qual': None, 'playoff': None}, "match_predictions": {'qual': None, 'playoff': None}, "ranking_predictions": None, "match_prediction_stats": {'qual': None, 'playoff': None}}
         )
         self.event2_details.put()
 


### PR DESCRIPTION
New predictions that solve for standard OPR equations with MMSE instead of LS. Also estimates team variance for more accurate probability estimates. New graphs. Updated to support 2017.

![image](https://cloud.githubusercontent.com/assets/1421884/23328990/7f63f308-fafc-11e6-93f0-02fbddfbaf21.png)

Benchmarks:
This new prediction method results in Brier scores of:
All 2016: 0.186904972648
Champs 2016: 0.17528888034

Comparison to others:
![image](https://cloud.githubusercontent.com/assets/1421884/23328999/c509568c-fafc-11e6-8dfd-ebbd69556063.png)
(from https://www.chiefdelphi.com/forums/showthread.php?t=152934)

This method does not use previous years to inform current year statistics.