### PR TITLE
Fix twitch chat to not prompt on first message

### DIFF
--- a/react/gameday2/components/TwitchChatEmbed.js
+++ b/react/gameday2/components/TwitchChatEmbed.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 
 const TwitchChatEmbed = (props) => {
   const id = `twich-chat-${props.channel}`
-  const src = `https://twitch.tv/embed/${props.channel}/chat`
+  const src = `https://twitch.tv/${props.channel}/chat`
   const style = {
     display: props.visible ? null : 'none',
     width: '100%',


### PR DESCRIPTION
## Motivation and Context
Old embed had a weird alert when a user tries to send their first message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
