### PR TITLE
Add team media suggestion API endpoint

### DIFF
--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -69,7 +69,7 @@ app = webapp2.WSGIApplication([
         atc.ApiTeamYearMediaController, methods=['GET', 'OPTIONS']),
     # Team Media Suggestions
     webapp2.Route(r'/api/v3/team/<team_key:>/suggest/media/<year:([0-9]+)>',
-        asgc.ApiSuggestTeamMediaController, methods=['POST', 'GET', 'OPTIONS']),
+        asgc.ApiSuggestTeamMediaController, methods=['POST', 'OPTIONS']),
     # Event List
     webapp2.Route(r'/api/v3/events/<year:([0-9]+)>',
         aec.ApiEventListController, methods=['GET', 'OPTIONS']),

--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -7,6 +7,7 @@ from controllers.apiv3 import api_district_controller as adc
 from controllers.apiv3 import api_event_controller as aec
 from controllers.apiv3 import api_match_controller as amc
 from controllers.apiv3 import api_team_controller as atc
+from controllers.apiv3 import api_suggest_controller as asgc
 
 # Ensure that APIv3 routes include OPTIONS method for CORS preflight compatibility
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
@@ -66,6 +67,9 @@ app = webapp2.WSGIApplication([
         atc.ApiTeamYearMatchesController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/team/<team_key:>/media/<year:([0-9]+)>',
         atc.ApiTeamYearMediaController, methods=['GET', 'OPTIONS']),
+    # Team Media Suggestions
+    webapp2.Route(r'/api/v3/team/<team_key:>/suggest/media/<year:([0-9]+)>',
+        asgc.ApiSuggestTeamMediaController, methods=['POST', 'GET', 'OPTIONS']),
     # Event List
     webapp2.Route(r'/api/v3/events/<year:([0-9]+)>',
         aec.ApiEventListController, methods=['GET', 'OPTIONS']),

--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -68,7 +68,7 @@ app = webapp2.WSGIApplication([
     webapp2.Route(r'/api/v3/team/<team_key:>/media/<year:([0-9]+)>',
         atc.ApiTeamYearMediaController, methods=['GET', 'OPTIONS']),
     # Team Media Suggestions
-    webapp2.Route(r'/api/v3/team/<team_key:>/suggest/media/<year:([0-9]+)>',
+    webapp2.Route(r'/api/v3/suggest/media/team/<team_key:>/<year:([0-9]+)>',
         asgc.ApiSuggestTeamMediaController, methods=['POST', 'OPTIONS']),
     # Event List
     webapp2.Route(r'/api/v3/events/<year:([0-9]+)>',

--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -112,7 +112,7 @@ class ApiBaseController(CacheableHandler):
         if not x_tba_auth_key:
             account = self._user_bundle.account
             if account:
-                self.auth_owner = account.key.id()
+                self.auth_owner = account.key
             else:
                 self._errors = json.dumps({"Error": "X-TBA-Auth-Key is a required header or URL param. Please get an access key at http://www.thebluealliance.com/account."})
                 self.abort(400)
@@ -122,9 +122,21 @@ class ApiBaseController(CacheableHandler):
         else:
             auth = ApiAuthAccess.get_by_id(x_tba_auth_key)
             if auth and auth.is_read_key:
-                self.auth_owner = auth.owner.id()
+                self.auth_owner = auth.owner
                 self.auth_description = auth.description
                 logging.info("Auth owner: {}, X-TBA-Auth-Key: {}".format(self.auth_owner, x_tba_auth_key))
             else:
                 self._errors = json.dumps({"Error": "X-TBA-Auth-Key is invalid. Please get an access key at http://www.thebluealliance.com/account."})
                 self.abort(400)
+
+class ApiSuggestBaseController(ApiBaseController):
+    def post(self, *args, **kw):
+        super(ApiSuggestBaseController, self).get(*args, **kw)
+
+    def options(self, *args, **kw):
+        """
+        Supply an OPTIONS method in order to comply with CORS preflghted requests
+        https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
+        """
+        self.response.headers['Access-Control-Allow-Methods'] = "POST, OPTIONS"
+        self.response.headers['Access-Control-Allow-Headers'] = 'X-TBA-Auth-Key'

--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -108,11 +108,13 @@ class ApiBaseController(CacheableHandler):
             x_tba_auth_key = self.request.get('X-TBA-Auth-Key')
 
         self.auth_owner = None
+        self.auth_owner_key = None
         self.auth_description = None
         if not x_tba_auth_key:
             account = self._user_bundle.account
             if account:
-                self.auth_owner = account.key
+                self.auth_owner = account.key.id()
+                self.auth_owner_key = account.key
             else:
                 self._errors = json.dumps({"Error": "X-TBA-Auth-Key is a required header or URL param. Please get an access key at http://www.thebluealliance.com/account."})
                 self.abort(400)
@@ -122,7 +124,8 @@ class ApiBaseController(CacheableHandler):
         else:
             auth = ApiAuthAccess.get_by_id(x_tba_auth_key)
             if auth and auth.is_read_key:
-                self.auth_owner = auth.owner
+                self.auth_owner = auth.owner.id()
+                self.auth_owner_key = auth.owner
                 self.auth_description = auth.description
                 logging.info("Auth owner: {}, X-TBA-Auth-Key: {}".format(self.auth_owner, x_tba_auth_key))
             else:

--- a/controllers/apiv3/api_suggest_controller.py
+++ b/controllers/apiv3/api_suggest_controller.py
@@ -12,32 +12,29 @@ class ApiSuggestTeamMediaController(ApiSuggestBaseController):
         self._track_call_defer('team/suggest/media', team_key)
 
     def _render(self, team_key, year):
-        if year in TeamParticipationQuery(team_key).fetch():
-            if 'media_url' in self.request.POST:
-                status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
-                    author_account_key=self.auth_owner_key,
-                    media_url=self.request.POST["media_url"],
-                    team_key=team_key,
-                    year_str=year)
+        if year not in TeamParticipationQuery(team_key).fetch():
+            self.abort(400)
 
-                if status == 'success':
-                    message = {
-                        "success": True
-                    }
-                else:
-                    message ={
-                        "success": False,
-                        "message": status
-                    }
-            else:
+        if 'media_url' in self.request.POST:
+            status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
+                author_account_key=self.auth_owner_key,
+                media_url=self.request.POST["media_url"],
+                team_key=team_key,
+                year_str=year)
+
+            if status == 'success':
                 message = {
+                    "success": True
+                }
+            else:
+                message ={
                     "success": False,
-                    "message": "missing media_url"
+                    "message": status
                 }
         else:
             message = {
                 "success": False,
-                "message": "invalid year"
+                "message": "missing media_url"
             }
 
         return json.dumps(message, ensure_ascii=True, indent=2, sort_keys=True)

--- a/controllers/apiv3/api_suggest_controller.py
+++ b/controllers/apiv3/api_suggest_controller.py
@@ -1,11 +1,11 @@
 import json
 
-from controllers.apiv3.api_base_controller import ApiSuggestBaseController
+from controllers.apiv3.api_base_controller import ApiBaseController
 from database.team_query import TeamParticipationQuery
 from helpers.suggestions.suggestion_creator import SuggestionCreator
 
 
-class ApiSuggestTeamMediaController(ApiSuggestBaseController):
+class ApiSuggestTeamMediaController(ApiBaseController):
     CACHE_VERSION = 0
 
     def _track_call(self, team_key, year):

--- a/controllers/apiv3/api_suggest_controller.py
+++ b/controllers/apiv3/api_suggest_controller.py
@@ -1,6 +1,7 @@
 import json
 
 from controllers.apiv3.api_base_controller import ApiSuggestBaseController
+from database.team_query import TeamParticipationQuery
 from helpers.suggestions.suggestion_creator import SuggestionCreator
 
 
@@ -11,26 +12,32 @@ class ApiSuggestTeamMediaController(ApiSuggestBaseController):
         self._track_call_defer('team/suggest/media', team_key)
 
     def _render(self, team_key, year):
-        if 'media_url' in self.request.POST:
-            status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
-                author_account_key=self.auth_owner_key,
-                media_url=self.request.POST["media_url"],
-                team_key=team_key,
-                year_str=year)
+        if year in TeamParticipationQuery(team_key).fetch():
+            if 'media_url' in self.request.POST:
+                status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
+                    author_account_key=self.auth_owner_key,
+                    media_url=self.request.POST["media_url"],
+                    team_key=team_key,
+                    year_str=year)
 
-            if status == 'success':
-                message = {
-                    "success": True
-                }
+                if status == 'success':
+                    message = {
+                        "success": True
+                    }
+                else:
+                    message ={
+                        "success": False,
+                        "message": status
+                    }
             else:
-                message ={
+                message = {
                     "success": False,
-                    "message": status
+                    "message": "missing media_url"
                 }
         else:
             message = {
                 "success": False,
-                "message": "missing media_url"
+                "message": "invalid year"
             }
 
         return json.dumps(message, ensure_ascii=True, indent=2, sort_keys=True)

--- a/controllers/apiv3/api_suggest_controller.py
+++ b/controllers/apiv3/api_suggest_controller.py
@@ -12,7 +12,7 @@ class ApiSuggestTeamMediaController(ApiBaseController):
         self._track_call_defer('team/suggest/media', team_key)
 
     def _render(self, team_key, year):
-        if year not in TeamParticipationQuery(team_key).fetch():
+        if int(year) not in list(TeamParticipationQuery(team_key).fetch()):
             self.abort(400)
 
         if 'media_url' in self.request.POST:

--- a/controllers/apiv3/api_suggest_controller.py
+++ b/controllers/apiv3/api_suggest_controller.py
@@ -1,0 +1,36 @@
+import json
+
+from controllers.apiv3.api_base_controller import ApiSuggestBaseController
+from helpers.suggestions.suggestion_creator import SuggestionCreator
+
+
+class ApiSuggestTeamMediaController(ApiSuggestBaseController):
+    CACHE_VERSION = 0
+
+    def _track_call(self, team_key, year):
+        self._track_call_defer('team/suggest/media', team_key)
+
+    def _render(self, team_key, year):
+        if 'media_url' in self.request.POST:
+            status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
+                author_account_key=self.auth_owner,
+                media_url=self.request.POST["media_url"],
+                team_key=team_key,
+                year_str=year)
+
+            if status == 'success':
+                message = {
+                    "success": True
+                }
+            else:
+                message ={
+                    "success": False,
+                    "message": status
+                }
+        else:
+            message = {
+                "success": False,
+                "message": "missing media_url"
+            }
+
+        return json.dumps(message, ensure_ascii=True, indent=2, sort_keys=True)

--- a/controllers/apiv3/api_suggest_controller.py
+++ b/controllers/apiv3/api_suggest_controller.py
@@ -13,7 +13,7 @@ class ApiSuggestTeamMediaController(ApiSuggestBaseController):
     def _render(self, team_key, year):
         if 'media_url' in self.request.POST:
             status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
-                author_account_key=self.auth_owner,
+                author_account_key=self.auth_owner_key,
                 media_url=self.request.POST["media_url"],
                 team_key=team_key,
                 year_str=year)


### PR DESCRIPTION
This will add an API endpoint for suggesting team media. A developer would make a POST request to `/api/v3/team/<team>/suggest/media/<year>` (subject to change) with the POST data `{ media_url: "some media link" }` in order to queue a suggestion. Should resolve #1037.

I've been playing with this quite a bit, and from my tests it should be working :)