### PR TITLE
Make match video accept/reject radio inputs

### DIFF
--- a/controllers/suggestions/suggest_match_video_review_controller.py
+++ b/controllers/suggestions/suggest_match_video_review_controller.py
@@ -1,3 +1,5 @@
+import logging
+
 from consts.account_permissions import AccountPermissions
 from controllers.suggestions.suggestions_review_base_controller import SuggestionsReviewBaseController
 from helpers.suggestions.match_suggestion_accepter import MatchSuggestionAccepter
@@ -37,12 +39,25 @@ class SuggestMatchVideoReviewController(SuggestionsReviewBaseController):
         self.response.out.write(jinja2_engine.render('suggestions/suggest_match_video_review_list.html', self.template_values))
 
     def post(self):
-        accept_keys = map(lambda x: int(x) if x.isdigit() else x, self.request.POST.getall("accept_keys[]"))
-        reject_keys = map(lambda x: int(x) if x.isdigit() else x, self.request.POST.getall("reject_keys[]"))
+        accept_keys = []
+        reject_keys = []
+        for value in self.request.POST.values():
+            logging.debug(value)
+            split_value = value.split('::')
+            if len(split_value) == 2:
+                key = split_value[1]
+            else:
+                continue
+            if value.startswith('accept'):
+                accept_keys.append(key)
+            elif value.startswith('reject'):
+                reject_keys.append(key)
 
+        # Process accepts
         for accept_key in accept_keys:
             self._process_accepted(accept_key)
 
+        # Process rejects
         self._process_rejected(reject_keys)
 
         self.redirect("/suggest/match/video/review")

--- a/controllers/suggestions/suggest_match_video_review_controller.py
+++ b/controllers/suggestions/suggest_match_video_review_controller.py
@@ -1,5 +1,3 @@
-import logging
-
 from consts.account_permissions import AccountPermissions
 from controllers.suggestions.suggestions_review_base_controller import SuggestionsReviewBaseController
 from helpers.suggestions.match_suggestion_accepter import MatchSuggestionAccepter
@@ -42,7 +40,6 @@ class SuggestMatchVideoReviewController(SuggestionsReviewBaseController):
         accept_keys = []
         reject_keys = []
         for value in self.request.POST.values():
-            logging.debug(value)
             split_value = value.split('::')
             if len(split_value) == 2:
                 key = split_value[1]

--- a/templates_jinja2/suggestions/suggest_match_video_review_list.html
+++ b/templates_jinja2/suggestions/suggest_match_video_review_list.html
@@ -28,9 +28,13 @@
             <div class="row">
                 <div class="well">
                     <div class="col-xs-2">
-                      <label class="checkbox text-success" for="accept_{{suggestion.key.id()}}"><input class="accept" type="checkbox" name="accept_keys[]" id="accept_{{suggestion.key.id()}}" value="{{suggestion.key.id()}}"> Accept</label>
-                      <label class="checkbox text-danger" for="reject_{{suggestion.key.id()}}"><input class="reject" type="checkbox" name="reject_keys[]" id="reject_{{suggestion.key.id()}}" value="{{suggestion.key.id()}}"> Reject</label>
-                      <input type="text" class="form-control" name="key-{{suggestion.key.id()}}" placeholder="Match Key" value="{{suggestion.target_key}}">
+                        <label class="radio text-success">
+                            <input class="accept" type="radio" name="accept_reject-{{suggestion.key.id()}}" value="accept::{{suggestion.key.id()}}"> Accept
+                        </label>
+                        <label class="radio text-danger">
+                            <input class="reject" type="radio" name="accept_reject-{{suggestion.key.id()}}" value="reject::{{suggestion.key.id()}}"> Reject
+                        </label>
+                        <input type="text" class="form-control" name="key-{{suggestion.key.id()}}" placeholder="Match Key" value="{{suggestion.target_key}}">
                     </div>
                     <div class="col-xs-7 fitvids">
                         <p><a href="/match/{{ suggestion.target_key }}" target="_blank"><strong>{{ suggestion.target_key }}</strong></a></p>

--- a/tests/suggestions/test_suggest_match_video_review_controller.py
+++ b/tests/suggestions/test_suggest_match_video_review_controller.py
@@ -193,7 +193,7 @@ class TestSuggestMatchVideoReviewController(unittest2.TestCase):
         self.givePermission()
         suggestion_id = self.createSuggestion()
         form = self.getSuggestionForm()
-        form.set('accept_keys[]', suggestion_id)
+        form['accept_reject-{}'.format(suggestion_id)] = 'accept::{}'.format(suggestion_id)
         response = form.submit().follow()
         self.assertEqual(response.status_int, 200)
 
@@ -213,8 +213,8 @@ class TestSuggestMatchVideoReviewController(unittest2.TestCase):
         self.givePermission()
         suggestion_id = self.createSuggestion()
         form = self.getSuggestionForm()
-        form.set('accept_keys[]', suggestion_id)
-        form.set('key-{}'.format(suggestion_id), '2016necmp_f1m2')
+        form['accept_reject-{}'.format(suggestion_id)] = 'accept::{}'.format(suggestion_id)
+        form['key-{}'.format(suggestion_id)] = '2016necmp_f1m2'
         response = form.submit().follow()
         self.assertEqual(response.status_int, 200)
 
@@ -240,8 +240,8 @@ class TestSuggestMatchVideoReviewController(unittest2.TestCase):
         self.givePermission()
         suggestion_id = self.createSuggestion()
         form = self.getSuggestionForm()
-        form.set('accept_keys[]', suggestion_id)
-        form.set('key-{}'.format(suggestion_id), '2016necmp_f1m3')  # This match doesn't exist
+        form['accept_reject-{}'.format(suggestion_id)] = 'accept::{}'.format(suggestion_id)
+        form['key-{}'.format(suggestion_id)] = '2016necmp_f1m3'  # This match doesn't exist
         response = form.submit().follow()
         self.assertEqual(response.status_int, 200)
 
@@ -261,7 +261,7 @@ class TestSuggestMatchVideoReviewController(unittest2.TestCase):
         self.givePermission()
         suggestion_id = self.createSuggestion()
         form = self.getSuggestionForm()
-        form.set('reject_keys[]', suggestion_id)
+        form['accept_reject-{}'.format(suggestion_id)] = 'reject::{}'.format(suggestion_id)
         response = form.submit().follow()
         self.assertEqual(response.status_int, 200)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes the inputs for match video suggestion reviewals radio buttons instead of checkboxes, making it consistent with other reviewals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Consistency. Fixes #1386.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev server.

## Screenshots (if appropriate):

![screen shot 2018-02-28 at 2 46 56 pm](https://user-images.githubusercontent.com/10191084/36817531-5451f018-1c96-11e8-95b7-55df52173606.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
