### PR TITLE
Optional "date" parameter for webcasts

### DIFF
--- a/controllers/gameday_controller.py
+++ b/controllers/gameday_controller.py
@@ -120,7 +120,7 @@ class GamedayRedirectHandler(webapp2.RequestHandler):
         # Allow an alias to be an event key
         if not ValidationHelper.event_id_validator(alias):
             event = Event.get_by_id(alias)
-            if event and event.webcast and event.within_a_day:
+            if event and event.within_a_day:
                 params = self.get_param_string_for_event(event)
                 self.redirect("/gameday{}".format(params))
                 return
@@ -132,7 +132,7 @@ class GamedayRedirectHandler(webapp2.RequestHandler):
             team_events_future = TeamYearEventsQuery(team_key, now.year).fetch_async()
             team_events = team_events_future.get_result()
             for event in team_events:
-                if event and event.webcast and event.within_a_day:
+                if event and event.within_a_day:
                     params = self.get_param_string_for_event(event)
                     self.redirect("/gameday{}".format(params))
                     return
@@ -142,12 +142,13 @@ class GamedayRedirectHandler(webapp2.RequestHandler):
 
     @staticmethod
     def get_param_string_for_event(event):
-        count = len(event.webcast)
+        current_webcasts = event.current_webcasts
+        count = len(current_webcasts)
         if count == 0:
             return ""
         layout = count - 1 if count < 5 else 6  # Fall back to hex-view
         params = "#layout={}".format(layout)
-        for i, webcast in enumerate(event.webcast):
+        for i, webcast in enumerate(current_webcasts):
             # The various streams for an event are 0-indexed in GD2
             params += "&view_{0}={1}-{0}".format(i, event.key.id())
 

--- a/controllers/suggestions/suggest_event_webcast_controller.py
+++ b/controllers/suggestions/suggest_event_webcast_controller.py
@@ -32,6 +32,7 @@ class SuggestEventWebcastController(LoggedInHandler):
 
         event_key = self.request.get("event_key")
         webcast_url = self.request.get("webcast_url")
+        webcast_date = self.request.get("webcast_date")
 
         if not webcast_url:
             self.redirect('/suggest/event/webcast?event_key={}&status=blank_webcast'.format(event_key), abort=True)
@@ -47,6 +48,7 @@ class SuggestEventWebcastController(LoggedInHandler):
         status = SuggestionCreator.createEventWebcastSuggestion(
             author_account_key=self.user_bundle.account.key,
             webcast_url=self.request.get("webcast_url"),
+            webcast_date=self.request.get("webcast_date"),
             event_key=event_key)
 
         self.redirect('/suggest/event/webcast?event_key={}&status={}'.format(event_key, status))

--- a/controllers/suggestions/suggest_event_webcast_review_controller.py
+++ b/controllers/suggestions/suggest_event_webcast_review_controller.py
@@ -27,6 +27,8 @@ class SuggestEventWebcastReviewController(SuggestionsReviewBaseController):
         webcast["channel"] = self.request.get("webcast_channel")
         if self.request.get("webcast_file"):
             webcast["file"] = self.request.get("webcast_file")
+        if self.request.get('webcast_date'):
+            webcast['date'] = self.request.get('webcast_date')
 
         event = Event.get_by_id(self.request.get("event_key"))
         # Defer because of transactions

--- a/helpers/bluezone_helper.py
+++ b/helpers/bluezone_helper.py
@@ -145,12 +145,13 @@ class BlueZoneHelper(object):
         if bluezone_matches and bluezone_matches[0].key_name != current_match_key:
             next_match = bluezone_matches[0]
             real_event = filter(lambda x: x.key_name == next_match.event_key_name, live_events)[0]
-            if real_event.webcast:
+            real_event_webcasts = real_event.current_webcasts
+            if real_event_webcasts:
                 # TODO should handle multiple webcasts per event
-                fake_event.webcast_json = json.dumps([real_event.webcast[0]])
+                fake_event.webcast_json = json.dumps([real_event_webcasts[0]])
                 FirebasePusher.update_event(fake_event)
                 bluezone_config.contents = {
-                    'current_webcast': real_event.webcast[0],
+                    'current_webcast': real_event_webcasts[0],
                     'current_match': next_match.event_key_name,
                     'current_match_added': now.strftime(cls.TIME_PATTERN),
                 }

--- a/helpers/firebase/firebase_pusher.py
+++ b/helpers/firebase/firebase_pusher.py
@@ -174,6 +174,7 @@ class FirebasePusher(object):
         live_events = []
         for event in week_events:
             if event.now:
+                event._webcast = event.current_webcasts  # Only show current webcasts
                 events_by_key[event.key.id()] = EventConverter.convert(event, 3)
             if event.within_a_day:
                 live_events.append(event)

--- a/models/event.py
+++ b/models/event.py
@@ -336,6 +336,22 @@ class Event(ndb.Model):
         return self._webcast
 
     @property
+    def current_webcasts(self):
+        if not self.webcast or not self.within_a_day:
+            return []
+
+        # Filter by date
+        current_webcasts = []
+        for webcast in self.webcast:
+            if 'date' in webcast:
+                webcast_datetime = datetime.datetime.strptime(webcast['date'], "%Y-%m-%d")
+                if self.local_time().date() == webcast_datetime.date():
+                    current_webcasts.append(webcast)
+            else:
+                current_webcasts.append(webcast)
+        return current_webcasts
+
+    @property
     def key_name(self):
         """
         Returns the string of the key_name of the Event object before writing it.

--- a/templates/suggest_event_webcast_review_list.html
+++ b/templates/suggest_event_webcast_review_list.html
@@ -53,7 +53,7 @@
                             <input type="hidden" name="event_key" value="{{suggestion_set.event.key_name}}" />
                             <button type="submit" class="btn btn-xs btn-danger pull-right" name="verdict" value="reject_all"><span class="glyphicon glyphicon-thumbs-down"></span> Reject All</button>
                         </form>
-                        <h3 class="panel-title"><a href="/event/{{suggestion_set.event.key_name}}">{{suggestion_set.event.key_name}}</a></h3>
+                        <h3 class="panel-title"><a href="/event/{{suggestion_set.event.key_name}}">{{suggestion_set.event.name}} ({{suggestion_set.event.start_date|date:"M jS"}} - {{suggestion_set.event.end_date|date:"M jS"}})</a></h3>
                     </div>
                     <div class="panel-body">
                         <ul><strong>Existing Webcasts</strong>
@@ -89,6 +89,10 @@
                                                     <tr>
                                                         <td>File (RTMP and Livestream only)</td>
                                                         <td><input type="text" name="webcast_file" value="{{webcast.file}}" /></td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>Date</td>
+                                                        <td><input type="text" name="webcast_date" value="{% if suggestion.contents.webcast_date%}{{suggestion.contents.webcast_date}}{% endif %}" /></td>
                                                     </tr>
                                                 </table>
                                                 {% endwith %}

--- a/templates_jinja2/suggestions/suggest_event_webcast.html
+++ b/templates_jinja2/suggestions/suggest_event_webcast.html
@@ -27,6 +27,12 @@
         <h4>Oops!</h4>
         <p>You have submitted an invalid webcast url. Please submit a valid (with no spaces), non Blue Alliance web address. Thanks!</p>
       </div>
+      {% elif status == 'invalid_date' %}
+      <div class="alert alert-warning">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <h4>Oops!</h4>
+        <p>You have submitted an invalid webcast date. Please submit a valid date in the format YYYY-MM-DD or leave the field blank. Thanks!</p>
+      </div>
       {% elif status == 'webcast_exists' %}
       <div class="alert alert-info">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
@@ -70,12 +76,15 @@
           <p>Find a webcast for {{event.name}} and paste it below so we can add it to the site :)</p>
           <form action="/suggest/event/webcast" method="post" id="suggest_webcast">
             <input name="event_key" type="hidden" value="{{event.key.id()}}" />
-            <div class="input-group">
+            <div class="form-group">
+              <label>Webcast Link</label>
               <input class="form-control" type="text" name="webcast_url" placeholder="like http://www.ustream.tv/nasa" value="" />
-              <span class="input-group-btn">
-                <button class="btn btn-success" type="submit"><span class="glyphicon glyphicon-plus-sign"></span> Add Webcast</button>
-              </span>
             </div>
+            <div class="form-group">
+              <label>Webcast Date (Only if the link only applies to one day of the event)</label>
+              <input class="form-control" type="text" name="webcast_date" placeholder="like 2017-02-28 or leave blank" value="" />
+            </div>
+            <button class="btn btn-success" type="submit"><span class="glyphicon glyphicon-plus-sign"></span> Add Webcast</button>
           </form>
         </div>
       </div>

--- a/tests/suggestions/test_suggest_event_webcast_review_controller.py
+++ b/tests/suggestions/test_suggest_event_webcast_review_controller.py
@@ -43,6 +43,7 @@ class TestSuggestApiWriteController(unittest2.TestCase):
     def createSuggestion(self):
         status = SuggestionCreator.createEventWebcastSuggestion(self.account.key,
                                                                 'https://twitch.tv/frcgamesense',
+                                                                '',
                                                                 '2016necmp')
         self.assertEqual(status, 'success')
         return 'webcast_2016necmp_twitch_frcgamesense_None'


### PR DESCRIPTION
So we can show the appropriate webcast in GameDay and BlueZone when there are different webcasts for different days.

We can add a nicer date picker in the future.

![image](https://cloud.githubusercontent.com/assets/1421884/23416181/dbfe72cc-fdaf-11e6-9e4d-3d3801f83123.png)
