### PR TITLE
Explicitly set predicted match time

### DIFF
--- a/helpers/match_time_prediction_helper.py
+++ b/helpers/match_time_prediction_helper.py
@@ -142,10 +142,11 @@ class MatchTimePredictionHelper(object):
             scheduled_time = cls.as_local(match.time, timezone)
             if (scheduled_time.day != last_match_day and last_match_day is not None) \
                     or last_comp_level != match.comp_level:
-                # Stop, once we exhaust all unplayed matches on this day or move to a new comp level
                 if i == 0:
                     write_logs = False
-                break
+                # Use predicted = scheduled once we exhaust all unplayed matches on this day or move to a new comp level
+                match.predicted_time = match.time
+                continue
 
             # For the first iteration, base the predictions off the newest known actual start time
             # Otherwise, use the predicted start time of the previously processed match


### PR DESCRIPTION
## Description
Don't skip matches that are not on the same day/comp level. Set them to the scheduled time instead.

## Motivation and Context
Since "is down" determination is based on predicted time vs. scheduled time, we should be predicting match times regardless.

## How Has This Been Tested?
Local dev with 2018isr1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
