### PR TITLE
Return error code 401 instead of 400 if auth header is incorrect or missing

### DIFF
--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -115,7 +115,7 @@ class ApiBaseController(CacheableHandler):
                 self.auth_owner = account.key.id()
             else:
                 self._errors = json.dumps({"Error": "X-TBA-Auth-Key is a required header or URL param. Please get an access key at http://www.thebluealliance.com/account."})
-                self.abort(400)
+                self.abort(401)
 
         if self.auth_owner:
             logging.info("Auth owner: {}, LOGGED IN".format(self.auth_owner))
@@ -127,4 +127,4 @@ class ApiBaseController(CacheableHandler):
                 logging.info("Auth owner: {}, X-TBA-Auth-Key: {}".format(self.auth_owner, x_tba_auth_key))
             else:
                 self._errors = json.dumps({"Error": "X-TBA-Auth-Key is invalid. Please get an access key at http://www.thebluealliance.com/account."})
-                self.abort(400)
+                self.abort(401)


### PR DESCRIPTION
See [@fangeugene's comment](https://github.com/the-blue-alliance/the-blue-alliance/pull/1882/files/fae50437048384a6a12b8929c2f4d95e41d491e4#r111207897).

Error `401` means "Unauthorized: Access is denied due to invalid credentials." BTW