### PR TITLE
Increase advanced insights prediction graph range

### DIFF
--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -174,10 +174,10 @@
   Chart.defaults.global.tooltips = false;
 
   var minQualScore = 1;
-  var maxQualScore = 199;
+  var maxQualScore = 399;
   var qualLineHeight = 0;
   var minPlayoffScore = 1;
-  var maxPlayoffScore = 199;
+  var maxPlayoffScore = 549;
   var playoffLineHeight = 0;
   for (var key in predictions) {
     var redScore = predictions[key]['red_actual_score'];


### PR DESCRIPTION
Championship prediction distributions have been off the edge of the graph. 
I think this will short-term fix it; I haven't gotten a chance to fully test it since I'm writing this PR on the drive down to St. Louis.
New numbers are based on the maximum values that I saw in Houston, rounded to the nearest 50.

Long term this should probably either be automated or parameterized; I'll think about ways to do that after season.