### PR TITLE
Fixed nesting of awards_posted example

### DIFF
--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -156,7 +156,7 @@
             </ul>
           <h4>Example JSON</h4>
             <pre class="example-json">
-            {"message_data": {"event_name": "New England FRC Region Championship", "awards": [{"event_key": "2014necmp", "award_type": 0, "name": "Regional Chairman's Award", "recipient_list": [{"team_number": 2067, "awardee": null}, {"team_number": 78, "awardee": null}, {"team_number": 811, "awardee": null}, {"team_number": 2648, "awardee": null}], "year": 2014}], "message_type": "awards_posted"} }
+            {"message_data": {"event_name": "New England FRC Region Championship", "awards": [{"event_key": "2014necmp", "award_type": 0, "name": "Regional Chairman's Award", "recipient_list": [{"team_number": 2067, "awardee": null}, {"team_number": 78, "awardee": null}, {"team_number": 811, "awardee": null}, {"team_number": 2648, "awardee": null}], "year": 2014}]}, "message_type": "awards_posted"}
             </pre>
         {% if types.awards_posted in enabled %}
         <h4>Test Notification</h4>


### PR DESCRIPTION
Previously, the message_type field was nested inside the message_data field in the example for the Awards Posted notification webhook. They now are both nested under the top level of the notification.