### PR TITLE
Special case GameDay for BlueZone

### DIFF
--- a/react/gameday2/components/TickerMatch.js
+++ b/react/gameday2/components/TickerMatch.js
@@ -68,7 +68,10 @@ const TickerMatch = (props) => {
   let compLevel = match.comp_level.toUpperCase()
   compLevel = (compLevel === 'QM') ? 'Q' : compLevel
   const matchNumber = (compLevel === 'QF' || compLevel === 'SF' || compLevel === 'F') ? `${match.set_number}-${match.match_number}` : match.match_number
-  const matchLabel = `${compLevel}${matchNumber}`
+  let matchLabel = `${compLevel}${matchNumber}`
+  if (props.isBlueZone) {
+    matchLabel = `${match.event_key.substring(4).toUpperCase()} ${matchLabel}`
+  }
 
   let redScore = match.alliances.red.score
   let blueScore = match.alliances.blue.score
@@ -99,6 +102,7 @@ const TickerMatch = (props) => {
 TickerMatch.propTypes = {
   match: PropTypes.object,
   hasFavorite: PropTypes.bool,
+  isBlueZone: PropTypes.bool,
 }
 
 export default TickerMatch

--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -87,6 +87,7 @@ export default class VideoCell extends React.Component {
           <VideoCellToolbarContainer
             style={toolbarStyle}
             webcast={this.props.webcast}
+            isBlueZone={this.props.webcast.key === 'bluezone'}
             onRequestOpenWebcastSelectionDialog={() => this.onRequestOpenWebcastSelectionDialog()}
             onRequestOpenSwapPositionDialog={() => this.onRequestOpenSwapPositionDialog()}
           />

--- a/react/gameday2/components/VideoCellToolbar.js
+++ b/react/gameday2/components/VideoCellToolbar.js
@@ -55,6 +55,7 @@ const VideoCellToolbar = (props) => {
         key={match.key}
         match={match}
         hasFavorite={hasFavorite}
+        isBlueZone={props.isBlueZone}
       />
     )
   })

--- a/react/gameday2/components/VideoCellToolbar.js
+++ b/react/gameday2/components/VideoCellToolbar.js
@@ -106,6 +106,7 @@ const VideoCellToolbar = (props) => {
 VideoCellToolbar.propTypes = {
   matches: PropTypes.arrayOf(PropTypes.object).isRequired,
   webcast: PropTypes.object.isRequired,
+  isBlueZone: PropTypes.bool.isRequired,
   /* eslint-disable react/no-unused-prop-types */
   onRequestOpenSwapPositionDialog: PropTypes.func.isRequired,
   onRequestOpenWebcastSelectionDialog: PropTypes.func.isRequired,

--- a/react/gameday2/components/WebcastSelectionOverlayDialogItem.js
+++ b/react/gameday2/components/WebcastSelectionOverlayDialogItem.js
@@ -5,6 +5,8 @@ export default class WebcastSelectionOverlayDialogItem extends React.Component {
   static propTypes = {
     webcast: PropTypes.object.isRequired,
     webcastSelected: PropTypes.func.isRequired,
+    secondaryText: PropTypes.string,
+    rightIcon: PropTypes.any,
   }
 
   handleClick() {
@@ -15,7 +17,9 @@ export default class WebcastSelectionOverlayDialogItem extends React.Component {
     return (
       <ListItem
         primaryText={this.props.webcast.name}
+        secondaryText={this.props.secondaryText}
         onTouchTap={() => this.handleClick()}
+        rightIcon={this.props.rightIcon}
       />
     )
   }

--- a/react/gameday2/containers/WebcastSelectionOverlayDialogContainer.js
+++ b/react/gameday2/containers/WebcastSelectionOverlayDialogContainer.js
@@ -6,6 +6,7 @@ import { getWebcastIdsInDisplayOrder } from '../selectors'
 const mapStateToProps = (state) => ({
   webcasts: getWebcastIdsInDisplayOrder(state),
   webcastsById: state.webcastsById,
+  specialWebcastIds: state.specialWebcastIds,
   displayedWebcasts: state.videoGrid.displayed,
   layoutId: state.videoGrid.layoutId,
 })

--- a/react/gameday2/reducers/chats.js
+++ b/react/gameday2/reducers/chats.js
@@ -42,6 +42,11 @@ const setChatsFromWebcasts = (webcasts, state) => {
   Object.keys(webcasts).forEach((key) => {
     const webcast = webcasts[key]
 
+    // Don't add BlueZone to chat
+    if (webcast.key === 'bluezone') {
+      return
+    }
+
     if (webcast.type === 'twitch') {
       // We found a twitch webcast!
       newState.chats[webcast.channel] = {

--- a/react/gameday2/reducers/index.js
+++ b/react/gameday2/reducers/index.js
@@ -1,7 +1,7 @@
 import Firebase from 'firebase'
 import Firedux from 'firedux'
 import { combineReducers } from 'redux'
-import webcastsById from './webcastsById'
+import { webcastsById, specialWebcastIds } from './webcastsById'
 import visibility from './visibility'
 import videoGrid from './videoGrid'
 import chats from './chats'
@@ -21,6 +21,7 @@ export const firedux = new Firedux({
 const gamedayReducer = combineReducers({
   firedux: firedux.reducer(),
   webcastsById,
+  specialWebcastIds,
   visibility,
   videoGrid,
   chats,

--- a/react/gameday2/reducers/webcastsById.js
+++ b/react/gameday2/reducers/webcastsById.js
@@ -4,6 +4,7 @@ import { getWebcastId } from '../utils/webcastUtils'
 const getWebcastsFromRawWebcasts = (webcasts) => {
   const webcastsById = {}
   const specialWebcasts = webcasts.special_webcasts
+  const specialWebcastIds = new Set()
   const eventsWithWebcasts = webcasts.ongoing_events_w_webcasts
 
   // First, deal with special webcasts
@@ -21,6 +22,7 @@ const getWebcastsFromRawWebcasts = (webcasts) => {
         channel: webcast.channel,
         sortOrder: index,
       }
+      specialWebcastIds.add(id)
     })
   }
 
@@ -45,16 +47,28 @@ const getWebcastsFromRawWebcasts = (webcasts) => {
     })
   }
 
-  return webcastsById
+  const allWebcasts = {
+    webcastsById,
+    specialWebcastIds,
+  }
+
+  return allWebcasts
 }
 
-const webcastsById = (state = {}, action) => {
+export const webcastsById = (state = {}, action) => {
   switch (action.type) {
     case SET_WEBCASTS_RAW:
-      return getWebcastsFromRawWebcasts(action.webcasts)
+      return getWebcastsFromRawWebcasts(action.webcasts).webcastsById
     default:
       return state
   }
 }
 
-export default webcastsById
+export const specialWebcastIds = (state = {}, action) => {
+  switch (action.type) {
+    case SET_WEBCASTS_RAW:
+      return getWebcastsFromRawWebcasts(action.webcasts).specialWebcastIds
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
Organizes webcasts in list with BlueZone first.
Don't show BlueZone chat as an option (use GameDay chat).
Show event codes on BlueZone ticker.


![image](https://cloud.githubusercontent.com/assets/1421884/23385447/e16e48fa-fd1d-11e6-81a7-3e44464f665f.png)

![image](https://cloud.githubusercontent.com/assets/1421884/23385452/e972d0f2-fd1d-11e6-8e73-69d44393dd70.png)
