### PR TITLE
Cache sharded avatars

### DIFF
--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -61,8 +61,24 @@ class Avatars2018Handler(CacheableHandler):
         self._cache_expiration = 60 * 60 * 24
 
     def _render(self, *args, **kw):
-        avatars_future = Media.query(Media.media_type_enum == MediaType.AVATAR).fetch_async()
-        avatars = sorted(avatars_future.get_result(), key=lambda a: int(a.references[0].id()[3:]))
+        avatars = []
+        shards = memcache.get_multi(['2018avatars_{}'.format(i) for i in xrange(10)])
+        for shard in shards.values():
+            if shard:
+                avatars += shard
+
+        if not avatars:
+            avatars_future = Media.query(Media.media_type_enum == MediaType.AVATAR).fetch_async()
+            avatars = sorted(avatars_future.get_result(), key=lambda a: int(a.references[0].id()[3:]))
+
+            shards = {}
+            size = len(avatars) / 10 + 1
+            for i in xrange(10):
+                start = i * size
+                end = start + size - 1
+                shards['2018avatars_{}'.format(i)] = avatars[start:end]
+            memcache.set_multi(shards, 60*60*24)
+
         self.template_values.update({
             'avatars': avatars,
         })

--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -64,8 +64,12 @@ class Avatars2018Handler(CacheableHandler):
         avatars = []
         shards = memcache.get_multi(['2018avatars_{}'.format(i) for i in xrange(10)])
         for shard in shards.values():
-            if shard:
+            if shard is not None:
                 avatars += shard
+            else:
+                # Missing a shard, must refetch all
+                avatars = []
+                break
 
         if not avatars:
             avatars_future = Media.query(Media.media_type_enum == MediaType.AVATAR).fetch_async()


### PR DESCRIPTION
## Motivation and Context
Cache all 2018 avatars in shards, since the page cannot be cached because it is too large.

## How Has This Been Tested?
Verified on local dev that RPC costs and request time are both lower.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
