### PR TITLE
Remove mixed content warning in GameDay

### DIFF
--- a/templates/gameday2.html
+++ b/templates/gameday2.html
@@ -5,7 +5,7 @@
 {% block main_style %}
   <link rel="stylesheet" href="/css/gameday2.min.css" type="text/css" />
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-  <link href="http://vjs.zencdn.net/5.8.8/video-js.css" rel="stylesheet">
+  <link href="https://vjs.zencdn.net/5.8.8/video-js.css" rel="stylesheet">
 {% endblock %}
 {% block font_awesome_css %}{% endblock %}
 {% block featherlight_css %}{% endblock %}


### PR DESCRIPTION
Load video.js over https to remove the mixed content warning on the top right in chrome and prevent it from getting blocked.