### PR TITLE
[GameDay] Fix ticker sort order

### DIFF
--- a/react/gameday2/selectors/index.js
+++ b/react/gameday2/selectors/index.js
@@ -73,14 +73,14 @@ export const getEventMatches = createSelector(
       f: 5,
     }
     function calculateOrder(match) {
-      let time = 9999999999
-      if (match.r !== -1 && match.b !== -1) {
-        time = 0
-      }
+      // let time = 9999999999
+      // if (match.r !== -1 && match.b !== -1) {
+      //   time = 0
+      // }
       // if (match.pt) {
       //   time = match.pt
       // }
-      return (time * 10000000) + (compLevelsPlayOrder[match.c] * 100000) + (match.m * 100) + match.s
+      return (compLevelsPlayOrder[match.c] * 100000) + (match.m * 100) + match.s
     }
 
     const matches = []


### PR DESCRIPTION
## Motivation and Context
Fix GameDay ticker matches being sorted incorrectly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
