### PR TITLE
Add warning to timeseries about accuracy.

### DIFF
--- a/templates_jinja2/match_timeseries.html
+++ b/templates_jinja2/match_timeseries.html
@@ -26,7 +26,7 @@
     <div class="col-xs-12">
       {% if timeseries_data %}
       <canvas id="timeseries-chart" style="width: 500px; height: 100px;">{{timeseries_data}}</canvas>
-      <small>This is not official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.</small>
+      <small>The above graph is unofficial, and is subject to signifiant error or missing data. Do not rely on the above data for any purpose.</small>
       {% endif %}
     </div>
   </div>

--- a/templates_jinja2/match_timeseries.html
+++ b/templates_jinja2/match_timeseries.html
@@ -26,6 +26,7 @@
     <div class="col-xs-12">
       {% if timeseries_data %}
       <canvas id="timeseries-chart" style="width: 500px; height: 100px;">{{timeseries_data}}</canvas>
+      <small>This is not official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.</small>
       {% endif %}
     </div>
   </div>

--- a/templates_jinja2/match_timeseries.html
+++ b/templates_jinja2/match_timeseries.html
@@ -26,7 +26,7 @@
     <div class="col-xs-12">
       {% if timeseries_data %}
       <canvas id="timeseries-chart" style="width: 500px; height: 100px;">{{timeseries_data}}</canvas>
-      <small>The above graph is unofficial, and is subject to signifiant error or missing data. Do not rely on the above data for any purpose.</small>
+      <small>The above graph is unofficial, and is subject to possible error or missing data. Do not rely on the above data for any purpose.</small>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
As requested in Slack, a warning blurb below the timeseries chart as to the accuracy of the data following multiple Chief Delphi threads about it.

## Motivation and Context
Teams were confusing the time series chart as a definitive source of data and minor bugs in the OCR were causing 200 point jumps in either direction (OCR'd a 1 as a 3).  This hopefully will clarify that it's an experimental feaure.

## How Has This Been Tested?
I used inspect element to check that it displayed properly and implemented it in the exact location in the jinja template creates it in.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
