### PR TITLE
Add background to team page avatars

### DIFF
--- a/static/css/less_css/less/tba/tba_media.less
+++ b/static/css/less_css/less/tba/tba_media.less
@@ -39,7 +39,7 @@
     }
 
     &.blue {
-      background-color: #5995de;
+      background-color: #487fcc;
     }
 
     &.red {

--- a/static/css/less_css/less/tba/tba_media.less
+++ b/static/css/less_css/less/tba/tba_media.less
@@ -31,6 +31,13 @@
     width: 40px;
     vertical-align: middle;
 
+    &.single {
+      height: 50px;
+      width: 50px;
+      padding: 5px;
+      border-radius: 5px;
+    }
+
     &.blue {
       background-color: #5995de;
     }

--- a/templates_jinja2/avatars2018.html
+++ b/templates_jinja2/avatars2018.html
@@ -23,12 +23,13 @@
       {% endfor %}
     </div>
   </div>
-  {% block inline_javascript %}
-  <script>
-    $("#color-switch").click(function(){
-      $(".team-avatar").toggleClass("red").toggleClass("blue")
-    });
-  </script>
-  {% endblock %}
 </div>
+{% endblock %}
+
+{% block inline_javascript %}
+<script>
+  $("#color-switch").click(function(){
+    $(".team-avatar").toggleClass("red").toggleClass("blue")
+  });
+</script>
 {% endblock %}

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -25,7 +25,7 @@
 
         <h2 class="visible-xs end_header">
         {% if avatar %}
-          <img class="team-avatar" src='{{avatar.avatar_image_source}}'/>
+          <img class="team-avatar single blue" src='{{avatar.avatar_image_source}}'/>
         {% endif %}
         Team {{team.team_number}}{% if team.nickname %} - {{team.nickname}}{% endif %}</h2>
         {% if team.motto %}<h4 class="visible-xs"><em>&quot;{{team.motto_without_quotes}}&quot;</em></h4>{% endif %}
@@ -225,4 +225,12 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block inline_javascript %}
+<script>
+  $(".team-avatar").click(function(){
+    $(this).toggleClass("red").toggleClass("blue")
+  });
+</script>
 {% endblock %}

--- a/templates_jinja2/team_partials/team_info.html
+++ b/templates_jinja2/team_partials/team_info.html
@@ -5,7 +5,7 @@
   <div class="col-xs-12">
     <h2>
     {% if avatar %}
-      <img class="team-avatar" src='{{avatar.avatar_image_source}}'/>
+      <img class="team-avatar single blue" src='{{avatar.avatar_image_source}}'/>
     {% endif %}
     Team {{team.team_number}}{% if team.nickname %} - {{team.nickname}}{% endif %}</h2>
     {% if district_name %}<blockquote><em>Part of the <a href="/events/{{district_abbrev}}/{{year}}">{{district_name}} District</a></em></blockquote>{% endif %}


### PR DESCRIPTION
## Description
Add blue background color to team page avatars with radius, so square & round icons don't look weird. Toggles to red on click.

## Motivation and Context
White avatars were not showing up.

## How Has This Been Tested?
Tested toggling works on local dev, all avatars page still works too.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/36877390-f3b3b44c-1d87-11e8-8e97-cd6992dae0c9.png)
![image](https://user-images.githubusercontent.com/1421884/36877416-0ce3173c-1d88-11e8-8581-49df05bd937a.png)
![image](https://user-images.githubusercontent.com/1421884/36877372-e258c67e-1d87-11e8-9180-ae0d0ae9dee0.png)
![image](https://user-images.githubusercontent.com/1421884/36877363-d9f7bf26-1d87-11e8-88cc-b6a65c1ee6ce.png)
![image](https://user-images.githubusercontent.com/1421884/36877404-002b3998-1d88-11e8-9e0d-d501a7995f92.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
