### PR TITLE
Serve additional ranking columns over API, add Total RP for 2017

### DIFF
--- a/database/dict_converters/event_details_converter.py
+++ b/database/dict_converters/event_details_converter.py
@@ -4,7 +4,7 @@ from database.dict_converters.converter_base import ConverterBase
 
 class EventDetailsConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        3: 1,
+        3: 2,
     }
 
     @classmethod


### PR DESCRIPTION
Fixes #1832 
```
"extra_stats_info": [
    {
      "name": "Total RP", 
      "precision": 0
    }
  ], 
```
```
"extra_stats": [
     13
 ],
```

![image](https://cloud.githubusercontent.com/assets/1421884/24012544/c3f139ba-0a54-11e7-8288-e5d48a0c546c.png)
