### PR TITLE
Update api_v3.json to match Swagger spec

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -2,10 +2,10 @@
   "swagger": "2.0",
   "info": {
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. If you are looking for the old version (v2) of the API, documentation can be found [here](/apidocs/v2). \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account). \n\n A `User-Agent` header may need to be set to prevent a 403 Unauthorized error.",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "title": "The Blue Alliance API v3",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "host": "www.thebluealliance.com",
   "basePath": "/api/v3",
@@ -3696,10 +3696,10 @@
           ]
         },
         "current_level_record": {
-          "$ref": "#definitions/WLT_Record"
+          "$ref": "#/definitions/WLT_Record"
         },
         "record": {
-          "$ref": "#definitions/WLT_Record"
+          "$ref": "#/definitions/WLT_Record"
         },
         "status": {
           "type": "string",
@@ -3829,31 +3829,36 @@
       "properties": {
         "points": {
           "type": "object",
-          "required": [
-            "alliance_points",
-            "award_points",
-            "qual_points",
-            "elim_points",
-            "total"
-          ],
           "description": "Points gained for each team at the event. Stored as a key-value pair with the team key as the key, and an object describing the points as its value.",
           "additionalProperties": {
             "type": "object",
+            "required": [
+              "alliance_points",
+              "award_points",
+              "qual_points",
+              "elim_points",
+              "total"
+            ],
             "properties": {
               "alliance_points": {
-                "type": "integer"
+                "type": "integer",
+                "description": "Points awarded for alliance selection"
               },
               "award_points": {
-                "type": "integer"
+                "type": "integer",
+                "description": "Points awarded for event awards."
               },
               "qual_points": {
-                "type": "integer"
+                "type": "integer",
+                "description": "Points awarded for qualification match performance."
               },
               "elim_points": {
-                "type": "integer"
+                "type": "integer",
+                "description": "Points awarded for elimination match performance."
               },
               "total": {
-                "type": "integer"
+                "type": "integer",
+                "description": "Total points awarded at this event."
               }
             }
           }
@@ -4537,17 +4542,16 @@
         "videos": {
           "type": "array",
           "items": {
-            "key": {
-              "type": "string",
-              "description": "The key used to identify this media on the video source."
-            },
-            "type": {
-              "type": "string",
-              "description": "Name of video source.",
-              "enum": [
-                "youtube",
-                "tba"
-              ]
+            "type": "object",
+            "properties" : {
+              "key": {
+                "type": "string",
+                "description": "Unique key representing this video"
+              },
+              "type": {
+                "type": "string",
+                "description": "Can be one of 'youtube' or 'tba'"
+              }
             }
           },
           "description": "Array of video objects associated with this match."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update the `api_v3.json` file to comply with Swagger spec and match data actually returned.
## Description
<!--- Describe your changes in detail -->
In the `api_v3.json` file:

- Update the lines that reference `WLT_Record` in the `Team_Event_Status_playoff` object to the correct syntax.
- Move the `required` block from the root of `Event_District_Points` into the inner `additionalProperties` object to match Swagger spec and correct the formatting on the `/apidocs/v3` webpage.
- Add descriptions to the children of `Event_District_Points` as required by Swagger spec. 
- Change the `Match.video` object to fix incorrect syntax and more correctly reflect what is currently returned by the API. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes syntax errors that prevent auto-generating an API client using swagger-codegen, and fixes some formatting on the `/apidocs/v3` webpage. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Validated syntax using the official [Swagger Editor](https://swagger.io/swagger-editor/), and confirmed that the new `api_v3.json` file matches what it returned by the API in its current state. 
## Screenshots (if appropriate):
If appropriate
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
