### PR TITLE
Special case GameDay/FUN chat name

### DIFF
--- a/react/gameday2/components/ChatSelector.js
+++ b/react/gameday2/components/ChatSelector.js
@@ -29,9 +29,14 @@ export default class ChatSelector extends React.Component {
       const isDefault = (chat.channel === this.props.defaultChat)
       const icon = isSelected ? <CheckmarkIcon /> : null
 
+      let chatName = chat.name
+      if (chat.channel == 'firstupdatesnow' && isDefault) {
+        chatName = 'TBA GameDay / FUN'
+      }
+
       chatItems.push(
         <ListItem
-          primaryText={chat.name}
+          primaryText={chatName}
           leftIcon={isDefault ? <ActionHome /> : null}
           rightIcon={icon}
           onTouchTap={(e) => this.setTwitchChat(e, chat.channel)}

--- a/react/gameday2/components/ChatSidebar.js
+++ b/react/gameday2/components/ChatSidebar.js
@@ -121,6 +121,9 @@ class ChatSidebar extends React.Component {
     let currentChatName = 'UNKNOWN'
     if (currentChat) {
       currentChatName = `${currentChat.name} Chat`
+      if (currentChat.channel === 'firstupdatesnow' && this.props.defaultChat === 'firstupdatesnow') {
+        currentChatName = 'TBA GameDay / FUN'
+      }
     }
 
     let content


### PR DESCRIPTION
## Description
Change FUN chat name to 'TBA GameDay / FUN' when it is the default.

## Motivation and Context
Less confusing for users

## How Has This Been Tested?
Local dev

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/36874629-a57d11f4-1d7a-11e8-8c68-92f09e84c993.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
