### PR TITLE
Fixed visual bug when hovering over linked avatars

### DIFF
--- a/static/css/less_css/less/tba/tba_media.less
+++ b/static/css/less_css/less/tba/tba_media.less
@@ -18,7 +18,12 @@
     background-size: cover;
 }
 
+.avatar-container {
+    text-align: center;
+}
+
 .team-avatar {
+    margin: 2px;
     image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
     image-rendering: -moz-crisp-edges;          /* Firefox                        */
     image-rendering: -o-crisp-edges;            /* Opera                          */
@@ -33,4 +38,8 @@
 
 .no-hover-underline:hover {
   text-decoration: none;
+}
+
+.no-link-font {
+    font-size: 0px;
 }

--- a/static/css/less_css/less/tba/tba_media.less
+++ b/static/css/less_css/less/tba/tba_media.less
@@ -30,3 +30,7 @@
     width: 40px;
     vertical-align: middle;
 }
+
+.no-hover-underline:hover {
+  text-decoration: none;
+}

--- a/static/css/less_css/less/tba/tba_media.less
+++ b/static/css/less_css/less/tba/tba_media.less
@@ -18,10 +18,6 @@
     background-size: cover;
 }
 
-.avatar-container {
-    text-align: center;
-}
-
 .team-avatar {
     margin: 2px;
     image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
@@ -36,10 +32,10 @@
     vertical-align: middle;
 }
 
-.no-hover-underline:hover {
-  text-decoration: none;
-}
+.avatar-link {
+  font-size: 0px;
 
-.no-link-font {
-    font-size: 0px;
+  &:hover {
+    text-decoration: none;
+  }
 }

--- a/templates_jinja2/avatars2018.html
+++ b/templates_jinja2/avatars2018.html
@@ -7,13 +7,13 @@
 {% block content %}
 <div class="container">
   <div class="row">
-    <div class="col-lg-8 col-lg-offset-2 avatar-container">
+    <div class="col-lg-8 col-lg-offset-2 text-center">
       <h1 class="end_header">2018 FIRST POWER UP Avatars</h1>
 
       <p>For more information about submitting avatars, please read the official FRC <a href="https://www.firstinspires.org/robotics/frc/blog/team-avatar-submission-system" target="_blank">blog post</a>.</p>
 
       {% for avatar in avatars %}
-        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="no-hover-underline no-link-font" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
+        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="avatar-link" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
           <img class="team-avatar" src='{{avatar.avatar_image_source}}'/>
         </a>
       {% endfor %}

--- a/templates_jinja2/avatars2018.html
+++ b/templates_jinja2/avatars2018.html
@@ -7,13 +7,13 @@
 {% block content %}
 <div class="container">
   <div class="row">
-    <div class="col-lg-8 col-lg-offset-2">
+    <div class="col-lg-8 col-lg-offset-2 avatar-container">
       <h1 class="end_header">2018 FIRST POWER UP Avatars</h1>
 
       <p>For more information about submitting avatars, please read the official FRC <a href="https://www.firstinspires.org/robotics/frc/blog/team-avatar-submission-system" target="_blank">blog post</a>.</p>
 
       {% for avatar in avatars %}
-        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="no-hover-underline" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
+        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="no-hover-underline no-link-font" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
           <img class="team-avatar" src='{{avatar.avatar_image_source}}'/>
         </a>
       {% endfor %}

--- a/templates_jinja2/avatars2018.html
+++ b/templates_jinja2/avatars2018.html
@@ -13,7 +13,7 @@
       <p>For more information about submitting avatars, please read the official FRC <a href="https://www.firstinspires.org/robotics/frc/blog/team-avatar-submission-system" target="_blank">blog post</a>.</p>
 
       {% for avatar in avatars %}
-        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
+        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="no-hover-underline" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
           <img class="team-avatar" src='{{avatar.avatar_image_source}}'/>
         </a>
       {% endfor %}


### PR DESCRIPTION
## Description
Linked avatars had a visual bug that showed a line next to them on hover.

## Motivation and Context
Bug reported [here](https://github.com/the-blue-alliance/the-blue-alliance/pull/2072#issuecomment-364163469)

## How Has This Been Tested?
Only locally.  See screenshots below 👇 

## Screenshots (if appropriate):
### Hover issue:
Before:
![](https://puu.sh/zjtv5/5063851472.png)

After:
![](https://puu.sh/zjtsW/8e5476dd6c.png)

### Listing cleanup:
Before:
![](https://puu.sh/zjybI/5313b257fd.png)

After:
![](https://puu.sh/zjy8g/39b1954da8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
