### PR TITLE
Clean junk JSON from FRC API

### DIFF
--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -223,7 +223,7 @@ class DatafeedFMSAPI(object):
                     logging.error("Error saving API response for: {}".format(url))
                     logging.error(traceback.format_exc())
             try:
-                json_content = json.loads(result.content)
+                json_content = json.loads(result.content.lstrip('\xef\xbb\xbf').rstrip('\x00'))
             except Exception, exception:
                 logging.error("Error parsing: {}".format(url))
                 logging.error(traceback.format_exc())


### PR DESCRIPTION
## Description
`lstrip` and `rstrip` FRC API responses

## Motivation and Context
FRC API returning stuff like:
`\xef\xbb\xbf{"Schedule":[]}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00`

## How Has This Been Tested?
Locally on dev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
