### PR TITLE
Close GameDay chat on small screens

### DIFF
--- a/react/gameday2/components/ChatSidebar.js
+++ b/react/gameday2/components/ChatSidebar.js
@@ -26,6 +26,19 @@ class ChatSidebar extends React.Component {
     this.state = {
       chatSelectorOpen: false,
     }
+
+    this.onResize = this.onResize.bind(this)
+  }
+
+  componentDidMount() {
+    this.onResize()
+    window.addEventListener('resize', this.onResize)
+  }
+
+  onResize() {
+    if (window.innerWidth < 760) {
+      this.props.setChatSidebarVisibility(false)
+    }
   }
 
   onRequestOpenChatSelector() {

--- a/react/gameday2/components/ChatSidebar.js
+++ b/react/gameday2/components/ChatSidebar.js
@@ -18,6 +18,8 @@ class ChatSidebar extends React.Component {
     currentChat: PropTypes.string.isRequired,
     setTwitchChat: PropTypes.func.isRequired,
     muiTheme: PropTypes.object.isRequired,
+    setChatSidebarVisibility: PropTypes.object.isRequired,
+    setHashtagSidebarVisibility: PropTypes.object.isRequired,
   }
 
   constructor(props) {
@@ -38,6 +40,7 @@ class ChatSidebar extends React.Component {
   onResize() {
     if (window.innerWidth < 760) {
       this.props.setChatSidebarVisibility(false)
+      this.props.setHashtagSidebarVisibility(false)
     }
   }
 

--- a/react/gameday2/containers/ChatSidebarContainer.js
+++ b/react/gameday2/containers/ChatSidebarContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { setTwitchChat } from '../actions'
+import { setTwitchChat, setChatSidebarVisibility } from '../actions'
 import ChatSidebar from '../components/ChatSidebar'
 import { getChatsInDisplayOrder } from '../selectors'
 
@@ -14,6 +14,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   setTwitchChat: (channel) => dispatch(setTwitchChat(channel)),
+  setChatSidebarVisibility: (visible) => dispatch(setChatSidebarVisibility(visible)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChatSidebar)

--- a/react/gameday2/containers/ChatSidebarContainer.js
+++ b/react/gameday2/containers/ChatSidebarContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { setTwitchChat, setChatSidebarVisibility } from '../actions'
+import { setTwitchChat, setChatSidebarVisibility, setHashtagSidebarVisibility } from '../actions'
 import ChatSidebar from '../components/ChatSidebar'
 import { getChatsInDisplayOrder } from '../selectors'
 
@@ -15,6 +15,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   setTwitchChat: (channel) => dispatch(setTwitchChat(channel)),
   setChatSidebarVisibility: (visible) => dispatch(setChatSidebarVisibility(visible)),
+  setHashtagSidebarVisibility: (visible) => dispatch(setHashtagSidebarVisibility(visible)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChatSidebar)

--- a/react/gameday2/gameday2.js
+++ b/react/gameday2/gameday2.js
@@ -11,7 +11,7 @@ import { indigo500, indigo700 } from 'material-ui/styles/colors'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import GamedayFrame from './components/GamedayFrame'
 import gamedayReducer, { firedux } from './reducers'
-import { setWebcastsRaw, setLayout, addWebcastAtPosition, setTwitchChat, setChatSidebarVisibility, setFavoriteTeams } from './actions'
+import { setWebcastsRaw, setLayout, addWebcastAtPosition, setTwitchChat, setFavoriteTeams } from './actions'
 import { MAX_SUPPORTED_VIEWS } from './constants/LayoutConstants'
 
 injectTapEventPlugin()

--- a/react/gameday2/gameday2.js
+++ b/react/gameday2/gameday2.js
@@ -140,8 +140,6 @@ firedux.ref.child('live_events').on('value', (snapshot) => {
         store.dispatch(addWebcastAtPosition(params[key], i))
       }
     }
-    // Always start with chat open
-    store.dispatch(setChatSidebarVisibility(true))
     if (params.chat) {
       store.dispatch(setTwitchChat(params.chat))
     }


### PR DESCRIPTION
It's hard to use GameDay on small/mobile screens because the chat is in the way. This will close the chat automatically if the screen size is smaller than 760px.