### PR TITLE
Use minified video.js scripts

### DIFF
--- a/templates/gameday2.html
+++ b/templates/gameday2.html
@@ -36,8 +36,8 @@
 {% block login_modal %}{% endblock %}
 
 {% block main_javascript %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/5.10.2/video.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls/3.0.2/videojs-contrib-hls.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/5.10.2/video.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls/3.0.2/videojs-contrib-hls.min.js"></script>
   <script type="text/javascript" src="javascript/gameday2.min.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Uses minified video.js scripts instead of large original scripts. Fixes #2035.

## Motivation and Context
Large reduction in GameDay page size (~133 kB).

## How Has This Been Tested?
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would chance API specifications or require data migrations)
