### PR TITLE
Add media tag API endpoint

### DIFF
--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -67,8 +67,13 @@ app = webapp2.WSGIApplication([
         atc.ApiTeamYearMatchesController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/team/<team_key:>/matches/<year:([0-9]+)>/<model_type:(simple|keys)>',
         atc.ApiTeamYearMatchesController, methods=['GET', 'OPTIONS']),
+    # Team Media
     webapp2.Route(r'/api/v3/team/<team_key:>/media/<year:([0-9]+)>',
         atc.ApiTeamYearMediaController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/team/<team_key:>/media/tag/<tag>',
+        atc.ApiTeamTagMediaController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/team/<team_key:>/media/tag/<tag>/<year:[0-9]+>',
+        atc.ApiTeamTagMediaController, methods=['GET', 'OPTIONS']),
     # Team Media Suggestions
     webapp2.Route(r'/api/v3/suggest/media/team/<team_key:>/<year:([0-9]+)>',
         asgc.ApiSuggestTeamMediaController, methods=['POST', 'OPTIONS']),

--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -8,6 +8,7 @@ from controllers.apiv3 import api_status_controller as asc
 from controllers.apiv3 import api_district_controller as adc
 from controllers.apiv3 import api_event_controller as aec
 from controllers.apiv3 import api_match_controller as amc
+from controllers.apiv3 import api_media_controller as amec
 from controllers.apiv3 import api_team_controller as atc
 from controllers.apiv3 import api_suggest_controller as asgc
 
@@ -104,6 +105,9 @@ app = webapp2.WSGIApplication([
         amc.ApiMatchController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/match/<match_key:>/<model_type:(simple)>',
         amc.ApiMatchController, methods=['GET', 'OPTIONS']),
+    # Media
+    webapp2.Route(r'/api/v3/media/tags',
+        amec.ApiMediaTagsController, methods=['GET', 'OPTIONS']),
     # District List
     webapp2.Route(r'/api/v3/districts/<year:([0-9]+)>',
         adc.ApiDistrictListController, methods=['GET', 'OPTIONS']),

--- a/consts/media_tag.py
+++ b/consts/media_tag.py
@@ -10,8 +10,22 @@ class MediaTag(object):
         CHAIRMANS_ESSAY: 'Chairman\'s Essay',
     }
 
+    tag_url_names = {
+        CHAIRMANS_VIDEO: 'chairmans_video',
+        CHAIRMANS_PRESENTATION: 'chairmans_presentation',
+        CHAIRMANS_ESSAY: 'chairmans_essay',
+    }
+
     chairmans_tags = [
         CHAIRMANS_VIDEO,
         CHAIRMANS_PRESENTATION,
         CHAIRMANS_ESSAY,
     ]
+
+    @classmethod
+    def get_enum_from_url(self, url_name):
+        inversed = {v: k for k, v in self.tag_url_names.items()}
+        if url_name in inversed:
+            return inversed[url_name]
+        else:
+            return None

--- a/controllers/apiv3/api_media_controller.py
+++ b/controllers/apiv3/api_media_controller.py
@@ -1,0 +1,24 @@
+import json
+
+from controllers.apiv3.api_base_controller import ApiBaseController
+from consts.media_tag import MediaTag
+
+
+class ApiMediaTagsController(ApiBaseController):
+    CACHE_VERSION = 0
+    CACHE_HEADER_LENGTH = 61
+
+    def _track_call(self):
+        self._track_call_defer('media/tags', 'media/tags')
+
+    def _render(self):
+        tagData = zip(MediaTag.tag_names, MediaTag.tag_url_names)
+
+        mediaTags = []
+        for index in MediaTag.tag_names:
+            mediaTags.append({
+                'name': MediaTag.tag_names[index],
+                'code': MediaTag.tag_url_names[index]
+            })
+
+        return json.dumps(mediaTags, ensure_ascii=True, indent=2, sort_keys=False)

--- a/controllers/apiv3/api_team_controller.py
+++ b/controllers/apiv3/api_team_controller.py
@@ -3,12 +3,14 @@ import json
 
 from google.appengine.ext import ndb
 
+from consts.media_tag import MediaTag
+
 from controllers.apiv3.api_base_controller import ApiBaseController
 from controllers.apiv3.model_properties import filter_event_properties, filter_team_properties, filter_match_properties
 from database.award_query import TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery
 from database.event_query import TeamEventsQuery, TeamYearEventsQuery
 from database.match_query import TeamEventMatchesQuery, TeamYearMatchesQuery
-from database.media_query import TeamYearMediaQuery, TeamSocialMediaQuery
+from database.media_query import TeamYearMediaQuery, TeamSocialMediaQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
 from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, TeamParticipationQuery, TeamDistrictsQuery
 from database.robot_query import TeamRobotsQuery
 from helpers.event_team_status_helper import EventTeamStatusHelper
@@ -246,6 +248,27 @@ class ApiTeamYearMediaController(ApiBaseController):
 
     def _render(self, team_key, year):
         medias, self._last_modified = TeamYearMediaQuery(team_key, int(year)).fetch(dict_version=3, return_updated=True)
+
+        return json.dumps(medias, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+class ApiTeamTagMediaController(ApiBaseController):
+    CACHE_VERSION = 0
+    CACHE_HEADER_LENGTH = 61
+
+    def _track_call(self, team_key, tag, year=None):
+        api_label = team_key
+        api_label += '/{}'.format(tag)
+        if year:
+            api_label += '/{}'.format(year)
+        self._track_call_defer('team/media/tag', api_label)
+
+    def _render(self, team_key, tag, year=None):
+        media_tag_enum = MediaTag.get_enum_from_url(tag)
+        if year:
+            medias, self._last_modified = TeamYearTagMediasQuery(team_key, int(year), media_tag_enum).fetch(dict_version=3, return_updated=True)
+        else:
+            medias, self._last_modified = TeamTagMediasQuery(team_key, media_tag_enum).fetch(dict_version=3, return_updated=True)
 
         return json.dumps(medias, ensure_ascii=True, indent=2, sort_keys=True)
 

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -7,7 +7,7 @@ from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
-    EventMediasQuery, TeamTagMediasQuery
+    EventMediasQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
 from database.robot_query import TeamRobotsQuery
 from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
 
@@ -127,6 +127,8 @@ def media_updated(affected_refs):
         if reference_key.kind() == 'Team':
             for year in years:
                 queries_and_keys.append((TeamYearMediaQuery(reference_key.id(), year)))
+                for media_tag in media_tags:
+                    queries_and_keys.append((TeamYearTagMediasQuery(reference_key.id(), media_tag, year)))
             for media_tag in media_tags:
                 queries_and_keys.append((TeamTagMediasQuery(reference_key.id(), media_tag)))
             queries_and_keys.append((TeamSocialMediaQuery(reference_key.id())))

--- a/database/media_query.py
+++ b/database/media_query.py
@@ -113,3 +113,20 @@ class TeamTagMediasQuery(DatabaseQuery):
             Media.references == team_key,
             Media.media_tag_enum == media_tag_enum).fetch_async()
         raise ndb.Return(medias)
+
+
+class TeamYearTagMediasQuery(DatabaseQuery):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = 'team_year_tag_medias_{}_{}_{}'  # (team_key, year, media_tag_enum)
+    DICT_CONVERTER = MediaConverter
+
+    @ndb.tasklet
+    def _query_async(self):
+        team_key = ndb.Key(Team, self._query_args[0])
+        year = self._query_args[1]
+        media_tag_enum = self._query_args[2]
+        medias = yield Media.query(
+            Media.references == team_key,
+            Media.year == year,
+            Media.media_tag_enum == media_tag_enum).fetch_async()
+        raise ndb.Return(medias)

--- a/helpers/cache_clearer.py
+++ b/helpers/cache_clearer.py
@@ -8,7 +8,7 @@ from controllers.api.api_match_controller import ApiMatchController
 from controllers.api.api_team_controller import ApiTeamController, ApiTeamEventsController, ApiTeamEventAwardsController, \
                                                 ApiTeamEventMatchesController, ApiTeamMediaController, ApiTeamYearsParticipatedController, \
                                                 ApiTeamListController, ApiTeamHistoryEventsController, ApiTeamHistoryAwardsController, ApiTeamHistoryRobotsController, \
-    ApiTeamHistoryDistrictsController
+                                                ApiTeamHistoryDistrictsController
 from database import get_affected_queries
 
 from models.district import District
@@ -149,8 +149,11 @@ class CacheClearer(object):
         """
         reference_keys = affected_refs['references']
         years = affected_refs['year']
+        media_tag_enums = affected_refs['media_tag_enum']
 
-        return cls._get_media_cache_keys_and_controllers(reference_keys, years) + \
+        tags = map(lambda media_tag_enum: MediaTag.tag_url_names[media_tag_enum], media_tag_enums)
+
+        return cls._get_media_cache_keys_and_controllers(reference_keys, years, tags) + \
             cls._queries_to_cache_keys_and_controllers(get_affected_queries.media_updated(affected_refs))
 
     @classmethod
@@ -287,7 +290,7 @@ class CacheClearer(object):
         return cache_keys_and_controllers
 
     @classmethod
-    def _get_media_cache_keys_and_controllers(cls, team_keys, years):
+    def _get_media_cache_keys_and_controllers(cls, team_keys, years, tags):
         cache_keys_and_controllers = []
         for team_key in filter(None, team_keys):
             for year in filter(None, years):

--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -73,6 +73,13 @@
       "type": "number",
       "format": "integer"
     },
+    "media_tag": {
+      "name": "media_tag",
+      "in": "path",
+      "description": "Media Tag which describes the Media.",
+      "required": true,
+      "type": "string"
+    },
     "team_key": {
       "name": "team_key",
       "in": "path",
@@ -1558,6 +1565,113 @@
           },
           {
             "$ref": "#/parameters/team_key"
+          },
+          {
+            "$ref": "#/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Media"
+              }
+            },
+            "headers": {
+              "Last-Modified": {
+                "type": "string",
+                "description": "Indicates the date and time the data returned was last updated. Used by clients in the `If-Modified-Since` request header."
+              },
+              "Cache-Control": {
+                "type": "string",
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly."
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/media/tag/{media_tag}": {
+      "get": {
+        "operationId": "getTeamMediaByTag",
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Media (videos / pictures) for the given team and tag.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          },
+          {
+            "$ref": "#/parameters/team_key"
+          },
+          {
+            "$ref": "#/parameters/media_tag"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Media"
+              }
+            },
+            "headers": {
+              "Last-Modified": {
+                "type": "string",
+                "description": "Indicates the date and time the data returned was last updated. Used by clients in the `If-Modified-Since` request header."
+              },
+              "Cache-Control": {
+                "type": "string",
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly."
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/media/tag/{media_tag}/{year}": {
+      "get": {
+        "operationId": "getTeamMediaByTagYear",
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Media (videos / pictures) for the given team, tag and year.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          },
+          {
+            "$ref": "#/parameters/team_key"
+          },
+          {
+            "$ref": "#/parameters/media_tag"
           },
           {
             "$ref": "#/parameters/year"

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -218,7 +218,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         affected_refs = {
             'references': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
             'year': {2014, 2015},
-            'media_tag_enum': {None, MediaTag.CHAIRMANS_VIDEO},
+            'media_tag_enum': {MediaTag.CHAIRMANS_ESSAY, MediaTag.CHAIRMANS_VIDEO},
         }
         cache_keys = [q.cache_key for q in get_affected_queries.media_updated(affected_refs)]
 
@@ -233,8 +233,10 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(EventTeamsMediasQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventTeamsPreferredMediasQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventTeamsPreferredMediasQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(TeamTagMediasQuery('frc254', MediaTag.CHAIRMANS_VIDEO).cache_key in cache_keys)
+        self.assertTrue(TeamTagMediasQuery('frc254', MediaTag.CHAIRMANS_ESSAY).cache_key in cache_keys)
         self.assertTrue(TeamTagMediasQuery('frc604', MediaTag.CHAIRMANS_VIDEO).cache_key in cache_keys)
+        self.assertTrue(TeamYearTagMediasQuery('frc254', MediaTag.CHAIRMANS_ESSAY, 2014).cache_key in cache_keys)
+        self.assertTrue(TeamYearTagMediasQuery('frc604', MediaTag.CHAIRMANS_VIDEO, 2015).cache_key in cache_keys)
 
     def test_media_updated_event(self):
         affected_refs = {

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -11,7 +11,7 @@ from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
-    EventMediasQuery, TeamTagMediasQuery
+    EventMediasQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
 from database.robot_query import TeamRobotsQuery
 from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
 

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -222,7 +222,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.media_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 12)
+        self.assertEqual(len(cache_keys), 22)
         self.assertTrue(TeamYearMediaQuery('frc254', 2014).cache_key in cache_keys)
         self.assertTrue(TeamYearMediaQuery('frc254', 2015).cache_key in cache_keys)
         self.assertTrue(TeamSocialMediaQuery('frc254').cache_key in cache_keys)


### PR DESCRIPTION
Adds ~~two~~ three API endpoints for querying media based on tags:

- `/api/v3/team/<team_key>/media/tag/<tag>`
- `/api/v3/team/<team_key>/media/tag/<tag>/<year:[0-9]+>`
- `/api/v3/media/tags`

### TODO:

- [x] Add endpoint to list available tags?