### PR TITLE
Update Vagrant config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,11 +79,9 @@ Vagrant.configure("2") do |config|
     privileged: false
 
   # Load in the datastore file, needs to run before devserver start
-  config.vm.provision "trigger", run: "always", :option => "value" do |trigger|
-    trigger.fire do
-      run "./ops/dev/pull-datastore.sh push"
-    end
-  end
+  config.vm.provision "shell",
+    inline: "cd /tba && ./ops/dev/pull-datastore.sh push",
+    privileged: false
 
   # Start the GAE devserver
   config.vm.provision "shell",
@@ -92,7 +90,7 @@ Vagrant.configure("2") do |config|
     run: "always"
 
   # When the container halts, pull the datastore files
-  config.trigger.before [:halt, :destroy] do
-    run "./ops/dev/pull-datastore.sh pull"
-  end
+  config.trigger.before [:halt, :destroy],
+    inline: "cd /tba && ./ops/dev/pull-datastore.sh pull",
+    privileged: false
 end

--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -30,7 +30,7 @@ RUN echo "export VISIBLE=now" >> /etc/profile
 EXPOSE 22
 
 # Get appengine environment
-ENV GAE_VERSION 1.9.61
+ENV GAE_VERSION 1.9.66
 RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -nv
 RUN unzip -q google_appengine_$GAE_VERSION.zip
 

--- a/ops/travis/travis-install.sh
+++ b/ops/travis/travis-install.sh
@@ -15,7 +15,7 @@ fi
 
 pip install -r travis_requirements.txt
 paver install_libs
-ENV GAE_VERSION 1.9.66
+GAE_VERSION="1.9.66"
 wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -nv
 unzip -q google_appengine_$GAE_VERSION.zip -d $HOME
 rm google_appengine_$GAE_VERSION.zip

--- a/ops/travis/travis-install.sh
+++ b/ops/travis/travis-install.sh
@@ -15,8 +15,9 @@ fi
 
 pip install -r travis_requirements.txt
 paver install_libs
-wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip -nv
-unzip -q google_appengine_1.9.40.zip -d $HOME
-rm google_appengine_1.9.40.zip
+ENV GAE_VERSION 1.9.66
+wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -nv
+unzip -q google_appengine_$GAE_VERSION.zip -d $HOME
+rm google_appengine_$GAE_VERSION.zip
 npm install
 npm install -g gulp-cli uglify-es uglifycss less request swagger-cli


### PR DESCRIPTION
## Description
I have updated the auto-downloaded GAE SDK to the current version, both in the `Dockerfile` as well as the Travis configuration in `ops\travis\travis-install.sh`

In addition, I have slightly tweaked the `Vagrant` configuration to what appears to be the new standard for how the calls are made, although I admittedly don't have much experience with `Vagrant`.

## Motivation and Context
`Docker` and `Travis` weren't able to pull the necessary GAE SDK zip, because Google has deprecated the download.  As such, I've bumped the versions to the current version, which is `1.9.66`.

## How Has This Been Tested?
~This famously "works on my machine".  Other than someone else trying out the changes, I'm not sure of another way to test this.~
These changes should now also be reflected in the running of `Travis`.

## Screenshots (if appropriate):
Current version of the GAE SDK:
![](https://i.imgur.com/b0MT6HU.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
