### PR TITLE
Add Two New Team@Event Status APIv3 Endpoints

### DIFF
--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -50,6 +50,8 @@ app = webapp2.WSGIApplication([
         atc.ApiTeamEventsController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/team/<team_key:>/events/<year:([0-9]+)>/<model_type:(simple|keys)>',
         atc.ApiTeamEventsController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/team/<team_key:>/events/<year:([0-9]+)>/statuses',
+        atc.ApiTeamYearEventsStatusesController, methods=['GET', 'OPTIONS']),
     # Team @ Event
     webapp2.Route(r'/api/v3/team/<team_key:>/event/<event_key:>/matches',
         atc.ApiTeamEventMatchesController, methods=['GET', 'OPTIONS']),
@@ -64,6 +66,7 @@ app = webapp2.WSGIApplication([
         atc.ApiTeamHistoryAwardsController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/team/<team_key:>/awards/<year:([0-9]+)>',
         atc.ApiTeamYearAwardsController, methods=['GET', 'OPTIONS']),
+    # Team Matches
     webapp2.Route(r'/api/v3/team/<team_key:>/matches/<year:([0-9]+)>',
         atc.ApiTeamYearMatchesController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/team/<team_key:>/matches/<year:([0-9]+)>/<model_type:(simple|keys)>',

--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -103,6 +103,8 @@ app = webapp2.WSGIApplication([
         aec.ApiEventMatchesController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/event/<event_key:>/awards',
         aec.ApiEventAwardsController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/event/<event_key:>/teams/statuses',
+        aec.ApiEventTeamsStatusesController, methods=['GET', 'OPTIONS']),
     # Match
     webapp2.Route(r'/api/v3/match/<match_key:>',
         amc.ApiMatchController, methods=['GET', 'OPTIONS']),

--- a/database/event_query.py
+++ b/database/event_query.py
@@ -77,6 +77,20 @@ class TeamYearEventsQuery(DatabaseQuery):
         raise ndb.Return(events)
 
 
+class TeamYearEventTeamsQuery(DatabaseQuery):
+    CACHE_VERSION = 1
+    CACHE_KEY_FORMAT = 'team_year_eventteams_{}_{}'  # (team_key, year)
+
+    @ndb.tasklet
+    def _query_async(self):
+        team_key = self._query_args[0]
+        year = self._query_args[1]
+        event_teams = yield EventTeam.query(
+            EventTeam.team == ndb.Key(Team, team_key),
+            EventTeam.year == year).fetch_async()
+        raise ndb.Return(event_teams)
+
+
 class EventDivisionsQuery(DatabaseQuery):
     CACHE_VERSION = 1
     CACHE_KEY_FORMAT = "event_divisions_{}"  # (event_key)

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -9,7 +9,7 @@ from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatches
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
     EventMediasQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
 from database.robot_query import TeamRobotsQuery
-from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
+from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, EventEventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
 
 from models.district_team import DistrictTeam
 from models.event import Event
@@ -175,6 +175,7 @@ def team_updated(affected_refs):
         page_num = _get_team_page_num(et_key.id().split('_')[1])
         queries_and_keys.append((TeamListYearQuery(year, page_num)))
         queries_and_keys.append((EventTeamsQuery(event_key)))
+        queries_and_keys.append((EventEventTeamsQuery(event_key)))
 
     for dt_key in district_team_keys_future.get_result():
         district_key = dt_key.id().split('_')[0]
@@ -200,6 +201,7 @@ def eventteam_updated(affected_refs):
 
     for event_key in event_keys:
         queries_and_keys.append(EventTeamsQuery(event_key.id()))
+        queries_and_keys.append(EventEventTeamsQuery(event_key.id()))
         queries_and_keys.append(EventTeamsMediasQuery(event_key.id()))
         queries_and_keys.append(EventTeamsPreferredMediasQuery(event_key.id()))
 

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -2,7 +2,7 @@ from google.appengine.ext import ndb
 
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery, TeamEventTypeAwardsQuery
 from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery, DistrictQuery
-from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, \
+from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, TeamYearEventTeamsQuery, \
     EventDivisionsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
@@ -73,6 +73,7 @@ def event_updated(affected_refs):
         year = int(et_key.id()[:4])
         queries_and_keys.append((TeamEventsQuery(team_key)))
         queries_and_keys.append((TeamYearEventsQuery(team_key, year)))
+        queries_and_keys.append((TeamYearEventTeamsQuery(team_key, year)))
 
     events_with_parents = filter(lambda e: e.get_result() is not None and e.get_result().parent_event is not None, events_future)
     parent_keys = set([e.get_result().parent_event for e in events_with_parents])
@@ -194,6 +195,7 @@ def eventteam_updated(affected_refs):
         page_num = _get_team_page_num(team_key.id())
         for year in years:
             queries_and_keys.append(TeamYearEventsQuery(team_key.id(), year))
+            queries_and_keys.append(TeamYearEventTeamsQuery(team_key.id(), year))
             queries_and_keys.append(TeamListYearQuery(year, page_num))
 
     for event_key in event_keys:

--- a/database/team_query.py
+++ b/database/team_query.py
@@ -89,6 +89,17 @@ class EventTeamsQuery(DatabaseQuery):
         raise ndb.Return(teams)
 
 
+class EventEventTeamsQuery(DatabaseQuery):
+    CACHE_VERSION = 1
+    CACHE_KEY_FORMAT = 'event_eventteams_{}'  # (event_key)
+
+    @ndb.tasklet
+    def _query_async(self):
+        event_key = self._query_args[0]
+        event_teams = yield EventTeam.query(EventTeam.event == ndb.Key(Event, event_key)).fetch_async()
+        raise ndb.Return(event_teams)
+
+
 class TeamParticipationQuery(DatabaseQuery):
     CACHE_VERSION = 0
     CACHE_KEY_FORMAT = 'team_participation_{}'  # (team_key)

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -13,7 +13,7 @@ from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatches
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
     EventMediasQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
 from database.robot_query import TeamRobotsQuery
-from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
+from database.team_query import TeamQuery, TeamListQuery, TeamListYearQuery, DistrictTeamsQuery, EventTeamsQuery, EventEventTeamsQuery, TeamParticipationQuery, TeamDistrictsQuery
 
 from consts.event_type import EventType
 from consts.award_type import AwardType
@@ -281,6 +281,9 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(EventTeamsQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventTeamsQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventTeamsQuery('2010cama').cache_key in cache_keys)
+        self.assertTrue(EventEventTeamsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(EventEventTeamsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(EventEventTeamsQuery('2010cama').cache_key in cache_keys)
 
     def test_eventteam_updated(self):
         affected_refs = {
@@ -309,6 +312,8 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(TeamListYearQuery(2015, 1).cache_key in cache_keys)
         self.assertTrue(EventTeamsQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventTeamsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(EventEventTeamsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(EventEventTeamsQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventTeamsMediasQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventTeamsMediasQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventTeamsPreferredMediasQuery('2015cama').cache_key in cache_keys)

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -166,7 +166,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.event_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 13)
+        self.assertEqual(len(cache_keys), 15)
         self.assertTrue(EventQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventListQuery(2014).cache_key in cache_keys)
@@ -267,7 +267,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.team_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 13)
+        self.assertEqual(len(cache_keys), 16)
         self.assertTrue(TeamQuery('frc254').cache_key in cache_keys)
         self.assertTrue(TeamQuery('frc604').cache_key in cache_keys)
         self.assertTrue(TeamListQuery(0).cache_key in cache_keys)
@@ -293,7 +293,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.eventteam_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 18)
+        self.assertEqual(len(cache_keys), 24)
         self.assertTrue(TeamEventsQuery('frc254').cache_key in cache_keys)
         self.assertTrue(TeamEventsQuery('frc604').cache_key in cache_keys)
         self.assertTrue(TeamParticipationQuery('frc254').cache_key in cache_keys)
@@ -340,7 +340,7 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.district_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 12)
+        self.assertEqual(len(cache_keys), 13)
         self.assertTrue(DistrictsInYearQuery(2015).cache_key in cache_keys)
         self.assertTrue(DistrictsInYearQuery(2016).cache_key in cache_keys)
         self.assertTrue(DistrictHistoryQuery('ne').cache_key in cache_keys)

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -6,7 +6,7 @@ from google.appengine.ext import testbed
 from database import get_affected_queries
 from database.award_query import EventAwardsQuery, TeamAwardsQuery, TeamYearAwardsQuery, TeamEventAwardsQuery, TeamEventTypeAwardsQuery
 from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery, DistrictQuery
-from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, \
+from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, TeamYearEventTeamsQuery, \
     EventDivisionsQuery
 from database.event_details_query import EventDetailsQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
@@ -177,6 +177,8 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(TeamEventsQuery('frc604').cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc604', 2015).cache_key in cache_keys)
         self.assertTrue(EventDivisionsQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventDivisionsQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(EventDivisionsQuery('2015cafoo').cache_key in cache_keys)
@@ -297,6 +299,10 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc604', 2014).cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc254', 2014).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc604', 2014).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc604', 2015).cache_key in cache_keys)
         self.assertTrue(TeamListYearQuery(2014, 0).cache_key in cache_keys)
         self.assertTrue(TeamListYearQuery(2014, 1).cache_key in cache_keys)
         self.assertTrue(TeamListYearQuery(2015, 0).cache_key in cache_keys)
@@ -343,4 +349,5 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         self.assertTrue(DistrictEventsQuery('2016ne').cache_key in cache_keys)
         self.assertTrue(TeamEventsQuery('frc125').cache_key in cache_keys)
         self.assertTrue(TeamYearEventsQuery('frc125', 2016).cache_key in cache_keys)
+        self.assertTrue(TeamYearEventTeamsQuery('frc125', 2016).cache_key in cache_keys)
         self.assertTrue(EventDivisionsQuery('2016necmp').cache_key in cache_keys)


### PR DESCRIPTION
Add two new APIv3 endpoints:
Team@Event statuses for all events for a team in one year:
`/api/v3/team/<team_key>/events/<year>/statuses`
Format: A dict of event_key: status_dict

Team@Event statuses for all teams at one event:
`/api/v3/event/<event_key>/teams/statuses`
Format: A dict of team_key: status_dict

`status_dict` is the same as what is currently available at:
`api/v3/team/<team_key>/event/<event_key>/status`

## Description
Added two new DBQueries to fetch EventTeams for 1) a specific team's year and 2) an event.
Updated cache clearing and tests to support new DBQueries

Added two new APIv3 endpoints that use the new DBQueries.

## Motivation and Context
Useful for the PWA

## How Has This Been Tested?
On local dev, verified that the following two endpoints work:
`/api/v3/team/frc254/events/2017/statuses`
`/api/v3/event/2017casj/teams/statuses`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
