### PR TITLE
Move avatar tooltip to img element. Closes #2077

### DIFF
--- a/templates_jinja2/avatars2018.html
+++ b/templates_jinja2/avatars2018.html
@@ -17,8 +17,8 @@
       <br><br>
 
       {% for avatar in avatars %}
-        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="avatar-link" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}">
-          <img class="team-avatar blue" src='{{avatar.avatar_image_source}}'/>
+        <a href="/team/{{avatar.references[0].id()[3:]}}/2018" class="avatar-link">
+          <img class="team-avatar blue" src="{{avatar.avatar_image_source}}" rel="tooltip" title="Team {{avatar.references[0].id()[3:]}}"/>
         </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
Move avatar tooltip from anchor element to image element to prevent flickering

## Motivation and Context
Hovering over an avatar at certain positions would cause tooltip to flicker because it loses focus.

## How Has This Been Tested?
Works on dev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
