### PR TITLE
Add Access-Control-Max-Age header for APIv3

### DIFF
--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -111,6 +111,7 @@ class ApiBaseController(CacheableHandler):
         """
         self.response.headers['Access-Control-Allow-Methods'] = "GET, POST, OPTIONS"
         self.response.headers['Access-Control-Allow-Headers'] = 'X-TBA-Auth-Key'
+        self.response.headers['Access-Control-Max-Age'] = '604800'  # 1 week
 
     def _track_call_defer(self, api_action, api_label):
         if random.random() < tba_config.GA_RECORD_FRACTION:


### PR DESCRIPTION
## Description
Add Access-Control-Max-Age for 1 week for APIv3 OPTIONS requests

## Motivation and Context
Allow caching of CORS preflight requests

## How Has This Been Tested?
In production when this gets merged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
