### PR TITLE
[apiv3] Add Endpoint for GDCV Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ coverage
 static/javascript/tba_js/tba_keys.js
 ops/deploy_keys.tar
 ops/tbatv-prod-hrd-deploy.json
+ops/dev/conf.json
+ops/dev/*-auth.json
 test_keys.json
 
 # Vagrant #

--- a/apiv3_main.py
+++ b/apiv3_main.py
@@ -9,6 +9,7 @@ from controllers.apiv3 import api_district_controller as adc
 from controllers.apiv3 import api_event_controller as aec
 from controllers.apiv3 import api_match_controller as amc
 from controllers.apiv3 import api_media_controller as amec
+from controllers.apiv3 import api_realtime_controller as arc
 from controllers.apiv3 import api_team_controller as atc
 from controllers.apiv3 import api_suggest_controller as asgc
 
@@ -99,6 +100,8 @@ app = webapp2.WSGIApplication([
         aec.ApiEventTeamsController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/event/<event_key:>/matches',
         aec.ApiEventMatchesController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/event/<event_key:>/matches/timeseries',
+        arc.ApiRealtimeEventMatchesController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/event/<event_key:>/matches/<model_type:(simple|keys)>',
         aec.ApiEventMatchesController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/event/<event_key:>/awards',
@@ -108,6 +111,8 @@ app = webapp2.WSGIApplication([
     # Match
     webapp2.Route(r'/api/v3/match/<match_key:>',
         amc.ApiMatchController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/match/<match_key:>/timeseries',
+        arc.ApiRealtimeMatchController, methods=['GET', 'OPTOINS']),
     webapp2.Route(r'/api/v3/match/<match_key:>/<model_type:(simple)>',
         amc.ApiMatchController, methods=['GET', 'OPTIONS']),
     # Media

--- a/app.yaml
+++ b/app.yaml
@@ -24,6 +24,8 @@ libraries:
   version: "2.6"
 - name: pytz
   version: "2016.4"
+- name: MySQLdb
+  version: "latest"
 
 handlers:
 - url: /css

--- a/controllers/apiv3/api_realtime_controller.py
+++ b/controllers/apiv3/api_realtime_controller.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+from controllers.apiv3.api_base_controller import ApiBaseController
+from database.gdcv_data_query import MatchGdcvDataQuery, EventMatchesGdcvDataQuery
+from database.event_query import EventQuery
+from database.match_query import MatchQuery
+
+
+class ApiRealtimeMatchController(ApiBaseController):
+
+    CACHE_VERSION = 0
+    CACHE_HEADER_LENGTH = 61
+
+    def _track_call(self, match_key):
+        action = 'realtime_match'
+        self._track_call_defer(action, match_key)
+
+    def _render(self, match_key):
+        match = MatchQuery(match_key).fetch()
+        if not match:
+            self.abort(404)
+        if not match.has_been_played:
+            # If FIRST hasn't published data yet, don't return anything
+            return json.dumps([])
+
+        match_key = match.key_name
+        gdcv_data = MatchGdcvDataQuery(match_key).fetch()
+        return json.dumps(gdcv_data, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+class ApiRealtimeEventMatchesController(ApiBaseController):
+
+    CACHE_VERSION = 0
+    CACHE_HEADER_LENGTH = 61
+
+    def _track_call(self, event_key):
+        action = 'realtime_event_matches'
+        self._track_call_defer(action, event_key)
+
+    def _render(self, event_key):
+        event = EventQuery(event_key).fetch()
+        if not event:
+            self.abort(404)
+        event.get_matches_async()
+        realtime_data = EventMatchesGdcvDataQuery(event.key_name).fetch()
+        realtime_by_key = {
+            "{}_{}".format(m['event_key'], m['match_id']): m
+            for m in realtime_data
+        }
+
+        event_matches = event.matches
+        result = {
+            m.key_name: realtime_by_key[m.key_name]
+            for m in event_matches
+            if m.has_been_played and m.key_name in realtime_by_key
+        }
+        return json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True)

--- a/database/gdcv_data_query.py
+++ b/database/gdcv_data_query.py
@@ -1,0 +1,125 @@
+import MySQLdb
+import MySQLdb.cursors
+import logging
+import os
+
+from google.appengine.ext import ndb
+
+import tba_config
+from database.database_query import DatabaseQuery
+from models.cached_query_result import CachedQueryResult
+from models.sitevar import Sitevar
+
+
+class BaseCloudSqlQuery(DatabaseQuery):
+
+    SCRUB_SQL_COLUMNS = []
+    FETCH_CHUCK_SIZE = 50
+
+    # Based on the GAE/CloudSQL documentation:
+    # https://cloud.google.com/appengine/docs/standard/python/cloud-sql/using-cloud-sql-mysql
+    def _connect_to_cloudsql(self):
+        secrets_sitevar = Sitevar.get_by_id('google.secrets')
+        cloudsql_connection = secrets_sitevar.contents.get('sql_connection')
+        cloudsql_db = secrets_sitevar.contents.get('sql_db')
+        cloudsql_user = secrets_sitevar.contents.get('sql_user')
+        cloudsql_pass = secrets_sitevar.contents.get('sql_pass')
+        # When deployed to App Engine, the `SERVER_SOFTWARE` environment variable
+        # will be set to 'Google App Engine/version'.
+        if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
+            # Connect using the unix socket located at
+            # /cloudsql/cloudsql-connection-name.
+            cloudsql_unix_socket = os.path.join(
+                '/cloudsql', cloudsql_connection)
+
+            db = MySQLdb.connect(
+                unix_socket=cloudsql_unix_socket,
+                user=cloudsql_user,
+                passwd=cloudsql_pass,
+                cursorclass=MySQLdb.cursors.SSDictCursor,
+                db=cloudsql_db)
+
+        # If the unix socket is unavailable, then try to connect using TCP. This
+        # will work if you're running a local MySQL server or using the Cloud SQL
+        # proxy, for example:
+        #
+        #   $ cloud_sql_proxy -instances=your-connection-name=tcp:3306
+        #
+        else:
+            db = MySQLdb.connect(
+                host='127.0.0.1',
+                user=cloudsql_user,
+                passwd=cloudsql_pass,
+                cursorclass=MySQLdb.cursors.SSDictCursor,
+                db=cloudsql_db)
+
+        return db
+
+    def _query_cloud_sql(self, connection, query):
+        cursor = connection.cursor()
+        cursor.execute(query)
+
+        while True:
+            result = cursor.fetchmany(self.FETCH_CHUCK_SIZE)
+            if not result:
+                break
+
+            # Filter out wall_time because it won't be consistent if we backfill, etc
+            for r in result:
+                del r['wall_time']
+                yield r
+
+        cursor.close()
+
+    def _query_async(self):
+        db = None
+        rows = []
+        query_result = []
+        try:
+            query = self._build_query()
+            db = self._connect_to_cloudsql()
+            rows = self._query_cloud_sql(db, query)
+
+            result_to_cache = None
+            for row_dict in rows:
+                for column in self.SCRUB_SQL_COLUMNS:
+                    del row_dict[column]
+                query_result.append(row_dict)
+        except Exception:
+            logging.exception("Error querying CloudSQL")
+        finally:
+            if db:
+                db.close()
+        result_future = ndb.Future()
+        result_future.set_result(query_result)
+        return result_future
+
+
+class MatchGdcvDataQuery(BaseCloudSqlQuery):
+    CACHE_VERSION = 1
+    CACHE_KEY_FORMAT = 'match_timeseries_{}'
+
+    def _build_query(self):
+        match_key = self._query_args[0]
+        event_key = match_key.split('_')[0]
+        match_id = match_key.split('_')[1]
+        year = int(event_key[:4])
+        query = """SELECT * FROM {}_matches
+            WHERE event_key = '{}' AND match_id = '{}'
+            ORDER BY wall_time ASC""".format(year, event_key, match_id)
+
+        return query
+
+
+class EventMatchesGdcvDataQuery(BaseCloudSqlQuery):
+    CACHE_VERSION = 1
+    CACHE_KEY_FORMAT = 'event_matches_timeseries_{}'
+
+    def _build_query(self):
+        event_key = self._query_args[0]
+        year = int(event_key[:4])
+        query = """SELECT * FROM {}_matches
+            WHERE event_key = '{}'
+            ORDER BY wall_time ASC""".format(year, event_key)
+
+        return query

--- a/database/get_affected_queries.py
+++ b/database/get_affected_queries.py
@@ -5,6 +5,7 @@ from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery, 
 from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, TeamYearEventTeamsQuery, \
     EventDivisionsQuery
 from database.event_details_query import EventDetailsQuery
+from database.gdcv_data_query import MatchGdcvDataQuery, EventMatchesGdcvDataQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
     EventMediasQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
@@ -102,9 +103,11 @@ def match_updated(affected_refs):
     queries_and_keys = []
     for match_key in match_keys:
         queries_and_keys.append((MatchQuery(match_key.id())))
+        queries_and_keys.append((MatchGdcvDataQuery(match_key.id())))
 
     for event_key in event_keys:
         queries_and_keys.append((EventMatchesQuery(event_key.id())))
+        queries_and_keys.append((EventMatchesGdcvDataQuery(event_key.id())))
         for team_key in team_keys:
             queries_and_keys.append((TeamEventMatchesQuery(team_key.id(), event_key.id())))
 

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -5,3 +5,4 @@ google-api-python-client==1.6.2
 google-cloud-bigquery==0.25.0
 beautifulsoup4
 GoogleAppEngineCloudStorageClient
+mysqlclient

--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y \
   python2.7-dev \
   python-pip \
   build-essential \
+  jq \
+  python-mysqldb \
   checkinstall \
   libssl-dev \
   tmux \

--- a/ops/dev/bootstrap-dev-container.sh
+++ b/ops/dev/bootstrap-dev-container.sh
@@ -20,3 +20,8 @@ npm install
 cp static/javascript/tba_js/tba_keys_template.js static/javascript/tba_js/tba_keys.js
 
 paver make
+
+
+echo "Downloading cloud sql proxy"
+wget -q https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O /cloud_sql_proxy
+chmod +x /cloud_sql_proxy

--- a/ops/dev/start-devserver.sh
+++ b/ops/dev/start-devserver.sh
@@ -10,11 +10,18 @@ if tmux has-session -t $session ; then
     tmux kill-session -t $session
 fi
 
+instance_name=$(cat ops/dev/conf.json | jq .cloud_sql_instance | jq -r 'select(type == "string")')
+auth_path=$(cat ops/dev/conf.json | jq .auth_file | jq -r 'select(type == "string")')
+
 echo "Starting devserver in new tmux session..."
 tmux new-session -d -s $session
 tmux new-window -t "$session:1" -n gae "paver devserver 2>&1 | tee /var/log/tba.log; read"
 tmux new-window -t "$session:2" -n gulp "gulp; read"
-tmux select-window -t "$session:0"
+if [ ! -z "$instance_name" ]; then
+  echo "Starting Cloud SQL proxy to connect to $instance_name"
+  tmux new-window -t "$session:3" -n sql "/cloud_sql_proxy -instances=$instance_name=tcp:3306 -credential_file=$auth_path | tee /var/log/sql.log; read"
+fi
+tmux select-window -t "$session:1"
 
 tmux list-sessions
 tmux list-windows

--- a/tests/test_database_cache_clearer.py
+++ b/tests/test_database_cache_clearer.py
@@ -9,6 +9,7 @@ from database.district_query import DistrictsInYearQuery, DistrictHistoryQuery, 
 from database.event_query import EventQuery, EventListQuery, DistrictEventsQuery, TeamEventsQuery, TeamYearEventsQuery, TeamYearEventTeamsQuery, \
     EventDivisionsQuery
 from database.event_details_query import EventDetailsQuery
+from database.gdcv_data_query import MatchGdcvDataQuery, EventMatchesGdcvDataQuery
 from database.match_query import MatchQuery, EventMatchesQuery, TeamEventMatchesQuery, TeamYearMatchesQuery
 from database.media_query import TeamSocialMediaQuery, TeamYearMediaQuery, EventTeamsMediasQuery, EventTeamsPreferredMediasQuery, \
     EventMediasQuery, TeamTagMediasQuery, TeamYearTagMediasQuery
@@ -202,11 +203,15 @@ class TestDatabaseCacheClearer(unittest2.TestCase):
         }
         cache_keys = [q.cache_key for q in get_affected_queries.match_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 12)
+        self.assertEqual(len(cache_keys), 16)
         self.assertTrue(MatchQuery('2015casj_qm1').cache_key in cache_keys)
         self.assertTrue(MatchQuery('2015casj_qm2').cache_key in cache_keys)
+        self.assertTrue(MatchGdcvDataQuery('2015casj_qm1').cache_key in cache_keys)
+        self.assertTrue(MatchGdcvDataQuery('2015casj_qm2').cache_key in cache_keys)
         self.assertTrue(EventMatchesQuery('2015casj').cache_key in cache_keys)
         self.assertTrue(EventMatchesQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(EventMatchesGdcvDataQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(EventMatchesGdcvDataQuery('2015cama').cache_key in cache_keys)
         self.assertTrue(TeamEventMatchesQuery('frc254', '2015casj').cache_key in cache_keys)
         self.assertTrue(TeamEventMatchesQuery('frc254', '2015cama').cache_key in cache_keys)
         self.assertTrue(TeamEventMatchesQuery('frc604', '2015casj').cache_key in cache_keys)


### PR DESCRIPTION
## Description
Add an apiv3 endpoint at `/api/v3/match/<key>/timseseries` that returns a list of gdcv score objects from CloudSQL. Also adds an endpoint at `/api/v3/event/<key>/matches/timeseries` that returns a dict mapping a played match key to a list of timeseries score objects. This implementation does require that we have existing score data from the FRC API for the match (we explicitly do _not_ want this endpoint to update it real-time, it should only be retrospective).

## Motivation and Context
Give the people what they want - a way to query for gdcv data

## How Has This Been Tested?
locally on the devserver

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
