### PR TITLE
Fix suggestions being improperly marked as official. Closes #2082

### DIFF
--- a/controllers/suggestions/suggest_offseason_event_review_controller.py
+++ b/controllers/suggestions/suggest_offseason_event_review_controller.py
@@ -41,7 +41,7 @@ class SuggestOffseasonEventReviewController(SuggestionsReviewBaseController):
         if existing_event:
             return 'duplicate_key', None
 
-        first_code = self.request.get("first_code", None)
+        first_code = self.request.get("first_code", '')
         event = Event(
             id=event_key,
             end_date=end_date,
@@ -59,7 +59,7 @@ class SuggestOffseasonEventReviewController(SuggestionsReviewBaseController):
             website=self.request.get("website"),
             year=int(self.request.get("year")),
             first_code=first_code,
-            official=(first_code is not None),
+            official=(not first_code == ''),
         )
         EventManipulator.createOrUpdate(event)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Suggested offseasons were being improperly set to `official = True`

## Description
Logic check for `first_code is not None` never evaluates to `False`. Should be checking for empty string.

## How Has This Been Tested?
Accept suggestion with no first_code, verify that official == False. Accept suggestion with first_code, verify that official == True.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
