### PR TITLE
Make Power Up icons pixelated

### DIFF
--- a/react/gameday2/livescore.less
+++ b/react/gameday2/livescore.less
@@ -64,6 +64,13 @@
     height: 25px;
     width: 25px;
     margin: 0;
+    image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
+    image-rendering: -moz-crisp-edges;          /* Firefox                        */
+    image-rendering: -o-crisp-edges;            /* Opera                          */
+    image-rendering: -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+    image-rendering: pixelated;                 /* Chrome */
+    image-rendering: optimize-contrast;         /* CSS3 Proposed                  */
+    -ms-interpolation-mode: nearest-neighbor;   /* IE8+                           */
   }
 
   .powerCube {
@@ -127,6 +134,13 @@
     width: 20px;
     height: 20px;
     margin: 2px auto;
+    image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
+    image-rendering: -moz-crisp-edges;          /* Firefox                        */
+    image-rendering: -o-crisp-edges;            /* Opera                          */
+    image-rendering: -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+    image-rendering: pixelated;                 /* Chrome */
+    image-rendering: optimize-contrast;         /* CSS3 Proposed                  */
+    -ms-interpolation-mode: nearest-neighbor;   /* IE8+                           */
   }
 
   .blue {

--- a/static/css/less_css/less/tba/tba_live_event_panel.less
+++ b/static/css/less_css/less/tba/tba_live_event_panel.less
@@ -34,6 +34,14 @@
     height: 15px;
     width: 15px;
     margin-bottom: 5px;
+    image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
+    image-rendering: -moz-crisp-edges;          /* Firefox                        */
+    image-rendering: -o-crisp-edges;            /* Opera                          */
+    image-rendering: -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+    image-rendering: pixelated;                 /* Chrome */
+    image-rendering: optimize-contrast;         /* CSS3 Proposed                  */
+    -ms-interpolation-mode: nearest-neighbor;   /* IE8+                           */
+
     @media (min-width: @screen-sm-min) {
       height: 25px;
       width: 25px;
@@ -110,6 +118,13 @@
     width: 15px;
     height: 15px;
     margin-right: 2px;
+    image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
+    image-rendering: -moz-crisp-edges;          /* Firefox                        */
+    image-rendering: -o-crisp-edges;            /* Opera                          */
+    image-rendering: -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+    image-rendering: pixelated;                 /* Chrome */
+    image-rendering: optimize-contrast;         /* CSS3 Proposed                  */
+    -ms-interpolation-mode: nearest-neighbor;   /* IE8+                           */
 
     @media (min-width: @screen-sm-min) {
       width: 20px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes Power Up icons pixelated instead of being anti-aliased.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The icons look weird and fuzzy when they're not pixelated as they should be.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev server.

## Screenshots (if appropriate):

## Before

![screen shot 2018-02-28 at 5 25 02 pm](https://user-images.githubusercontent.com/10191084/36822726-51c1223e-1cae-11e8-8070-ff2950d1db37.png)

## After

![screen shot 2018-02-28 at 5 24 03 pm](https://user-images.githubusercontent.com/10191084/36822729-56ac0c50-1cae-11e8-8909-29293e381b8e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
