### PR TITLE
Automatic Team Remapping. Fixes #1638

### DIFF
--- a/controllers/admin/admin_event_controller.py
+++ b/controllers/admin/admin_event_controller.py
@@ -156,64 +156,21 @@ class AdminEventRemapTeams(LoggedInHandler):
             remap_teams['frc{}'.format(key)] = 'frc{}'.format(value)
 
         # Remap matches
-        for match in event.matches:
-            for old_team, new_team in remap_teams.items():
-                # Update team key names
-                for i, key in enumerate(match.team_key_names):
-                    if key == old_team:
-                        match.dirty = True
-                        if new_team.isdigit():  # Only if non "B" teams
-                            match.team_key_names[i] = new_team
-                        else:
-                            del match.team_key_names[i]
-                # Update alliances
-                for color in ['red', 'blue']:
-                    for i, key in enumerate(match.alliances[color]['teams']):
-                        if key == old_team:
-                            match.dirty = True
-                            match.alliances[color]['teams'][i] = new_team
-                            match.alliances_json = json.dumps(match.alliances)
+        EventHelper.remapteams_matches(event.matches, remap_teams)
         MatchManipulator.createOrUpdate(event.matches)
 
         # Remap alliance selections
         if event.alliance_selections:
-            for row in event.alliance_selections:
-                for choice in ['picks', 'declines']:
-                    for old_team, new_team in remap_teams.items():
-                        for i, key in enumerate(row[choice]):
-                            if key == old_team:
-                                row[choice][i] = new_team
-
+            EventHelper.remapteams_alliances(event.alliance_selections, remap_teams)
         # Remap rankings
         if event.rankings:
-            for row in event.rankings:
-                for old_team, new_team in remap_teams.items():
-                    if row[1] == old_team[3:]:
-                        row[1] = new_team[3:]
+            EventHelper.remapteams_rankings(event.rankings, remap_teams)
         if event.details and event.details.rankings2:
-            for ranking in event.details.rankings2:
-                if ranking['team_key'] in remap_teams:
-                    ranking['team_key'] = remap_teams[ranking['team_key']]
-
+            EventHelper.remapteams_rankings2(event.details.rankings2, remap_teams)
         EventDetailsManipulator.createOrUpdate(event.details)
 
         # Remap awards
-        for award in event.awards:
-            for old_team, new_team in remap_teams.items():
-                # Update team keys
-                for i, key in enumerate(award.team_list):
-                    if key.id() == old_team:
-                        award.dirty = True
-                        if new_team.isdigit():  # Only if non "B" teams
-                            award.team_list[i] = ndb.Key(Team, new_team)
-                        else:
-                            del award.team_list[i]
-                # Update recipient list
-                for recipient in award.recipient_list:
-                    if str(recipient['team_number']) == old_team[3:]:
-                        award.dirty = True
-                        recipient['team_number'] = new_team[3:]
-                        award.recipient_json_list = [json.dumps(r) for r in award.recipient_list]
+        EventHelper.remapteams_awards(event.awards, remap_teams)
         AwardManipulator.createOrUpdate(event.awards, auto_union=False)
 
         self.redirect("/admin/event/" + event.key_name)

--- a/controllers/backup_controller.py
+++ b/controllers/backup_controller.py
@@ -23,8 +23,11 @@ from google.appengine.ext import ndb
 from google.appengine.ext import webapp
 from google.appengine.ext.webapp import template
 
-from google.cloud import bigquery
-from google.cloud.bigquery.job import WriteDisposition
+try:  # Tests fail on import. 2017-11-13
+    from google.cloud import bigquery
+    from google.cloud.bigquery.job import WriteDisposition
+except Exception:
+    logging.error("bigquery import failed")
 
 from helpers.award_manipulator import AwardManipulator
 from helpers.event_manipulator import EventManipulator

--- a/cron_main.py
+++ b/cron_main.py
@@ -12,7 +12,7 @@ from controllers.datafeed_controller import FMSAPIAwardsGet, FMSAPIEventAlliance
 from controllers.datafeed_controller import HallOfFameTeamsGet
 
 from controllers.cron_controller import DistrictPointsCalcEnqueue, DistrictPointsCalcDo, \
-    MatchTimePredictionsEnqueue, MatchTimePredictionsDo, BlueZoneUpdateDo, SuggestionQueueDailyNag
+    MatchTimePredictionsEnqueue, MatchTimePredictionsDo, BlueZoneUpdateDo, SuggestionQueueDailyNag, RemapTeamsDo
 from controllers.cron_controller import DistrictRankingsCalcEnqueue, DistrictRankingsCalcDo
 from controllers.cron_controller import EventTeamStatusCalcEnqueue, EventTeamStatusCalcDo
 from controllers.cron_controller import EventShortNameCalcEnqueue, EventShortNameCalcDo
@@ -82,5 +82,6 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/do/update_team_search_index/(.*)', AdminUpdateTeamSearchIndexDo),
                                ('/tasks/do/update_live_events', UpdateLiveEventsDo),
                                ('/tasks/do/nag_suggestions', SuggestionQueueDailyNag),
+                               ('/tasks/do/remap_teams/(.*)', RemapTeamsDo),
                                ],
                               debug=tba_config.DEBUG)

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import collections
 import datetime
@@ -354,3 +355,85 @@ class EventHelper(object):
         year = event_key[:4]
         event_short = event_key[4:]
         return year == '2015' and event_short not in {'cc', 'cacc', 'mttd'}
+
+    @classmethod
+    def remapteams_matches(cls, matches, remap_teams):
+        """
+        Remaps teams in matches
+        Mutates in place
+        """
+        for match in matches:
+            for old_team, new_team in remap_teams.items():
+                # Update team key names
+                for i, key in enumerate(match.team_key_names):
+                    if key == old_team:
+                        match.dirty = True
+                        if new_team.isdigit():  # Only if non "B" teams
+                            match.team_key_names[i] = new_team
+                        else:
+                            del match.team_key_names[i]
+                # Update alliances
+                for color in ['red', 'blue']:
+                    for attr in ['teams', 'surrogates', 'dqs']:
+                        for i, key in enumerate(match.alliances[color][attr]):
+                            if key == old_team:
+                                match.dirty = True
+                                match.alliances[color][attr][i] = new_team
+                                match.alliances_json = json.dumps(match.alliances)
+
+    @classmethod
+    def remapteams_alliances(cls, alliance_selections, remap_teams):
+        """
+        Remaps teams in alliance selections
+        Mutates in place
+        """
+        for row in alliance_selections:
+            for choice in ['picks', 'declines']:
+                for old_team, new_team in remap_teams.items():
+                    for i, key in enumerate(row[choice]):
+                        if key == old_team:
+                            row[choice][i] = new_team
+
+    @classmethod
+    def remapteams_rankings(cls, rankings, remap_teams):
+        """
+        Remaps teams in rankings
+        Mutates in place
+        """
+        for row in rankings:
+            for old_team, new_team in remap_teams.items():
+                if row[1] == old_team[3:]:
+                    row[1] = new_team[3:]
+
+    @classmethod
+    def remapteams_rankings2(cls, rankings2, remap_teams):
+        """
+        Remaps teams in rankings2
+        Mutates in place
+        """
+        for ranking in rankings2:
+            if ranking['team_key'] in remap_teams:
+                ranking['team_key'] = remap_teams[ranking['team_key']]
+
+    @classmethod
+    def remapteams_awards(cls, awards, remap_teams):
+        """
+        Remaps teams in awards
+        Mutates in place
+        """
+        for award in awards:
+            for old_team, new_team in remap_teams.items():
+                # Update team keys
+                for i, key in enumerate(award.team_list):
+                    if key.id() == old_team:
+                        award.dirty = True
+                        if new_team.isdigit():  # Only if non "B" teams
+                            award.team_list[i] = ndb.Key(Team, new_team)
+                        else:
+                            del award.team_list[i]
+                # Update recipient list
+                for recipient in award.recipient_list:
+                    if str(recipient['team_number']) == old_team[3:]:
+                        award.dirty = True
+                        recipient['team_number'] = new_team[3:]
+                        award.recipient_json_list = [json.dumps(r) for r in award.recipient_list]

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -402,7 +402,7 @@ class EventHelper(object):
         """
         for row in rankings:
             for old_team, new_team in remap_teams.items():
-                if row[1] == old_team[3:]:
+                if str(row[1]) == old_team[3:]:
                     row[1] = new_team[3:]
 
     @classmethod

--- a/helpers/event_manipulator.py
+++ b/helpers/event_manipulator.py
@@ -93,7 +93,8 @@ class EventManipulator(ManipulatorBase):
             "venue_address",
             "webcast_json",
             "website",
-            "year"
+            "year",
+            "remap_teams",
         ]
 
         allow_none_attrs = {

--- a/models/event.py
+++ b/models/event.py
@@ -53,6 +53,7 @@ class Event(ndb.Model):
     website = ndb.StringProperty(indexed=False)
     webcast_json = ndb.TextProperty(indexed=False)  # list of dicts, valid keys include 'type' and 'channel'
     enable_predictions = ndb.BooleanProperty(default=False)
+    remap_teams = ndb.JsonProperty()  # Map of temporary team numbers to pre-rookie and B teams
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -155,6 +155,10 @@
             <p><a href="/tasks/admin/do/clear_eventteams/{{ event.key_name }}" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Delete All</a></p></td>
     </tr>
     <tr>
+        <td>Remap Teams</td>
+        <td>{{event.remap_teams}}</td>
+    </tr>
+    <tr>
         <td>Created - Updated</td>
         <td>{{ event.created }} - {{ event.updated }}</td>
     </tr>

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -725,3 +725,134 @@ class TestApiTrustedController(unittest2.TestCase):
         sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
         response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_9', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
+
+    def test_remapping(self):
+        self.event_info_auth.put()
+        self.matches_auth.put()
+        self.rankings_auth.put()
+        self.alliances_auth.put()
+        self.awards_auth.put()
+
+        request = {
+            'remap_teams': {
+                'frc1': 'frc101B',
+                'frc2': 'frc102B',
+                'frc3': 'frc102C',
+                'frc4': 'frc104'
+            },
+        }
+        request_body = json.dumps(request)
+        request_path = '/api/trusted/v1/event/2014casj/info/update'
+        sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_9', 'X-TBA-Auth-Sig': sig})
+        self.assertEqual(response.status_code, 200)
+
+        # Test remapped matches
+        matches = [{
+            'comp_level': 'f',
+            'set_number': 1,
+            'match_number': 2,
+            'alliances': {
+                'red': {'teams': ['frc1', 'frc2', 'frc3'],
+                        'score': 250,
+                        'surrogates': ['frc1'],
+                        'dqs': ['frc2']},
+                'blue': {'teams': ['frc4', 'frc5', 'frc6'],
+                         'score': 260,
+                         'surrogates': [],
+                         'dqs': []},
+            },
+            'score_breakdown': {
+                'red': {'auto': 20, 'assist': 40, 'truss+catch': 20, 'teleop_goal+foul': 20},
+                'blue': {'auto': 40, 'assist': 60, 'truss+catch': 10, 'teleop_goal+foul': 40},
+            },
+            'time_string': '11:00 AM',
+            'time_utc': '2014-08-31T18:00:00',
+        }]
+        request_body = json.dumps(matches)
+        request_path = '/api/trusted/v1/event/2014casj/matches/update'
+        sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_1', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        self.assertEqual(response.status_code, 200)
+
+        # verify remapped match data
+        match = Match.get_by_id('2014casj_f1m2')
+        self.assertEqual(match.time, datetime.datetime(2014, 8, 31, 18, 0))
+        self.assertEqual(match.time_string, '11:00 AM')
+        self.assertEqual(match.alliances['red']['teams'], ['frc101B', 'frc102B', 'frc102C'])
+        self.assertEqual(match.alliances['red']['score'], 250)
+        self.assertEqual(match.alliances['red']['surrogates'], ['frc101B'])
+        self.assertEqual(match.alliances['red']['dqs'], ['frc102B'])
+        self.assertEqual(match.score_breakdown['red']['truss+catch'], 20)
+        self.assertEqual(match.alliances['blue']['teams'], ['frc104', 'frc5', 'frc6'])
+        self.assertEqual(match.alliances['blue']['score'], 260)
+        self.assertEqual(match.alliances['blue']['surrogates'], [])
+        self.assertEqual(match.alliances['blue']['dqs'], [])
+
+        # Test remapped alliances
+        alliances = [['frc1', 'frc2', 'frc3'],
+                     ['frc4', 'frc5', 'frc6'],
+                     ['frc7', 'frc8', 'frc9']]
+        request_body = json.dumps(alliances)
+
+        request_path = '/api/trusted/v1/event/2014casj/alliance_selections/update'
+        sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_3', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        self.assertEqual(response.status_code, 200)
+
+        # Test remapped rankings
+        rankings = {
+            'breakdowns': ['QS', 'Auton', 'Teleop', 'T&C', 'wins', 'losses', 'ties'],
+            'rankings': [
+                {'team_key': 'frc1', 'rank': 1, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc2', 'rank': 2, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc3', 'rank': 3, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc4', 'rank': 4, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc5', 'rank': 5, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+                {'team_key': 'frc6', 'rank': 6, 'wins': 10, 'losses': 0, 'ties': 0, 'played': 10, 'dqs': 0, 'QS': 20, 'Auton': 500, 'Teleop': 500, 'T&C': 200},
+            ],
+        }
+        request_body = json.dumps(rankings)
+
+        request_path = '/api/trusted/v1/event/2014casj/rankings/update'
+        sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_2', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        self.assertEqual(response.status_code, 200)
+
+        # verify remapped alliances
+        self.assertEqual(len(self.event.alliance_selections), 3)
+        self.assertEqual(self.event.alliance_selections[0]['picks'], ['frc101B', 'frc102B', 'frc102C'])
+        self.assertEqual(self.event.alliance_selections[1]['picks'], ['frc104', 'frc5', 'frc6'])
+        self.assertEqual(self.event.alliance_selections[2]['picks'], ['frc7', 'frc8', 'frc9'])
+
+        # verify remapped rankings
+        self.assertEqual(self.event.rankings[0], ['Rank', 'Team', 'QS', 'Auton', 'Teleop', 'T&C', 'Record (W-L-T)', 'DQ', 'Played'])
+        self.assertEqual(self.event.rankings[1], [1, '101B', 20, 500, 500, 200, '10-0-0', 0, 10])
+        self.assertEqual(self.event.rankings[2], [2, '102B', 20, 500, 500, 200, '10-0-0', 0, 10])
+        self.assertEqual(self.event.rankings[3], [3, '102C', 20, 500, 500, 200, '10-0-0', 0, 10])
+        self.assertEqual(self.event.rankings[4], [4, '104', 20, 500, 500, 200, '10-0-0', 0, 10])
+        self.assertEqual(self.event.rankings[5], [5, '5', 20, 500, 500, 200, '10-0-0', 0, 10])
+        self.assertEqual(self.event.rankings[6], [6, '6', 20, 500, 500, 200, '10-0-0', 0, 10])
+
+        # Test remapped awards
+        awards = [{'name_str': 'Winner', 'team_key': 'frc1'},
+                  {'name_str': 'Winner', 'team_key': 'frc2'},
+                  {'name_str': 'Winner', 'team_key': 'frc3'},
+                  {'name_str': 'Volunteer Blahblah', 'team_key': 'frc4', 'awardee': 'Bob Bobby'},
+                  {'name_str': 'Chairman\'s Blahblah', 'team_key': 'frc5'},
+                  {'name_str': 'Finalist', 'team_key': 'frc6'}]
+        request_body = json.dumps(awards)
+
+        request_path = '/api/trusted/v1/event/2014casj/awards/update'
+        sig = md5.new('{}{}{}'.format('321tEsTsEcReT', request_path, request_body)).hexdigest()
+        response = self.testapp.post(request_path, request_body, headers={'X-TBA-Auth-Id': 'tEsT_id_4', 'X-TBA-Auth-Sig': sig}, expect_errors=True)
+        self.assertEqual(response.status_code, 200)
+
+        for team in Award.get_by_id('2014casj_1').recipient_dict.keys():
+            self.assertTrue(str(team) in {'101B', '102B', '102C'})
+        for team in Award.get_by_id('2014casj_5').recipient_dict.keys():
+            self.assertTrue(str(team) in {'104'})
+        for team in Award.get_by_id('2014casj_0').recipient_dict.keys():
+            self.assertTrue(str(team) in {'5'})
+        for team in Award.get_by_id('2014casj_2').recipient_dict.keys():
+            self.assertTrue(str(team) in {'6'})


### PR DESCRIPTION
- [x] Store team remappings like `{"frc9254": "frc254B"}` in the Event model. 
- [x] Set mapping via the trusted API event info endpoint
- [x] Remap incoming data from the trusted API (matches, rankings, awards, alliances)
- [x] Remap incoming data from FRC API
- [x] Setting mappings from trusted API should trigger remapping of existing data
- [x] Setting mappings from admin console should behave the same as setting from trusted API (set in Event model, trigger remapping)

Future PR:
- Expose interface in EventWizard2