### PR TITLE
Fix match time predictions when no matches have been played

### DIFF
--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -101,7 +101,12 @@ class MatchTimePredictionHelper(object):
                 .format(next_match.key_name, cls.as_local(next_match.time, timezone), cls.as_local(next_match.predicted_time, timezone))
 
         if not last_match or not last_match.actual_time:
-            # We can't do this without knowing when matches actually end
+            # No matches have been played yet. Set all predicted times to scheduled times
+            to_log += "[TIME PREDICTIONS] Setting predicted_time to scheduled time"
+            for match in unplayed_matches:
+                if match.time:
+                    match.predicted_time = match.time
+            MatchManipulator.createOrUpdate(unplayed_matches)
             return
 
         if len(played_matches) >= 2:


### PR DESCRIPTION
## Description
Set match predicted time to scheduled time if no matches have been played.

## Motivation and Context
Match times were no being predicted when no matches are played.

## How Has This Been Tested?
On local dev, an event with no matches played had no scheduled time. After this fix, they do.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
