### PR TITLE
Add event status to event table

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -453,3 +453,13 @@ class Event(ndb.Model):
             return '{} {}'.format(self.short_name, EventType.short_type_names[self.event_type_enum])
         else:
             return self.name
+
+    @property
+    def next_match(self):
+        from helpers.match_helper import MatchHelper
+        return MatchHelper.upcomingMatches(self.matches, 1)[0]
+
+    @property
+    def previous_match(self):
+        from helpers.match_helper import MatchHelper
+        return MatchHelper.recentMatches(self.matches, 1)[0]

--- a/templates/event_partials/event_table.html
+++ b/templates/event_partials/event_table.html
@@ -15,7 +15,9 @@
             <br>
             <small>{{event.city_state_country}}</small>
             <br>
-            {% if event.now and event.next_match %}
+          {% endif %}
+          {% if event.now %}
+            {% if event.next_match %}
               <b>Next Match: </b> {{event.next_match.verbose_name}}
             {% else %}
               {% if not event.alliance_selections and event.previous_match %}

--- a/templates/event_partials/event_table.html
+++ b/templates/event_partials/event_table.html
@@ -14,6 +14,14 @@
           {% if event.city_state_country %}
             <br>
             <small>{{event.city_state_country}}</small>
+            <br>
+            {% if event.now and event.next_match %}
+              <b>Next Match: </b> {{event.next_match.verbose_name}}
+            {% else %}
+              {% if not event.alliance_selections and event.previous_match %}
+                <b>Next: </b> Alliance Selections
+              {% endif %}
+            {% endif %}
           {% endif %}
         </td>
         <td class="hidden-xs">

--- a/templates/event_partials/event_table.html
+++ b/templates/event_partials/event_table.html
@@ -14,13 +14,14 @@
           {% if event.city_state_country %}
             <br>
             <small>{{event.city_state_country}}</small>
-            <br>
           {% endif %}
           {% if event.now %}
             {% if event.next_match %}
+              <br>
               <b>Next Match: </b> {{event.next_match.verbose_name}}
             {% else %}
               {% if not event.alliance_selections and event.previous_match %}
+                <br>
                 <b>Next: </b> Alliance Selections
               {% endif %}
             {% endif %}


### PR DESCRIPTION
This adds the status for each event to the event table to give an overview of how all of the events are progressing in one place.
![screencapture-localhost-8088-1489855741573](https://cloud.githubusercontent.com/assets/4777935/24074188/8b207866-0bd1-11e7-842b-00f51970135b.png)
