### PR TITLE
Delete avatars if FRC API returns null

### DIFF
--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -408,10 +408,12 @@ class TeamAvatarGet(webapp.RequestHandler):
         year = datetime.date.today().year
         team = Team.get_by_id(key_name)
 
-        avatar = fms_df.getTeamAvatar(year, key_name)
+        avatar, keys_to_delete = fms_df.getTeamAvatar(year, key_name)
 
         if avatar:
             MediaManipulator.createOrUpdate(avatar)
+
+        MediaManipulator.delete_keys(keys_to_delete)
 
         template_values = {
             'key_name': key_name,
@@ -623,9 +625,10 @@ class EventDetailsGet(webapp.RequestHandler):
             event_teams = [event_teams]
 
         if event.year == 2018:
-            avatars = df.getEventTeamAvatars(event.key_name)
+            avatars, keys_to_delete = df.getEventTeamAvatars(event.key_name)
             if avatars:
                 MediaManipulator.createOrUpdate(avatars)
+            MediaManipulator.delete_keys(keys_to_delete)
 
         template_values = {
             'event': event,

--- a/datafeeds/parsers/fms_api/fms_api_team_avatar_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_avatar_parser.py
@@ -23,20 +23,21 @@ class FMSAPITeamAvatarParser(object):
         total_pages = response['pageTotal']
         teams = response['teams']
         avatars = []
+        keys_to_delete = set()
 
         for teamData in teams:
+            team_number = teamData['teamNumber']
+            foreign_key = "avatar_{}_frc{}".format(self.year, team_number)
+            media_key = ndb.Key('Media', Media.render_key_name(MediaType.AVATAR, foreign_key))
+
             if not teamData['encodedAvatar']:
+                keys_to_delete.add(media_key)
                 continue
             else:
                 encoded_avatar = teamData['encodedAvatar']
 
-            team_number = teamData['teamNumber']
-
-            foreign_key = "avatar_{}_frc{}".format(self.year, team_number)
-            media_key = Media.render_key_name(MediaType.AVATAR, foreign_key)
-
             avatar = Media(
-                key=ndb.Key('Media', media_key),
+                key=media_key,
                 details_json=json.dumps({'base64Image': encoded_avatar}),
                 foreign_key=foreign_key,
                 media_type_enum=MediaType.AVATAR,
@@ -46,4 +47,4 @@ class FMSAPITeamAvatarParser(object):
 
             avatars.append(avatar)
 
-        return (avatars, (current_page < total_pages))
+        return (avatars, keys_to_delete, (current_page < total_pages))

--- a/tests/test_fms_api_team_avatar_parser.py
+++ b/tests/test_fms_api_team_avatar_parser.py
@@ -23,7 +23,7 @@ class TestFMSAPITeamAvatarParser(unittest2.TestCase):
 
     def test_parse_team_with_avatar(self):
         with open('test_data/fms_api/2018_avatars_frc1741.json', 'r') as f:
-            models, more_pages = FMSAPITeamAvatarParser(2018).parse(json.loads(f.read()))
+            models, _, more_pages = FMSAPITeamAvatarParser(2018).parse(json.loads(f.read()))
 
             self.assertFalse(more_pages)
             self.assertEqual(len(models), 1)
@@ -39,14 +39,14 @@ class TestFMSAPITeamAvatarParser(unittest2.TestCase):
 
     def test_parse_team_with_no_avatar(self):
         with open('test_data/fms_api/2018_avatars_frc1.json', 'r') as f:
-            models, more_pages = FMSAPITeamAvatarParser(2018).parse(json.loads(f.read()))
+            models, _, more_pages = FMSAPITeamAvatarParser(2018).parse(json.loads(f.read()))
 
             self.assertFalse(more_pages)
             self.assertEqual(len(models), 0)
 
     def test_parse_result_with_multiple_teams(self):
         with open('test_data/fms_api/2018_avatars_multiple.json', 'r') as f:
-            models, more_pages = FMSAPITeamAvatarParser(2018).parse(json.loads(f.read()))
+            models, _, more_pages = FMSAPITeamAvatarParser(2018).parse(json.loads(f.read()))
 
             self.assertFalse(more_pages)
             self.assertEqual(len(models), 1)


### PR DESCRIPTION
## Description
When parsing avatars, keep track of those with null keys to be deleted.

## Motivation and Context
Currently, we do not delete a team avatar even if the FRC API stops returning one. A reason for this can be FIRST rejecting avatars that have initially been approved due to copyright violations. We should remove team avatars if the FRC API does not return one.

Closes #2085 

## How Has This Been Tested?
Verified that avatars that are Null from FRC API get deleted in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
