### PR TITLE
Don't track API calls with errors. Fixes #2050

### DIFF
--- a/controllers/api/api_base_controller.py
+++ b/controllers/api/api_base_controller.py
@@ -84,10 +84,12 @@ class ApiBaseController(CacheableHandler):
         if self._errors:
             self.abort(400)
 
-        self._track_call(*args, **kw)
         super(ApiBaseController, self).get(*args, **kw)
         self.response.headers['X-TBA-Version'] = '{}'.format(self.API_VERSION)
         self.response.headers['Vary'] = 'Accept-Encoding'
+
+        if not self._errors:
+            self._track_call(*args, **kw)
 
     def options(self, *args, **kw):
         """

--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -83,10 +83,12 @@ class ApiBaseController(CacheableHandler):
         if self._errors:
             self.abort(404)
 
-        self._track_call(*args, **kw)
         super(ApiBaseController, self).get(*args, **kw)
         self.response.headers['X-TBA-Version'] = '{}'.format(self.API_VERSION)
         self.response.headers['Vary'] = 'Accept-Encoding'
+
+        if not self._errors:
+            self._track_call(*args, **kw)
 
     def post(self, *args, **kw):
         self._validate_tba_auth_key()
@@ -95,10 +97,12 @@ class ApiBaseController(CacheableHandler):
             self.abort(404)
 
         rendered = self._render(*args, **kw)
-        self._track_call(*args, **kw)
         self.response.out.write(rendered)
         self.response.headers['X-TBA-Version'] = '{}'.format(self.API_VERSION)
         self.response.headers['Vary'] = 'Accept-Encoding'
+
+        if not self._errors:
+            self._track_call(*args, **kw)
 
     def options(self, *args, **kw):
         """


### PR DESCRIPTION
## Motivation and Context
Throws off actual usage stats and maybe inflates APIv2 usage stats compared to APIv3.

Note: API statistics may decrease for 2018 vs. 2017 because we won't be logging "bad" calls anymore.

## How Has This Been Tested?
Tried valid and invalid API calls (v2 and v3) and verified that only valid calls called the tracking function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
