### PR TITLE
Base prediction graph ranges on predictions and results

### DIFF
--- a/templates_jinja2/event_insights.html
+++ b/templates_jinja2/event_insights.html
@@ -173,11 +173,11 @@
   Chart.defaults.global.maintainAspectRatio = false;
   Chart.defaults.global.tooltips = false;
 
-  var minQualScore = 1;
-  var maxQualScore = 399;
+  var minQualScore = Infinity;
+  var maxQualScore = 0;
   var qualLineHeight = 0;
-  var minPlayoffScore = 1;
-  var maxPlayoffScore = 549;
+  var minPlayoffScore = Infinity;
+  var maxPlayoffScore = 0;
   var playoffLineHeight = 0;
   for (var key in predictions) {
     var redScore = predictions[key]['red_actual_score'];
@@ -189,6 +189,19 @@
         minQualScore = Math.min(minQualScore, blueScore);
         maxQualScore = Math.max(maxQualScore, redScore);
         maxQualScore = Math.max(maxQualScore, blueScore);
+      } else {
+        minQualScore = Math.min(minQualScore,
+                                predictions[key]['red_mean']
+                                - 2*Math.sqrt(predictions[key]['red_var']));
+        minQualScore = Math.min(minQualScore,
+                                predictions[key]['blue_mean']
+                                - 2*Math.sqrt(predictions[key]['blue_var']));
+        maxQualScore = Math.min(maxQualScore,
+                                predictions[key]['red_mean']
+                                + 2*Math.sqrt(predictions[key]['red_var']));
+        maxQualScore = Math.min(maxQualScore,
+                                predictions[key]['blue_mean']
+                                + 2*Math.sqrt(predictions[key]['blue_var']));
       }
       qualLineHeight = Math.max(qualLineHeight,
         Math.max(gaussian(predictions[key]['red_mean'],
@@ -203,6 +216,19 @@
         minPlayoffScore = Math.min(minPlayoffScore, blueScore);
         maxPlayoffScore = Math.max(maxPlayoffScore, redScore);
         maxPlayoffScore = Math.max(maxPlayoffScore, blueScore);
+      } else {
+        minPlayoffScore = Math.min(minPlayoffScore, 
+                                   predictions[key]['red_mean']
+                                   - 2*Math.sqrt(predictions[key]['red_var']));
+        minPlayoffScore = Math.min(minPlayoffScore,
+                                   predictions[key]['blue_mean']
+                                   - 2*Math.sqrt(predictions[key]['blue_var']));
+        maxPlayoffScore = Math.min(maxPlayoffScore,
+                                   predictions[key]['red_mean']
+                                   + 2*Math.sqrt(predictions[key]['red_var']));
+        maxPlayoffScore = Math.min(maxPlayoffScore,
+                                   predictions[key]['blue_mean']
+                                   + 2*Math.sqrt(predictions[key]['blue_var']));
       }
       playoffLineHeight = Math.max(playoffLineHeight,
         Math.max(gaussian(predictions[key]['red_mean'],
@@ -213,6 +239,9 @@
                           Math.sqrt(predictions[key]['blue_var']))));
     }
   }
+
+  minQualScore = Math.max(minQualScore, 0)
+  minPlayoffScore = Math.max(minPlayoffScore, 0)
 
   var xMinQual = minQualScore - (minQualScore % 50);
   var xMaxQual = maxQualScore - (maxQualScore % 50) + 50;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Augment existing code that defines ranges based on scores by also defining them based on 95% confidence intervals of predictions.

Also makes formerly fixed ranges fully variable, removing game dependence.

Since negative scores haven't been possible in FRC, doesn't allow lower bounds to be negative.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ensures graphs are in range when there are matches yet to be played. Removes hacky solution from #1917 where bounds were adjusted per game to make it work out, and makes sure they make sense per event.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

paver test passes in my development environment, visual testing looks reasonable.

## Screenshots (if appropriate):

<img width="1153" alt="2017nvlv Qualifications Advanced Insights" src="https://user-images.githubusercontent.com/2940350/34555047-6a5ccc7e-f0f5-11e7-8ad2-f047d738dbcf.png">
<img width="1149" alt="2017nvlv Playoffs Advanced Insights" src="https://user-images.githubusercontent.com/2940350/34555046-6a5111d6-f0f5-11e7-83ee-58c11dbe6502.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)