### PR TITLE
Check last played match time when determining event is down

### DIFF
--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -673,11 +673,13 @@ class MatchTimePredictionsDo(webapp.RequestHandler):
         MatchTimePredictionHelper.predict_future_matches(event_key, played_matches, unplayed_matches, timezone, event.within_a_day)
 
         # Detect whether the event is down
-        # An event NOT down if ANY unplayed match's predicted time is within its scheduled time by a threshold
+        # An event NOT down if ANY unplayed match's predicted time is within its scheduled time by a threshold and
+        # the last played match (if it exists) wasn't too long ago.
         event_down = len(unplayed_matches) > 0
         for unplayed_match in unplayed_matches:
             if (unplayed_match.predicted_time and unplayed_match.time and
-                unplayed_match.predicted_time < unplayed_match.time + datetime.timedelta(minutes=30)):
+                unplayed_match.predicted_time < unplayed_match.time + datetime.timedelta(minutes=30) and
+                (played_matches == [] or played_matches[-1].actual_time > datetime.datetime.now() - datetime.timedelta(minutes=30))):
                 event_down = False
                 break
 


### PR DESCRIPTION
## Motivation and Context
Events were being incorrectly marked as "down" if they were only behind schedule.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
