### PR TITLE
Link to event page from GameDay

### DIFF
--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -77,6 +77,7 @@ export default class VideoCell extends React.Component {
         bottom: 0,
         width: '100%',
         height: '48px',
+        paddingLeft: '8px',
       }
 
       return (

--- a/react/gameday2/components/VideoCellToolbar.js
+++ b/react/gameday2/components/VideoCellToolbar.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
-import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar'
+import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar'
+import FlatButton from 'material-ui/FlatButton'
 import IconButton from 'material-ui/IconButton'
 import CloseIcon from 'material-ui/svg-icons/navigation/close'
 import SwapIcon from 'material-ui/svg-icons/action/compare-arrows'
@@ -19,6 +20,8 @@ const VideoCellToolbar = (props) => {
   const titleStyle = {
     color: white,
     fontSize: 16,
+    marginLeft: 0,
+    marginRight: 0,
   }
 
   const matchTickerGroupStyle = {
@@ -82,9 +85,12 @@ const VideoCellToolbar = (props) => {
   return (
     <Toolbar style={toolbarStyle}>
       <ToolbarGroup>
-        <ToolbarTitle
-          text={props.webcast.name}
+        <FlatButton
+          label={props.webcast.name}
           style={titleStyle}
+          href={`/event/${props.webcast.key}`}
+          target="_blank"
+          disabled={props.specialWebcastIds.has(props.webcast.id)}
         />
       </ToolbarGroup>
       <ToolbarGroup style={matchTickerGroupStyle}>
@@ -126,6 +132,7 @@ const VideoCellToolbar = (props) => {
 VideoCellToolbar.propTypes = {
   matches: PropTypes.arrayOf(PropTypes.object).isRequired,
   webcast: PropTypes.object.isRequired,
+  specialWebcastIds: PropTypes.set.isRequired,
   /* eslint-disable react/no-unused-prop-types */
   isBlueZone: PropTypes.bool.isRequired,
   livescoreOn: PropTypes.bool.isRequired,

--- a/react/gameday2/containers/VideoCellToolbarContainer.js
+++ b/react/gameday2/containers/VideoCellToolbarContainer.js
@@ -8,6 +8,7 @@ const mapStateToProps = (state, props) => ({
   favoriteTeams: state.favoriteTeams,
   webcasts: getWebcastIdsInDisplayOrder(state),
   webcastsById: state.webcastsById,
+  specialWebcastIds: state.specialWebcastIds,
   displayedWebcasts: state.videoGrid.displayed,
   layoutId: state.videoGrid.layoutId,
 })


### PR DESCRIPTION
Closes #2107

## Description
Make event title to event page from GameDay. Disabled for special webcasts.

## Motivation and Context
Going to an event page from GameDay was clunky.

## How Has This Been Tested?
Verified events link and special webcasts don't on local dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
