### PR TITLE
Add popular teams competing to homepage

### DIFF
--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -15,13 +15,62 @@
       </div>
       {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
-        <h2>This Week's Events</h2>
-        {% with events as events %}
-          {% include "event_partials/event_table.html" %}
-        {% endwith %}
-        <div>
-          <a class="btn btn-default" href="/webcasts"><span class="glyphicon glyphicon-info-sign"></span> Add Webcasts</a>
-          <a class="btn btn-default" href="/contact"><span class="glyphicon glyphicon-upload"></span> Add YouTube Videos</a>
+        <h2>This Week:</h2>
+
+
+        <div class="row">
+          <div class="col-sm-12">
+            <ul class="nav nav-tabs nav-justified">
+              <li class="active"><a href="#events" data-toggle="tab">Events</a></li>
+              <li><a href="#popular-teams" data-toggle="tab">Popular Teams</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="tab-content">
+          <div class="tab-pane active" id="events">
+            <div class="row">
+              <div class="col-sm-12">
+                {% with events as events %}
+                  {% include "event_partials/event_table.html" %}
+                {% endwith %}
+                <div>
+                  <a class="btn btn-default" href="/webcasts"><span class="glyphicon glyphicon-info-sign"></span> Add Webcasts</a>
+                  <a class="btn btn-default" href="/contact"><span class="glyphicon glyphicon-upload"></span> Add YouTube Videos</a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="tab-pane" id="popular-teams">
+            <div class="row">
+              <div class="col-sm-12">
+                <p>* This list of teams is automatically generated based on how many people have Favorited them in myTBA.</p>
+                <table class="table table-striped table-condensed table-center team-table">
+                  <thead>
+                    <tr><th>Team</th><th>Location</th></tr>
+                  </thead>
+                  <tbody>
+                    {% for team in popular_teams %}
+                    <tr>
+                      <td>
+                        <div class="team-name-container">
+                          <div class="favorite-team-icon" data-team="{{team.key.id}}">
+                              <span class="favorite-team-icon-spacer"></span>
+                              <span class="glyphicon glyphicon-star"></span>
+                          </div>
+                          <div class="team-name">
+                            <a href="/team/{{ team.team_number }}/{{event.year}}">{{ team.team_number }}<br>{% if team.nickname %}{{ team.nickname }}{% else %}--{% endif %}</a>
+                          </div>
+                        </div>
+                      </td>
+                      <td>{% if team.city_state_country %}{{ team.city_state_country }}{% else %}--{% endif %}</td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
         </div>
       {% else %}
         <h2>Build season has ended. Competitions start soon!</h2>

--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -15,12 +15,20 @@
       </div>
       {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
-        <h2>This Week:</h2>
+        {% with events|first as first_event %}
+        {% with events|last as last_event %}
+        {% if first_event.week != None %}
+          <h2>Week {{first_event.week|add:"1"}}{% if first_event.week != last_event.week %} - {{last_event.week|add:"1"}}{% endif %}:</h2>
+        {% else %}
+          <h2>This Week:</h2>
+        {% endif %}
+        {% endwith %}
+        {% endwith %}
 
         <div class="row">
           <div class="col-sm-12">
             <ul class="nav nav-tabs nav-justified">
-              <li class="active"><a href="#events" data-toggle="tab">Events</a></li>
+              <li class="active"><a href="#events" data-toggle="tab">Events This Week</a></li>
               <li><a href="#popular-teams" data-toggle="tab">Popular Teams Competing</a></li>
             </ul>
           </div>

--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -54,10 +54,10 @@
                 <p>* This list of teams is automatically generated based on how many people have Favorited them in myTBA.</p>
                 <table class="table table-striped table-condensed table-center team-table">
                   <thead>
-                    <tr><th>Team</th><th>Location</th></tr>
+                    <tr><th>Team</th><th>Event</th></tr>
                   </thead>
                   <tbody>
-                    {% for team in popular_teams %}
+                    {% for team, event in popular_teams_events %}
                     <tr>
                       <td>
                         <div class="team-name-container">
@@ -70,7 +70,7 @@
                           </div>
                         </div>
                       </td>
-                      <td>{% if team.city_state_country %}{{ team.city_state_country }}{% else %}--{% endif %}</td>
+                      <td><a href="/event/{{event.key.id}}">{{event.name}}</a></td>
                     </tr>
                     {% endfor %}
                   </tbody>

--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -17,12 +17,11 @@
       {% if events %}
         <h2>This Week:</h2>
 
-
         <div class="row">
           <div class="col-sm-12">
             <ul class="nav nav-tabs nav-justified">
               <li class="active"><a href="#events" data-toggle="tab">Events</a></li>
-              <li><a href="#popular-teams" data-toggle="tab">Popular Teams</a></li>
+              <li><a href="#popular-teams" data-toggle="tab">Popular Teams Competing</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Closes #2124 

## Description
Add a list of top (25) Favorited teams in myTBA to competition homepage, sorted by team number.

Event Teams and Favorite counts are cached for 24 hours. This could be longer, but 24 hours should be fine.

## Motivation and Context
@tombot suggested it. Why not?

## How Has This Been Tested?
Local dev with actual week 1 teams and some fake Favorites.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/36713264-bf24060c-1b5a-11e8-9695-58851e6ad6c1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
