### PR TITLE
Improved how swap functions with 1 & 2 view layouts

### DIFF
--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -29,7 +29,7 @@ export default class VideoCell extends React.Component {
 
   onRequestSwapPosition() {
     const numViewsInLayout = NUM_VIEWS_FOR_LAYOUT[this.props.layoutId]
-    if (numViewsInLayout == 2) {
+    if (numViewsInLayout === 2) {
       // It doesn't matter which position we are
       this.props.swapWebcasts(0, 1)
     } else {

--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -5,7 +5,7 @@ import VideoCellToolbarContainer from '../containers/VideoCellToolbarContainer'
 import WebcastSelectionDialogContainer from '../containers/WebcastSelectionDialogContainer'
 import SwapPositionDialogContainer from '../containers/SwapPositionDialogContainer'
 import { webcastPropType } from '../utils/webcastUtils'
-import { LAYOUT_STYLES } from '../constants/LayoutConstants'
+import { LAYOUT_STYLES, NUM_VIEWS_FOR_LAYOUT } from '../constants/LayoutConstants'
 
 export default class VideoCell extends React.Component {
   static propTypes = {
@@ -15,6 +15,7 @@ export default class VideoCell extends React.Component {
     layoutId: PropTypes.number.isRequired,
     position: PropTypes.number.isRequired,
     addWebcastAtPosition: PropTypes.func.isRequired,
+    swapWebcasts: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -23,6 +24,16 @@ export default class VideoCell extends React.Component {
     this.state = {
       webcastSelectionDialogOpen: false,
       swapPositionDialogOpen: false,
+    }
+  }
+
+  onRequestSwapPosition() {
+    const numViewsInLayout = NUM_VIEWS_FOR_LAYOUT[this.props.layoutId]
+    if (numViewsInLayout == 2) {
+      // It doesn't matter which position we are
+      this.props.swapWebcasts(0, 1)
+    } else {
+      this.onRequestOpenSwapPositionDialog()
     }
   }
 
@@ -70,8 +81,8 @@ export default class VideoCell extends React.Component {
             style={toolbarStyle}
             webcast={this.props.webcast}
             isBlueZone={this.props.webcast.key === 'bluezone'}
-            onRequestOpenWebcastSelectionDialog={() => this.onRequestOpenWebcastSelectionDialog()}
-            onRequestOpenSwapPositionDialog={() => this.onRequestOpenSwapPositionDialog()}
+            onRequestSelectWebcast={() => this.onRequestOpenWebcastSelectionDialog()}
+            onRequestSwapPosition={() => this.onRequestSwapPosition()}
           />
           <WebcastSelectionDialogContainer
             open={this.state.webcastSelectionDialogOpen}

--- a/react/gameday2/components/VideoCellToolbar.js
+++ b/react/gameday2/components/VideoCellToolbar.js
@@ -62,10 +62,8 @@ const VideoCellToolbar = (props) => {
     )
   })
 
-  const numViewInLayout = NUM_VIEWS_FOR_LAYOUT[props.layoutId]
-  console.log('Num views: ' + numViewInLayout)
   let swapButton
-  if (NUM_VIEWS_FOR_LAYOUT[props.layoutId] == 1) {
+  if (NUM_VIEWS_FOR_LAYOUT[props.layoutId] === 1) {
     swapButton = null
   } else {
     swapButton = (

--- a/react/gameday2/components/VideoCellToolbar.js
+++ b/react/gameday2/components/VideoCellToolbar.js
@@ -5,7 +5,9 @@ import CloseIcon from 'material-ui/svg-icons/navigation/close'
 import SwapIcon from 'material-ui/svg-icons/action/compare-arrows'
 import VideocamIcon from 'material-ui/svg-icons/av/videocam'
 import { white, grey900 } from 'material-ui/styles/colors'
+
 import TickerMatch from './TickerMatch'
+import { NUM_VIEWS_FOR_LAYOUT } from '../constants/LayoutConstants'
 
 const VideoCellToolbar = (props) => {
   const toolbarStyle = {
@@ -60,6 +62,24 @@ const VideoCellToolbar = (props) => {
     )
   })
 
+  const numViewInLayout = NUM_VIEWS_FOR_LAYOUT[props.layoutId]
+  console.log('Num views: ' + numViewInLayout)
+  let swapButton
+  if (NUM_VIEWS_FOR_LAYOUT[props.layoutId] == 1) {
+    swapButton = null
+  } else {
+    swapButton = (
+      <IconButton
+        tooltip="Swap position"
+        tooltipPosition="top-center"
+        onTouchTap={() => props.onRequestSwapPosition()}
+        touch
+      >
+        <SwapIcon color={white} />
+      </IconButton>
+    )
+  }
+
   return (
     <Toolbar style={toolbarStyle}>
       <ToolbarGroup>
@@ -74,18 +94,11 @@ const VideoCellToolbar = (props) => {
         </div>
       </ToolbarGroup>
       <ToolbarGroup lastChild style={controlsStyle}>
-        <IconButton
-          tooltip="Swap position"
-          tooltipPosition="top-center"
-          onTouchTap={() => props.onRequestOpenSwapPositionDialog()}
-          touch
-        >
-          <SwapIcon color={white} />
-        </IconButton>
+        {swapButton}
         <IconButton
           tooltip="Change webcast"
           tooltipPosition="top-center"
-          onTouchTap={() => props.onRequestOpenWebcastSelectionDialog()}
+          onTouchTap={() => props.onRequestSelectWebcast()}
           touch
         >
           <VideocamIcon color={white} />
@@ -108,11 +121,12 @@ VideoCellToolbar.propTypes = {
   webcast: PropTypes.object.isRequired,
   /* eslint-disable react/no-unused-prop-types */
   isBlueZone: PropTypes.bool.isRequired,
-  onRequestOpenSwapPositionDialog: PropTypes.func.isRequired,
-  onRequestOpenWebcastSelectionDialog: PropTypes.func.isRequired,
+  onRequestSwapPosition: PropTypes.func.isRequired,
+  onRequestSelectWebcast: PropTypes.func.isRequired,
   /* eslint-enable react/no-unused-prop-types */
   removeWebcast: PropTypes.func.isRequired,
   style: PropTypes.object,
+  layoutId: PropTypes.number.isRequired,
 }
 
 export default VideoCellToolbar

--- a/react/gameday2/components/VideoGrid.js
+++ b/react/gameday2/components/VideoGrid.js
@@ -1,17 +1,14 @@
 import React, { PropTypes } from 'react'
-import VideoCell from './VideoCell'
+import VideoCellContainer from '../containers/VideoCellContainer'
 import { getNumViewsForLayout } from '../utils/layoutUtils'
 import { webcastPropType } from '../utils/webcastUtils'
 
 export default class VideoGrid extends React.Component {
   static propTypes = {
-    displayedWebcasts: PropTypes.arrayOf(PropTypes.string).isRequired,
     domOrder: PropTypes.arrayOf(PropTypes.string).isRequired,
     positionMap: PropTypes.arrayOf(PropTypes.number).isRequired,
-    webcasts: PropTypes.arrayOf(PropTypes.string).isRequired,
     webcastsById: PropTypes.objectOf(webcastPropType).isRequired,
     layoutId: PropTypes.number.isRequired,
-    addWebcastAtPosition: PropTypes.func.isRequired,
   }
 
   renderLayout(webcastCount) {
@@ -61,14 +58,10 @@ export default class VideoGrid extends React.Component {
       }
       if (hasWebcast) {
         videoCells.push(
-          <VideoCell
+          <VideoCellContainer
             position={position}
-            layoutId={this.props.layoutId}
             key={id}
             webcast={webcast}
-            webcasts={this.props.webcasts}
-            displayedWebcasts={this.props.displayedWebcasts}
-            addWebcastAtPosition={this.props.addWebcastAtPosition}
           />
         )
       } else {

--- a/react/gameday2/containers/VideoCellContainer.js
+++ b/react/gameday2/containers/VideoCellContainer.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux'
+import VideoCell from '../components/VideoCell'
+import { addWebcastAtPosition, setLayout, swapWebcasts } from '../actions'
+import { getWebcastIdsInDisplayOrder } from '../selectors'
+
+const mapStateToProps = (state) => ({
+  webcasts: getWebcastIdsInDisplayOrder(state),
+  displayedWebcasts: state.videoGrid.displayed,
+  layoutId: state.videoGrid.layoutId,
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  addWebcastAtPosition: (webcastId, position) => dispatch(addWebcastAtPosition(webcastId, position)),
+  setLayout: (layoutId) => dispatch(setLayout(layoutId)),
+  swapWebcasts: (firstPosition, secondPosition) => dispatch(swapWebcasts(firstPosition, secondPosition)),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(VideoCell)

--- a/react/gameday2/containers/VideoGridContainer.js
+++ b/react/gameday2/containers/VideoGridContainer.js
@@ -1,21 +1,11 @@
 import { connect } from 'react-redux'
 import VideoGrid from '../components/VideoGrid'
-import { addWebcastAtPosition, setLayout } from '../actions'
-import { getWebcastIdsInDisplayOrder } from '../selectors'
 
 const mapStateToProps = (state) => ({
-  webcasts: getWebcastIdsInDisplayOrder(state),
   domOrder: state.videoGrid.domOrder,
   positionMap: state.videoGrid.positionMap,
   webcastsById: state.webcastsById,
-  displayedWebcasts: state.videoGrid.displayed,
   layoutId: state.videoGrid.layoutId,
 })
 
-const mapDispatchToProps = (dispatch) => ({
-  addWebcastAtPosition: (webcastId, position) => dispatch(addWebcastAtPosition(webcastId, position)),
-  setLayout: (layoutId) => dispatch(setLayout(layoutId)),
-})
-
-
-export default connect(mapStateToProps, mapDispatchToProps)(VideoGrid)
+export default connect(mapStateToProps)(VideoGrid)


### PR DESCRIPTION
In layouts with exactly one cell, the swap button is hidden completely.

In layouts with exactly two cells, the swap button doesn't prompt with a dialog; it just swaps with the only other view that's there.

For all other layout, the swap button functions as it did before.