### PR TITLE
Fix refetch avatar shards if missing one

### DIFF
--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -63,13 +63,9 @@ class Avatars2018Handler(CacheableHandler):
     def _render(self, *args, **kw):
         avatars = []
         shards = memcache.get_multi(['2018avatars_{}'.format(i) for i in xrange(5)])
-        for _, shard in sorted(shards.items(), key=lambda kv: kv[0]):
-            if shard is not None:
+        if len(shards) == 5:  # If missing a shard, must refetch all
+            for _, shard in sorted(shards.items(), key=lambda kv: kv[0]):
                 avatars += shard
-            else:
-                # Missing a shard, must refetch all
-                avatars = []
-                break
 
         if not avatars:
             avatars_future = Media.query(Media.media_type_enum == MediaType.AVATAR).fetch_async()


### PR DESCRIPTION
## Motivation and Context
Checking whether all avatar shards were fetched was being done incorrectly.

## How Has This Been Tested?
Reproduced old bug locally, this fix makes it so that bug doesn't occur.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
