### PR TITLE
Catch memcache ValueError

### DIFF
--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -136,7 +136,10 @@ class CacheableHandler(webapp2.RequestHandler):
     def _write_cache(self, response):
         if tba_config.CONFIG["memcache"] and not self._is_admin:
             compressed = zlib.compress(cPickle.dumps((response, self._last_modified)))
-            memcache.set(self.cache_key, compressed, self._get_cache_expiration())
+            try:
+                memcache.set(self.cache_key, compressed, self._get_cache_expiration())
+            except ValueError:
+                logging.info("Setting memcache failed for key: {}".format(self.cache_key))
 
     @classmethod
     def delete_cache_multi(cls, cache_keys):


### PR DESCRIPTION
Catch `ValueError` thrown when setting memcache over 1 mb.

## Motivation and Context
Avatars page 500ing

## How Has This Been Tested?
Local dev no longer 500s on avatar page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
