### PR TITLE
Update short_name regex to support numbered events

### DIFF
--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -224,16 +224,15 @@ class EventHelper(object):
         match = re.match(re_string, name_str)
         if match:
             partial = match.group(1).strip()
-            match2 = re.match(r'(.+)Event', partial)
-            if match2:
-                return match2.group(1).strip()
-            else:
-                return partial
+            match2 = re.sub(r'(?<=[\w\s])Event\s*(?:[\w\s]*$)?', '', partial)
+            return match2.strip()
 
         # district championships, other districts, and regionals
-        match = re.match(r'\s*(?:MAR |PNW |)(?:FIRST Robotics|FRC|)(.+)(?:District|Regional|Region|Provincial|State|Tournament|FRC|Field)\b', name_str)
+        name_str = re.sub(r'\s?Event','', name_str)
+        match = re.match(r'\s*(?:MAR |PNW |)(?:FIRST Robotics|FRC|)(.+)(?:District|Regional|Region|Provincial|State|Tournament|FRC|Field)(?:\b)(?:[\w\s]+?(#\d*)*)?', name_str)
+
         if match:
-            short = match.group(1)
+            short = ''.join(match.groups(''))
             match = re.match(r'(.+)(?:FIRST Robotics|FRC)', short)
             if match:
                 result = match.group(1).strip()
@@ -333,4 +332,3 @@ class EventHelper(object):
         year = event_key[:4]
         event_short = event_key[4:]
         return year == '2015' and event_short not in {'cc', 'cacc', 'mttd'}
-

--- a/tests/test_event_get_short_name.py
+++ b/tests/test_event_get_short_name.py
@@ -243,3 +243,5 @@ class TestEventGetShortName(unittest2.TestCase):
         # 2017 edge cases
         self.assertEqual(EventHelper.getShortName("ONT District - McMaster University Event"), "McMaster University")
         self.assertEqual(EventHelper.getShortName("FIRST Ontario Provincial Championship"), "Ontario")
+        self.assertEqual(EventHelper.getShortName("FIM District - Kettering University Event #1"), "Kettering University #1")
+        self.assertEqual(EventHelper.getShortName("ISR District Event #1"), "ISR #1")


### PR DESCRIPTION
The title pretty much explains it.  While the regex did get a little more complicated, I tried to also simplify the logic a little bit as well. 

I've also added the corresponding names to the tests: `tests/test_event_get_short_name.py`

Fixes #1937