### PR TITLE
[vagrant bootstrap] Fix bug preventing provisioning multiple times

### DIFF
--- a/ops/dev/bootstrap-dev-container.sh
+++ b/ops/dev/bootstrap-dev-container.sh
@@ -17,6 +17,6 @@ paver install_libs
 npm install
 
 # Put in a dummy keys so that paver make works
-mv static/javascript/tba_js/tba_keys_template.js static/javascript/tba_js/tba_keys.js
+cp static/javascript/tba_js/tba_keys_template.js static/javascript/tba_js/tba_keys.js
 
 paver make


### PR DESCRIPTION
The first time this runs, the template gets renamed. So it fails the second time