### PR TITLE
Add automatic playlist-ing for team details page

### DIFF
--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -104,13 +104,25 @@ class TeamRenderer(object):
                         team_rank = ranking['rank']
                         break
 
+            video_ids = ""
+            for lv in Match.COMP_LEVELS:
+                ms = matches_organized[lv] # All matches at this level
+                for m in ms:
+                    vidstr = ""
+                    for v in m.youtube_videos: # All videos for this match
+                        # Split to remove time links, they dont work in playlists
+                        vidstr = vidstr + v.split("?")[0] + ","
+                    video_ids = video_ids + vidstr
+            video_ids = video_ids[:-1] # Remove trailing comma
+
             participation.append({"event": event,
                                   "matches": matches_organized,
                                   "wlt": display_wlt,
                                   "qual_avg": qual_avg,
                                   "elim_avg": elim_avg,
                                   "rank": team_rank,
-                                  "awards": event_awards})
+                                  "awards": event_awards,
+                                  "video_ids" : video_ids})
 
         season_wlt = None
         offseason_wlt = None

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -104,15 +104,16 @@ class TeamRenderer(object):
                         team_rank = ranking['rank']
                         break
 
-            video_ids = ""
-            for lv in Match.COMP_LEVELS:
-                ms = matches_organized[lv]
-                for m in ms:
-                    vidstr = ""
-                    for v in m.youtube_videos:
-                        if len(v) > 0:
-                            vidstr = vidstr + v.split("?")[0] + ","
-                    video_ids = video_ids + vidstr
+            video_ids = []
+            playlist = ""
+            for level in Match.COMP_LEVELS:
+                matches = matches_organized[level]
+                for match in matches:
+                    video_ids += [video.split("?")[0] for video in match.youtube_videos]
+            if video_ids:
+                playlist_title = "{} (Team {})".format(event.name, team.team_number)
+                playlist = "https://www.youtube.com/watch_videos?video_ids={}&title={}"
+                playlist = playlist.format(",".join(video_ids), playlist_title)
 
             participation.append({"event": event,
                                   "matches": matches_organized,
@@ -121,7 +122,7 @@ class TeamRenderer(object):
                                   "elim_avg": elim_avg,
                                   "rank": team_rank,
                                   "awards": event_awards,
-                                  "video_ids": video_ids})
+                                  "playlist": playlist})
 
         season_wlt = None
         offseason_wlt = None

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -106,14 +106,12 @@ class TeamRenderer(object):
 
             video_ids = ""
             for lv in Match.COMP_LEVELS:
-                ms = matches_organized[lv] # All matches at this level
+                ms = matches_organized[lv]
                 for m in ms:
                     vidstr = ""
-                    for v in m.youtube_videos: # All videos for this match
-                        # Split to remove time links, they dont work in playlists
-                        vidstr = vidstr + v.split("?")[0] + ","
+                    for v in m.youtube_videos:
+                        if len(v) > 0: vidstr = vidstr + v.split("?")[0] + ","
                     video_ids = video_ids + vidstr
-            video_ids = video_ids[:-1] # Remove trailing comma
 
             participation.append({"event": event,
                                   "matches": matches_organized,

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -110,7 +110,8 @@ class TeamRenderer(object):
                 for m in ms:
                     vidstr = ""
                     for v in m.youtube_videos:
-                        if len(v) > 0: vidstr = vidstr + v.split("?")[0] + ","
+                        if len(v) > 0: 
+                            vidstr = vidstr + v.split("?")[0] + ","
                     video_ids = video_ids + vidstr
 
             participation.append({"event": event,
@@ -120,7 +121,7 @@ class TeamRenderer(object):
                                   "elim_avg": elim_avg,
                                   "rank": team_rank,
                                   "awards": event_awards,
-                                  "video_ids" : video_ids})
+                                  "video_ids": video_ids})
 
         season_wlt = None
         offseason_wlt = None

--- a/renderers/team_renderer.py
+++ b/renderers/team_renderer.py
@@ -110,7 +110,7 @@ class TeamRenderer(object):
                 for m in ms:
                     vidstr = ""
                     for v in m.youtube_videos:
-                        if len(v) > 0: 
+                        if len(v) > 0:
                             vidstr = vidstr + v.split("?")[0] + ","
                     video_ids = video_ids + vidstr
 

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -142,6 +142,8 @@
                   </ul>
                   {% endif %}
                 </p>
+                <a class="btn btn-default" href="https://www.youtube.com/watch_videos?video_ids=oHg5SJYRHA0" target="_blank">
+                  <span class="glyphicon glyphicon-play-circle"></span> Watch Me at This Event</a>
                 {% endif %}
               </div>
               <div class="col-sm-8" style="margin-top: 1em">

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -142,7 +142,7 @@
                   </ul>
                   {% endif %}
                 </p>
-                <a class="btn btn-default" href="https://www.youtube.com/watch_videos?video_ids=oHg5SJYRHA0" target="_blank">
+                <a class="btn btn-default" href="https://www.youtube.com/watch_videos?video_ids={{comp.video_ids}}" target="_blank">
                   <span class="glyphicon glyphicon-play-circle"></span> Watch Me at This Event</a>
                 {% endif %}
               </div>

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -142,8 +142,10 @@
                   </ul>
                   {% endif %}
                 </p>
-                <a class="btn btn-default" href="https://www.youtube.com/watch_videos?video_ids={{comp.video_ids}}" target="_blank">
-                  <span class="glyphicon glyphicon-play-circle"></span> Watch Me at This Event</a>
+                {% if comp.playlist %}
+                <a class="btn btn-default" href="{{comp.playlist}}" target="_blank">
+                  <span class="glyphicon glyphicon-play-circle"></span> Watch All Matches</a>
+                {% endif %}
                 {% endif %}
               </div>
               <div class="col-sm-8" style="margin-top: 1em">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modify the team_details page to have an additional button that links to a youtube playlist containing all the match videos of a team for the indicated event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found myself having to click a lot to watch a team through the eliminations at their event and thought that was unnecessary. This button lets you sit back and watch a team's performance at an event.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this on events with missing videos, no videos, videos that contain time links (don't work in playlists), and with multiple event entries for a team. 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10108848/37619328-96619712-2b8f-11e8-8ebd-aab880781483.png)


![image](https://user-images.githubusercontent.com/10108848/37619540-29495e0c-2b90-11e8-9ab3-c1fad86e1de8.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
