### PR TITLE
Add trusted API endpoint for event info

### DIFF
--- a/api_main.py
+++ b/api_main.py
@@ -20,7 +20,7 @@ from controllers.api.api_status_controller import ApiStatusController
 from controllers.api.api_trusted_controller import ApiTrustedEventAllianceSelectionsUpdate, ApiTrustedEventAwardsUpdate, \
                                                    ApiTrustedEventMatchesUpdate, ApiTrustedEventMatchesDelete, ApiTrustedEventMatchesDeleteAll, ApiTrustedEventRankingsUpdate, \
                                                    ApiTrustedEventTeamListUpdate, ApiTrustedAddMatchYoutubeVideo, \
-    ApiTrustedAddEventMedia
+                                                   ApiTrustedAddEventMedia, ApiTrustedUpdateEventInfo
 
 # Ensure that APIv2 routes include OPTIONS method for CORS preflight compatibility
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
@@ -135,5 +135,8 @@ app = webapp2.WSGIApplication([webapp2.Route(r'/api/v1/<:.*>',
                                              methods=['POST', 'OPTIONS']),
                                webapp2.Route(r'/api/trusted/v1/event/<event_key:>/media/add',
                                              ApiTrustedAddEventMedia,
-                                             methods=['POST', 'OPTIONS'])
+                                             methods=['POST', 'OPTIONS']),
+                               webapp2.Route(r'/api/trusted/v1/event/<event_key:>/info/update',
+                                             ApiTrustedUpdateEventInfo,
+                                             methods=['POST', 'OPTIONS']),
                                ], debug=tba_config.DEBUG)

--- a/consts/auth_type.py
+++ b/consts/auth_type.py
@@ -11,6 +11,7 @@ class AuthType(object):
     EVENT_RANKINGS = 4
     EVENT_ALLIANCES = 5
     EVENT_AWARDS = 6
+    EVENT_INFO = 7
 
     # Read Type
     READ_API = 1000
@@ -22,5 +23,6 @@ class AuthType(object):
         EVENT_MATCHES: "event matches",
         EVENT_RANKINGS: "event rankings",
         EVENT_ALLIANCES: "event alliances",
-        EVENT_AWARDS: "event awards"
+        EVENT_AWARDS: "event awards",
+        EVENT_INFO: "event info",
     }

--- a/controllers/api/api_trusted_controller.py
+++ b/controllers/api/api_trusted_controller.py
@@ -305,7 +305,6 @@ class ApiTrustedUpdateEventInfo(ApiTrustedBaseController):
 
     ALLOWED_EVENT_PARAMS = {
         "first_code",
-        "official",
         "playoff_type",
         "webcasts",  # this is a list of stream URLs, we'll mutate it ourselves
     }
@@ -339,6 +338,7 @@ class ApiTrustedUpdateEventInfo(ApiTrustedBaseController):
                         {"Error": "Invalid json. Check input"}
                     )
                     self.abort(400)
+                    return
                 webcast_list = [
                     WebcastParser.webcast_dict_from_url(url) for url in value
                 ]
@@ -350,6 +350,8 @@ class ApiTrustedUpdateEventInfo(ApiTrustedBaseController):
             else:
                 try:
                     setattr(event, field, value)
+                    if field == "first_code":
+                        event.official = value is not None
                 except Exception, e:
                     self._errors({
                         "Error": "Unable to set event field",

--- a/helpers/event/event_webcast_adder.py
+++ b/helpers/event/event_webcast_adder.py
@@ -7,10 +7,12 @@ from helpers.memcache.memcache_webcast_flusher import MemcacheWebcastFlusher
 class EventWebcastAdder(object):
 
     @classmethod
-    def add_webcast(cls, event, webcast):
+    def add_webcast(cls, event, webcast, update=True):
         """Takes a webcast dictionary and adds it to an event"""
 
-        if event.webcast:
+        if isinstance(webcast, list):
+            event.webcast_json = json.dumps(webcast)
+        elif event.webcast:
             webcasts = event.webcast
             if webcast in webcasts:
                 return event
@@ -20,8 +22,10 @@ class EventWebcastAdder(object):
         else:
             event.webcast_json = json.dumps([webcast])
         event.dirty = True
-        EventManipulator.createOrUpdate(event)
-        MemcacheWebcastFlusher.flushEvent(event.key_name)
+
+        if update:
+            EventManipulator.createOrUpdate(event)
+            MemcacheWebcastFlusher.flushEvent(event.key_name)
 
         return event
 

--- a/static/swagger/api_trusted_v1.json
+++ b/static/swagger/api_trusted_v1.json
@@ -56,6 +56,28 @@
     "authSig": []
   ],
   "paths": {
+    "/event/{eventKey}/info/update": {
+      "post": {
+        "tags": [
+          "Event Details"
+         ],
+         "summary": "Update top-level properties for the event",
+         "description": "An endpoint to overwrite certain event fields",
+         "operationId": "updateEventInfo",
+         "parameters": [
+           { "$ref": "#/parameters/eventKeyParam" },
+           {
+             "name": "eventInfo",
+             "in": "body",
+             "description": "A JSON dictionary, mapping property name to the new value.",
+             "required": true,
+             "schema": {
+               "$ref": "#/definitions/EventInfo"
+             }
+           }
+         ]
+      }
+    },
      "/event/{eventKey}/alliance_selections/update": {
        "post": {
          "tags": [
@@ -463,6 +485,34 @@
           "type": "string",
           "description": "Name of the individual winning this award. Can be null",
           "example": "Bob Bobby"
+        }
+      }
+    },
+    "EventInfo": {
+      "type": "object",
+      "properties": {
+        "first_code": {
+          "type": "string",
+          "description": "Event code used to sync data with FIRST",
+          "example": "IRI"
+        },
+        "official": {
+          "type": "boolean",
+          "description": "Should TBA automatically sync results for this event?"
+        },
+        "playoff_type": {
+          "type": "integer",
+          "description": "Integer constant representing the playoff format. References constants here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py",
+          "example": "0"
+        },
+        "webcasts": {
+          "type": "array",
+          "description": "A list of webcast URLs to set for this event",
+          "items": {
+            "type": "string",
+            "description": "A webcast URL",
+            "example": "https://youtu.be/THbUtPIQcOY"
+          }
         }
       }
     },

--- a/static/swagger/api_trusted_v1.json
+++ b/static/swagger/api_trusted_v1.json
@@ -496,10 +496,6 @@
           "description": "Event code used to sync data with FIRST",
           "example": "IRI"
         },
-        "official": {
-          "type": "boolean",
-          "description": "Should TBA automatically sync results for this event?"
-        },
         "playoff_type": {
           "type": "integer",
           "description": "Integer constant representing the playoff format. References constants here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py",

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -617,9 +617,9 @@ class TestApiTrustedController(unittest2.TestCase):
 
         request = {
             'first_code': 'abc123',
-            'official': True,
             'playoff_type': PlayoffType.ROUND_ROBIN_6_TEAM,
             'webcasts': ['https://youtu.be/abc123'],
+            'someother': 'randomstuff',  # This should be ignored
         }
         request_body = json.dumps(request)
         request_path = '/api/trusted/v1/event/2014casj/info/update'


### PR DESCRIPTION
Will provide a way (eventually exposed in eventwizard2) for event managers to change some limited properties about their events. This will include:

 - FIRST event code (so they can manually enable syncing)
 - Webcasts
 - Playoff Type

I still need to do some testing and update the docs, but feedback (as well as other fields?) is appreciated