### PR TITLE
Live event tweaks for practice day

### DIFF
--- a/react/liveevent/components/LiveEventPanel.js
+++ b/react/liveevent/components/LiveEventPanel.js
@@ -71,8 +71,7 @@ class LiveEventPanel extends React.PureComponent {
     let forcePreMatch = false
     if (unplayedMatchesCopy !== null) {
       if (matchState === null) {
-        upcomingMatches = unplayedMatchesCopy.slice(1, 4)
-        currentMatch = unplayedMatchesCopy[0]
+        upcomingMatches = unplayedMatchesCopy.slice(0, 3)
       } else {
         playedMatchesCopy.forEach((match, i) => {
           if (match.shortKey === matchState.mk && matchState.m !== 'post_match') {
@@ -95,15 +94,17 @@ class LiveEventPanel extends React.PureComponent {
     const year = parseInt(this.props.eventKey.substring(0, 4), 10)
     return (
       <div>
-        <div className="col-lg-3 text-center livePanelColumn">
+        <div className={`${currentMatch ? 'col-lg-3' : 'col-lg-6'} text-center livePanelColumn`}>
           <h4>Last Matches</h4>
           <LastMatchesTable year={year} matches={playedMatchesCopy && playedMatchesCopy.slice(-3)} />
         </div>
+        {currentMatch &&
         <div className="col-lg-6 text-center livePanelColumn">
           <h4>Current Match: { currentMatch && `${getCompLevelStr(currentMatch)} ${getMatchSetStr(currentMatch)}` }</h4>
           <CurrentMatchDisplay year={year} match={currentMatch} matchState={matchState} forcePreMatch={forcePreMatch} />
         </div>
-        <div className="col-lg-3 text-center livePanelColumn">
+        }
+        <div className={`${currentMatch ? 'col-lg-3' : 'col-lg-6'} text-center livePanelColumn`}>
           <h4>Upcoming Matches</h4>
           <UpcomingMatchesTable year={year} matches={upcomingMatches} />
         </div>

--- a/react/liveevent/components/LiveEventPanel.js
+++ b/react/liveevent/components/LiveEventPanel.js
@@ -70,7 +70,7 @@ class LiveEventPanel extends React.PureComponent {
     let currentMatch = null
     let forcePreMatch = false
     if (unplayedMatchesCopy !== null) {
-      if (matchState === null) {
+      if (matchState === null || matchState.mk.startsWith('pm')) {
         upcomingMatches = unplayedMatchesCopy.slice(0, 3)
       } else {
         playedMatchesCopy.forEach((match, i) => {

--- a/react/liveevent/components/UpcomingMatchesTable.js
+++ b/react/liveevent/components/UpcomingMatchesTable.js
@@ -31,6 +31,8 @@ class UpcomingMatchesTable extends React.PureComponent {
         const etaMin = (match.pt - this.state.currentTime) / 60
         if (etaMin < 5) {
           etaStr = '<5 min'
+        } else if (etaMin > 120) {
+          etaStr = `~${Math.round(etaMin / 60)} h`
         } else {
           etaStr = `~${Math.round(etaMin)} min`
         }


### PR DESCRIPTION
Show ETA in hours if > 120 minutes
Only show current match if live score is available

## How Has This Been Tested?
Local dev with prod Firebase data.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/36865117-96f8ab2a-1d5c-11e8-892c-c87c92c556ec.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
