### PR TITLE
Update offseason sidebar

### DIFF
--- a/templates/index_lhc_offseason.html
+++ b/templates/index_lhc_offseason.html
@@ -1,13 +1,22 @@
 <p>The Blue Alliance is the best way to scout, watch, and relive the <i>FIRST</i> Robotics Competition. Learn more about <i>FIRST</i> at <a href="http://www.firstinspires.org/" target="_blank" title="FIRST Robotics">firstinspires.org</a>.</p>
 
 <hr>
-
 <div>
   <h4 class="text-center">Help other <i>FIRST</i> teams!</h4>
-  <a class="btn btn-default btn-block" href="/suggest/offseason"><span class="glyphicon glyphicon-plus"></span> Add an Offseason Event</a>
-  <a class="btn btn-default btn-block" href="/eventwizard"><span class="glyphicon glyphicon-pencil"></span> Add Offseason Event Data</a>
-  <a class="btn btn-default btn-block" href="/add-data"><span class="glyphicon glyphicon-info-sign"></span> Adding Data Overview</a>
-  <a class="btn btn-default btn-block" href="https://github.com/the-blue-alliance" target="_blank"><span class="glyphicon glyphicon-wrench"></span> Hack on TBA</a>
+  <a class="btn btn-success btn-block" href="/suggest/offseason"><span class="glyphicon glyphicon-plus"></span> Add an Offseason Event</a>
+  <a class="btn btn-block btn-primary" href="/eventwizard"><span class="glyphicon glyphicon-pencil"></span> Add Offseason Event Data</a>
+  <a class="btn btn-block btn-info" href="/add-data"><span class="glyphicon glyphicon-info-sign"></span> Adding Data Overview</a>
+  <a class="btn btn-block btn-default" href="https://github.com/the-blue-alliance" target="_blank"><span class="glyphicon glyphicon-wrench"></span> Hack on TBA</a>
+</div>
+
+<hr>
+
+<form action="/search">
+  <input type="text" class="form-control typeahead" placeholder="Search teams and events" name="q">
+</form>
+<div class="btn-group btn-group-block-2">
+  <a class="btn btn-primary btn-lg" href="/events"><span class="glyphicon glyphicon-calendar"></span> Events</a>
+  <a class="btn btn-primary btn-lg" href="/teams"><span class="glyphicon glyphicon-user"></span> Teams</a>
 </div>
 
 <hr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds search and colorizes buttons

## Description
Adds a team/event search box and team/event buttons, similar to those on the sidebar for during season.

## Motivation and Context
The buttons on the homepage were looking plain

## How Has This Been Tested?
Hasn't. 

## Screenshots (if appropriate):
#### New
![image](https://user-images.githubusercontent.com/22439365/39410887-09db6756-4bb4-11e8-9d33-f9d3226094ca.png)
#### Current
![image](https://user-images.githubusercontent.com/22439365/39410892-1e2e72d4-4bb4-11e8-9085-18443f37684c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
