### PR TITLE
Improves Match Details page, fixes #2213

### DIFF
--- a/templates_jinja2/match_details.html
+++ b/templates_jinja2/match_details.html
@@ -37,6 +37,12 @@
   </div>
   <div class="row">
     <div class="col-sm-12 col-md-6">
+      {% if match_breakdown_template %}
+      <h3>Detailed Results</h3>
+        {% include match_breakdown_template %}
+      {% endif %}
+    </div>
+    <div class="col-sm-12 col-md-6">
       <h3>Video</h3>
       {% if match.tba_video %}
         {% include "video_partials/tbavideo_player.html" %}
@@ -52,12 +58,6 @@
         <a class="btn btn-success" href="/suggest/match/video?match_key={{match.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add videos</a>
         <a class="btn btn-primary" href="https://www.youtube.com/results?search_query={{match.short_name|urlencode}}+{{event.year}}+{{event.name|urlencode}}" target="_blank"><span class="glyphicon glyphicon-search"></span> Search YouTube</a>
       </p>
-    </div>
-    <div class="col-sm-12 col-md-6">
-      {% if match_breakdown_template %}
-      <h3>Detailed Results</h3>
-        {% include match_breakdown_template %}
-      {% endif %}
     </div>
   </div>
   <div class="row">

--- a/templates_jinja2/match_details.html
+++ b/templates_jinja2/match_details.html
@@ -27,19 +27,16 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-12">
-      <p><a class="btn btn-default" href="/event/{{event.key_name}}"><span class="glyphicon glyphicon-chevron-left"></span> {{ event.year }} {{ event.name }}</a></p>
       <h1>{{match.verbose_name}} <small><a href="/event/{{event.key_name}}">{{ event.year }} {{ event.name }}</a></small></h1>
     </div>
   </div>
   <div class="row">
-    <div class="col-xs-12 col-sm-7 col-md-6">
-      <h3>Match Results</h3>
+    <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
       {{mtm.single_match_table(match)}}
-      {% if match_breakdown_template %}
-        {% include match_breakdown_template %}
-      {% endif %}
     </div>
-    <div class="col-xs-12 col-sm-5 col-md-6">
+  </div>
+  <div class="row">
+    <div class="col-sm-12 col-md-6">
       <h3>Video</h3>
       {% if match.tba_video %}
         {% include "video_partials/tbavideo_player.html" %}
@@ -48,13 +45,23 @@
         {% include "video_partials/youtube_video_player.html" %}
       {% endfor %}
       {% if not match.tba_video and not match.youtube_videos %}
-        <p>We don't know about any videos for this match yet. :(</p>
+        <p>We don't know about any videos for this match yet. 🙁</p>
         <p>Help others out by searching YouTube and adding videos!</p>
       {% endif %}
       <p>
         <a class="btn btn-success" href="/suggest/match/video?match_key={{match.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add videos</a>
         <a class="btn btn-primary" href="https://www.youtube.com/results?search_query={{match.short_name|urlencode}}+{{event.year}}+{{event.name|urlencode}}" target="_blank"><span class="glyphicon glyphicon-search"></span> Search YouTube</a>
       </p>
+    </div>
+    <div class="col-sm-12 col-md-6">
+      {% if match_breakdown_template %}
+      <h3>Detailed Results</h3>
+        {% include match_breakdown_template %}
+      {% endif %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-12">
       <hr>
       <div class="fb-comments" data-href="http://www.thebluealliance.com/match/{{match.key_name}}" data-num-posts="3" data-width="470"></div>
     </div>


### PR DESCRIPTION
## Description
Moves Videos above Match Details on Mobile. Removes "Button to go back" since event link already present.

## Motivation and Context
Addresses issues I observed using this page on an iPhone.

## How Has This Been Tested?
Tested on dev instance.

## Screenshots (if appropriate):
### Before
![image](https://user-images.githubusercontent.com/57101/38178742-04716e42-35ce-11e8-8b71-d5befc57bab5.png)

### After No Video
![image](https://user-images.githubusercontent.com/57101/38178743-0a1d0aae-35ce-11e8-8e9c-9569a61ce50c.png)

### After Video
![image](https://user-images.githubusercontent.com/57101/38178746-0fe0c0a2-35ce-11e8-8edf-67028d7a4782.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
