### PR TITLE
Create Container-Based Dev Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ static/javascript/tba_js/tba_keys.js
 ops/deploy_keys.tar
 ops/tbatv-prod-hrd-deploy.json
 test_keys.json
+
+# Vagrant #
+###########
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ If you're having trouble getting set up, reach out to us at [our mailing list](h
 
 Setup
 -----
+We have a beta development container setup that uses [`vagrant`](https://www.vagrantup.com/)+[`docker`](https://www.docker.com/). Install those two dependencies for your system, then run `vagrant up --provider=docker && vagrant rsync-auto` to bootstrap the environment and kick off file syncing.
+
+To debug, ssh into the container using `vagrant ssh` and then run `tmux attach` to see the GAE devserver logs (use `^B-D` to detach from tmux).
+
+Setup (manual)
+--------------
 1. Learn a bit about Git and GitHub:
   * Install git on your PATH
   * [GitHub help](https://help.github.com/)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,52 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby:expandtab:tabstop=2:softtabstop=2
+
+Vagrant.configure("2") do |config|
+
+  # Sync the TBA code directory
+  config.vm.synced_folder "./", "/tba",
+    type: "rsync",
+    owner: "root",
+    group: "root",
+    rsync__rsync_path: "rsync",
+    rsync__exclude: [
+      ".git/"
+    ],
+    rsync__auto: true
+
+  # Forward GAE modules
+  ports = []
+  for i in 8080..8089
+    ports.push("#{i}:#{i}")
+    config.vm.network "forwarded_port", guest: i, host: i
+  end
+
+  # Forward GAE admin
+  ports.push("8000:8000")
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+
+  # Provision with docker
+  config.vm.hostname = "tba-docker"
+  config.vm.provider "docker" do |d|
+    d.build_dir = "ops/dev"
+    d.ports = ports
+    d.has_ssh = true
+  end
+
+  # Configure ssh into container
+  config.ssh.insert_key = true
+  config.ssh.username = "root"
+  config.ssh.password = "tba"
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+
+  # Provision dependencies
+  config.vm.provision "shell",
+    inline: "cd /tba && ./ops/dev/bootstrap-dev-container.sh",
+    privileged: false
+ 
+  # Start the GAE devserver
+  config.vm.provision "shell",
+    inline: "cd /tba && ./ops/dev/start-devserver.sh",
+    privileged: false,
+    run: "always"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,9 @@ Vagrant.configure("2") do |config|
     group: "root",
     rsync__rsync_path: "rsync",
     rsync__exclude: [
-      ".git/"
+      ".git/",
+      "node_modules/",
+      "lib",
     ],
     rsync__auto: true
 

--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:16.04
+MAINTAINER The Blue Alliance
+
+# Set debconf to run non-interactively
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Get apt dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  wget \
+  unzip \
+  sudo \
+  python2.7 \
+  python2.7-dev \
+  python-pip \
+  build-essential \
+  checkinstall \
+  libssl-dev \
+  tmux \
+  openssh-server
+
+# Configure ssh server
+RUN mkdir /var/run/sshd
+RUN echo 'root:tba' | chpasswd
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+EXPOSE 22
+
+# Get appengine environment
+ENV GAE_VERSION 1.9.61
+RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -nv
+RUN unzip -q google_appengine_$GAE_VERSION.zip
+
+# Set up nvm and nodejs
+ENV NVM_DIR /nvm
+ENV NODE_VERSION 8.0.0
+RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION --silent \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default --silent
+
+# Expose ports for TBA
+EXPOSE 8000
+EXPOSE 8080-8089
+
+# Start SSH server
+CMD ["/usr/sbin/sshd", "-D"]

--- a/ops/dev/bootstrap-dev-container.sh
+++ b/ops/dev/bootstrap-dev-container.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+set -e
+
+source ops/dev/vars.sh
+
+npm install uglify-js@2.7.0 -g --silent
+npm install -g gulp-cli uglify-es uglifycss less request --silent
+
+pip install --upgrade pip
+pip install --upgrade -r requirements.txt
+pip install --upgrade -r travis_requirements.txt -t lib
+paver install_libs
+npm install
+
+paver make

--- a/ops/dev/start-devserver.sh
+++ b/ops/dev/start-devserver.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+set -e
+
+source ops/dev/vars.sh
+echo "Starting devserver in tmux session..."
+tmux new-session -d "paver devserver; read"

--- a/ops/dev/vars.sh
+++ b/ops/dev/vars.sh
@@ -1,0 +1,11 @@
+# Constants for env config
+GAE_DIR=/google_appengine
+NVM_DIR=/nvm
+NODE_VERSION=8.0.0
+NODE_DIR=${NVM_DIR}/versions/node/v${NODE_VERSION}
+
+# First, configure environment
+export PYTHONPATH="${PYTHONPATH}:${GAE_DIR}"
+export NODE_PATH="${NODE_DIR}/lib/node_modules"
+export PATH="${PATH}:${GAE_DIR}:${NODE_DIR}/bin"
+

--- a/pavement.py
+++ b/pavement.py
@@ -172,6 +172,7 @@ def bootstrap(options):
     print "Running {}".format(subprocess.list2cmdline(args))
     subprocess.call(args)
 
+
 @task
 def devserver():
     sh("dev_appserver.py --skip_sdk_update_check=true --host=0.0.0.0 dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml")

--- a/pavement.py
+++ b/pavement.py
@@ -93,10 +93,14 @@ def make():
     less()
     jinja2()
 
-    git_branch_name = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    git_last_commit = subprocess.check_output(["git", "log", "-1"])
     build_time = time.ctime()
     travis_job = os.environ.get('TRAVIS_BUILD_ID', '')
+    try:
+        git_branch_name = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        git_last_commit = subprocess.check_output(["git", "log", "-1"])
+    except Exception:
+        git_branch_name = 'dev'
+        git_last_commit = 'dev'
     data = {"git_branch_name": git_branch_name,
             "git_last_commit": git_last_commit,
             "build_time": build_time,
@@ -167,6 +171,10 @@ def bootstrap(options):
     args = ["python", "bootstrap.py", "--url", url, key]
     print "Running {}".format(subprocess.list2cmdline(args))
     subprocess.call(args)
+
+@task
+def devserver():
+    sh("dev_appserver.py --skip_sdk_update_check=true --host=0.0.0.0 dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml")
 
 
 def test_function(args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jinja2==2.6
 numpy==1.6.1
 Paver==1.2.4
 pep8==1.7.0
+pyyaml


### PR DESCRIPTION
Using [`vagrant`](https://www.vagrantup.com/)+[`docker`](https://www.docker.com/).

Test it out by running `vagrant up --provider=docker && vagrant rsync-auto` and then going to `localhost:8080`.

To debug, ssh into the container using `vagrant ssh` and then run `tmux attach` to see the GAE devserver logs (use `^B-D` to detach from tmux).