### PR TITLE
Include teams with 0 points in district rankings calc

### DIFF
--- a/helpers/district_helper.py
+++ b/helpers/district_helper.py
@@ -145,14 +145,13 @@ class DistrictHelper(object):
         for team in teams:
             if type(team) == ndb.tasklets.Future:
                 team = team.get_result()
-            bonus = None
+            bonus = 0
             if team.rookie_year == year:
                 bonus = 10
             elif team.rookie_year == year - 1:
                 bonus = 5
-            if bonus is not None:
-                team_totals[team.key.id()]['rookie_bonus'] = bonus
-                team_totals[team.key.id()]['point_total'] += bonus
+            team_totals[team.key.id()]['rookie_bonus'] = bonus
+            team_totals[team.key.id()]['point_total'] += bonus
 
             valid_team_keys.add(team.key.id())
 


### PR DESCRIPTION
Includes teams with 0 points in district rankings.

## Description
Add all teams to team totals instead of just those that have points.

## Motivation and Context
Useful for seeing teams before they have competed.

## How Has This Been Tested?
It hasn't

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
