### PR TITLE
#1867 "Watch Now" visibility fix for Extra Small Devices (<768px)

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -72,7 +72,7 @@
     <div class="col-sm-12">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <div class="hidden-xs pull-right">
+          <div class="pull-right">
             {% if event.webcast %}
               {% if event.webcast_status == 'offline' %}
                 <a class="btn btn-default btn-xs" href="{{event.gameday_url}}" target="_blank"><span class="glyphicon glyphicon-facetime-video"></span> Offline</a>


### PR DESCRIPTION
Removed "hidden-xs" property from event_details.html to allow for the stream button to display on mobile devices where browser width <768px

See: http://getbootstrap.com/css/#responsive-utilities

PR for #1867 