### PR TITLE
add a horizontal split view to gameday

### DIFF
--- a/react/gameday2/components/LayoutDrawer.js
+++ b/react/gameday2/components/LayoutDrawer.js
@@ -9,7 +9,7 @@ import Toggle from 'material-ui/Toggle'
 import { red500, fullWhite } from 'material-ui/styles/colors'
 import CheckmarkIcon from 'material-ui/svg-icons/navigation/check'
 import { getLayoutSvgIcon } from '../utils/layoutUtils'
-import { NUM_LAYOUTS, NAME_FOR_LAYOUT } from '../constants/LayoutConstants'
+import { NUM_LAYOUTS, LAYOUT_DISPLAY_ORDER, NAME_FOR_LAYOUT } from '../constants/LayoutConstants'
 
 class LayoutDrawer extends React.Component {
   static propTypes = {
@@ -37,17 +37,18 @@ class LayoutDrawer extends React.Component {
     const layouts = []
     if (this.props.hasWebcasts) {
       for (let i = 0; i < NUM_LAYOUTS; i++) {
-        const showCheck = (i === this.props.selectedLayout && this.props.layoutSet)
+        const layoutNum = LAYOUT_DISPLAY_ORDER[i]
+        const showCheck = (layoutNum === this.props.selectedLayout && this.props.layoutSet)
         const icon = showCheck ? <CheckmarkIcon /> : null
 
         layouts.push(
           <ListItem
-            primaryText={NAME_FOR_LAYOUT[i]}
+            primaryText={NAME_FOR_LAYOUT[layoutNum]}
             insetChildren
-            onTouchTap={() => this.props.setLayout(i)}
+            onTouchTap={() => this.props.setLayout(layoutNum)}
             key={i.toString()}
             rightIcon={icon}
-            leftIcon={getLayoutSvgIcon(i)}
+            leftIcon={getLayoutSvgIcon(layoutNum)}
           />
         )
       }

--- a/react/gameday2/components/LayoutSelectionPanel.js
+++ b/react/gameday2/components/LayoutSelectionPanel.js
@@ -3,7 +3,7 @@ import Paper from 'material-ui/Paper'
 import { List, ListItem } from 'material-ui/List'
 import EventListener from 'react-event-listener'
 import { getLayoutSvgIcon } from '../utils/layoutUtils'
-import { NUM_LAYOUTS, NAME_FOR_LAYOUT } from '../constants/LayoutConstants'
+import { NUM_LAYOUTS, LAYOUT_DISPLAY_ORDER, NAME_FOR_LAYOUT } from '../constants/LayoutConstants'
 
 export default class LayoutSelectionPanelMaterial extends React.Component {
   static propTypes = {
@@ -48,12 +48,13 @@ export default class LayoutSelectionPanelMaterial extends React.Component {
   render() {
     const layouts = []
     for (let i = 0; i < NUM_LAYOUTS; i++) {
+      const layoutNum = LAYOUT_DISPLAY_ORDER[i]
       layouts.push(
         <ListItem
-          primaryText={NAME_FOR_LAYOUT[i]}
-          onTouchTap={() => this.props.setLayout(i)}
+          primaryText={NAME_FOR_LAYOUT[layoutNum]}
+          onTouchTap={() => this.props.setLayout(layoutNum)}
           key={i.toString()}
-          rightIcon={getLayoutSvgIcon(i)}
+          rightIcon={getLayoutSvgIcon(layoutNum)}
         />
       )
     }

--- a/react/gameday2/constants/LayoutConstants.js
+++ b/react/gameday2/constants/LayoutConstants.js
@@ -8,13 +8,12 @@ export const MAX_SUPPORTED_VIEWS = 9
 
 // Maps a layout ID to the number of views that layout supports
 // The layout ID is the index into this array
-export const NUM_VIEWS_FOR_LAYOUT = [1, 2, 2, 3, 4, 4, 5, 6, 8, 9]
+export const NUM_VIEWS_FOR_LAYOUT = [1, 2, 3, 4, 4, 5, 6, 8, 9, 2]
 
 // Maps a layout ID for the appropriate name for that layout
 export const NAME_FOR_LAYOUT = [
   'Single View',
   'Vertical Split View',
-  'Horizontal Split View',
   '"1+2" View',
   'Quad View',
   '"1+3" View',
@@ -22,6 +21,7 @@ export const NAME_FOR_LAYOUT = [
   'Hex View',
   'Octo-View',
   'Nona-View',
+  'Horizontal Split View',
 ]
 
 // Holds SVG path data that can be used to render icons for each layout
@@ -29,7 +29,6 @@ export const NAME_FOR_LAYOUT = [
 export const LAYOUT_SVG_PATHS = [
   'M0 0h23v15h-23v-15z',
   'M0 0h11v15h-11v-15zM12 0h11v15h-11v-15z',
-  'M0 0h23v7h-23v-7z M0 8h23v7h-23v-7z',
   'M0 0h14v15h-14v-15zM15 0h8v7h-8v-7zM15 8h8v7h-8v-7z',
   'M0 0h11v7h-11v-7z M0 8h11v7h-11v-7z M12 0h11v7h-11v-7z M12 8h11v7h-11v-7z',
   'M0 0h14v15h-14v-15z M15 0h8v4.333h-8v-4.33z M15 5.33h8v4.333h-8v-4.33z M15 10.67h8v4.333h-8v-4.33z',
@@ -37,6 +36,7 @@ export const LAYOUT_SVG_PATHS = [
   'M0 0h7v7h-7v-7z M8 0h7v7h-7v-7z M16 0h7v7h-7v-7z M8 8h7v7h-7v-7z M16 8h7v7h-7v-7z M0 8h7v7h-7v-7z',
   'M0 0h5v7h-5v-7z M6 0h5v7h-5v-7z M12 0h5v7h-5v-7z M18 0h5v7h-5v-7z M0 8h5v7h-5v-7z M6 8h5v7h-5v-7z M12 8h5v7h-5v-7z M18 8h5v7h-5v-7z',
   'M0 0h7v4.33h-7v-4.33z M8 0h7v4.33h-7v-4.33z M16 0h7v4.33h-7v-4.33z M0 5.33h7v4.33h-7v-4.33z M8 5.33h7v4.33h-7v-4.33z M16 5.33h7v4.33h-7v-4.33z M0 10.67h7v4.33h-7v-4.33z M8 10.67h7v4.33h-7v-4.33z M16 10.67h7v4.33h-7v-4.33z',
+  'M0 0h23v7h-23v-7z M0 8h23v7h-23v-7z',
 ]
 
 // Holds styling information about the various layouts
@@ -87,31 +87,6 @@ const LAYOUT_1 = [
 
 /* Layout 2
 
- +-------------+
- |      0      |
- |-------------|
- |      1      |
- +-------------+
-
- */
-const LAYOUT_2 = [
-  {
-    width: '100%',
-    height: '50%',
-    top: 0,
-    left: 0,
-    position: 'absolute',
-  }, {
-    width: '100%',
-    height: '50%',
-    top: '50%',
-    left: 0,
-    position: 'absolute',
-  },
-]
-
-/* Layout 3
-
 +------+------+
 |      |   1  |
 |  0   |------|
@@ -119,7 +94,7 @@ const LAYOUT_2 = [
 +------+------+
 
 */
-const LAYOUT_3 = [
+const LAYOUT_2 = [
   {
     width: '65%',
     height: '100%',
@@ -141,7 +116,7 @@ const LAYOUT_3 = [
   },
 ]
 
-/* Layout 4
+/* Layout 3
 
 +------+------+
 |   0  |   1  |
@@ -150,7 +125,7 @@ const LAYOUT_3 = [
 +------+------+
 
 */
-const LAYOUT_4 = [
+const LAYOUT_3 = [
   {
     width: '50%',
     height: '50%',
@@ -178,7 +153,7 @@ const LAYOUT_4 = [
   },
 ]
 
-/* Layout 5
+/* Layout 4
 
 +------+------+
 |      |   1  |
@@ -189,7 +164,7 @@ const LAYOUT_4 = [
 +------+------+
 
 */
-const LAYOUT_5 = [
+const LAYOUT_4 = [
   {
     width: '75%',
     height: '100%',
@@ -217,7 +192,7 @@ const LAYOUT_5 = [
   },
 ]
 
-/* Layout 6
+/* Layout 5
 
 +------+------+
 |      |   1  |
@@ -230,7 +205,7 @@ const LAYOUT_5 = [
 +------+------+
 
 */
-const LAYOUT_6 = [
+const LAYOUT_5 = [
   {
     width: '75%',
     height: '100%',
@@ -264,7 +239,7 @@ const LAYOUT_6 = [
   },
 ]
 
-/* Layout 7
+/* Layout 6
 
 +-----+-----+-----+
 |  0  |  1  |  2  |
@@ -273,7 +248,7 @@ const LAYOUT_6 = [
 +-----+-----+-----+
 
 */
-const LAYOUT_7 = [
+const LAYOUT_6 = [
   {
     width: '33.33%',
     height: '50%',
@@ -313,7 +288,7 @@ const LAYOUT_7 = [
   },
 ]
 
-/* Layout 8
+/* Layout 7
 
 +-----+-----+-----+-----+
 |  0  |  1  |  2  |  3  |
@@ -322,7 +297,7 @@ const LAYOUT_7 = [
 +-----+-----+-----+-----+
 
 */
-const LAYOUT_8 = [
+const LAYOUT_7 = [
   {
     width: '25%',
     height: '50%',
@@ -374,7 +349,7 @@ const LAYOUT_8 = [
   },
 ]
 
-/* Layout 9
+/* Layout 8
 
 +-----+-----+-----+
 |  0  |  1  |  2  |
@@ -385,7 +360,7 @@ const LAYOUT_8 = [
 +-----+-----+-----+
 
 */
-const LAYOUT_9 = [
+const LAYOUT_8 = [
   {
     width: '33.33%',
     height: '33.33%',
@@ -439,6 +414,32 @@ const LAYOUT_9 = [
     height: '33.33%',
     top: '66.67%',
     left: '66.67%',
+    position: 'absolute',
+  },
+]
+
+
+/* Layout 9
+
+ +-------------+
+ |      0      |
+ |-------------|
+ |      1      |
+ +-------------+
+
+ */
+const LAYOUT_9 = [
+  {
+    width: '100%',
+    height: '50%',
+    top: 0,
+    left: 0,
+    position: 'absolute',
+  }, {
+    width: '100%',
+    height: '50%',
+    top: '50%',
+    left: 0,
     position: 'absolute',
   },
 ]

--- a/react/gameday2/constants/LayoutConstants.js
+++ b/react/gameday2/constants/LayoutConstants.js
@@ -1,6 +1,6 @@
 // How many layouts are defined
 // Valid layout IDs are in the range [0, NUM_LAYOUTS - 1]
-export const NUM_LAYOUTS = 9
+export const NUM_LAYOUTS = 10
 
 // The maximum number of views any layout can support.
 // Currently 9 for the nona-view
@@ -8,12 +8,13 @@ export const MAX_SUPPORTED_VIEWS = 9
 
 // Maps a layout ID to the number of views that layout supports
 // The layout ID is the index into this array
-export const NUM_VIEWS_FOR_LAYOUT = [1, 2, 3, 4, 4, 5, 6, 8, 9]
+export const NUM_VIEWS_FOR_LAYOUT = [1, 2, 2, 3, 4, 4, 5, 6, 8, 9]
 
 // Maps a layout ID for the appropriate name for that layout
 export const NAME_FOR_LAYOUT = [
   'Single View',
-  'Split View',
+  'Vertical Split View',
+  'Horizontal Split View',
   '"1+2" View',
   'Quad View',
   '"1+3" View',
@@ -28,6 +29,7 @@ export const NAME_FOR_LAYOUT = [
 export const LAYOUT_SVG_PATHS = [
   'M0 0h23v15h-23v-15z',
   'M0 0h11v15h-11v-15zM12 0h11v15h-11v-15z',
+  'M0 0h23v7h-23v-7z M0 8h23v7h-23v-7z',
   'M0 0h14v15h-14v-15zM15 0h8v7h-8v-7zM15 8h8v7h-8v-7z',
   'M0 0h11v7h-11v-7z M0 8h11v7h-11v-7z M12 0h11v7h-11v-7z M12 8h11v7h-11v-7z',
   'M0 0h14v15h-14v-15z M15 0h8v4.333h-8v-4.33z M15 5.33h8v4.333h-8v-4.33z M15 10.67h8v4.333h-8v-4.33z',
@@ -85,6 +87,31 @@ const LAYOUT_1 = [
 
 /* Layout 2
 
+ +-------------+
+ |      0      |
+ |-------------|
+ |      1      |
+ +-------------+
+
+ */
+const LAYOUT_2 = [
+    {
+        width: '100%',
+        height: '50%',
+        top: 0,
+        left: 0,
+        position: 'absolute',
+    }, {
+        width: '100%',
+        height: '50%',
+        top: '50%',
+        left: 0,
+        position: 'absolute',
+    },
+]
+
+/* Layout 3
+
 +------+------+
 |      |   1  |
 |  0   |------|
@@ -92,7 +119,7 @@ const LAYOUT_1 = [
 +------+------+
 
 */
-const LAYOUT_2 = [
+const LAYOUT_3 = [
   {
     width: '65%',
     height: '100%',
@@ -114,7 +141,7 @@ const LAYOUT_2 = [
   },
 ]
 
-/* Layout 3
+/* Layout 4
 
 +------+------+
 |   0  |   1  |
@@ -123,7 +150,7 @@ const LAYOUT_2 = [
 +------+------+
 
 */
-const LAYOUT_3 = [
+const LAYOUT_4 = [
   {
     width: '50%',
     height: '50%',
@@ -151,7 +178,7 @@ const LAYOUT_3 = [
   },
 ]
 
-/* Layout 4
+/* Layout 5
 
 +------+------+
 |      |   1  |
@@ -162,7 +189,7 @@ const LAYOUT_3 = [
 +------+------+
 
 */
-const LAYOUT_4 = [
+const LAYOUT_5 = [
   {
     width: '75%',
     height: '100%',
@@ -190,7 +217,7 @@ const LAYOUT_4 = [
   },
 ]
 
-/* Layout 5
+/* Layout 6
 
 +------+------+
 |      |   1  |
@@ -203,7 +230,7 @@ const LAYOUT_4 = [
 +------+------+
 
 */
-const LAYOUT_5 = [
+const LAYOUT_6 = [
   {
     width: '75%',
     height: '100%',
@@ -237,7 +264,7 @@ const LAYOUT_5 = [
   },
 ]
 
-/* Layout 6
+/* Layout 7
 
 +-----+-----+-----+
 |  0  |  1  |  2  |
@@ -246,7 +273,7 @@ const LAYOUT_5 = [
 +-----+-----+-----+
 
 */
-const LAYOUT_6 = [
+const LAYOUT_7 = [
   {
     width: '33.33%',
     height: '50%',
@@ -286,7 +313,7 @@ const LAYOUT_6 = [
   },
 ]
 
-/* Layout 7
+/* Layout 8
 
 +-----+-----+-----+-----+
 |  0  |  1  |  2  |  3  |
@@ -295,7 +322,7 @@ const LAYOUT_6 = [
 +-----+-----+-----+-----+
 
 */
-const LAYOUT_7 = [
+const LAYOUT_8 = [
   {
     width: '25%',
     height: '50%',
@@ -347,7 +374,7 @@ const LAYOUT_7 = [
   },
 ]
 
-/* Layout 8
+/* Layout 9
 
 +-----+-----+-----+
 |  0  |  1  |  2  |
@@ -358,7 +385,7 @@ const LAYOUT_7 = [
 +-----+-----+-----+
 
 */
-const LAYOUT_8 = [
+const LAYOUT_9 = [
   {
     width: '33.33%',
     height: '33.33%',
@@ -426,4 +453,5 @@ export const LAYOUT_STYLES = [
   LAYOUT_6,
   LAYOUT_7,
   LAYOUT_8,
+  LAYOUT_9,
 ]

--- a/react/gameday2/constants/LayoutConstants.js
+++ b/react/gameday2/constants/LayoutConstants.js
@@ -10,6 +10,10 @@ export const MAX_SUPPORTED_VIEWS = 9
 // The layout ID is the index into this array
 export const NUM_VIEWS_FOR_LAYOUT = [1, 2, 3, 4, 4, 5, 6, 8, 9, 2]
 
+// Defines the order layouts are shown in the layout selection list
+// Each element is the number of the layout that should be shown at that index
+export const LAYOUT_DISPLAY_ORDER = [0, 1, 9, 2, 3, 4, 5, 6, 7, 8]
+
 // Maps a layout ID for the appropriate name for that layout
 export const NAME_FOR_LAYOUT = [
   'Single View',

--- a/react/gameday2/constants/LayoutConstants.js
+++ b/react/gameday2/constants/LayoutConstants.js
@@ -95,19 +95,19 @@ const LAYOUT_1 = [
 
  */
 const LAYOUT_2 = [
-    {
-        width: '100%',
-        height: '50%',
-        top: 0,
-        left: 0,
-        position: 'absolute',
-    }, {
-        width: '100%',
-        height: '50%',
-        top: '50%',
-        left: 0,
-        position: 'absolute',
-    },
+  {
+    width: '100%',
+    height: '50%',
+    top: 0,
+    left: 0,
+    position: 'absolute',
+  }, {
+    width: '100%',
+    height: '50%',
+    top: '50%',
+    left: 0,
+    position: 'absolute',
+  },
 ]
 
 /* Layout 3


### PR DESCRIPTION
On some smaller (more square) screens when both the chat and social side bars are enabled, the videos are quite small in split view. This adds a horizontal split view for this situation.

This adds the horizontal split view as layout 2 and shifts the rest down. Will this be a problem for existing links to gameday? Should the new layout be 9 instead?

![image](https://cloud.githubusercontent.com/assets/4777935/23841966/4342aef2-077f-11e7-960b-4b611676c6ac.png)
![image](https://cloud.githubusercontent.com/assets/4777935/23841932/f2fdf9b0-077e-11e7-8c02-520bf9bc5d2f.png)
![image](https://cloud.githubusercontent.com/assets/4777935/23841934/f6b35d70-077e-11e7-828c-46452b83d55d.png)
