### PR TITLE
Fixed an unmet dependency error that caused provisioning to fail

### DIFF
--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install -y \
   libssl-dev \
   tmux \
   vim \
-  openssh-server
+  openssh-server \
+  libmysqlclient-dev
 
 # Configure ssh server
 RUN mkdir /var/run/sshd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an apt dependency that was causing dev environment setup to fail.

## Motivation and Context
This change is required to set up a new development environment correctly. It solves a mysql_config environment error on first-time setup.

## How Has This Been Tested?
Issue was discovered trying to set up a development environment, applied fixes, reran setup commands and did not get the error. This was on an Ubuntu 16.04 system.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
