### PR TITLE
Adds property safety to event/{event_key}/insights endpoint

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -2122,8 +2122,7 @@
           "200": {
             "description": "Successful response",
             "schema": {
-              "type": "object",
-              "description": "A year-specific event insight object expressed as a JSON string. See also Event_Insights_2016 & Event_Insights_2017"
+              "$ref": "#/definitions/Event_Insights"
             },
             "headers": {
               "Last-Modified": {
@@ -4094,20 +4093,23 @@
         }
       }
     },
+    "Event_Insights": {
+      "type": "object",
+      "description": "A year-specific event insight object expressed as a JSON string, separated in to `qual` and `playoff` fields. See also Event_Insights_2016 & Event_Insights_2017",
+      "properties": {
+        "qual": {
+          "type": "object",
+          "description": "Inights for the qualification round of an event",
+        },
+        "playoff": {
+          "type": "object",
+          "description": "Insights for the playoff round of an event",
+        },
+      }
+    },
     "Event_Insights_2016": {
       "type": "object",
       "description": "Insights for FIRST Stronghold qualification and elimination matches.",
-      "properties": {
-        "qual": {
-          "$ref": "#/definitions/Event_Insights_2016_Detail"
-        },
-        "playoff": {
-          "$ref": "#/definitions/Event_Insights_2016_Detail"
-        }
-      }
-    },
-    "Event_Insights_2016_Detail": {
-      "type": "object",
       "required": [
         "LowBar",
         "A_ChevalDeFrise",
@@ -4301,17 +4303,6 @@
     "Event_Insights_2017": {
       "type": "object",
       "description": "Insights for FIRST STEAMWORKS qualification and elimination matches.",
-      "properties": {
-        "qual": {
-          "$ref": "#/definitions/Event_Insights_2017_Detail"
-        },
-        "playoff": {
-          "$ref": "#/definitions/Event_Insights_2017_Detail"
-        }
-      }
-    },
-    "Event_Insights_2017_Detail": {
-      "type": "object",
       "required": [
         "average_foul_score",
         "average_fuel_points",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Modifies the Event Insights endpoint (`event/{event_key}/insights`) to add a year-independent model to represent the `qual` and `playoff` fields for event insights. This should be a non-breaking change for API consumers

## Motivation and Context

If we're going to have Event Insights models for every year, we don't need to have models that duplicate functionality (ex: `Event_Insights_2017` and `Event_Insights_2018` used to be the same model)

## How Has This Been Tested?

Only in the Swagger editor and it *looks* right - let me know if there's code changes to be made

## Screenshots (if appropriate):

<img width="994" alt="screen shot 2018-04-29 at 10 48 36 am" src="https://user-images.githubusercontent.com/516458/39407866-0e311d6e-4b9b-11e8-86fb-eb66ad28670c.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
