### PR TITLE
[Trusted API] Support surrogates/dqs

### DIFF
--- a/datafeeds/parsers/json/json_matches_parser.py
+++ b/datafeeds/parsers/json/json_matches_parser.py
@@ -69,9 +69,13 @@ class JSONMatchesParser(ParserBase):
                     for team_key in details.get('surrogates', []):
                         if not re.match(r'frc\d+', str(team_key)):
                             raise ParserInputException("Bad surrogate team: '{}'. Must follow format 'frcXXX'.".format(team_key))
+                        if team_key not in details['teams']:
+                            raise ParserInputException("Bad surrogate team: '{}'. Must be a team in the match.'.".format(team_key))
                     for team_key in details.get('dqs', []):
                         if not re.match(r'frc\d+', str(team_key)):
                             raise ParserInputException("Bad dq team: '{}'. Must follow format 'frcXXX'.".format(team_key))
+                        if team_key not in details['teams']:
+                            raise ParserInputException("Bad dq team: '{}'. Must be a team in the match.'.".format(team_key))
 
             if score_breakdown is not None:
                 if type(score_breakdown) is not dict:

--- a/datafeeds/parsers/json/json_matches_parser.py
+++ b/datafeeds/parsers/json/json_matches_parser.py
@@ -14,7 +14,7 @@ class JSONMatchesParser(ParserBase):
         comp_level: String in the set {"qm", "ef", "qf", "sf", "f"}
         set_number: Integer identifying the elim set number. Ignored for qual matches. ex: the 4 in qf4m2
         match_number: Integer identifying the match number within a set. ex: the 2 in qf4m2
-        alliances: Dict of {'red': {'teams': ['frcXXX'...], 'score': S}, 'blue': {...}}. Where scores (S) are integers. Null scores indicate that a match has not yet been played.
+        alliances: Dict of {'red': {'teams': ['frcXXX'...], 'score': S, 'surrogates': ['frcXXX'...], 'dqs': ['frcXXX'...]}, 'blue': {...}}. Where scores (S) are integers. Null scores indicate that a match has not yet been played. surrogates and dqs are optional.
         score_breakdown: Dict of {'red': {K1: V1, K2: V2, ...}, 'blue': {...}}. Where Kn are keys and Vn are values for those keys.
         time_string: String in the format "(H)H:MM AM/PM" for when the match will be played in the event's local timezone. ex: "9:15 AM"
         time: UTC time of the match as a string in ISO 8601 format (YYYY-MM-DDTHH:MM:SS).
@@ -66,6 +66,13 @@ class JSONMatchesParser(ParserBase):
                     if details['score'] is not None and type(details['score']) is not int:
                         raise ParserInputException("alliances[color]['score'] must be an integer or null")
 
+                    for team_key in details.get('surrogates', []):
+                        if not re.match(r'frc\d+', str(team_key)):
+                            raise ParserInputException("Bad surrogate team: '{}'. Must follow format 'frcXXX'.".format(team_key))
+                    for team_key in details.get('dqs', []):
+                        if not re.match(r'frc\d+', str(team_key)):
+                            raise ParserInputException("Bad dq team: '{}'. Must follow format 'frcXXX'.".format(team_key))
+
             if score_breakdown is not None:
                 if type(score_breakdown) is not dict:
                     raise ParserInputException("'score_breakdown' must be a dict")
@@ -93,10 +100,14 @@ class JSONMatchesParser(ParserBase):
                 'red': {
                     'teams': alliances['red']['teams'],
                     'score': alliances['red']['score'],
+                    'surrogates': alliances['red'].get('surrogates', []),
+                    'dqs': alliances['red'].get('dqs', []),
                 },
                 'blue': {
                     'teams': alliances['blue']['teams'],
                     'score': alliances['blue']['score'],
+                    'surrogates': alliances['blue'].get('surrogates', []),
+                    'dqs': alliances['blue'].get('dqs', []),
                 },
             }
             parsed_match = {

--- a/static/swagger/api_trusted_v1.json
+++ b/static/swagger/api_trusted_v1.json
@@ -524,6 +524,10 @@
         "teams",
         "score"
       ],
+      "optional": [
+        "surrogates",
+        "dqs"
+      ],
       "properties": {
         "teams": {
           "type": "array",
@@ -538,6 +542,22 @@
           "format": "int32",
           "description": "Score of the match. Null means the match has not been played",
           "example": 10
+        },
+        "surrogates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Key of a surrogate team on the alliance, in the format `frcXXXX` where `XXXX` is the team number",
+            "example": "frc254"
+          }
+        },
+        "dqs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Key of a disqualified team on the alliance, in the format `frcXXXX` where `XXXX` is the team number",
+            "example": "frc254"
+          }
         }
       }
     },

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -379,9 +379,13 @@ class TestApiTrustedController(unittest2.TestCase):
             'match_number': 2,
             'alliances': {
                 'red': {'teams': ['frc1', 'frc2', 'frc3'],
-                        'score': 250},
+                        'score': 250,
+                        'surrogates': ['frc1'],
+                        'dqs': ['frc2']},
                 'blue': {'teams': ['frc4', 'frc5', 'frc6'],
-                         'score': 260},
+                         'score': 260,
+                         'surrogates': [],
+                         'dqs': []},
             },
             'score_breakdown': {
                 'red': {'auto': 20, 'assist': 40, 'truss+catch': 20, 'teleop_goal+foul': 20},
@@ -416,8 +420,15 @@ class TestApiTrustedController(unittest2.TestCase):
         match = Match.get_by_id('2014casj_f1m2')
         self.assertEqual(match.time, datetime.datetime(2014, 8, 31, 18, 0))
         self.assertEqual(match.time_string, '11:00 AM')
+        self.assertEqual(match.alliances['red']['teams'], ['frc1', 'frc2', 'frc3'])
         self.assertEqual(match.alliances['red']['score'], 250)
+        self.assertEqual(match.alliances['red']['surrogates'], ['frc1'])
+        self.assertEqual(match.alliances['red']['dqs'], ['frc2'])
         self.assertEqual(match.score_breakdown['red']['truss+catch'], 20)
+        self.assertEqual(match.alliances['blue']['teams'], ['frc4', 'frc5', 'frc6'])
+        self.assertEqual(match.alliances['blue']['score'], 260)
+        self.assertEqual(match.alliances['blue']['surrogates'], [])
+        self.assertEqual(match.alliances['blue']['dqs'], [])
 
         # test delete all matches
         request_body = ''


### PR DESCRIPTION
Backwards compatible; `surrogates` and `dqs` are optional.