### PR TITLE
Improve event media examples

### DIFF
--- a/templates_jinja2/suggestions/suggest_event_media.html
+++ b/templates_jinja2/suggestions/suggest_event_media.html
@@ -56,7 +56,7 @@
           <ul>
             <li>YouTube Videos
               <ul>
-                <li>Example: <code>https://www.youtube.com/watch?v=DojyJ9bZ4fk</code></li>
+                <li>Example: <code>https://www.youtube.com/watch?v=pRaKQ0yCLJY</code></li>
               </ul>
             </li>
           </ul>
@@ -103,7 +103,7 @@
                 <input name="event_key" type="hidden" value="{% if event %}{{event.key.id()}}{% endif %}" />
                 <div class="input-group">
                   <span class="input-group-addon">{{year}}</span>
-                  <input class="form-control" type="text" name="media_url" placeholder="http://www.chiefdelphi.com/media/photos/36646" value="" />
+                  <input class="form-control" type="text" name="media_url" placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ" value="" />
                   <span class="input-group-btn">
                     <button class="btn btn-success" type="submit"><span class="glyphicon glyphicon-plus-sign"></span> Add Media</button>
                   </span>


### PR DESCRIPTION
This changes the example youtube video on the event media page to be a video that is a good example of event media (instead of a robot reveal).

The placeholder text for the suggestion media url box was a chiefdelphi photo link. We currently don't support chiefdelphi photos for event media, so this is misleading. This changes to placeholder text to be a link for a youtube video.
![capture](https://cloud.githubusercontent.com/assets/4777935/23840601/924a8840-0774-11e7-81f4-64d19e1a6e96.PNG)
