### PR TITLE
Lining up columns across all tables.

### DIFF
--- a/templates/event_partials/event_table.html
+++ b/templates/event_partials/event_table.html
@@ -1,4 +1,9 @@
 <table class="event-table">
+  <colgroup>
+    <col width="auto">
+    <col width="10%" class="hidden-xs">
+    <col width="30%">
+  </colgroup>
   <thead>
     <tr>
       <th>Event</th>

--- a/templates_jinja2/event_partials/event_table.html
+++ b/templates_jinja2/event_partials/event_table.html
@@ -1,4 +1,9 @@
 <table class="event-table">
+  <colgroup>
+    <col width="auto">
+    <col width="10%" class="hidden-xs">
+    <col width="30%">
+  </colgroup>
   <thead>
     <tr>
       <th>Event</th>


### PR DESCRIPTION
On Event List pages, the columns of the event lists don't line up.

## Description
As an example, the New England District event list([ref](https://www.thebluealliance.com/events/ne/2018)), shows tables for each week.  These tables show 1-2 events each week, with column widths varying widely between weeks.

## Motivation and Context
This is simply a template change to fix a UI issue that had been bugging me.

## How Has This Been Tested?
I don't have a local environment set up to test this.  All testing was done in browser dev tools.

## Screenshots (if appropriate):
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
