### PR TITLE
WIP: Fix broken links

### DIFF
--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -16,7 +16,7 @@
           <p>For deferring hosting costs</p>
         </li>
         <li>
-          <h3><a href="https://www.firebase.google.com/" title="Firebase">Firebase</a></h3>
+          <h3><a href="https://firebase.google.com/" title="Firebase">Firebase</a></h3>
           <p>For sponsoring the backend service that handles our push notifications</p>
         </li>
         <li>


### PR DESCRIPTION
This fixes a broken link on the Thanks page.

I noticed that the [link to Komodo Media](https://github.com/the-blue-alliance/the-blue-alliance/blob/master/templates/thanks.html#L31) on the thanks page is broken as the site no longer exists. Do we still use their icons? Could this just be removed?

I also found a [broken link](https://github.com/the-blue-alliance/the-blue-alliance/blob/master/templates_jinja2/district_details.html#L168-L172) on the bottom of the district ranking page to FIRST's documentation on how the rankings are calculated. The link is broken since FIRST took down their archive site. I looked all over the [firstinspires.org](https://www.firstinspires.org/), but could not find an equivalent document. The documents are still available on [web.archive.org](http://web.archive.org/), so we could link to this version