### PR TITLE
[GD] Shift cell toolbar controls shadow so it doesn't overlay the embed

### DIFF
--- a/react/gameday2/components/VideoCellToolbar.js
+++ b/react/gameday2/components/VideoCellToolbar.js
@@ -35,7 +35,7 @@ const VideoCellToolbar = (props) => {
     right: 0,
     marginRight: 0,
     backgroundColor: grey900,
-    boxShadow: '-2px 0px 15px 6px rgba(0, 0, 0, 0.5)',
+    boxShadow: '-2px 0px 15px -2px rgba(0, 0, 0, 0.5)',
   }
 
   // Create tickerMatches


### PR DESCRIPTION
Before:
![Imgur](http://i.imgur.com/WFCItax.png)
After:
![Imgur](http://i.imgur.com/Wh74SZw.png)