### PR TITLE
Shadow ban & suggestion autoreject

### DIFF
--- a/controllers/admin/admin_user_controller.py
+++ b/controllers/admin/admin_user_controller.py
@@ -119,6 +119,7 @@ class AdminUserEdit(LoggedInHandler):
         user = Account.get_by_id(user_id)
 
         user.display_name = self.request.get("display_name")
+        user.shadow_banned = True if self.request.get("shadow_banned") else False
         user.permissions = []
         for enum in AccountPermissions.permissions:
             permcheck = self.request.get("perm-" + str(enum))

--- a/models/account.py
+++ b/models/account.py
@@ -11,6 +11,7 @@ class Account(ndb.Model):
     nickname = ndb.StringProperty()
     registered = ndb.BooleanProperty()
     permissions = ndb.IntegerProperty(repeated=True)
+    shadow_banned = ndb.BooleanProperty(default=False)
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
 

--- a/models/suggestion.py
+++ b/models/suggestion.py
@@ -31,6 +31,7 @@ class Suggestion(ndb.Model):
     REVIEW_ACCEPTED = 1
     REVIEW_PENDING = 0
     REVIEW_REJECTED = -1
+    REVIEW_AUTOREJECTED = -2
 
     review_state = ndb.IntegerProperty(default=0)
     reviewed_at = ndb.DateTimeProperty()
@@ -46,6 +47,13 @@ class Suggestion(ndb.Model):
     def __init__(self, *args, **kw):
         self._contents = None
         super(Suggestion, self).__init__(*args, **kw)
+
+    def put(self, *args, **kwargs):
+        if self.review_state == 0:
+            user = self.author.get()
+            if user and user.shadow_banned:
+                self.review_state = self.REVIEW_AUTOREJECTED
+        return super(Suggestion, self).put(*args, **kwargs)
 
     @property
     def contents(self):

--- a/templates/admin/user_details.html
+++ b/templates/admin/user_details.html
@@ -37,6 +37,10 @@
         </td>
     </tr>
     <tr>
+        <td>Shadow Banned</td>
+        <td>{{ user.shadow_banned }}</td>
+    </tr>
+    <tr>
         <td>Created</td>
         <td>{{ user.created }}</td>
     </tr>

--- a/templates/admin/user_edit.html
+++ b/templates/admin/user_edit.html
@@ -19,15 +19,19 @@
             <ul style="list-style-type: none; padding: 0">
             {% for enum, permission in permissions.items %}
                 <li>
-	                <input 
-	                	type="checkbox" 
-	                	name="perm-{{enum}}" 
-	                	{% if enum in user.permissions %}checked{% endif %} />
-                	<strong>{{permission.name}}</strong> – {{permission.description}}
-        		</li>
+                    <input
+                        type="checkbox"
+                        name="perm-{{enum}}"
+                        {% if enum in user.permissions %}checked{% endif %} />
+                    <strong>{{permission.name}}</strong> – {{permission.description}}
+                </li>
             {% endfor %}
             </ul>
         </td>
+        </tr>
+        <tr>
+            <td>Shadow Banned</td>
+            <td><input type="checkbox" name="shadow_banned" {% if user.shadow_banned %}checked{% endif %} /></td>
         </tr>
     </table>
 


### PR DESCRIPTION
Closes #2174 

## Description
Add ability to shadow ban users and autoreject their suggestions

## Motivation and Context
Reduce spam

## How Has This Been Tested?
Verify on local dev that suggestions from shadow banned users don't show up in the suggestion queue, and other suggestions do.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
