### PR TITLE
Added 2018 avatars link to build season and comp season landing pages

### DIFF
--- a/templates/index_buildseason.html
+++ b/templates/index_buildseason.html
@@ -28,6 +28,10 @@
       <div>
         <a class="btn btn-lg btn-block btn-primary" href="/advanced_team_search"><span class="glyphicon glyphicon-search"></span> Search for previous successful robots</a>
       </div>
+      <br>
+      <div>
+        <a class="btn btn-lg btn-block btn-primary" href="/avatars/2018"><span class="glyphicon glyphicon-user"></span> View all 2018 FIRST POWER UP Team Avatars</a>
+      </div>
 
       {% if events %}
         <h2>This Week's Events</h2>

--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -26,6 +26,10 @@
           <a class="btn btn-default" href="http://www.firstinspires.org/resource-library/frc/competition-manual-qa-system" target="_blank"><span class="glyphicon glyphicon-file"></span> {{game_name}} Game Manual and Materials</a>
         </div>
         <br><br>
+        <div>
+          <a class="btn btn-lg btn-block btn-primary" href="/avatars/2018"><span class="glyphicon glyphicon-user"></span> View all 2018 FIRST POWER UP Team Avatars</a>
+        </div>
+        <br><br>
         <div class="fitvids">
           <iframe width="420" height="315" src="https://www.youtube.com/embed/{{game_animation_youtube_id}}" frameborder="0" allowfullscreen></iframe>
         </div>


### PR DESCRIPTION
## Description
(see PR title 😁 )

## Motivation and Context
There was no actual link to the page on the site, just ~word of mouth~ Facebook links

## How Has This Been Tested?
It works locally.  See also the screenshots section.  👇 

## Screenshots (if appropriate):
Updated build season page:
![](https://puu.sh/zjsFN/f68813ef2a.png)

Updated competition season page:
![](https://puu.sh/zjsDA/06627bf38c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
