### PR TITLE
Restrict base time for time predictions

### DIFF
--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -151,7 +151,12 @@ class MatchTimePredictionHelper(object):
             # Otherwise, use the predicted start time of the previously processed match
             last_predicted = None
             if last_match:
-                last_predicted = cls.as_local(last_match.actual_time if i == 0 else last.predicted_time, timezone)
+                cycle_time = average_cycle_time if average_cycle_time else 60 * 7  # Default to 7 min
+                base_time = max(
+                    cls.as_local(last_match.actual_time, timezone),
+                    now - datetime.timedelta(seconds=cycle_time)
+                )
+                last_predicted = base_time if i == 0 else cls.as_local(last.predicted_time, timezone)
             if last_predicted and average_cycle_time:
                 predicted = last_predicted + datetime.timedelta(seconds=average_cycle_time)
             else:


### PR DESCRIPTION
## Description
Restricts the base time (time that all future match times are calculated from as `base_time + i * cycle_time` to be no older than `now - some_amount`

## Motivation and Context
Fixing an edge case for match time predictions.

## How Has This Been Tested?
Tested with 2018txda, 2018vahay, and 2018ohmv with different faked current times to see that predicted match times are bounded by `current time - some amount`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
