### PR TITLE
Correct API Docs

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -2,10 +2,10 @@
   "swagger": "2.0",
   "info": {
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. If you are looking for the old version (v2) of the API, documentation can be found [here](/apidocs/v2). \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "title": "The Blue Alliance API v3",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "host": "www.thebluealliance.com",
   "basePath": "/api/v3",
@@ -3577,9 +3577,11 @@
             "f"
           ]
         },
+        "current_level_record": {
+          "$ref": "#definitions/WLT_Record"
+        },
         "record": {
-          "type": "string",
-          "description": "Record in playoffs as a string in the format `WINS-LOSSES-TIES`."
+          "$ref": "#definitions/WLT_Record"
         },
         "status": {
           "type": "string",
@@ -3589,6 +3591,10 @@
             "eliminated",
             "playing"
           ]
+        },
+        "playoff_average": {
+          "type": "integer",
+          "description": "The average match score during playoffs. Year specific. May be null if not relevant for a given year."
         }
       },
       "description": "Playoff status for this team, may be null if the team did not make playoffs, or playoffs have not begun."
@@ -3630,17 +3636,7 @@
                 "description": "The team's rank at the event as provided by FIRST."
               },
               "record": {
-                "properties": {
-                  "qualifications": {
-                    "$ref": "#/definitions/WLT_Record",
-                    "description": "W-L-T record in qualification matches."
-                  },
-                  "overall": {
-                    "$ref": "#/definitions/WLT_Record",
-                    "description": "W-L-T record across all matches at an event."
-                  }
-                },
-                "description": "Win-Loss-Tie record information, if available. May be null."
+                "$ref": "#/definitions/WLT_Record"
               },
               "sort_orders": {
                 "type": "array",


### PR DESCRIPTION
`Team_Event_Status` and `Event_Ranking` models updated to reflect actual API return values. Changes centered on W-L-T and related properties.

Fixes #1967 