### PR TITLE
Change type of first_event_id in API to match spec

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -3518,7 +3518,7 @@
           "description": "The event's website, if any."
         },
         "first_event_id": {
-          "type": "integer",
+          "type": "string",
           "description": "The FIRST internal Event ID, used to link to the event on the FRC webpage."
         },
         "first_event_code": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes the data type of `first_event_id` in the API docs to match what is actually returned
## Description
<!--- Describe your changes in detail -->
Changes the data type of `first_event_id` from `integer` to `string` in the API docs
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2041, an issue where automatically-generated API clients crash when receiving data about certain offseason events. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linted using Swagger Editor
## Screenshots (if appropriate):
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
