### PR TITLE
Manipulator whitelist

### DIFF
--- a/helpers/award_manipulator.py
+++ b/helpers/award_manipulator.py
@@ -41,7 +41,7 @@ class AwardManipulator(ManipulatorBase):
                 method='GET')
 
     @classmethod
-    def updateMerge(self, new_award, old_award, auto_union=True):
+    def updateMerge(self, new_award, old_award, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" Award object, replace the fields in the
         "old" award that are present in the "new" award, but keep fields from

--- a/helpers/district_manipulator.py
+++ b/helpers/district_manipulator.py
@@ -48,7 +48,7 @@ class DistrictManipulator(ManipulatorBase):
         return CacheClearer.get_district_cache_keys_and_controllers(affected_refs)
 
     @classmethod
-    def updateMerge(self, new_district, old_district, auto_union=True):
+    def updateMerge(self, new_district, old_district, auto_union=True, attr_whitelist=None):
         """
         Update and return Districts
         """

--- a/helpers/district_team_manipulator.py
+++ b/helpers/district_team_manipulator.py
@@ -27,7 +27,7 @@ class DistrictTeamManipulator(ManipulatorBase):
                 logging.error(traceback.format_exc())
 
     @classmethod
-    def updateMerge(self, new_district_team, old_district_team, auto_union=True):
+    def updateMerge(self, new_district_team, old_district_team, auto_union=True, attr_whitelist=None):
         """
         Update and return DistrictTeams
         """

--- a/helpers/event_details_manipulator.py
+++ b/helpers/event_details_manipulator.py
@@ -60,7 +60,7 @@ class EventDetailsManipulator(ManipulatorBase):
                 logging.warning("Firebase update_event_details failed!")
 
     @classmethod
-    def updateMerge(self, new_event_details, old_event_details, auto_union=True):
+    def updateMerge(self, new_event_details, old_event_details, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" EventDetails object, replace the fields in the
         "old" event that are present in the "new" EventDetails, but keep fields from

--- a/helpers/event_manipulator.py
+++ b/helpers/event_manipulator.py
@@ -60,7 +60,7 @@ class EventManipulator(ManipulatorBase):
         cls.createOrUpdate(events, run_post_update_hook=False)
 
     @classmethod
-    def updateMerge(self, new_event, old_event, auto_union=True):
+    def updateMerge(self, new_event, old_event, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" Event object, replace the fields in the
         "old" event that are present in the "new" event, but keep fields from

--- a/helpers/event_team_manipulator.py
+++ b/helpers/event_team_manipulator.py
@@ -11,7 +11,7 @@ class EventTeamManipulator(ManipulatorBase):
         return CacheClearer.get_eventteam_cache_keys_and_controllers(affected_refs)
 
     @classmethod
-    def updateMerge(self, new_event_team, old_event_team, auto_union=True):
+    def updateMerge(self, new_event_team, old_event_team, auto_union=True, attr_whitelist=None):
         """
         Update and return EventTeams.
         """

--- a/helpers/insight_manipulator.py
+++ b/helpers/insight_manipulator.py
@@ -7,7 +7,7 @@ class InsightManipulator(ManipulatorBase):
     """
 
     @classmethod
-    def updateMerge(self, new_insight, old_insight, auto_union=True):
+    def updateMerge(self, new_insight, old_insight, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" Insight object, replace the fields in the
         "old" Insight that are present in the "new" Insight, but keep fields from

--- a/helpers/match_manipulator.py
+++ b/helpers/match_manipulator.py
@@ -119,7 +119,7 @@ class MatchManipulator(ManipulatorBase):
                 logging.error(traceback.format_exc())
 
     @classmethod
-    def updateMerge(self, new_match, old_match, auto_union=True):
+    def updateMerge(cls, new_match, old_match, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" Match object, replace the fields in the
         "old" team that are present in the "new" team, but keep fields from
@@ -133,7 +133,7 @@ class MatchManipulator(ManipulatorBase):
             "year",
         ]  # These build key_name, and cannot be changed without deleting the model.
 
-        attrs = [
+        attrs = cls._filterAttrs([
             "no_auto_update",
             "time",
             "time_string",
@@ -142,21 +142,21 @@ class MatchManipulator(ManipulatorBase):
             "post_result_time",
             "push_sent",
             "tiebreak_match_key",
-        ]
+        ], attr_whitelist)
 
-        json_attrs = [
+        json_attrs = cls._filterAttrs([
             "alliances_json",
             "score_breakdown_json",
-        ]
+        ], attr_whitelist)
 
-        list_attrs = [
+        list_attrs = cls._filterAttrs([
             "team_key_names"
-        ]
+        ], attr_whitelist)
 
-        auto_union_attrs = [
+        auto_union_attrs = cls._filterAttrs([
             "tba_videos",
             "youtube_videos"
-        ]
+        ], attr_whitelist)
 
         old_match._updated_attrs = []
 

--- a/helpers/match_manipulator.py
+++ b/helpers/match_manipulator.py
@@ -130,10 +130,10 @@ class MatchManipulator(ManipulatorBase):
             "event",
             "set_number",
             "match_number",
+            "year",
         ]  # These build key_name, and cannot be changed without deleting the model.
 
         attrs = [
-            "year",
             "no_auto_update",
             "time",
             "time_string",

--- a/helpers/media_manipulator.py
+++ b/helpers/media_manipulator.py
@@ -11,7 +11,7 @@ class MediaManipulator(ManipulatorBase):
         return CacheClearer.get_media_cache_keys_and_controllers(affected_refs)
 
     @classmethod
-    def updateMerge(self, new_media, old_media, auto_union=True):
+    def updateMerge(self, new_media, old_media, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" Media object, replace the fields in the
         "old" object that are present in the "new" object, but keep fields from

--- a/helpers/robot_manipulator.py
+++ b/helpers/robot_manipulator.py
@@ -11,7 +11,7 @@ class RobotManipulator(ManipulatorBase):
         return CacheClearer.get_robot_cache_keys_and_controllers(affected_refs)
 
     @classmethod
-    def updateMerge(self, new_robot, old_robot, auto_union=True):
+    def updateMerge(self, new_robot, old_robot, auto_union=True, attr_whitelist=None):
         """
         Update and return Robots
         """

--- a/helpers/team_manipulator.py
+++ b/helpers/team_manipulator.py
@@ -46,7 +46,7 @@ class TeamManipulator(ManipulatorBase):
         cls.createOrUpdate(teams, run_post_update_hook=False)
 
     @classmethod
-    def updateMerge(self, new_team, old_team, auto_union=True):
+    def updateMerge(self, new_team, old_team, auto_union=True, attr_whitelist=None):
         """
         Given an "old" and a "new" Team object, replace the fields in the
         "old" team that are present in the "new" team, but keep fields from

--- a/tests/test_match_manipulator.py
+++ b/tests/test_match_manipulator.py
@@ -118,6 +118,12 @@ class TestMatchManipulator(unittest2.TestCase):
         MatchManipulator.createOrUpdate(self.new_match, attr_whitelist=set())
         self.assertOldMatch(Match.get_by_id("2012ct_qm1"))
 
+    def test_junk_whitelist(self):
+        MatchManipulator.createOrUpdate(self.old_match)
+        MatchManipulator.createOrUpdate(self.new_match, attr_whitelist=set(''))
+        MatchManipulator.createOrUpdate(self.new_match, attr_whitelist=set('junk'))
+        self.assertOldMatch(Match.get_by_id("2012ct_qm1"))
+
     def test_whitelist_single(self):
         MatchManipulator.createOrUpdate(self.old_match)
         MatchManipulator.createOrUpdate(self.new_match, attr_whitelist={'alliances_json'})


### PR DESCRIPTION
Towards #2020 

This enables specifying a set of whitelisted attributes for manipulators. Attributes not whitelisted will not be merged in. A null whitelist will merge everything, but an empty set whitelist will merge nothing.

Currently only implemented/used in MatchManipulator so that after an event has passed, match updates from the FRC API will not be merged unless they are explicitly whitelisted.

Examples:
`/tasks/enqueue/fmsapi_matches/2017?attr_whitelist=alliances_json+time`
`/tasks/get/fmsapi_matches/2017casj?attr_whitelist=alliances_json+time`