### PR TITLE
Minor tweaks to upcoming match times

### DIFF
--- a/react/gameday2/components/LivescoreDisplay.js
+++ b/react/gameday2/components/LivescoreDisplay.js
@@ -130,8 +130,10 @@ class LivescoreDisplay extends React.PureComponent {
 
       if (this.state.currentTime && match.pt) {
         const etaMin = (match.pt - this.state.currentTime) / 60
-        if (etaMin < 1) {
-          etaStr = ' in <1 min'
+        if (etaMin < 2) {
+          etaStr = ' in <2 min'
+        } else if (etaMin > 120) {
+          etaStr = ` in ~${Math.round(etaMin / 60)} h`
         } else {
           etaStr = ` in ~${Math.round(etaMin)} min`
         }

--- a/react/liveevent/components/UpcomingMatchesTable.js
+++ b/react/liveevent/components/UpcomingMatchesTable.js
@@ -29,8 +29,8 @@ class UpcomingMatchesTable extends React.PureComponent {
       let etaStr = '?'
       if (this.state.currentTime && match.pt) {
         const etaMin = (match.pt - this.state.currentTime) / 60
-        if (etaMin < 5) {
-          etaStr = '<5 min'
+        if (etaMin < 2) {
+          etaStr = '<2 min'
         } else if (etaMin > 120) {
           etaStr = `~${Math.round(etaMin / 60)} h`
         } else {


### PR DESCRIPTION
## Description
Show <2 mins instead 1 or 5 to be more consistent between GameDay and Event pages.
Change GameDay time above 120 min to hours to match Event pages.

## Motivation and Context
Consistency

## How Has This Been Tested?
Local dev with prod Firebase works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
