### PR TITLE
Backfill DQ from FRC API

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -20,7 +20,7 @@ from controllers.admin.admin_match_controller import AdminVideosAdd, AdminMatchC
 from controllers.admin.admin_media_controller import AdminMediaDashboard, AdminMediaDeleteReference, AdminMediaMakePreferred, AdminMediaRemovePreferred, AdminMediaAdd, \
     AdminMediaInstagramImport
 from controllers.admin.admin_memcache_controller import AdminMemcacheMain
-from controllers.admin.admin_migration_controller import AdminMigration, AdminMigrationCreateEventDetails, AdminMigrationRankings, AdminMigrationAddSurrogates
+from controllers.admin.admin_migration_controller import AdminMigration, AdminMigrationCreateEventDetails, AdminMigrationRankings, AdminMigrationAddSurrogates, AdminMigrationBackfillYearDQ, AdminMigrationBackfillEventDQ
 from controllers.admin.admin_mobile_controller import AdminMobile, AdminBroadcast, AdminMobileWebhooks
 from controllers.admin.admin_offseason_scraper_controller import AdminOffseasonScraperController
 from controllers.admin.admin_offseason_spreadsheet_controller import AdminOffseasonSpreadsheetController
@@ -83,6 +83,8 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/migration/create_event_details', AdminMigrationCreateEventDetails),
                                ('/admin/migration/migrate_rankings/([0-9]*)', AdminMigrationRankings),
                                ('/admin/migration/add_surrogates/([0-9]*)', AdminMigrationAddSurrogates),
+                               ('/admin/migration/backfill_year_dq/([0-9]*)', AdminMigrationBackfillYearDQ),
+                               ('/admin/migration/backfill_event_dq/(.*)', AdminMigrationBackfillEventDQ),
                                ('/admin/offseasons', AdminOffseasonScraperController),
                                ('/admin/offseasons/spreadsheet', AdminOffseasonSpreadsheetController),
                                ('/admin/sitevars', AdminSitevarList),

--- a/controllers/admin/admin_migration_controller.py
+++ b/controllers/admin/admin_migration_controller.py
@@ -93,12 +93,8 @@ class AdminMigrationBackfillYearDQ(LoggedInHandler):
 class AdminMigrationBackfillEventDQ(LoggedInHandler):
     def get(self, event_key):
         df = DatafeedFMSAPI('v2.0', save_response=True)
-        matches = MatchHelper.deleteInvalidMatches(
-            df.getMatches(event_key),
-            Event.get_by_id(event_key)
-        )
         updated_matches = []
-        for m1 in matches:
+        for m1 in df.getMatches(event_key):
             m2 = m1.key.get()
             # Only update if teams and scores are equal
             if m2 and (m1.alliances['red']['teams'] == m2.alliances['red']['teams'] and

--- a/controllers/admin/admin_migration_controller.py
+++ b/controllers/admin/admin_migration_controller.py
@@ -1,68 +1,117 @@
 import os
+import json
 import logging
+from google.appengine.api import taskqueue
 from google.appengine.ext import ndb
 from google.appengine.ext import deferred
 from google.appengine.ext.webapp import template
 from controllers.base_controller import LoggedInHandler
-
+from datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from models.event import Event
 from models.event_details import EventDetails
+from models.match import Match
 from helpers.event_details_manipulator import EventDetailsManipulator
 from helpers.match_helper import MatchHelper
+from helpers.match_manipulator import MatchManipulator
 from helpers.rankings_helper import RankingsHelper
 
 
 def create_event_details(event_key):
-  event = Event.get_by_id(event_key)
-  if event.alliance_selections or event.district_points or event.matchstats or event.rankings:
-    event_details = EventDetails(
-      id=event_key,
-      alliance_selections=event.alliance_selections,
-      district_points=event.district_points,
-      matchstats=event.matchstats,
-      rankings=event.rankings)
-    EventDetailsManipulator.createOrUpdate(event_details)
+    event = Event.get_by_id(event_key)
+    if event.alliance_selections or event.district_points or event.matchstats or event.rankings:
+        event_details = EventDetails(
+            id=event_key,
+            alliance_selections=event.alliance_selections,
+            district_points=event.district_points,
+            matchstats=event.matchstats,
+            rankings=event.rankings)
+        EventDetailsManipulator.createOrUpdate(event_details)
 
 
 class AdminMigration(LoggedInHandler):
-  def get(self):
-    self._require_admin()
-    path = os.path.join(os.path.dirname(__file__), '../../templates/admin/migration.html')
-    self.response.out.write(template.render(path, self.template_values))
+    def get(self):
+        self._require_admin()
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/migration.html')
+        self.response.out.write(template.render(path, self.template_values))
 
 
 class AdminMigrationCreateEventDetails(LoggedInHandler):
-  def get(self):
-    self._require_admin()
-    for event_key in Event.query().fetch(keys_only=True):
-      deferred.defer(create_event_details, event_key.id(), _queue="admin")
+    def get(self):
+        self._require_admin()
+        for event_key in Event.query().fetch(keys_only=True):
+            deferred.defer(create_event_details, event_key.id(), _queue="admin")
 
-    self.response.out.write("DONE")
+        self.response.out.write("DONE")
 
 
 class AdminMigrationRankings(LoggedInHandler):
-  def get(self, year):
-    self._require_admin()
+    def get(self, year):
+        self._require_admin()
 
-    event_keys = Event.query(Event.year==int(year)).fetch(keys_only=True)
-    event_details = ndb.get_multi([ndb.Key(EventDetails, key.id()) for key in event_keys])
-    updated = []
-    for event_detail in event_details:
-      if event_detail:
-        logging.info(event_detail.key.id())
-        event_detail.rankings2 = RankingsHelper.convert_rankings(event_detail)
-        updated.append(event_detail)
-    EventDetailsManipulator.createOrUpdate(updated)
+        event_keys = Event.query(Event.year==int(year)).fetch(keys_only=True)
+        event_details = ndb.get_multi([ndb.Key(EventDetails, key.id()) for key in event_keys])
+        updated = []
+        for event_detail in event_details:
+            if event_detail:
+                logging.info(event_detail.key.id())
+                event_detail.rankings2 = RankingsHelper.convert_rankings(event_detail)
+                updated.append(event_detail)
+        EventDetailsManipulator.createOrUpdate(updated)
 
-    self.response.out.write("DONE")
+        self.response.out.write("DONE")
 
 
 class AdminMigrationAddSurrogates(LoggedInHandler):
-  def get(self, year):
-    self._require_admin()
+    def get(self, year):
+        self._require_admin()
 
-    events = Event.query(Event.year==int(year)).fetch()
-    for event in events:
-      deferred.defer(MatchHelper.add_surrogates, event, _queue="admin")
+        events = Event.query(Event.year==int(year)).fetch()
+        for event in events:
+            deferred.defer(MatchHelper.add_surrogates, event, _queue="admin")
 
-    self.response.out.write("DONE")
+        self.response.out.write("DONE")
+
+
+class AdminMigrationBackfillYearDQ(LoggedInHandler):
+    def get(self, year):
+        self._require_admin()    # This technically isn't needed because of app.yaml
+
+        event_keys = Event.query(
+            Event.year==int(year),
+            Event.official==True,
+        ).fetch(keys_only=True)
+        for event_key in event_keys:
+            taskqueue.add(
+                url='/admin/migration/backfill_event_dq/{}'.format(event_key.id()),
+                method='GET',
+                queue_name='admin',
+                )
+
+        self.response.out.write("DONE")
+
+
+class AdminMigrationBackfillEventDQ(LoggedInHandler):
+    def get(self, event_key):
+        df = DatafeedFMSAPI('v2.0', save_response=True)
+        matches = MatchHelper.deleteInvalidMatches(
+            df.getMatches(event_key),
+            Event.get_by_id(event_key)
+        )
+        updated_matches = []
+        for m1 in matches:
+            m2 = m1.key.get()
+            # Only update if teams and scores are equal
+            if m2 and (m1.alliances['red']['teams'] == m2.alliances['red']['teams'] and
+                    m1.alliances['blue']['teams'] == m2.alliances['blue']['teams'] and
+                    m1.alliances['red']['score'] == m2.alliances['red']['score'] and
+                    m1.alliances['blue']['score'] == m2.alliances['blue']['score']):
+                old_alliances = m2.alliances
+                old_alliances['red']['dqs'] = m1.alliances['red']['dqs']
+                old_alliances['blue']['dqs'] = m1.alliances['blue']['dqs']
+                m2.alliances_json = json.dumps(old_alliances)
+                updated_matches.append(m2)
+            else:
+                logging.warning("Match not equal: {}".format(m1.key.id()))
+        MatchManipulator.createOrUpdate(updated_matches)
+
+        self.response.out.write("DONE")

--- a/models/match.py
+++ b/models/match.py
@@ -134,6 +134,9 @@ class Match(ndb.Model):
                 # add surrogates if not present
                 if 'surrogates' not in self._alliances[color]:
                     self._alliances[color]['surrogates'] = []
+                # add dqs if not present
+                if 'dqs' not in self._alliances[color]:
+                    self._alliances[color]['dqs'] = []
 
         return self._alliances
 


### PR DESCRIPTION
For #2020 

Running `/admin/migration/backfill_year_dq/<year>` enqueues tasks to backfill match DQ info for all events==official (can be pulled from FRC API). Only backfills data if match teams & scores in the DB are equal to data from the FRC API.