### PR TITLE
Allow Skipping Deployment via Commit Message

### DIFF
--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -26,13 +26,22 @@ fetch_apiv3_status() {
 }
 
 check_killswitch() {
-    ENABLED=$(fetch_apiv3_status | jq '.contbuild_enabled')
-    if [ "$ENABLED" != "true" ]; then
+    enabled=$(fetch_apiv3_status | jq '.contbuild_enabled')
+    if [ "$enabled" != "true" ]; then
         echo "Continuous Deployment disabled via killswitch..."
         exit 0
     fi
 }
 
+check_commit_tag() {
+    # The most recent commit message
+    msg=$(git log -1 --pretty=%B)
+    case "$msg" in
+        *\[nodeploy\]*) echo "Skipping due to [nodeploy] tag"; exit 0 ;;
+    esac
+}
+
+check_commit_tag
 check_killswitch
 
 echo "python 2.7 version:"


### PR DESCRIPTION
Put `[nodeploy]` in the commit message somewhere and we'll skip deploying it