### PR TITLE
Store Divisional Mappings

### DIFF
--- a/backend_main.py
+++ b/backend_main.py
@@ -3,7 +3,8 @@ import webapp2
 
 import tba_config
 
-from controllers.admin.admin_cron_controller import AdminPostEventTasksDo, AdminCreateDistrictTeamsEnqueue, AdminCreateDistrictTeamsDo
+from controllers.admin.admin_cron_controller import AdminPostEventTasksDo, AdminCreateDistrictTeamsEnqueue, AdminCreateDistrictTeamsDo, \
+    AdminRebuildDivisionsDo, AdminRebuildDivisionsEnqueue
 from controllers.datafeed_controller import EventListEnqueue, EventDetailsEnqueue
 from controllers.datafeed_controller import EventListGet, EventDetailsGet, TeamDetailsGet
 
@@ -16,5 +17,7 @@ app = webapp2.WSGIApplication([('/backend-tasks/enqueue/event_list/([0-9]*)', Ev
                                ('/backend-tasks/do/post_event_tasks/(.*)', AdminPostEventTasksDo),
                                ('/backend-tasks/enqueue/rebuild_district_teams/([0-9]+)', AdminCreateDistrictTeamsEnqueue),
                                ('/backend-tasks/do/rebuild_district_teams/([0-9]+)', AdminCreateDistrictTeamsDo),
+                               ('/backend-tasks/enqueue/rebuild_divisions/([0-9]+)', AdminRebuildDivisionsEnqueue),
+                               ('/backend-tasks/do/rebuild_divisions/([0-9]+)', AdminRebuildDivisionsDo)
                                ],
                               debug=tba_config.DEBUG)

--- a/controllers/admin/admin_event_controller.py
+++ b/controllers/admin/admin_event_controller.py
@@ -378,6 +378,10 @@ class AdminEventEdit(LoggedInHandler):
             end_date = datetime.strptime(self.request.get("end_date"), "%Y-%m-%d")
 
         district_key = self.request.get("event_district_key", None)
+        parent_key = self.request.get("parent_event", None)
+
+        division_key_names = json.loads(self.request.get('divisions'), '[]')
+        division_keys = [ndb.Key(Event, key) for key in division_key_names] if division_key_names else []
 
         event = Event(
             id=str(self.request.get("year")) + str.lower(str(self.request.get("event_short"))),
@@ -401,6 +405,8 @@ class AdminEventEdit(LoggedInHandler):
             custom_hashtag=self.request.get("custom_hashtag"),
             webcast_json=self.request.get("webcast_json"),
             playoff_type=int(self.request.get("playoff_type")),
+            parent_event=ndb.Key(Event, parent_key) if parent_key and parent_key.lower() != 'none' else None,
+            divisions=division_keys,
         )
         event = EventManipulator.createOrUpdate(event)
 

--- a/database/dict_converters/event_converter.py
+++ b/database/dict_converters/event_converter.py
@@ -5,7 +5,7 @@ from database.dict_converters.district_converter import DistrictConverter
 
 class EventConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        3: 4,
+        3: 5,
     }
 
     @classmethod
@@ -30,9 +30,11 @@ class EventConverter(ConverterBase):
             'event_code': event.event_short,
             'event_type': event.event_type_enum,
             'event_type_string': event.event_type_str,
+            'parent_event_key': event.parent_event.id() if event.parent_event else None,
             'playoff_type': event.playoff_type,
             'playoff_type_string': PlayoffType.type_names[event.playoff_type],
             'district': DistrictConverter.convert(district_future.get_result(), 3) if district_future else None,
+            'division_keys': [key.id() for key in event.divisions],
             'first_event_id': event.first_eid,
             'year': event.year,
             'timezone': event.timezone_id,

--- a/database/event_query.py
+++ b/database/event_query.py
@@ -75,3 +75,16 @@ class TeamYearEventsQuery(DatabaseQuery):
         event_keys = map(lambda event_team: event_team.event, event_teams)
         events = yield ndb.get_multi_async(event_keys)
         raise ndb.Return(events)
+
+
+class EventDivisionsQuery(DatabaseQuery):
+    CACHE_VERSION = 1
+    CACHE_KEY_FORMAT = "event_divisions_{}"  # (event_key)
+    DICT_CONVERTER = EventConverter
+
+    @ndb.tasklet
+    def _query_async(self):
+        event_key = self._query_args[0]
+        event = yield Event.get_by_id_async(event_key)
+        divisions = yield ndb.get_multi_async(event.divisions)
+        raise ndb.Return(divisions)

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -302,6 +302,8 @@ class EventHelper(object):
         if ('district' in event_type_str) or ('state' in event_type_str)\
            or ('region' in event_type_str) or ('qualif' in event_type_str):
             if 'championship' in event_type_str:
+                if 'division' in event_type_str:
+                    return EventType.DISTRICT_CMP_DIVISION
                 return EventType.DISTRICT_CMP
             else:
                 return EventType.DISTRICT

--- a/helpers/event_manipulator.py
+++ b/helpers/event_manipulator.py
@@ -73,6 +73,7 @@ class EventManipulator(ManipulatorBase):
             "event_type_enum",
             "event_district_enum",
             "district_key",
+            "divisions",
             "custom_hashtag",
             "facebook_eid",
             "first_eid",
@@ -80,6 +81,7 @@ class EventManipulator(ManipulatorBase):
             "state_prov",
             "country",
             "postalcode",
+            "parent_event",
             "playoff_type",
             "normalized_location",  # Overwrite whole thing as one
             "timezone_id",

--- a/models/event.py
+++ b/models/event.py
@@ -46,6 +46,8 @@ class Event(ndb.Model):
     timezone_id = ndb.StringProperty()  # such as 'America/Los_Angeles' or 'Asia/Jerusalem'
     official = ndb.BooleanProperty(default=False)  # Is the event FIRST-official?
     first_eid = ndb.StringProperty()  # from USFIRST
+    parent_event = ndb.KeyProperty()  # This is the division -> event champs relationship
+    divisions = ndb.KeyProperty(repeated=True)  # event champs -> all divisions
     facebook_eid = ndb.StringProperty(indexed=False)  # from Facebook
     custom_hashtag = ndb.StringProperty(indexed=False)  # Custom HashTag
     website = ndb.StringProperty(indexed=False)
@@ -366,6 +368,11 @@ class Event(ndb.Model):
             else:
                 current_webcasts.append(webcast)
         return current_webcasts
+
+    @property
+    def division_keys_json(self):
+        keys = [key.id() for key in self.divisions]
+        return json.dumps(keys)
 
     @property
     def key_name(self):

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -132,6 +132,15 @@
         <td>{{event.webcast_json}}</td>
     </tr>
     <tr>
+        <td>Parent Event</td>
+        <td>{% if event.parent_event %}<a href="/admin/event/{{ event.parent_event.id }}">{{ event.parent_event.id }}</a>{% else %}None{% endif %}</td>
+    </tr>
+    <tr>
+        <td>Divisions</td>
+        <td>{{ event.divisions|length }} Divisions - {% for div_key in event.divisions %}<a href="/admin/event/{{ div_key.id }}">{{ div_key.id }}</a>, {% endfor %}<ul>
+        </ul></td>
+    </tr>
+    <tr>
         <td>Teams Attending</td>
         <td>{{ event.teams|length }} teams - {% for team in event.teams %}<a href="/admin/team/{{team.team_number}}">{{team.team_number}}</a>, {% endfor %}</td>
     </tr>

--- a/templates/admin/event_edit.html
+++ b/templates/admin/event_edit.html
@@ -99,6 +99,14 @@
             <td><input type="text" name="custom_hashtag" value="{{event.custom_hashtag}}" /></td>
         </tr>
         <tr>
+            <td>Parent Event</td>
+            <td><input type="text" name="parent_event" value="{% if event.parent_event %}{{ event.parent_event.id }}{% endif %}"/></td>
+        </tr>
+        <tr>
+            <td>Event Divisions</td>
+            <td><input type="text" name="divisions" value="{{ event.division_keys_json }}"</td>
+        </tr>
+        <tr>
             <td>Webcast JSON</td>
             <td>
                 <textarea name="webcast_json">{{event.webcast_json}}</textarea>

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -6,7 +6,8 @@
 {% block meta_description %}Videos and match results for the {{event.year}} {{event.name}} FIRST Robotics Competition in {{event.location}}.{% endblock %}
 
 {% block more_head_tags %}
-  <meta property="og:title" content="{{event.year}} {{event.name}}" />
+    <meta property="og:title" content="{{ event.year }} {{ event.name }}"
+          xmlns="http://www.w3.org/1999/html"/>
   <meta property="og:type" content="article" />
   <meta property="og:image" content="http://www.thebluealliance.com/images/logo_square_512.png" />
   <meta property="og:description" content="Videos and match results for the {{event.year}} {{event.name}} FIRST Robotics Competition in {{event.location}}."/>
@@ -26,9 +27,29 @@
       {% if event.year == 2016 and event.event_type_enum == 3 %}
       <p class="pull-right"><a class="btn btn-primary" href="/event/{{event.key_name}}/insights"><span class="glyphicon glyphicon-align-left"></span> Advanced Insights</a></p>
       {% endif %}
-      <p><a class="btn btn-default" href="/events/{{event.year}}"><span class="glyphicon glyphicon-chevron-left"></span> {{event.year}} Events</a></p>
+      <div class="row">
+          <a class="btn btn-default" href="/events/{{event.year}}"><span class="glyphicon glyphicon-chevron-left"></span> {{event.year}} Events</a>
+          {% if event_divisions %}
+          <div class="btn-group">
+          <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">
+            {% if event.divisions %}Event Divisions{% elif parent_event %}Other Divisions{% endif %}
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu tba-dropdown-menu-limited">
+            {% for division in event_divisions%}
+              {% if division.key_name != event.key_name %}
+                <li><a href="/event/{{division.key_name}}">{{division.short_name}}</a></li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+      </div>
       <h1 itemprop="summary">{{event.name}} {{event.year}}</h1>
-      {% if district_name %}<blockquote><em>Part of the <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a></em></blockquote>{% endif %}
+      {% if district_name or parent_event %}<blockquote>
+          {% if district_name %}<p></p><em>Part of the <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a></em></p>{% endif %}
+          {% if parent_event %}<p><em>Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a></em></p>{% endif %}
+      </blockquote>{% endif %}
     </div>
   </div>
   <div class="row">

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -6,7 +6,8 @@ from google.appengine.ext import testbed
 from database import get_affected_queries
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery
 from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery, DistrictQuery
-from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery
+from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, \
+    EventDivisionsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
@@ -115,6 +116,15 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         )
         self.event_2016necmp.put()
 
+        self.event_2015casj = Event(
+            id='2015casj',
+            year=2015,
+            event_short='casj',
+            event_type_enum=EventType.REGIONAL,
+            parent_event=ndb.Key(Event, '2015cafoo'),
+        )
+        self.event_2015casj.put()
+
     def tearDown(self):
         self.testbed.deactivate()
 
@@ -148,7 +158,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.event_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 10)
+        self.assertEqual(len(cache_keys), 13)
         self.assertTrue(EventQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventListQuery(2014).cache_key in cache_keys)
@@ -159,6 +169,9 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(TeamEventsQuery('frc604').cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(EventDivisionsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(EventDivisionsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(EventDivisionsQuery('2015cafoo').cache_key in cache_keys)
 
     def test_event_details_updated(self):
         affected_refs = {
@@ -302,7 +315,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.district_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 11)
+        self.assertEqual(len(cache_keys), 12)
         self.assertTrue(DistrictsInYearQuery(2015).cache_key in cache_keys)
         self.assertTrue(DistrictsInYearQuery(2016).cache_key in cache_keys)
         self.assertTrue(DistrictHistoryQuery('ne').cache_key in cache_keys)
@@ -316,3 +329,4 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(DistrictEventsQuery('2016ne').cache_key in cache_keys)
         self.assertTrue(TeamEventsQuery('frc125').cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc125', 2016).cache_key in cache_keys)
+        self.assertTrue(EventDivisionsQuery('2016necmp').cache_key in cache_keys)


### PR DESCRIPTION
Adds keys for `parent_event` and `divisions` to the event model.

Works for Einstein(s) and MSC this year.

![image](https://cloud.githubusercontent.com/assets/2754863/25105304/ff4192fc-2391-11e7-815b-993a2330b0c9.png)

![image](https://cloud.githubusercontent.com/assets/2754863/25105322/0d5e13d8-2392-11e7-8eb1-9b96e7ccc2f2.png)

Closes #1895 