### PR TITLE
Use rankings2 for showing rank on team pages

### DIFF
--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -98,10 +98,10 @@ class TeamRenderer(object):
                     display_wlt = wlt
 
             team_rank = None
-            if event.rankings:
-                for element in event.rankings:
-                    if str(element[1]) == str(team.team_number):
-                        team_rank = element[0]
+            if event.details and event.details.rankings2:
+                for ranking in event.details.rankings2:
+                    if ranking['team_key'] == team.key.id():
+                        team_rank = ranking['rank']
                         break
 
             participation.append({"event": event,


### PR DESCRIPTION
## Motivation and Context
`rankings` are no longer being computed. Use `rankings2` instead.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
