### PR TITLE
Simplify Event Details Header

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -6,7 +6,7 @@
 {% block meta_description %}Videos and match results for the {{event.year}} {{event.name}} FIRST Robotics Competition in {{event.location}}.{% endblock %}
 
 {% block more_head_tags %}
-    <meta property="og:title" content="{{ event.year }} {{ event.name }}"
+  <meta property="og:title" content="{{ event.year }} {{ event.name }}"
           xmlns="http://www.w3.org/1999/html"/>
   <meta property="og:type" content="article" />
   <meta property="og:image" content="http://www.thebluealliance.com/images/logo_square_512.png" />
@@ -37,7 +37,6 @@
       {% if event.year == 2016 and event.event_type_enum == 3 %}
       <p class="pull-right"><a class="btn btn-primary" href="/event/{{event.key_name}}/insights"><span class="glyphicon glyphicon-align-left"></span> Advanced Insights</a></p>
       {% endif %}
-      <a class="btn btn-default" href="/events/{{event.year}}"><span class="glyphicon glyphicon-chevron-left"></span> {{event.year}} Events</a>
       {% if event_divisions %}
         <div class="btn-group">
         <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">
@@ -54,16 +53,18 @@
       </div>
       {% endif %}
       <h1 itemprop="summary">{{event.name}} {{event.year}}</h1>
-      {% if district_name or parent_event %}<blockquote>
-          {% if district_name %}<p></p><em>Part of the <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a></em></p>{% endif %}
-          {% if parent_event %}<p><em>Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a></em></p>{% endif %}
-      </blockquote>{% endif %}
     </div>
   </div>
   <div class="row">
     <div class="col-sm-12">
-      <a class="btn btn-success pull-right" href="/suggest/event/video?event_key={{event.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add Match Videos!</a>
+      <a class="btn btn-success pull-right hidden-xs" href="/suggest/event/video?event_key={{event.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add Match Videos!</a>
       <p>
+        {% if district_name %}
+          <span class="glyphicon glyphicon-globe"></span> <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a> Event<br />
+        {% endif %}
+        {% if parent_event %}
+          <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
+        {% endif %}
         {% if event.start_date %}
           <span class="glyphicon glyphicon-calendar"></span> <time itemprop="startDate" datetime="{{event.start_date.isoformat()}}">{{ event.start_date|strftime("%B %d") }}{% if event.start_date.date() != event.end_date.date() %}</time> to <time itemprop="endDate" datetime="{{event.end_date.isoformat()}}">{{ event.end_date|strftime("%B %d") }}{% endif %}, {{ event.end_date|strftime("%Y") }}</time>
         {% endif %}
@@ -82,16 +83,9 @@
             <a href="http://maps.google.com/maps?q={{ event.location|urlencode }}" target="_blank">{{event.location}}</a>
           {% endif %}
         {% endif %}
-        {% if event.website %}<br><span class="glyphicon glyphicon-globe"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
+        {% if event.website %}<br><span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
         {% if event.first_eid %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="http://www.firstinspires.org/team-event-search/event?id={{ event.first_eid }}" target="_blank">firstinspires.org</a>{% endif %}
         {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank">RSVP on Facebook</a><br>{% endif %}
-      </p>
-
-      <p><strong>#{{ event.hashtag }}</strong> <small><a href="/hashtags" rel="tooltip" title="What are hashtags?">?</a></small> - Search
-        <a class="hashtag-link hashtag-twitter" href="https://twitter.com/search/%23{{ event.hashtag }}" target="_blank" title="Search Twitter">Twitter</a> &middot;
-        <a class="hashtag-link hashtag-youtube" href="http://www.youtube.com/results?search_query=%23{{ event.hashtag }}+OR+%22{{ event.name|urlencode }}%22" target="_blank" title="Search YouTube">YouTube</a> &middot;
-        <a class="hashtag-link hashtag-cd" href="http://www.chiefdelphi.com/media/photos/tags/{{ event.hashtag }}" target="_blank" title="Search Chief Delphi">Chief Delphi</a> &middot;
-        <a class="hashtag-link hashtag-flickr" href="http://www.flickr.com/search/?q=%23{{ event.hashtag }}" target="_blank" title="Search Flickr">Flickr</a>
       </p>
     </div>
   </div>

--- a/templates_jinja2/match_details.html
+++ b/templates_jinja2/match_details.html
@@ -37,6 +37,12 @@
   </div>
   <div class="row">
     <div class="col-sm-12 col-md-6">
+      {% if match_breakdown_template %}
+      <h3>Detailed Results</h3>
+        {% include match_breakdown_template %}
+      {% endif %}
+    </div>
+    <div class="col-sm-12 col-md-6">
       <h3>Video</h3>
       {% if match.tba_video %}
         {% include "video_partials/tbavideo_player.html" %}
@@ -52,12 +58,6 @@
         <a class="btn btn-success" href="/suggest/match/video?match_key={{match.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add videos</a>
         <a class="btn btn-primary" href="https://www.youtube.com/results?search_query={{match.short_name|urlencode}}+{{event.year}}+{{event.name|urlencode}}" target="_blank"><span class="glyphicon glyphicon-search"></span> Search YouTube</a>
       </p>
-    </div>
-    <div class="col-sm-12 col-md-6">
-      {% if match_breakdown_template %}
-      <h3>Detailed Results</h3>
-        {% include match_breakdown_template %}
-      {% endif %}
     </div>
   </div>
   <div class="row">

--- a/templates_jinja2/match_details.html
+++ b/templates_jinja2/match_details.html
@@ -27,19 +27,16 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-12">
-      <p><a class="btn btn-default" href="/event/{{event.key_name}}"><span class="glyphicon glyphicon-chevron-left"></span> {{ event.year }} {{ event.name }}</a></p>
       <h1>{{match.verbose_name}} <small><a href="/event/{{event.key_name}}">{{ event.year }} {{ event.name }}</a></small></h1>
     </div>
   </div>
   <div class="row">
-    <div class="col-xs-12 col-sm-7 col-md-6">
-      <h3>Match Results</h3>
+    <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
       {{mtm.single_match_table(match)}}
-      {% if match_breakdown_template %}
-        {% include match_breakdown_template %}
-      {% endif %}
     </div>
-    <div class="col-xs-12 col-sm-5 col-md-6">
+  </div>
+  <div class="row">
+    <div class="col-sm-12 col-md-6">
       <h3>Video</h3>
       {% if match.tba_video %}
         {% include "video_partials/tbavideo_player.html" %}
@@ -48,13 +45,23 @@
         {% include "video_partials/youtube_video_player.html" %}
       {% endfor %}
       {% if not match.tba_video and not match.youtube_videos %}
-        <p>We don't know about any videos for this match yet. :(</p>
+        <p>We don't know about any videos for this match yet. 🙁</p>
         <p>Help others out by searching YouTube and adding videos!</p>
       {% endif %}
       <p>
         <a class="btn btn-success" href="/suggest/match/video?match_key={{match.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add videos</a>
         <a class="btn btn-primary" href="https://www.youtube.com/results?search_query={{match.short_name|urlencode}}+{{event.year}}+{{event.name|urlencode}}" target="_blank"><span class="glyphicon glyphicon-search"></span> Search YouTube</a>
       </p>
+    </div>
+    <div class="col-sm-12 col-md-6">
+      {% if match_breakdown_template %}
+      <h3>Detailed Results</h3>
+        {% include match_breakdown_template %}
+      {% endif %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-12">
       <hr>
       <div class="fb-comments" data-href="http://www.thebluealliance.com/match/{{match.key_name}}" data-num-posts="3" data-width="470"></div>
     </div>


### PR DESCRIPTION
## Description
Updates Event Details header to be simpler and shorter for mobile phones.

1. Remove "back to year" button to save space
2. Move "part of X district" and "winners advance to x" to info items in event details block
3. Change link icon to a link, since I am using globe for districts

## Motivation and Context
Fit better on phones.

## How Has This Been Tested?
Dev instance. Separately checked case of normal event, district event, and "winners advance" event.

## Screenshots (if appropriate):

### Before
![image](https://user-images.githubusercontent.com/57101/38179412-e90b2cc4-35d7-11e8-92be-11703f833176.png)

### Afters
![image](https://user-images.githubusercontent.com/57101/38179414-ef28b16c-35d7-11e8-95db-368d1a4568a6.png)

![image](https://user-images.githubusercontent.com/57101/38179417-f31492e6-35d7-11e8-81f9-8c3d4198d32a.png)

![image](https://user-images.githubusercontent.com/57101/38179418-f7a39726-35d7-11e8-9643-72c1c225ba80.png)


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
