### PR TITLE
Add FIRST Global link to Upcoming Events block

### DIFF
--- a/templates/index_lhc_offseason.html
+++ b/templates/index_lhc_offseason.html
@@ -3,6 +3,8 @@
 <hr>
 
 <h4 class="text-center">Upcoming Events:</h4>
+<a class="btn btn-default btn-xs pull-right" href="https://www.thebluealliance.com/gameday#chat=tbagameday&layout=0&view_0=firstglobal-0"><span class="glyphicon glyphicons-facetime-video"></span> Watch Live</a>
+<h5><b><a href="http://first.global/">FIRST Global Challenge</a><br><small>July 14-18, 2017</small></b></h5>
 <a class="btn btn-default btn-xs pull-right" href="https://www.facebook.com/events/495511237506787/"><span class="glyphicon glyphicon-calendar"></span> RSVP on Facebook</a>
 <h5><b><a href="/event/2017nhfoc"><i>FIRST</i> Festival of Champions</a><br><small>July 28-29, 2017</small></b></h5>
 


### PR DESCRIPTION
Since this isn't really an event, I'm not sure what the best way to do this is but I thought given that the event is happening right now, this could be a quick and easy fix.