### PR TITLE
Changes chairman's award to use correct name ordering

### DIFF
--- a/consts/award_type.py
+++ b/consts/award_type.py
@@ -106,7 +106,7 @@ class AwardType(object):
             None: "Chairman's Award",
         },
         CHAIRMANS_FINALIST: {
-            None: "Chairman's Finalist Award",
+            None: "Chairman's Award Finalist",
         },
         WINNER: {
             None: "Winner",


### PR DESCRIPTION
Changes `"Chairman's Finalist Award"` to `"Chairman's Award Finalist"`, per the API description for the award:
```
{
  "awardId": 659,
  "eventType": "Championship",
  "description": "Chairman's Award Finalist",
  "forPerson": false
}
```