### PR TITLE
Show event names in match video suggestion review

### DIFF
--- a/controllers/suggestions/suggest_match_video_review_controller.py
+++ b/controllers/suggestions/suggest_match_video_review_controller.py
@@ -1,6 +1,7 @@
 from consts.account_permissions import AccountPermissions
 from controllers.suggestions.suggestions_review_base_controller import SuggestionsReviewBaseController
 from helpers.suggestions.match_suggestion_accepter import MatchSuggestionAccepter
+from models.event import Event
 from models.match import Match
 from models.suggestion import Suggestion
 from template_engine import jinja2_engine
@@ -30,8 +31,12 @@ class SuggestMatchVideoReviewController(SuggestionsReviewBaseController):
         # Roughly sort by event and match for easier review
         suggestions = sorted(suggestions, key=lambda s: s.target_key)
 
+        event_futures = [Event.get_by_id_async(suggestion.target_key.split("_")[0]) for suggestion in suggestions]
+        events = [event_future.get_result() for event_future in event_futures]
+
         self.template_values.update({
             "suggestions": suggestions,
+            "suggestions_and_events": zip(suggestions, events),
         })
 
         self.response.out.write(jinja2_engine.render('suggestions/suggest_match_video_review_list.html', self.template_values))

--- a/templates_jinja2/media_partials/social_media_macros.html
+++ b/templates_jinja2/media_partials/social_media_macros.html
@@ -51,6 +51,7 @@
     {% elif suggestion.contents.media_type_enum == 6 %}
         <!-- GitHub profile -->
         <div class="github-card" data-user="{{ suggestion.contents.foreign_key }}"></div>
+        <p><a href="//www.github.com/{{ suggestion.contents.foreign_key }}">github.com/{{ suggestion.contents.foreign_key }}</a></p>
     {% elif suggestion.contents.media_type_enum == 7 %}
         <!-- Instagram profile -->
         {{ suggestion.contents.site_name }}:

--- a/templates_jinja2/media_partials/social_media_macros.html
+++ b/templates_jinja2/media_partials/social_media_macros.html
@@ -51,7 +51,6 @@
     {% elif suggestion.contents.media_type_enum == 6 %}
         <!-- GitHub profile -->
         <div class="github-card" data-user="{{ suggestion.contents.foreign_key }}"></div>
-        <p><a href="//www.github.com/{{ suggestion.contents.foreign_key }}">github.com/{{ suggestion.contents.foreign_key }}</a></p>
     {% elif suggestion.contents.media_type_enum == 7 %}
         <!-- Instagram profile -->
         {{ suggestion.contents.site_name }}:

--- a/templates_jinja2/suggestions/suggest_match_video_review_list.html
+++ b/templates_jinja2/suggestions/suggest_match_video_review_list.html
@@ -24,7 +24,7 @@
                 </div>
             </div><br>
 
-            {% for suggestion in suggestions %}
+            {% for suggestion, event in suggestions_and_events %}
             <div class="row">
                 <div class="well">
                     <div class="col-xs-2">
@@ -37,7 +37,7 @@
                         <input type="text" class="form-control" name="key-{{suggestion.key.id()}}" placeholder="Match Key" value="{{suggestion.target_key}}">
                     </div>
                     <div class="col-xs-7 fitvids">
-                        <p><a href="/match/{{ suggestion.target_key }}" target="_blank"><strong>{{ suggestion.target_key }}</strong></a></p>
+                        <p><a href="/match/{{ suggestion.target_key }}" target="_blank"><strong>{{ suggestion.target_key }}</strong></a> @ <a href="/event/{{ event.key_name}}">{{ event.name }}</a></p>
                         <iframe width="240" height="180" src="https://www.youtube.com/embed/{{suggestion.youtube_video|yt_start}}" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div class="col-xs-3">


### PR DESCRIPTION
## Description
Adds event names in header of match video suggestion review.

## Motivation and Context
@bdaroz asked for it to make approving videos easier.

## Failure Case
If the start of the `suggestion.target_key` is not an Event, creating the Event object will fail and the page will 500. There is no way to create a malformed suggestion other than writing a bad request, but if a malicious suggestion were created, it would break the page. I have not added error handling for this case.

## How Has This Been Tested?
Tested on local machine.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/57101/38461822-e39bfc62-3a8e-11e8-8538-05502c46078e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
