### PR TITLE
Store, display, and expose match DQ info. Fixes #1959

### DIFF
--- a/database/dict_converters/match_converter.py
+++ b/database/dict_converters/match_converter.py
@@ -23,6 +23,7 @@ class MatchConverter(ConverterBase):
         for alliance in ['red', 'blue']:
             match.alliances[alliance]['team_keys'] = match.alliances[alliance].pop('teams')
             match.alliances[alliance]['surrogate_team_keys'] = match.alliances[alliance].pop('surrogates')
+            match.alliances[alliance]['dq_team_keys'] = match.alliances[alliance].pop('dqs')
 
         match_dict = {
             'key': match.key.id(),

--- a/database/dict_converters/match_converter.py
+++ b/database/dict_converters/match_converter.py
@@ -4,7 +4,7 @@ from database.dict_converters.converter_base import ConverterBase
 
 class MatchConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        3: 5,
+        3: 6,
     }
 
     @classmethod

--- a/database/match_query.py
+++ b/database/match_query.py
@@ -7,7 +7,7 @@ from models.match import Match
 
 
 class MatchQuery(DatabaseQuery):
-    CACHE_VERSION = 0
+    CACHE_VERSION = 1
     CACHE_KEY_FORMAT = 'match_{}'  # (match_key)
     DICT_CONVERTER = MatchConverter
 
@@ -19,7 +19,7 @@ class MatchQuery(DatabaseQuery):
 
 
 class EventMatchesQuery(DatabaseQuery):
-    CACHE_VERSION = 0
+    CACHE_VERSION = 1
     CACHE_KEY_FORMAT = 'event_matches_{}'  # (event_key)
     DICT_CONVERTER = MatchConverter
 
@@ -32,7 +32,7 @@ class EventMatchesQuery(DatabaseQuery):
 
 
 class TeamEventMatchesQuery(DatabaseQuery):
-    CACHE_VERSION = 0
+    CACHE_VERSION = 1
     CACHE_KEY_FORMAT = 'team_event_matches_{}_{}'  # (team_key, event_key)
     DICT_CONVERTER = MatchConverter
 
@@ -48,7 +48,7 @@ class TeamEventMatchesQuery(DatabaseQuery):
 
 
 class TeamYearMatchesQuery(DatabaseQuery):
-    CACHE_VERSION = 0
+    CACHE_VERSION = 1
     CACHE_KEY_FORMAT = 'team_year_matches_{}_{}'  # (team_key, year)
     DICT_CONVERTER = MatchConverter
 

--- a/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -74,6 +74,8 @@ class FMSAPIHybridScheduleParser(object):
             blue_teams = []
             red_surrogates = []
             blue_surrogates = []
+            red_dqs = []
+            blue_dqs = []
             team_key_names = []
             null_team = False
             sorted_teams = sorted(match['Teams'], key=lambda team: team['station'])  # Sort by station to ensure correct ordering. Kind of hacky.
@@ -86,10 +88,14 @@ class FMSAPIHybridScheduleParser(object):
                     red_teams.append(team_key)
                     if team['surrogate']:
                         red_surrogates.append(team_key)
+                    if team['dq']:
+                        red_dqs.append(team_key)
                 elif 'Blue' in team['station']:
                     blue_teams.append(team_key)
                     if team['surrogate']:
                         blue_surrogates.append(team_key)
+                    if team['dq']:
+                        blue_dqs.append(team_key)
 
             if null_team and match['scoreRedFinal'] is None and match['scoreBlueFinal'] is None:
                 continue
@@ -98,11 +104,13 @@ class FMSAPIHybridScheduleParser(object):
                 'red': {
                     'teams': red_teams,
                     'surrogates': red_surrogates,
+                    'dqs': red_dqs,
                     'score': match['scoreRedFinal']
                 },
                 'blue': {
                     'teams': blue_teams,
                     'surrogates': blue_surrogates,
+                    'dqs': blue_dqs,
                     'score': match['scoreBlueFinal']
                 },
             }

--- a/models/match.py
+++ b/models/match.py
@@ -52,11 +52,13 @@ class Match(ndb.Model):
     #   "red": {
     #     "teams": ["frc177", "frc195", "frc125"], # These are Team keys
     #     "surrogates": ["frc177", "frc195"],
+    #     "dqs": [],
     #     "score": 25
     #   },
     #   "blue": {
     #     "teams": ["frc433", "frc254", "frc222"],
     #     "surrogates": ["frc433"],
+    #     "dqs": ["frc433"],
     #     "score": 12
     #   }
     # }

--- a/static/css/less_css/less/tba/tba_match_table.less
+++ b/static/css/less_css/less/tba/tba_match_table.less
@@ -149,10 +149,14 @@ table.match-table .top-left-dot-2 {
   width: 4px;
 }
 
-table.match-table .tooltip-inner{
+table.match-table .tooltip-inner {
   width: 130px;
 }
 
 table.match-table .surrogate {
   border-bottom: 1px dotted;
+}
+
+table.match-table .dq {
+  text-decoration: line-through;
 }

--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -4540,6 +4540,14 @@
             "type": "string",
             "description": "Team key of a surrogate team."
           }
+        },
+        "dq_team_keys": {
+          "type": "array",
+          "description": "TBA team keys (eg `frc254`) of any disqualified teams.",
+          "items": {
+            "type": "string",
+            "description": "Team key of a disqualified team."
+          }
         }
       }
     },

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -62,7 +62,7 @@
   {% if fake_matches %}
   {{ team_key|strip_frc }}
   {% else %}
-  <a href="/team/{{team_key|digits}}/{{match.year}}"{% if team_key in match.alliances.get(alliance_color).surrogates %} class="surrogate" rel="tooltip" title="Team {{team_key|strip_frc}} is playing as a surrogate."{% endif %}>{{ team_key|strip_frc }}</a>
+  <a href="/team/{{team_key|digits}}/{{match.year}}"{% if team_key in match.alliances.get(alliance_color).surrogates and team_key in match.alliances.get(alliance_color).dqs %} class="surrogate dq" rel="tooltip" title="Surrogate | DQ"{% elif team_key in match.alliances.get(alliance_color).surrogates %} class="surrogate" rel="tooltip" title="Surrogate"{% elif team_key in match.alliances.get(alliance_color).dqs %} class="dq" rel="tooltip" title="DQ"{% endif %}>{{ team_key|strip_frc }}</a>
   {% endif %}
 </td>
 {% endmacro %}

--- a/tests/test_fms_api_event_parser.py
+++ b/tests/test_fms_api_event_parser.py
@@ -75,7 +75,7 @@ class TestFMSAPIEventParser(unittest2.TestCase):
         self.assertEqual(match.set_number, 1)
         self.assertEqual(match.match_number, 1)
         self.assertEqual(match.team_key_names, [u'frc4131', u'frc4469', u'frc3663', u'frc3684', u'frc5295', u'frc2976'])
-        self.assertEqual(match.alliances_json, """{"blue": {"surrogates": [], "score": 30, "teams": ["frc4131", "frc4469", "frc3663"]}, "red": {"surrogates": [], "score": 18, "teams": ["frc3684", "frc5295", "frc2976"]}}""")
+        self.assertEqual(match.alliances_json, """{"blue": {"dqs": [], "surrogates": [], "score": 30, "teams": ["frc4131", "frc4469", "frc3663"]}, "red": {"dqs": [], "surrogates": [], "score": 18, "teams": ["frc3684", "frc5295", "frc2976"]}}""")
         self.assertEqual(match.time, datetime.datetime(2015, 2, 27, 0, 0))
         self.assertEqual(match.actual_time, datetime.datetime(2015, 2, 27, 0, 0))
 
@@ -85,7 +85,7 @@ class TestFMSAPIEventParser(unittest2.TestCase):
         self.assertEqual(match.set_number, 1)
         self.assertEqual(match.match_number, 12)
         self.assertEqual(match.team_key_names, [u'frc3663', u'frc5295', u'frc2907', u'frc2046', u'frc3218', u'frc2412'])
-        self.assertEqual(match.alliances_json, """{"blue": {"surrogates": [], "score": null, "teams": ["frc3663", "frc5295", "frc2907"]}, "red": {"surrogates": [], "score": null, "teams": ["frc2046", "frc3218", "frc2412"]}}""")
+        self.assertEqual(match.alliances_json, """{"blue": {"dqs": [], "surrogates": [], "score": null, "teams": ["frc3663", "frc5295", "frc2907"]}, "red": {"dqs": [], "surrogates": [], "score": null, "teams": ["frc2046", "frc3218", "frc2412"]}}""")
         self.assertEqual(match.time, datetime.datetime(2015, 2, 27, 2, 17))
         self.assertEqual(match.actual_time, None)
 


### PR DESCRIPTION
Still need to update swagger. 

API looks like this:
```
  "alliances": {
    "blue": {
      "dq_team_keys": [], 
      "score": 160, 
      "surrogate_team_keys": [], 
      "team_keys": [
        "frc5677", 
        "frc2473", 
        "frc4186"
      ]
    }, 
    "red": {
      "dq_team_keys": [
        "frc5027"
      ], 
      "score": 100, 
      "surrogate_team_keys": [], 
      "team_keys": [
        "frc5027", 
        "frc2489", 
        "frc2367"
      ]
    }
  }, 
```

![image](https://user-images.githubusercontent.com/1421884/32390832-4fc03d44-c0a6-11e7-89d2-90965fecb293.png)
