### PR TITLE
Add average winning margin by week and winning margin distribution to insights page

### DIFF
--- a/models/insight.py
+++ b/models/insight.py
@@ -28,6 +28,8 @@ class Insight(ndb.Model):
     MATCH_PREDICTIONS = 16
     MATCH_AVERAGE_MARGINS_BY_WEEK = 17
     ELIM_MATCH_AVERAGE_MARGINS_BY_WEEK = 18
+    WINNING_MARGIN_DISTRIBUTION = 19
+    ELIM_WINNING_MARGIN_DISTRIBUTION = 20
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -51,6 +53,8 @@ class Insight(ndb.Model):
                      MATCH_PREDICTIONS: 'match_predictions',
                      MATCH_AVERAGE_MARGINS_BY_WEEK: 'match_average_margins_by_week',
                      ELIM_MATCH_AVERAGE_MARGINS_BY_WEEK: 'elim_match_average_margins_by_week',
+                     WINNING_MARGIN_DISTRIBUTION: 'winning_margin_distribution',
+                     ELIM_WINNING_MARGIN_DISTRIBUTION: 'elim_winning_margin_distribution',
                      YEAR_SPECIFIC_BY_WEEK: 'year_specific_by_week',
                      YEAR_SPECIFIC: 'year_specific',
                      }

--- a/models/insight.py
+++ b/models/insight.py
@@ -26,6 +26,8 @@ class Insight(ndb.Model):
     REGIONAL_DISTRICT_WINNERS = 14
     SUCCESSFUL_ELIM_TEAMUPS = 15
     MATCH_PREDICTIONS = 16
+    MATCH_AVERAGE_MARGINS_BY_WEEK = 17
+    ELIM_MATCH_AVERAGE_MARGINS_BY_WEEK = 18
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -47,6 +49,8 @@ class Insight(ndb.Model):
                      REGIONAL_DISTRICT_WINNERS: 'regional_district_winners',
                      SUCCESSFUL_ELIM_TEAMUPS: 'successful_elim_teamups',
                      MATCH_PREDICTIONS: 'match_predictions',
+                     MATCH_AVERAGE_MARGINS_BY_WEEK: 'match_average_margins_by_week',
+                     ELIM_MATCH_AVERAGE_MARGINS_BY_WEEK: 'elim_match_average_margins_by_week',
                      YEAR_SPECIFIC_BY_WEEK: 'year_specific_by_week',
                      YEAR_SPECIFIC: 'year_specific',
                      }

--- a/templates/index_insights.html
+++ b/templates/index_insights.html
@@ -93,19 +93,6 @@
         <br><br>
       {% endif %}
 
-      {% if score_distribution %}
-        <h3>Match Score Distribution <small>Percent of Matches vs. Match Score</small></h3>
-        {% if elim_score_distribution %}
-          <div class="chart-key"><div class="color-key blue-color-key"></div><div class="chart-key-text">All Match Scores</div></div>
-          <div class="chart-key"><div class="color-key green-color-key"></div><div class="chart-key-text">Elim Match Scores</div></div>
-          <figure style="width: 90%; height: 300px;" id="elim-match-distribution-chart"></figure>
-          <div id="elim-match-distribution" class="xcharts-data xcharts-bar-data">[{{ score_distribution.data_json|safe }}, {{ elim_score_distribution.data_json|safe }}]</div>
-        {% else %}
-          <figure style="width: 90%; height: 300px;" id="match-distribution-chart"></figure>
-          <div id="match-distribution" class="xcharts-data xcharts-bar-data">[{{ score_distribution.data_json|safe }}]</div>
-        {% endif %}
-        <br><br>
-      {% endif %}
     </div>
   </div>
 </div>

--- a/templates_jinja2/insights_details.html
+++ b/templates_jinja2/insights_details.html
@@ -155,6 +155,21 @@
     {% endif %}
   {% endif %}
 
+  {% if winning_margin_distribution %}
+  <h3>Winning Margin Distribution <small>Percent of Matches vs. Winning Margin</small></h3>
+    {% if elim_winning_margin_distribution %}
+    <div class="row">
+      <div class="col-sm-6 col-xs-12"><div class="color-key blue-color-key"></div><div class="chart-key-text">All Winning Margins</div></div>
+      <div class="col-sm-6 col-xs-12"><div class="color-key green-color-key"></div><div class="chart-key-text">{% if selected_year >= 2015 %}Playoff{% else %}Elim{% endif %} Winning Margins</div></div>
+    </div>
+    <figure style="width: 90%; height: 300px;" id="elim-match-margin-distribution-chart"></figure>
+    <div id="elim-match-margin-distribution" class="xcharts-data xcharts-bar-data">[{{ winning_margin_distribution.data_json|safe }}, {{ elim_winning_margin_distribution.data_json|safe }}]</div>
+    {% else %}
+    <figure style="width: 90%; height: 300px;" id="match-margin-distribution-chart"></figure>
+    <div id="match-margin-distribution" class="xcharts-data xcharts-bar-data">[{{ winning_margin_distribution.data_json|safe }}]</div>
+    {% endif %}
+  {% endif %}
+
   {% if year_specific_by_week or year_specific %}
   <h3>Year Specific Statistics</h3>
   <ul class="nav nav-tabs nav-justified">

--- a/templates_jinja2/insights_details.html
+++ b/templates_jinja2/insights_details.html
@@ -129,14 +129,14 @@
   <h3>Average Winning Margin By Week</h3>
     {% if elim_match_average_margins_by_week %}
     <div class="row">
-      <div class="col-sm-6 col-xs-12"><div class="color-key blue-color-key"></div><div class="chart-key-text">All Match Margin Averages</div></div>
-      <div class="col-sm-6 col-xs-12"><div class="color-key green-color-key"></div><div class="chart-key-text">{% if selected_year >= 2015 %}Playoff{% else %}Elim{% endif %} Match Margin Averages</div></div>
+      <div class="col-sm-6 col-xs-12"><div class="color-key blue-color-key"></div><div class="chart-key-text">All Match Averages</div></div>
+      <div class="col-sm-6 col-xs-12"><div class="color-key green-color-key"></div><div class="chart-key-text">{% if selected_year >= 2015 %}Playoff{% else %}Elim{% endif %} Match Averages</div></div>
     </div>
-    <figure style="width: 90%; height: 300px;" id="elim-match-average-chart"></figure>
-    <div id="elim-match-average" class="xcharts-data xcharts-line-data">[{{ match_average_margins_by_week.data_json|safe }}, {{ elim_match_average_margins_by_week.data_json|safe }}]</div>
+    <figure style="width: 90%; height: 300px;" id="elim-match-margin-average-chart"></figure>
+    <div id="elim-match-margin-average" class="xcharts-data xcharts-line-data">[{{ match_average_margins_by_week.data_json|safe }}, {{ elim_match_average_margins_by_week.data_json|safe }}]</div>
     {% else %}
-    <figure style="width: 90%; height: 300px;" id="match-average-chart"></figure>
-    <div id="match-average" class="xcharts-data xcharts-line-data">[{{ match_average_margins_by_week.data_json|safe }}]</div>
+    <figure style="width: 90%; height: 300px;" id="match-margin-average-chart"></figure>
+    <div id="match-margin-average" class="xcharts-data xcharts-line-data">[{{ match_average_margins_by_week.data_json|safe }}]</div>
     {% endif %}
   {% endif %}
 

--- a/templates_jinja2/insights_details.html
+++ b/templates_jinja2/insights_details.html
@@ -125,6 +125,21 @@
     {% endif %}
   {% endif %}
 
+  {% if match_average_margins_by_week %}
+  <h3>Average Winning Margin By Week</h3>
+    {% if elim_match_average_margins_by_week %}
+    <div class="row">
+      <div class="col-sm-6 col-xs-12"><div class="color-key blue-color-key"></div><div class="chart-key-text">All Match Margin Averages</div></div>
+      <div class="col-sm-6 col-xs-12"><div class="color-key green-color-key"></div><div class="chart-key-text">{% if selected_year >= 2015 %}Playoff{% else %}Elim{% endif %} Match Margin Averages</div></div>
+    </div>
+    <figure style="width: 90%; height: 300px;" id="elim-match-average-chart"></figure>
+    <div id="elim-match-average" class="xcharts-data xcharts-line-data">[{{ match_average_margins_by_week.data_json|safe }}, {{ elim_match_average_margins_by_week.data_json|safe }}]</div>
+    {% else %}
+    <figure style="width: 90%; height: 300px;" id="match-average-chart"></figure>
+    <div id="match-average" class="xcharts-data xcharts-line-data">[{{ match_average_margins_by_week.data_json|safe }}]</div>
+    {% endif %}
+  {% endif %}
+
   {% if score_distribution %}
   <h3>Match Score Distribution <small>Percent of Matches vs. Match Score</small></h3>
     {% if elim_score_distribution %}


### PR DESCRIPTION
## Description
Add winning margin distribution to insights page.

### TODO:
- [x] Add backend for average winning margin by week
- [x] Add frontend for average winning margin by week
- [x] Add backend for winning margin distribution
- [x] Add frontend for winning margin distribution

## Motivation and Context
@gregmarra, among others, have suggested (#2168) showing winning margin distribution on the insights page.
"Showing the distribution of win margin would give an insight into how close matches are, and how many seconds of ownership are deciding matches."

## How Has This Been Tested?
Locally only at this point.  ~When it's more complete,~ I'd like others to test.
In addition, I'm planning on adding tests, once I've fleshed out more of the functionality.
(tests coming soon, if we feel they're needed)

## Screenshots (if appropriate):
Week 1:
![average winning margin by week](https://puu.sh/zDIfT/39da5ca925.png)
![winning margin distribution](https://puu.sh/zDIhz/3635a403e6.png)

Week 2:
![average winning margin by week](https://puu.sh/zGjuI/4a46769c75.png)
![winning margin distribution](https://puu.sh/zGjwI/dafadc367a.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
