### PR TITLE
Fixed pip error causing container setup to fail

### DIFF
--- a/ops/dev/bootstrap-dev-container.sh
+++ b/ops/dev/bootstrap-dev-container.sh
@@ -9,7 +9,6 @@ mkdir -p /datastore
 npm install uglify-js@2.7.0 -g --silent
 npm install -g gulp-cli uglify-es uglifycss less request swagger-cli --silent
 
-pip install --upgrade pip
 pip install --upgrade -r requirements.txt
 
 pip install --upgrade -r travis_requirements.txt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the upgrade pip line from the bootstrap-dev-container script
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because it breaks provisioning of the dev container. It solves not being able to set up a dev container.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Could not run setup because provisioning would fail at this setup. Removing the line to upgrade pip made provisioning complete, and introduced no additional errors.
<!--- Include details of your testing environment, and the tests you ran to -->
Tested setup commands on Ubuntu 16.04. Went from not being able to set up a container to having the container run correctly.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
