### PR TITLE
Add (sub)division wins insight

### DIFF
--- a/helpers/insights_helper.py
+++ b/helpers/insights_helper.py
@@ -589,6 +589,12 @@ class InsightsHelper(object):
             for team in insight.data:
                 world_champions[team] += 1
 
+        year_division_winners = Insight.query(Insight.name == Insight.INSIGHT_NAMES[Insight.DIVISION_WINNERS], Insight.year != 0).fetch(1000)
+        division_winners = defaultdict(int)
+        for insight in year_division_winners:
+            for team in insight.data:
+                division_winners[team] += 1
+
         year_successful_elim_teamups = Insight.query(Insight.name == Insight.INSIGHT_NAMES[Insight.SUCCESSFUL_ELIM_TEAMUPS], Insight.year != 0).fetch(1000)
         successful_elim_teamups = defaultdict(int)
         for insight in year_successful_elim_teamups:
@@ -606,6 +612,7 @@ class InsightsHelper(object):
         blue_banners = self._sortTeamWinsDict(blue_banners)
         rca_winners = self._sortTeamWinsDict(rca_winners)
         world_champions = self._sortTeamWinsDict(world_champions)
+        division_winners = self._sortTeamWinsDict(division_winners)
 
         # Creating Insights
         if regional_winners:
@@ -619,6 +626,9 @@ class InsightsHelper(object):
 
         if world_champions:
             insights.append(self._createInsight(world_champions, Insight.INSIGHT_NAMES[Insight.WORLD_CHAMPIONS], 0))
+
+        if division_winners:
+            insights.append(self._createInsight(division_winners, Insight.INSIGHT_NAMES[Insight.DIVISION_WINNERS], 0))
 
         if year_successful_elim_teamups:
             insights.append(self._createInsight(successful_elim_teamups_sorted, Insight.INSIGHT_NAMES[Insight.SUCCESSFUL_ELIM_TEAMUPS], 0))

--- a/templates_jinja2/insights.html
+++ b/templates_jinja2/insights.html
@@ -85,7 +85,7 @@
   {% if division_winners %}
   <div class="row">
     <div class="col-xs-12">
-    <h3>Most (Sub)Division Wins</h3>
+    <h3>Most (Sub)Division Wins <small>(Most Einstein Appearances)</small></h3>
       <table class="table table-striped table-condensed table-center insights-table">
         <thead>
           <tr>

--- a/templates_jinja2/insights.html
+++ b/templates_jinja2/insights.html
@@ -82,6 +82,36 @@
   </div>
   {% endif %}
 
+  {% if division_winners %}
+  <div class="row">
+    <div class="col-xs-12">
+    <h3>Most (Sub)Division Wins</h3>
+      <table class="table table-striped table-condensed table-center insights-table">
+        <thead>
+          <tr>
+            <th>Number</th>
+            <th>Teams</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for number, team_list in division_winners.data %}
+        {% if number != 1 %}
+          <tr>
+            <td>{{number}}</td>
+            <td>
+              {% for team in team_list %}
+              <a href="/team/{{team|digits}}/history">{{team|digits}}</a>{% if not loop.last %},{% endif %}
+              {% endfor %}
+            </td>
+          </tr>
+        {% endif %}
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
+
   {% if rca_winners %}
   <div class="row">
     <div class="col-xs-12">


### PR DESCRIPTION
## Description
Add insight that lists (sub)division wins

## Motivation and Context
Unsure why we didn't already have it.

## How Has This Been Tested?
Local dev with partial 2017 data

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/37005519-63b37274-20a2-11e8-8e68-a12360bc4c51.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
