### PR TITLE
Link to Instagram accounts so people can find media more easily.

### DIFF
--- a/controllers/suggestions/suggest_team_media_controller.py
+++ b/controllers/suggestions/suggest_team_media_controller.py
@@ -42,11 +42,17 @@ class SuggestTeamMediaController(LoggedInHandler):
         medias = [media_future.get_result() for media_future in media_futures]
         medias_by_slugname = MediaHelper.group_by_slugname(medias)
 
+        media_key_futures = Media.query(Media.references == team.key, Media.year == None).fetch_async(500, keys_only=True)
+        media_futures = ndb.get_multi_async(media_key_futures.get_result())
+        medias = [media_future.get_result() for media_future in media_futures]
+        social_medias = [media for media in medias if media.media_type_enum == MediaType.INSTAGRAM_PROFILE] # we only allow IG media, so only show IG profile
+
         self.template_values.update({
+            "medias_by_slugname": medias_by_slugname,
+            "social_medias": social_medias,
             "status": self.request.get("status"),
             "team": team,
             "year": year,
-            "medias_by_slugname": medias_by_slugname,
         })
 
         self.response.out.write(jinja2_engine.render('suggestions/suggest_team_media.html', self.template_values))

--- a/templates_jinja2/suggestions/suggest_team_media.html
+++ b/templates_jinja2/suggestions/suggest_team_media.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import 'media_partials/social_media_macros.html' as smm %}
 
 {% block title %}The Blue Alliance - Add Team Media{% endblock %}
 
@@ -55,31 +56,11 @@
 
           <p><strong>Currently supported formats are:</strong></p>
           <ul>
-            <li>Chief Delphi Images
-              <ul>
-                <li>Example: <code>http://www.chiefdelphi.com/media/photos/36646</code></li>
-              </ul>
-            </li>
-            <li>Imgur Images
-              <ul>
-                <li>Example: <code>http://imgur.com/aF8T5ZE</code></li>
-              </ul>
-            </li>
-            <li>Instagram Images
-              <ul>
-                <li>Example: <code>https://www.instagram.com/p/BUnZiriBYre</code></li>
-              </ul>
-            </li>
-            <li>YouTube Videos
-              <ul>
-                <li>Example: <code>https://www.youtube.com/watch?v=DojyJ9bZ4fk</code></li>
-              </ul>
-            </li>
-            <li>GrabCAD Files
-              <ul>
-                <li>Example: <code>https://grabcad.com/library/cad-stuff</code></li>
-              </ul>
-            </li>
+            <li><strong>Chief Delphi images</strong>, like <code>http://www.chiefdelphi.com/media/photos/36646</code></li>
+            <li><strong>Imgur images</strong>, like <code>http://imgur.com/aF8T5ZE</code></li>
+            <li><strong>Instagram photos and videos</strong>, like <code>https://www.instagram.com/p/BUnZiriBYre</code></li>
+            <li><strong>YouTube videos</strong>, like <code>https://www.youtube.com/watch?v=DojyJ9bZ4fk</code></li>
+            <li><strong>GrabCAD files</strong>, like <code>https://grabcad.com/library/cad-stuff</code></li>
           </ul>
 
           <p><strong>Please do not submit:</strong></p>
@@ -93,6 +74,21 @@
           <hr>
 
           <h3>Team {{team.team_number}}{% if team.nickname %} - {{team.nickname}}{% endif %} ({{year}})</h3>
+
+          <div class="row">
+            {{social_media}}
+            <div class="col-xs-12">
+              {% if social_medias %}
+                <h4>Team {{team.team_number}}'s social media accounts</h4>
+                <p>You may be able to find photos or videos that have been shared on social media.</p>
+                <ul>
+                {% for media in social_medias %}
+                  <li>{{smm.social_media_icon_link(media)}}</li>
+                {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
+          </div>
 
           {% if medias_by_slugname.cdphotothread %}
           <div class="row">


### PR DESCRIPTION
Fixes #2215 

## Description
Link to Instagram accounts on Team Add Media pages to recommend people look for photos.

## Motivation and Context
Makes it easier to add media.

## How Has This Been Tested?
Tested on dev instance.
1. Instagram accounts appear
2. No other social media types appear.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/57101/38178932-8d63a014-35d1-11e8-8b7a-d2d95847d600.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
