### PR TITLE
Add last-modified header to team event status API requests

### DIFF
--- a/controllers/apiv3/api_team_controller.py
+++ b/controllers/apiv3/api_team_controller.py
@@ -190,6 +190,7 @@ class ApiTeamEventStatusController(ApiBaseController):
 
     def _render(self, team_key, event_key):
         event_team = EventTeam.get_by_id('{}_{}'.format(event_key, team_key))
+        self._last_modified = event_team.updated
         status = None
         if event_team:
             status = event_team.status


### PR DESCRIPTION
This should fix what @ThePlasmaGuy was talking about here: https://github.com/the-blue-alliance/the-blue-alliance/issues/1507#issuecomment-295099866