### PR TITLE
Move account last in nav menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -69,8 +69,8 @@
       <li class="tba-nav-persistent hidden-xs hidden-sm dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-option-vertical"></span> More</a>
           <ul class="dropdown-menu">
-            <li><a href="/account"><span class="glyphicon glyphicon-cog"></span> Account</a></li>
             <li><a href="/swag"><span class="glyphicon glyphicon-shopping-cart"></span> Swag</a></li>
+            <li><a href="/account"><span class="glyphicon glyphicon-cog"></span> Account</a></li>
           </ul>
         </li>
     </ul>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -65,8 +65,8 @@
       <li class="tba-nav-persistent hidden-xs hidden-sm dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-option-vertical"></span> More</a>
           <ul class="dropdown-menu">
-            <li><a href="/account"><span class="glyphicon glyphicon-cog"></span> Account</a></li>
             <li><a href="/swag"><span class="glyphicon glyphicon-shopping-cart"></span> Swag</a></li>
+            <li><a href="/account"><span class="glyphicon glyphicon-cog"></span> Account</a></li>
           </ul>
         </li>
     </ul>


### PR DESCRIPTION
## Description
To be more consistent with other websites, which tend to put the "account settings" menu last, swap the order of "Swag" and "Account".

I'm fine with this diff being rejected, just a nit.

## Motivation and Context
Consistency with other websites.

## How Has This Been Tested?
Dev instance.

## Screenshots (if appropriate):

### Other Sites

![image](https://user-images.githubusercontent.com/57101/38179825-5c34f078-35dc-11e8-8c56-7ed689eae374.png)

![image](https://user-images.githubusercontent.com/57101/38179832-6780662e-35dc-11e8-982c-4090b5e1356a.png)

### After

![image](https://user-images.githubusercontent.com/57101/38179863-ac78aa52-35dc-11e8-9a3d-7f2edc4c7d08.png)



## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
