### PR TITLE
Compute district points with rankings2

### DIFF
--- a/helpers/district_helper.py
+++ b/helpers/district_helper.py
@@ -60,7 +60,6 @@ class DistrictHelper(object):
                 'highest_qual_scores': [],
             }),
         }
-        single_district_points = copy.deepcopy(district_points)
 
         # match points
         if event.year >= 2015:
@@ -282,13 +281,13 @@ class DistrictHelper(object):
         from helpers.match_helper import MatchHelper  # circular import issue
 
         # qual match points are calculated by rank
-        if event.rankings and len(event.rankings) > 1:
-            rankings = event.rankings[1:]  # skip title row
+        rankings = event.details.rankings2
+        if rankings:
             num_teams = len(rankings)
             alpha = 1.07
-            for row in rankings:
-                rank = int(row[0])
-                team = 'frc{}'.format(row[1])
+            for ranking in rankings:
+                rank = ranking['rank']
+                team = ranking['team_key']
                 qual_points = int(math.ceil(cls.inverf(float(num_teams - 2 * rank + 2) / (alpha * num_teams)) * (
                 10.0 / cls.inverf(1.0 / alpha)) + 12))
                 district_points['points'][team]['qual_points'] = qual_points * POINTS_MULTIPLIER


### PR DESCRIPTION
## Description
Compute district points with `rankings2` instead of `rankings`

## Motivation and Context
`rankings` is deprecated and not used anymore

## How Has This Been Tested?
Verified that district points are correctly calculated on local dev using 2018mitvr data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
