### PR TITLE
Move avatar button to lhc for competition season

### DIFF
--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -10,9 +10,6 @@
       {% include "index_lhc.html" %}
     </div>
     <div class="col-sm-8">
-      <div>
-        <a class="btn btn-lg btn-block btn-primary" href="/avatars/2018"><span class="glyphicon glyphicon-user"></span> View All 2018 Team Avatars</a>
-      </div>
       {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
         {% with events|first as first_event %}

--- a/templates/index_lhc.html
+++ b/templates/index_lhc.html
@@ -11,6 +11,7 @@
 <br><br>
 <a class="btn btn-success btn-block" href="/nearby"><span class="glyphicon glyphicon-search"></span> Find Nearby Teams and Events</a>
 <a class="btn btn-block btn-info" href="/advanced_team_search"><span class="glyphicon glyphicon-search"></span> Advanced Team Search</a>
+<a class="btn btn-block btn-primary" href="/avatars/2018"><span class="glyphicon glyphicon-user"></span> View All 2018 Team Avatars</a>
 
 <!-- <a class="btn btn-info btn-block" href="https://sites.google.com/view/firsthelpnow/need-help-now" target="_blank"><span class="glyphicon glyphicon-earphone"></span> Get 24/7 advice from FIRST Help Now</a> -->
 


### PR DESCRIPTION
Moves the large team avatar button on the homepage to the left sidebar with other buttons.

## Description
Remove the avatar button from the comp season template. Add the avatar button to the lhc template.

## Motivation and Context
The button is really big right now 😄 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/36766191-a8bfce0c-1be9-11e8-8d52-d7ff73886a95.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
