### PR TITLE
Add page to display all 2018 team avatars

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/apidocs/trusted', redirect_to='/apidocs/trusted/v1', name='api-trusted-documentation', strict_slash=True),
       RedirectRoute(r'/apidocs/webhooks', WebhookDocumentationHandler, 'webhook-documentation', strict_slash=True),
       RedirectRoute(r'/apiwrite', ApiWriteHandler, 'api-write', strict_slash=True),
-      RedirectRoute(r'/avatars2018', Avatars2018Handler, 'avatars-2018', strict_slash=True),
+      RedirectRoute(r'/avatars/2018', Avatars2018Handler, 'avatars-2018', strict_slash=True),
       RedirectRoute(r'/bigquery', redirect_to='https://bigquery.cloud.google.com/dataset/tbatv-prod-hrd:the_blue_alliance'),
       RedirectRoute(r'/contact', ContactHandler, 'contact', strict_slash=True),
       RedirectRoute(r'/event/<event_key>', EventDetail, 'event-detail', strict_slash=True),

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from controllers.event_controller import EventList, EventDetail, EventInsights, 
 from controllers.event_wizard_controller import EventWizardHandler, ReactEventWizardHandler
 from controllers.gameday_controller import Gameday2Controller, GamedayHandler, GamedayRedirectHandler
 from controllers.insights_controller import InsightsOverview, InsightsDetail
-from controllers.main_controller import TwoChampsHandler, ContactHandler, HashtagsHandler, FIRSTHOFHandler, \
+from controllers.main_controller import Avatars2018Handler, TwoChampsHandler, ContactHandler, HashtagsHandler, FIRSTHOFHandler, \
     MainLandingHandler, OprHandler, PredictionsHandler, PrivacyHandler, SearchHandler, \
     AboutHandler, ThanksHandler, handle_404, handle_500, \
     WebcastsHandler, RecordHandler, ApiWriteHandler, MatchInputHandler
@@ -95,6 +95,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/apidocs/trusted', redirect_to='/apidocs/trusted/v1', name='api-trusted-documentation', strict_slash=True),
       RedirectRoute(r'/apidocs/webhooks', WebhookDocumentationHandler, 'webhook-documentation', strict_slash=True),
       RedirectRoute(r'/apiwrite', ApiWriteHandler, 'api-write', strict_slash=True),
+      RedirectRoute(r'/avatars2018', Avatars2018Handler, 'avatars-2018', strict_slash=True),
       RedirectRoute(r'/bigquery', redirect_to='https://bigquery.cloud.google.com/dataset/tbatv-prod-hrd:the_blue_alliance'),
       RedirectRoute(r'/contact', ContactHandler, 'contact', strict_slash=True),
       RedirectRoute(r'/event/<event_key>', EventDetail, 'event-detail', strict_slash=True),

--- a/templates_jinja2/avatars2018.html
+++ b/templates_jinja2/avatars2018.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}The Blue Alliance - 2018 Avatars{% endblock %}
+
+{% block meta_description %}Team avatars for the 2018 season{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 col-lg-offset-2">
+      <h1 class="end_header">2018 FIRST POWER UP Avatars</h1>
+
+      <p>For more information about submitting avatars, please read the official FRC <a href="https://www.firstinspires.org/robotics/frc/blog/team-avatar-submission-system" target="_blank">blog post</a>.</p>
+
+      {% for avatar in avatars %}
+        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
+          <img class="team-avatar" src='{{avatar.avatar_image_source}}'/>
+        </a>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Description
Added a page at `/avatars/2018` that fetches all avatars and displays them. Might get slow once more teams submit avatars, and currently only backed by memcache, but we'll see what happens.

Team number shows on hover and links to team page on click.

## Motivation and Context
It would be fun to see all teams' avatars.

## How Has This Been Tested?
Load team avatars from FRC API, visit `/avatars/2018`

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/35939865-6c425f22-0c1b-11e8-9cb5-2cc3ed3b29d2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
