### PR TITLE
Use HTTPS for chiefdelphi.com links

### DIFF
--- a/consts/district_point_values.py
+++ b/consts/district_point_values.py
@@ -11,7 +11,7 @@ class DistrictPointValues(object):
      - 2012: http://www.firstinmichigan.org/FRC_2012/2012_Rules_Supplement.pdf
      - 2011: http://www.firstinmichigan.org/FRC_2011/2011_Rules_Supplement.pdf
      - 2010: http://www.firstinmichigan.org/FRC_2010/2010_Update_3.pdf
-     - 2009: http://www.chiefdelphi.com/forums/showpost.php?p=759453&postcount=67
+     - 2009: https://www.chiefdelphi.com/forums/showpost.php?p=759453&postcount=67
     """
 
     STANDARD_MULTIPLIER = 1

--- a/helpers/matchstats_helper.py
+++ b/helpers/matchstats_helper.py
@@ -1,6 +1,6 @@
 # Calculates OPR/DPR/CCWM
 # For implementation details, see
-# http://www.chiefdelphi.com/forums/showpost.php?p=484220&postcount=19
+# https://www.chiefdelphi.com/forums/showpost.php?p=484220&postcount=19
 
 # M is n x n where n is # of teams
 # s is n x 1 where n is # of teams

--- a/helpers/media_helper.py
+++ b/helpers/media_helper.py
@@ -265,10 +265,10 @@ class MediaParser(object):
     def _parse_cdphotothread_image_partial(cls, html):
         """
         Input: the HTML from the thread page
-        ex: http://www.chiefdelphi.com/media/photos/38464,
+        ex: https://www.chiefdelphi.com/media/photos/38464,
 
         returns the url of the image in the thread
-        ex: http://www.chiefdelphi.com/media/img/3f5/3f5db241521ae5f2636ff8460f277997_l.jpg
+        ex: https://www.chiefdelphi.com/media/img/3f5/3f5db241521ae5f2636ff8460f277997_l.jpg
         """
         from bs4 import BeautifulSoup
         html = html.decode("utf-8", "replace")

--- a/models/media.py
+++ b/models/media.py
@@ -97,7 +97,7 @@ class Media(ndb.Model):
     # URL renderers
     @property
     def cdphotothread_image_url(self):
-        return 'http://www.chiefdelphi.com/media/img/{}'.format(self.details['image_partial'])
+        return 'https://www.chiefdelphi.com/media/img/{}'.format(self.details['image_partial'])
 
     @property
     def cdphotothread_image_url_med(self):
@@ -109,7 +109,7 @@ class Media(ndb.Model):
 
     @property
     def cdphotothread_thread_url(self):
-        return 'http://www.chiefdelphi.com/media/photos/{}'.format(self.foreign_key)
+        return 'https://www.chiefdelphi.com/media/photos/{}'.format(self.foreign_key)
 
     @property
     def external_link(self):

--- a/templates/about.html
+++ b/templates/about.html
@@ -43,7 +43,7 @@
       <h2>Other Community Sites</h2>
       <p>Here are some other amazing resources that the <em>FIRST</em> community has to offer.</p>
       <ul>
-        <li><a href="http://www.chiefdelphi.com" target="_blank">Chief Delphi</a> &ndash; The go-to forum for <em>FIRST</em> discussion</li>
+        <li><a href="https://www.chiefdelphi.com" target="_blank">Chief Delphi</a> &ndash; The go-to forum for <em>FIRST</em> discussion</li>
         <li><a href="http://frc.link" target="_blank">FRC Links</a> &ndash; Easy access to specific <em>FIRST</em> team and event pages</li>
       </ul>
 

--- a/templates/admin/team_details.html
+++ b/templates/admin/team_details.html
@@ -106,7 +106,7 @@
     <table class="table table-striped table-hover table-condensed">
         <tr>
             <td>URL</td>
-            <td><input class="form-control" name="media_url" type="text" placeholder="http://www.chiefdelphi.com/media/photos/39142"></td>
+            <td><input class="form-control" name="media_url" type="text" placeholder="https://www.chiefdelphi.com/media/photos/39142"></td>
         </tr>
         <tr>
             <td>Year (can be blank)</td>

--- a/templates/index_kickoff.html
+++ b/templates/index_kickoff.html
@@ -34,7 +34,7 @@
       <p>Come back at {{kickoff_datetime_est|date:"fA"}} EST on {{kickoff_datetime_est|date:"F jS, Y"}} to watch live!</p>
       <div>
         <span class="glyphicon glyphicon-globe"></span> <a href="http://www.firstinspires.org/2018-frc-teaser" target="_blank" title="FIRST Kickoff Page"><em>FIRST</em> Kickoff Page</a><br>
-        <!-- <a class="hashtag-link hashtag-cd" href="http://www.chiefdelphi.com/forums/showthread.php?threadid=138575" target="_blank" title="Chief Delphi Discussion Thread">Chief Delphi Game Hint Thread</a><br> -->
+        <!-- <a class="hashtag-link hashtag-cd" href="https://www.chiefdelphi.com/forums/showthread.php?threadid=138575" target="_blank" title="Chief Delphi Discussion Thread">Chief Delphi Game Hint Thread</a><br> -->
         <!--<span class="glyphicon glyphicon-info-sign"></span> <a href="#" target="_blank">Download {{kickoff_datetime_est|date:"Y"}} Game Manual</a><br />-->
         <br>
         <div class="fitvids">

--- a/templates_jinja2/suggestions/suggest_team_media.html
+++ b/templates_jinja2/suggestions/suggest_team_media.html
@@ -56,7 +56,7 @@
 
           <p><strong>Currently supported formats are:</strong></p>
           <ul>
-            <li><strong>Chief Delphi images</strong>, like <code>http://www.chiefdelphi.com/media/photos/36646</code></li>
+            <li><strong>Chief Delphi images</strong>, like <code>https://www.chiefdelphi.com/media/photos/36646</code></li>
             <li><strong>Imgur images</strong>, like <code>http://imgur.com/aF8T5ZE</code></li>
             <li><strong>Instagram photos and videos</strong>, like <code>https://www.instagram.com/p/BUnZiriBYre</code></li>
             <li><strong>YouTube videos</strong>, like <code>https://www.youtube.com/watch?v=DojyJ9bZ4fk</code></li>
@@ -151,7 +151,7 @@
                 <input name="year" type="hidden" value="{{year}}" />
                 <div class="input-group">
                   <span class="input-group-addon">{{year}}</span>
-                  <input class="form-control" type="text" name="media_url" placeholder="http://www.chiefdelphi.com/media/photos/36646" value="" />
+                  <input class="form-control" type="text" name="media_url" placeholder="https://www.chiefdelphi.com/media/photos/36646" value="" />
                   <span class="input-group-btn">
                     <button class="btn btn-success" type="submit"><span class="glyphicon glyphicon-plus-sign"></span> Add Media</button>
                   </span>

--- a/tests/suggestions/test_media_url_parse.py
+++ b/tests/suggestions/test_media_url_parse.py
@@ -31,7 +31,7 @@ class TestMediaUrlParser(unittest2.TestCase):
         self.assertEqual(yt_from_playlist['foreign_key'], 'VP992UKFbko')
 
     def test_cdphotothread_parse(self):
-        cd = MediaParser.partial_media_dict_from_url("http://www.chiefdelphi.com/media/photos/41999")
+        cd = MediaParser.partial_media_dict_from_url("https://www.chiefdelphi.com/media/photos/41999")
         self.assertEqual(cd['media_type_enum'], MediaType.CD_PHOTO_THREAD)
         self.assertEqual(cd['foreign_key'], "41999")
         self.assertTrue(cd['details_json'])


### PR DESCRIPTION
This avoids mixed content warnings and issues.

<!--- Provide a general summary of your changes in the Title above -->

## Description
A simple find and replace of `http://www.chiefdelphi.com` to `https://www.chiefdelphi.com`.
<!--- Describe your changes in detail -->

## Motivation and Context
I noticed images weren't loading after I set one of my privacy enhancing Firefox addons to block mixed content. Further investigation showed that it was being blocked due to loading over HTTP.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
To be honest, I haven't.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
