### PR TITLE
Fix OPR page header

### DIFF
--- a/templates/opr.html
+++ b/templates/opr.html
@@ -6,9 +6,9 @@
 
 {% block content %}
 <div class="container">
-  <h1 class="end_header">What is OPR?</h1>
   <div class="row">
     <div class="col-xs-8 col-sm-offset-2 col-lg-offset-2">
+      <h1 class="end_header">What is OPR?</h1>
       <p>OPR stands for <strong>Offensive Power Rating</strong>, which is a system to attempt to deduce the average point contribution of a team to an alliance. It is based on <a href="https://en.wikipedia.org/wiki/Sports_rating_system">sports rating systems</a> used in other sports. OPRs are an interesting way to slice the data for teams at particular events, but aren't a perfect system for assessing a team's performance or contribution.</p>
       <p>The Blue Alliance opts to show the top 15 OPRs for each competition.</p>
       </div>


### PR DESCRIPTION
This is a minor styling fix to the header of the OPR page.

### Before
![before](https://cloud.githubusercontent.com/assets/10191084/24645713/35b15e86-18ce-11e7-8338-37aefdeff4d5.png)

### After
![after](https://cloud.githubusercontent.com/assets/10191084/24645702/27213d46-18ce-11e7-8434-e1128bb59d9e.png)