### PR TITLE
Show ETA for next match in GameDay livescore widget

### DIFF
--- a/react/gameday2/components/LivescoreDisplay.js
+++ b/react/gameday2/components/LivescoreDisplay.js
@@ -3,174 +3,238 @@ import PropTypes from 'prop-types'
 import AutoScale from './AutoScale/AutoScale'
 import PowerupCount from '../../liveevent/components/PowerupCount'
 
-const LivescoreDisplay = (props) => {
-  const { matches, matchState } = props
-
-  if (!matchState) {
-    return (
-      <div className="livescore-wrapper">
-        <div className="livescore-container">
-          <div className="livescore-display">Live match info not available</div>
-        </div>
-      </div>
-    )
+class LivescoreDisplay extends React.PureComponent {
+  state = {
+    currentTime: undefined,
   }
 
-  const {
-    mk: matchKey,
-    m: mode,
-    t: timeRemaining,
-    rs: redScore,
-    rfc: redForceCount,
-    rfp: redForcePlayed,
-    rlc: redLevitateCount,
-    rlp: redLevitatePlayed,
-    rbc: redBoostCount,
-    rbp: redBoostPlayed,
-    rswo: redSwitchOwned,
-    rsco: redScaleOwned,
-    rcp: redCurrentPowerup,
-    rpt: redPowerupTimeRemaining,
-    raq: redAutoQuest,
-    rfb: redFaceTheBoss,
-    bs: blueScore,
-    bfc: blueForceCount,
-    bfp: blueForcePlayed,
-    blc: blueLevitateCount,
-    blp: blueLevitatePlayed,
-    bbc: blueBoostCount,
-    bbp: blueBoostPlayed,
-    bswo: blueSwitchOwned,
-    bsco: blueScaleOwned,
-    bcp: blueCurrentPowerup,
-    bpt: bluePowerupTimeRemaining,
-    baq: blueAutoQuest,
-    bfb: blueFaceTheBoss,
-  } = matchState
+  componentDidMount() {
+    this.updateCurrentTime()
+    setInterval(this.updateCurrentTime, 10000)
+  }
 
-  let match = null
-  matches.forEach((m) => {
-    if (m.key.split('_')[1] === matchKey) {
-      match = m
+  updateCurrentTime = () => {
+    this.setState({ currentTime: new Date().getTime() / 1000 })
+  }
+
+  render() {
+    const { matches, matchState } = this.props
+
+    if (!matchState) {
+      return (
+        <div className="livescore-wrapper">
+          <div className="livescore-container">
+            <div className="livescore-display">Live match info not available</div>
+          </div>
+        </div>
+      )
     }
-  })
 
-  if (!match) {
-    return (
-      <div className="livescore-wrapper">
-        <div className="livescore-container">
-          <div className="livescore-display">Live match info not available</div>
+    let {
+      m: mode,
+      t: timeRemaining,
+      rs: redScore,
+      rfc: redForceCount,
+      rfp: redForcePlayed,
+      rlc: redLevitateCount,
+      rlp: redLevitatePlayed,
+      rbc: redBoostCount,
+      rbp: redBoostPlayed,
+      rswo: redSwitchOwned,
+      rsco: redScaleOwned,
+      rcp: redCurrentPowerup,
+      rpt: redPowerupTimeRemaining,
+      raq: redAutoQuest,
+      rfb: redFaceTheBoss,
+      bs: blueScore,
+      bfc: blueForceCount,
+      bfp: blueForcePlayed,
+      blc: blueLevitateCount,
+      blp: blueLevitatePlayed,
+      bbc: blueBoostCount,
+      bbp: blueBoostPlayed,
+      bswo: blueSwitchOwned,
+      bsco: blueScaleOwned,
+      bcp: blueCurrentPowerup,
+      bpt: bluePowerupTimeRemaining,
+      baq: blueAutoQuest,
+      bfb: blueFaceTheBoss,
+    } = matchState
+
+    let match
+    let nextMatch
+    matches.forEach((m, i) => {
+      if (m.key.split('_')[1] === matchState.mk) {
+        match = m
+        nextMatch = matches[i + 1]  // Can be undefined
+      }
+    })
+
+    // If match has been played, display next match and ETA
+    let matchWaiting = false
+    if (match && match.alliances.red.score !== -1 && match.alliances.blue.score !== -1) {
+      match = nextMatch
+      matchWaiting = true
+    }
+
+    if (!match) {
+      return (
+        <div className="livescore-wrapper">
+          <div className="livescore-container">
+            <div className="livescore-display">Live match info not available</div>
+          </div>
         </div>
-      </div>
+      )
+    }
+
+    let etaStr = ''
+    if (matchWaiting) {  // Reset to pre match defaults
+      mode = 'pre_match'
+      timeRemaining = 0
+      redScore = 0
+      redForceCount = 0
+      redForcePlayed = false
+      redLevitateCount = 0
+      redLevitatePlayed = false
+      redBoostCount = 0
+      redBoostPlayed = false
+      redSwitchOwned = 0
+      redScaleOwned = 0
+      redCurrentPowerup = null
+      redPowerupTimeRemaining = null
+      redAutoQuest = false
+      redFaceTheBoss = false
+      blueScore = 0
+      blueForceCount = 0
+      blueForcePlayed = false
+      blueLevitateCount = 0
+      blueLevitatePlayed = false
+      blueBoostCount = 0
+      blueBoostPlayed = false
+      blueSwitchOwned = false
+      blueScaleOwned = false
+      blueCurrentPowerup = null
+      bluePowerupTimeRemaining = null
+      blueAutoQuest = false
+      blueFaceTheBoss = false
+
+      if (this.state.currentTime && match.predicted_time) {
+        const etaMin = (match.predicted_time - this.state.currentTime) / 60
+        if (etaMin < 1) {
+          etaStr = ' in <1 min'
+        } else {
+          etaStr = ` in ~${Math.round(etaMin)} min`
+        }
+      }
+    }
+
+    let compLevel = match.comp_level.toUpperCase()
+    compLevel = (compLevel === 'QM') ? 'Q' : compLevel
+    const matchNumber = (compLevel === 'QF' || compLevel === 'SF' || compLevel === 'F') ? `${match.set_number}-${match.match_number}` : match.match_number
+    const matchLabel = `${compLevel}${matchNumber}${etaStr}`
+
+    let progressColor
+    if (mode === 'post_match' || (timeRemaining === 0 && mode === 'teleop')) {
+      progressColor = 'progress-bar-red'
+    } else if (timeRemaining <= 30 && mode === 'teleop') {
+      progressColor = 'progress-bar-yellow'
+    } else {
+      progressColor = 'progress-bar-green'
+    }
+
+    let progressWidth
+    if (mode === 'post_match') {
+      progressWidth = '100%'
+    } else if (mode === 'teleop') {
+      progressWidth = `${((150 - timeRemaining) * 100) / 150}%`
+    } else if (mode === 'auto') {
+      progressWidth = `${((15 - timeRemaining) * 100) / 150}%`
+    } else {
+      progressWidth = '0%'
+    }
+
+    let currentPowerup = null
+    let powerupTimeRemaining = null
+    let powerupColor = null
+    if (redCurrentPowerup) {
+      currentPowerup = redCurrentPowerup
+      powerupTimeRemaining = redPowerupTimeRemaining
+      powerupColor = 'red'
+    } else if (blueCurrentPowerup) {
+      currentPowerup = blueCurrentPowerup
+      powerupTimeRemaining = bluePowerupTimeRemaining
+      powerupColor = 'blue'
+    }
+
+    return (
+      <AutoScale
+        wrapperClass="livescore-wrapper"
+        containerClass="livescore-container"
+        maxWidth={800}
+      >
+        <div className="livescore-display">
+          <h3>
+            { matchLabel }
+          </h3>
+          <div className="col-container">
+            <div className="side-col">
+              <div className={`booleanIndicator ${redScaleOwned && 'red'}`}>Scale</div>
+              <div className={`booleanIndicator ${redSwitchOwned && 'red'}`}>Switch</div>
+              <div className="powerupsContainer">
+                <PowerupCount color="red" type="force" count={redForceCount} played={redForcePlayed} />
+                <PowerupCount color="red" type="levitate" count={redLevitateCount} played={redLevitatePlayed} isCenter />
+                <PowerupCount color="red" type="boost" count={redBoostCount} played={redBoostPlayed} />
+              </div>
+              <div className={`booleanIndicator ${redAutoQuest && 'red'}`}>Auto Quest</div>
+              <div className={`booleanIndicator ${redFaceTheBoss && 'red'}`}>Face The Boss</div>
+            </div>
+            <div className="mid-col">
+              <div className="progress">
+                <div className={`progress-bar ${progressColor}`} style={{ width: progressWidth }} />
+                <div className="timeRemainingContainer">
+                  <span className="timeRemaining">{ timeRemaining }</span>
+                </div>
+              </div>
+              <div className="scoreContainer">
+                <div className="redAlliance">
+                  {match.alliances.red.team_keys.map((teamKey) => {
+                    const teamNum = teamKey.substring(3)
+                    return <div key={teamKey} >{teamNum}</div>
+                  })}
+                  <div className="score red">{ redScore }</div>
+                </div>
+                <div className="blueAlliance">
+                  {match.alliances.blue.team_keys.map((teamKey) => {
+                    const teamNum = teamKey.substring(3)
+                    return <div key={teamKey} >{teamNum}</div>
+                  })}
+                  <div className="score blue">{ blueScore }</div>
+                </div>
+              </div>
+              {currentPowerup &&
+                <div className={`currentPowerup ${powerupColor}`}>
+                  <img src={`/images/2018_${currentPowerup}.png`} className="currentPowerupIcon" role="presentation" />
+                  <br />
+                  { powerupTimeRemaining }
+                </div>
+              }
+            </div>
+            <div className="side-col">
+              <div className={`booleanIndicator ${blueScaleOwned && 'blue'}`}>Scale</div>
+              <div className={`booleanIndicator ${blueSwitchOwned && 'blue'}`}>Switch</div>
+              <div className="powerupsContainer">
+                <PowerupCount color="blue" type="force" count={blueForceCount} played={blueForcePlayed} />
+                <PowerupCount color="blue" type="levitate" count={blueLevitateCount} played={blueLevitatePlayed} isCenter />
+                <PowerupCount color="blue" type="boost" count={blueBoostCount} played={blueBoostPlayed} />
+              </div>
+              <div className={`booleanIndicator ${blueAutoQuest && 'blue'}`}>Auto Quest</div>
+              <div className={`booleanIndicator ${blueFaceTheBoss && 'blue'}`}>Face The Boss</div>
+            </div>
+          </div>
+        </div>
+      </AutoScale>
     )
   }
-
-  let compLevel = match.comp_level.toUpperCase()
-  compLevel = (compLevel === 'QM') ? 'Q' : compLevel
-  const matchNumber = (compLevel === 'QF' || compLevel === 'SF' || compLevel === 'F') ? `${match.set_number}-${match.match_number}` : match.match_number
-  const matchLabel = `${compLevel}${matchNumber}`
-
-  let progressColor
-  if (mode === 'post_match' || (timeRemaining === 0 && mode === 'teleop')) {
-    progressColor = 'progress-bar-red'
-  } else if (timeRemaining <= 30 && mode === 'teleop') {
-    progressColor = 'progress-bar-yellow'
-  } else {
-    progressColor = 'progress-bar-green'
-  }
-
-  let progressWidth
-  if (mode === 'post_match') {
-    progressWidth = '100%'
-  } else if (mode === 'teleop') {
-    progressWidth = `${((150 - timeRemaining) * 100) / 150}%`
-  } else if (mode === 'auto') {
-    progressWidth = `${((15 - timeRemaining) * 100) / 150}%`
-  } else {
-    progressWidth = '0%'
-  }
-
-  let currentPowerup = null
-  let powerupTimeRemaining = null
-  let powerupColor = null
-  if (redCurrentPowerup) {
-    currentPowerup = redCurrentPowerup
-    powerupTimeRemaining = redPowerupTimeRemaining
-    powerupColor = 'red'
-  } else if (blueCurrentPowerup) {
-    currentPowerup = blueCurrentPowerup
-    powerupTimeRemaining = bluePowerupTimeRemaining
-    powerupColor = 'blue'
-  }
-
-  return (
-    <AutoScale
-      wrapperClass="livescore-wrapper"
-      containerClass="livescore-container"
-      maxWidth={800}
-    >
-      <div className="livescore-display">
-        <h3>
-          { matchLabel }
-        </h3>
-        <div className="col-container">
-          <div className="side-col">
-            <div className={`booleanIndicator ${redScaleOwned && 'red'}`}>Scale</div>
-            <div className={`booleanIndicator ${redSwitchOwned && 'red'}`}>Switch</div>
-            <div className="powerupsContainer">
-              <PowerupCount color="red" type="force" count={redForceCount} played={redForcePlayed} />
-              <PowerupCount color="red" type="levitate" count={redLevitateCount} played={redLevitatePlayed} isCenter />
-              <PowerupCount color="red" type="boost" count={redBoostCount} played={redBoostPlayed} />
-            </div>
-            <div className={`booleanIndicator ${redAutoQuest && 'red'}`}>Auto Quest</div>
-            <div className={`booleanIndicator ${redFaceTheBoss && 'red'}`}>Face The Boss</div>
-          </div>
-          <div className="mid-col">
-            <div className="progress">
-              <div className={`progress-bar ${progressColor}`} style={{ width: progressWidth }} />
-              <div className="timeRemainingContainer">
-                <span className="timeRemaining">{ timeRemaining }</span>
-              </div>
-            </div>
-            <div className="scoreContainer">
-              <div className="redAlliance">
-                {match.alliances.red.team_keys.map((teamKey) => {
-                  const teamNum = teamKey.substring(3)
-                  return <div key={teamKey} >{teamNum}</div>
-                })}
-                <div className="score red">{ redScore }</div>
-              </div>
-              <div className="blueAlliance">
-                {match.alliances.blue.team_keys.map((teamKey) => {
-                  const teamNum = teamKey.substring(3)
-                  return <div key={teamKey} >{teamNum}</div>
-                })}
-                <div className="score blue">{ blueScore }</div>
-              </div>
-            </div>
-            {currentPowerup &&
-              <div className={`currentPowerup ${powerupColor}`}>
-                <img src={`/images/2018_${currentPowerup}.png`} className="currentPowerupIcon" role="presentation" />
-                <br />
-                { powerupTimeRemaining }
-              </div>
-            }
-          </div>
-          <div className="side-col">
-            <div className={`booleanIndicator ${blueScaleOwned && 'blue'}`}>Scale</div>
-            <div className={`booleanIndicator ${blueSwitchOwned && 'blue'}`}>Switch</div>
-            <div className="powerupsContainer">
-              <PowerupCount color="blue" type="force" count={blueForceCount} played={blueForcePlayed} />
-              <PowerupCount color="blue" type="levitate" count={blueLevitateCount} played={blueLevitatePlayed} isCenter />
-              <PowerupCount color="blue" type="boost" count={blueBoostCount} played={blueBoostPlayed} />
-            </div>
-            <div className={`booleanIndicator ${blueAutoQuest && 'blue'}`}>Auto Quest</div>
-            <div className={`booleanIndicator ${blueFaceTheBoss && 'blue'}`}>Face The Boss</div>
-          </div>
-        </div>
-      </div>
-    </AutoScale>
-  )
 }
 
 LivescoreDisplay.propTypes = {

--- a/react/gameday2/components/LivescoreDisplay.js
+++ b/react/gameday2/components/LivescoreDisplay.js
@@ -70,14 +70,14 @@ class LivescoreDisplay extends React.PureComponent {
       }
     })
 
-    let matchWaiting = false
+    let showETA = false
     if (match && match.alliances.red.score !== -1 && match.alliances.blue.score !== -1) {
       // If match has been played, display next match and ETA
       match = nextMatch
-      matchWaiting = true
+      showETA = true
     } else if (mode === 'pre_match') {
       // If match mode is pre_match, display match and ETA
-      matchWaiting = true
+      showETA = true
     }
 
     if (!match) {
@@ -91,7 +91,7 @@ class LivescoreDisplay extends React.PureComponent {
     }
 
     let etaStr = ''
-    if (matchWaiting) {  // Reset to pre match defaults
+    if (showETA) {  // Reset to pre match defaults
       mode = 'pre_match'
       timeRemaining = 0
       redScore = 0

--- a/react/gameday2/components/LivescoreDisplay.js
+++ b/react/gameday2/components/LivescoreDisplay.js
@@ -128,6 +128,8 @@ class LivescoreDisplay extends React.PureComponent {
         } else {
           etaStr = ` in ~${Math.round(etaMin)} min`
         }
+      } else {
+        etaStr = ' is next'
       }
     }
 

--- a/react/gameday2/components/LivescoreDisplay.js
+++ b/react/gameday2/components/LivescoreDisplay.js
@@ -70,10 +70,13 @@ class LivescoreDisplay extends React.PureComponent {
       }
     })
 
-    // If match has been played, display next match and ETA
     let matchWaiting = false
     if (match && match.alliances.red.score !== -1 && match.alliances.blue.score !== -1) {
+      // If match has been played, display next match and ETA
       match = nextMatch
+      matchWaiting = true
+    } else if (mode === 'pre_match') {
+      // If match mode is pre_match, display match and ETA
       matchWaiting = true
     }
 

--- a/react/gameday2/selectors/index.js
+++ b/react/gameday2/selectors/index.js
@@ -62,7 +62,7 @@ export const getFireduxData = (state) => state.firedux.data
 
 export const getEventKey = (state, props) => props.webcast.key
 
-export const getTickerMatches = createSelector(
+export const getEventMatches = createSelector(
   [getFireduxData, getEventKey],
   (fireduxData, eventKey) => {
     const compLevelsPlayOrder = {
@@ -89,9 +89,15 @@ export const getTickerMatches = createSelector(
         fireduxData.events[eventKey] &&
         fireduxData.events[eventKey].matches) {
       matches = Object.values(fireduxData.events[eventKey].matches)
+      matches.sort((match1, match2) => calculateOrder(match1) - calculateOrder(match2))
     }
-    matches.sort((match1, match2) => calculateOrder(match1) - calculateOrder(match2))
+    return matches
+  }
+)
 
+export const getTickerMatches = createSelector(
+  [getFireduxData, getEventMatches],
+  (fireduxData, matches) => {
     let lastMatch = null
     let selectedMatches = []
     matches.forEach((match) => {
@@ -109,19 +115,6 @@ export const getTickerMatches = createSelector(
     }
 
     return selectedMatches
-  }
-)
-
-export const getEventMatches = createSelector(
-  [getFireduxData, getEventKey],
-  (fireduxData, eventKey) => {
-    if (fireduxData &&
-        fireduxData.events &&
-        fireduxData.events[eventKey] &&
-        fireduxData.events[eventKey].matches) {
-      return Object.values(fireduxData.events[eventKey].matches)
-    }
-    return []
   }
 )
 


### PR DESCRIPTION
## Description
When the current live match is played, show ETA to next match.
When the current live match mode is pre_match, show ETA to current match.

## Motivation and Context
Lets users know when matches will start.

## How Has This Been Tested?
Local dev with week 0 data.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/36743066-536d5d70-1bb7-11e8-9d92-9520ed61bfae.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
