### PR TITLE
Use cloud endpoints v2

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,10 +16,10 @@ libraries:
   version: "1.5"
 - name: numpy
   version: "1.6.1"
-- name: endpoints
-  version: "1.0"
 - name: pycrypto  # for mobile API
   version: "2.6"
+- name: ssl  # for mobile API
+  version: "2.7.11"
 - name: jinja2
   version: "2.6"
 - name: pytz
@@ -70,7 +70,7 @@ handlers:
   script: apiv3_main.app
 - url: /api/.*
   script: api_main.app
-- url: /_ah/spi/.* # Endpoints for internal mobile API
+- url: /_ah/api/.* # Endpoints for internal mobile API
   script: mobile_main.app
 - url: .*
   script: main.app

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -5,3 +5,4 @@ google-api-python-client==1.6.2
 google-cloud-bigquery==0.25.0
 beautifulsoup4
 GoogleAppEngineCloudStorageClient
+google-endpoints


### PR DESCRIPTION
Followed migration guide: https://cloud.google.com/endpoints/docs/frameworks/python/migrating

According to the docs, no client updates are required