### PR TITLE
Minor cleanup to team detail pages.

### DIFF
--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -62,14 +62,14 @@
           <hr>
           <h2 id="event-results">Event Results</h2>
           {% if season_wlt %}
-            <p>Team #{{team.team_number}} was <strong>{{season_wlt.win}}-{{season_wlt.loss}}-{{season_wlt.tie}}</strong> in official play
+            <p>Team {{team.team_number}} was <strong>{{season_wlt.win}}-{{season_wlt.loss}}-{{season_wlt.tie}}</strong> in official play
             {% if offseason_wlt %}and <strong>{{season_wlt.win+offseason_wlt.win}}-{{season_wlt.loss+offseason_wlt.loss}}-{{season_wlt.tie+offseason_wlt.tie}}</strong> overall
             {% endif %} in {{year}}.</p>
           {% elif offseason_wlt %}
-            <p>Team #{{team.team_number}} was <strong>{{offseason_wlt.win}}-{{offseason_wlt.loss}}-{{offseason_wlt.tie}}</strong> during the {{year}} offseason.</p>
+            <p>Team {{team.team_number}} was <strong>{{offseason_wlt.win}}-{{offseason_wlt.loss}}-{{offseason_wlt.tie}}</strong> during the {{year}} offseason.</p>
           {% else %}
             {% if year_qual_avg or year_elim_avg %}
-              <p>Overall, team {{team.team_number}} had
+              <p>Overall, Team {{team.team_number}} had
               {% if year_qual_avg %}an average qual score of <strong>{{year_qual_avg|floatformat(2)}}</strong>{% endif %}
               {% if year_qual_avg and year_elim_avg %}
                 and


### PR DESCRIPTION
## Description
Standardize references to teams as "Team 1234" on team details page. IMO, we shouldn't use #'s to refer to teams, and we should capitalize "Team" when referring to a specific team. If there is any official style guide from FIRST I would love to follow that!

## Motivation and Context
Consistency.

## How Has This Been Tested?
Tested on local dev machine

## Screenshots (if appropriate):

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
