### PR TITLE
Fix "Currently competing at" panel on team page

### DIFF
--- a/templates_jinja2/team_partials/team_info.html
+++ b/templates_jinja2/team_partials/team_info.html
@@ -13,7 +13,7 @@
 </div>
 
 <div class="row">
-  <div class="col-sm-7">
+  <div class="col-sm-6">
     <p>
       {% if team.city_state_country or (team.nl and team.nl.name and team.nl.city_state_country) %}
         <span class="glyphicon glyphicon-map-marker"></span> From
@@ -45,7 +45,7 @@
 
     {% include "team_partials/team_social_media.html" %}
   </div>
-  <div class="col-sm-5">
+  <div class="col-sm-6">
   {% if current_event %}
     <div class="panel panel-default">
       <div class="panel-heading">


### PR DESCRIPTION
## Description
I changed the amount of screen each section had to work with, taking 1/12 from the left-hand side container and giving it to the right-hand side container.

## Motivation and Context
There's plenty of screen reality to work with, so nothing should be overflowing.  😁 

## How Has This Been Tested?
Locally only.  See screenshots blow.  👇 

## Screenshots (if appropriate):
Before:
![Before](https://i.imgur.com/79di5Wt.png)

After:
![After](https://i.imgur.com/kyLmBDY.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
