### PR TITLE
Admin Event Page Revamp

### DIFF
--- a/common/my_filters.py
+++ b/common/my_filters.py
@@ -53,5 +53,10 @@ def local_time(value, timezone_str):
 
 
 @register.filter
+def sort_by(values, prop):
+    return sorted(values, key=lambda item: getattr(item, prop))
+
+
+@register.filter
 def get_item(dictionary, key):
     return dictionary.get(key)

--- a/common/my_filters.py
+++ b/common/my_filters.py
@@ -1,4 +1,7 @@
+import pytz
 from google.appengine.ext import webapp
+from pytz import timezone
+
 from helpers.youtube_video_helper import YouTubeVideoHelper
 import re
 
@@ -37,6 +40,16 @@ def yt_start(value):
         value = '%s?start=%i' % (video_id, total_seconds)
 
     return value
+
+
+@register.filter
+def local_time(value, timezone_str):
+    if timezone_str:
+        tz = timezone(timezone_str)
+        local = pytz.utc.localize(value).astimezone(tz)
+    else:
+        local = value
+    return local.strftime("%a %b %d %Y %H:%M:%S %Z") if local else ""
 
 
 @register.filter

--- a/common/my_filters.py
+++ b/common/my_filters.py
@@ -44,7 +44,7 @@ def yt_start(value):
 
 @register.filter
 def local_time(value, timezone_str):
-    if timezone_str:
+    if timezone_str and value:
         tz = timezone(timezone_str)
         local = pytz.utc.localize(value).astimezone(tz)
     else:

--- a/controllers/admin/admin_event_controller.py
+++ b/controllers/admin/admin_event_controller.py
@@ -25,6 +25,7 @@ from models.event import Event
 from models.event_details import EventDetails
 from models.event_team import EventTeam
 from models.match import Match
+from models.media import Media
 from models.team import Team
 
 import tba_config
@@ -307,8 +308,11 @@ class AdminEventDetail(LoggedInHandler):
             self.abort(404)
         event.prepAwardsMatchesTeams()
 
+        event_medias = Media.query(Media.references == event.key).fetch(500)
+
         self.template_values.update({
-            "event": event
+            "event": event,
+            "medias": event_medias,
         })
 
         path = os.path.join(os.path.dirname(__file__), '../../templates/admin/event_details.html')

--- a/models/match.py
+++ b/models/match.py
@@ -249,6 +249,28 @@ class Match(ndb.Model):
                 videos.append({"type": "tba", "key": tba_path})
         return videos
 
+    @property
+    def prediction_error_str(self):
+        if self.actual_time and self.predicted_time:
+            delta = self.actual_time - self.predicted_time
+            if self.actual_time > self.predicted_time:
+                return "{} early".format(delta)
+            elif self.predicted_time > self.actual_time:
+                return "{} late".format(delta)
+            else:
+                return "On Time"
+
+    @property
+    def schedule_error_str(self):
+        if self.actual_time and self.time:
+            delta = self.actual_time - self.time
+            if self.actual_time > self.time:
+                return "{} behind".format(delta)
+            elif self.time > self.actual_time:
+                return "{} ahead".format(delta)
+            else:
+                return "On Time"
+
     @classmethod
     def renderKeyName(self, event_key_name, comp_level, set_number, match_number):
         if comp_level == "qm":

--- a/models/match.py
+++ b/models/match.py
@@ -1,7 +1,10 @@
 import json
+
+import datetime
 import numpy as np
 import re
 
+import time
 from google.appengine.ext import ndb
 
 from helpers.tbavideo_helper import TBAVideoHelper
@@ -252,11 +255,15 @@ class Match(ndb.Model):
     @property
     def prediction_error_str(self):
         if self.actual_time and self.predicted_time:
-            delta = self.actual_time - self.predicted_time
             if self.actual_time > self.predicted_time:
-                return "{} early".format(delta)
+                delta = self.actual_time - self.predicted_time
+                s = int(delta.total_seconds())
+                return '{:02}:{:02}:{:02} early'.format(s // 3600, s % 3600 // 60, s % 60)
             elif self.predicted_time > self.actual_time:
-                return "{} late".format(delta)
+                diff = time.mktime(self.actual_time.timetuple()) - time.mktime(self.predicted_time.timetuple())
+                delta = datetime.datetime.timedelta(seconds=diff)
+                s = delta.total_seconds()
+                return '{:02}:{:02}:{:02} late'.format(s // 3600, s % 3600 // 60, s % 60)
             else:
                 return "On Time"
 

--- a/models/match.py
+++ b/models/match.py
@@ -260,9 +260,8 @@ class Match(ndb.Model):
                 s = int(delta.total_seconds())
                 return '{:02}:{:02}:{:02} early'.format(s // 3600, s % 3600 // 60, s % 60)
             elif self.predicted_time > self.actual_time:
-                diff = time.mktime(self.actual_time.timetuple()) - time.mktime(self.predicted_time.timetuple())
-                delta = datetime.datetime.timedelta(seconds=diff)
-                s = delta.total_seconds()
+                delta = self.predicted_time - self.actual_time
+                s = int(delta.total_seconds())
                 return '{:02}:{:02}:{:02} late'.format(s // 3600, s % 3600 // 60, s % 60)
             else:
                 return "On Time"
@@ -270,11 +269,14 @@ class Match(ndb.Model):
     @property
     def schedule_error_str(self):
         if self.actual_time and self.time:
-            delta = self.actual_time - self.time
             if self.actual_time > self.time:
-                return "{} behind".format(delta)
+                delta = self.actual_time - self.time
+                s = int(delta.total_seconds())
+                return '{:02}:{:02}:{:02} behind'.format(s // 3600, s % 3600 // 60, s % 60)
             elif self.time > self.actual_time:
-                return "{} ahead".format(delta)
+                delta = self.time - self.actual_time
+                s = int(delta.total_seconds())
+                return '{:02}:{:02}:{:02} ahead'.format(s // 3600, s % 3600 // 60, s % 60)
             else:
                 return "On Time"
 

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -286,14 +286,25 @@
 <table class="table table-striped table-condensed table-center">
     <thead>
         <th>Match Key</th>
+        <th>Scheduled Time</th>
+        <th>Predicted Time</th>
+        <th>Actual Time</th>
         <th>Alliances JSON</th>
         <th>Score Breakdown JSON</th>
     </thead>
     {% for match in event.matches %}
     <tr>
-        <td><a href="/admin/match/{{match.key_name}}">{{ match.key_name }}</a></td>
+        <td><a href="/admin/match/{{match.key_name}}">{{ match.verbose_name }}</a></td>
+        <td>{{ match.time|local_time:event.timezone_id}}</td>
+        <td>{{ match.predicted_time|local_time:event.timezone_id}}
+            {% if match.prediction_error_str %}<br>({{ match.prediction_error_str}}){% endif %}</td>
+        <td>{{ match.actual_time|local_time:event.timezone_id}}
+            {% if match.schedule_error_str%}<br>({{ match.schedule_error_str}}){% endif %}</td>
         <td>{{ match.alliances_json }}</td>
-        <td>{{ match.score_breakdown_json }}</td>
+        <td>{% if match.score_breakdown_json %}
+            <button data-toggle="collapse" data-target="#breakdown_{{ match.key_name }}" class="btn btn-info">Show</button>
+            <div id="breakdown_{{ match.key_name }}" class="collapse">{{ match.score_breakdown_json }}</div>
+            {% endif %}</td>
     </tr>
     {% endfor %}
 </table>

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -26,6 +26,7 @@
     <li><a href="#alliances" data-toggle="tab">Alliances</a></li>
     <li><a href="#awards" data-toggle="tab">Awards</a></li>
     <li><a href="#matches" data-toggle="tab">Matches</a></li>
+    <li><a href="#media" data-toggle="tab">Media</a></li>
   </ul>
 </div>
 </div>
@@ -314,5 +315,47 @@
 </div>
 </div>
 
+<div class="tab-pane" id="media">
+<div class="row">
+<h2>Event Media</h2>
+  {% for media in medias %}
+    <li>{% include "partials/admin_media_display.html" %}</li>
+  {% empty %}
+    <p>No media found</p>
+  {% endfor %}
+
+<div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                Confirm media reference removal
+            </div>
+            <div class="modal-body">
+                Are you sure you want to remove this reference to this media? References to other models will persist.
+            </div>
+            <div class="modal-footer">
+                <form id="delete_media_form" method="post">
+                <input name="reference_type" type="hidden" value="event" />
+                <input name="reference_key_name" type="hidden" value="{{event.key_name}}" />
+                <input name="originating_url" type="hidden" value="/admin/event/{{event.key_name}}" />
+
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button class="btn btn-danger" type="submit"><span class="glyphicon glyphicon-delete"></span> Remove reference</button>
+                </form>
+            </div>
+        </div>
+    </div>
 </div>
+</div>
+</div>
+
+</div>
+
+<script>
+$(document).ready(function(){
+    $('#confirm-delete').on('show.bs.modal', function(e) {
+        $(this).find('#delete_media_form').attr('action', '/admin/media/delete_reference/' + $(e.relatedTarget).data('key-name'));
+    });
+});
+</script>
 {% endblock %}

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -300,7 +300,10 @@
             {% if match.prediction_error_str %}<br>({{ match.prediction_error_str}}){% endif %}</td>
         <td>{{ match.actual_time|local_time:event.timezone_id}}
             {% if match.schedule_error_str%}<br>({{ match.schedule_error_str}}){% endif %}</td>
-        <td>{{ match.alliances_json }}</td>
+        <td>{% if match.alliances_json %}
+            <button data-toggle="collapse" data-target="#alliances_{{ match.key_name }}" class="btn btn-info">Show</button>
+            <div id="alliances_{{ match.key_name }}" class="collapse">{{ match.alliances_json }}</div>
+            {% endif %}</td>
         <td>{% if match.score_breakdown_json %}
             <button data-toggle="collapse" data-target="#breakdown_{{ match.key_name }}" class="btn btn-info">Show</button>
             <div id="breakdown_{{ match.key_name }}" class="collapse">{{ match.score_breakdown_json }}</div>

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -13,8 +13,26 @@
     <a href="/backend-tasks/get/event_details/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Refresh from FIRST</a>
     <a href="/backend-tasks/do/post_event_tasks/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-play"></span> Run Post-Event Tasks</a>
 </div>
-<br />
 
+<hr>
+
+<div class="row">
+<div class="col-sm-12">
+  <ul class="nav nav-tabs">
+    <li class="active"><a href="#info" data-toggle="tab">Info</a></li>
+    <li><a href="#tasks" data-toggle="tab">Tasks</a></li>
+    <li><a href="#webcasts" data-toggle="tab">Webcasts</a></li>
+    <li><a href="#rankings" data-toggle="tab">Rankings</a></li>
+    <li><a href="#alliances" data-toggle="tab">Alliances</a></li>
+    <li><a href="#awards" data-toggle="tab">Awards</a></li>
+    <li><a href="#matches" data-toggle="tab">Matches</a></li>
+  </ul>
+</div>
+</div>
+
+<div class="tab-content">
+<div class="tab-pane active" id="info">
+<div class="row">
 <table class="table table-striped table-hover">
     <tr>
         <td>Name</td>
@@ -109,6 +127,11 @@
         <td>{{ event.created }} - {{ event.updated }}</td>
     </tr>
 </table>
+</div>
+</div>
+
+<div class="tab-pane" id="tasks">
+<div class="row">
 <h2>Remap Teams</h2>
 <p>Change all matches, awards and alliance selections for one team to another</p>
 <p>Example:</p>
@@ -161,14 +184,23 @@
   <p>Outgoing team that was replaced: <input name="backup_out" placeholder="456"/></p>
   <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-plus-sign"></span> Add Backup Team</button>
 </form>
+</div>
+</div>
 
+<div class="tab-pane" id="webcasts">
+<div class="row">
 <h2>Add Webcast</h2>
+<p>Current webcast JSON: {{event.webcast_json}}</p>
 {% include "partials/webcast_add_instructions_partial.html" %}
 <form action="/admin/event/add_webcast/{{event.key_name}}" method="post">
     {% include "partials/webcast_add_form_partial.html" %}
     <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Add Webcast</button>
 </form>
+</div>
+</div>
 
+<div class="tab-pane" id="rankings">
+<div class="row">
 <h2>Rankings</h2>
 <table class="table table-striped table-condensed table-center">
   {% for row in event.rankings %}
@@ -183,9 +215,15 @@
         {% endfor %}
     {% endif %}
     </tr>
+  {% empty %}
+      <p>No ranking data yet</p>
   {% endfor %}
 </table>
+</div>
+</div>
 
+<div class="tab-pane" id="alliances">
+<div class="row">
 <h2>Alliances</h2>
 <table class="table table-striped table-condensed">
 {% for alliance in event.alliance_selections %}
@@ -195,9 +233,15 @@
             <td>{{ team }}{% if alliance.backup and alliance.backup.out == team %} ({{alliance.backup.in}}){% endif %}</td>
         {% endfor %}
     </tr>
+{% empty %}
+    <p>No alliance data yet</p>
 {% endfor %}
 </table>
+</div>
+</div>
 
+<div class="tab-pane" id="awards">
+<div class="row">
 <h2>Awards</h2>
 <table class="table table-striped table-condensed">
     <tbody>
@@ -232,7 +276,11 @@
       {% endfor %}
     </tbody>
   </table>
+</div>
+</div>
 
+<div class="tab-pane" id="matches">
+<div class="row">
 <h2>Match Listing</h2>
 
 <table class="table table-striped table-condensed table-center">
@@ -249,5 +297,8 @@
     </tr>
     {% endfor %}
 </table>
+</div>
+</div>
 
+</div>
 {% endblock %}

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -292,7 +292,7 @@
         <th>Alliances JSON</th>
         <th>Score Breakdown JSON</th>
     </thead>
-    {% for match in event.matches %}
+    {% for match in event.matches|sort_by:"play_order" %}
     <tr>
         <td><a href="/admin/match/{{match.key_name}}">{{ match.verbose_name }}</a></td>
         <td>{{ match.time|local_time:event.timezone_id}}</td>


### PR DESCRIPTION
Adds tabs to the admin page detailing events to declutter it a bit. Also adds the following:
 - Match scheduling details (and schedule offset)
 - Match prediction times (and offset)
 - Hides long match json blobs by default
 - Show event media and give a button to delete references

![screenshot from 2017-02-27 00-54-12](https://cloud.githubusercontent.com/assets/2754863/23350278/7ba24f80-fc87-11e6-9318-5bae234f91c3.png)
![screenshot from 2017-02-27 00-54-35](https://cloud.githubusercontent.com/assets/2754863/23350277/7ba1f5c6-fc87-11e6-8242-0287aad7a934.png)
![screenshot from 2017-02-27 00-53-35](https://cloud.githubusercontent.com/assets/2754863/23350279/7ba383fa-fc87-11e6-9105-40b0eb4dff08.png)
