### PR TITLE
Switching notifications to FCM over (now deprecated) GCM

### DIFF
--- a/controllers/gcm/gcm.py
+++ b/controllers/gcm/gcm.py
@@ -109,10 +109,9 @@ class GCMConnection:
         self.GOOGLE_LOGIN_URL = 'https://www.google.com/accounts/ClientLogin'
         # Can't use https on localhost due to Google cert bug
         self.GOOGLE_GCM_SEND_URL = 'https://fcm.googleapis.com/fcm'
-        self.GOOGLE_GCM_SEND_URL = 'https://fcm.googleapis.com/fcm'
 
         self.GCM_QUEUE_NAME = 'gcm-retries'
-        self.GCM_QUEUE_CALLBACK_URL = '/gae_python_fcm/send_request'
+        self.GCM_QUEUE_CALLBACK_URL = '/gae_python_gcm/send_request'
 
     # Call this to send a push notification
     def notify_device(self, message, deferred=False):

--- a/controllers/gcm/gcm.py
+++ b/controllers/gcm/gcm.py
@@ -63,8 +63,8 @@ class GCMMessage:
     def json_string(self):
 
         if not self.device_tokens or not isinstance(self.device_tokens, list):
-            logging.error('GCMMessage generate_json_string error. Invalid device tokens: ' + repr(self))
-            raise Exception('GCMMessage generate_json_string error. Invalid device tokens.')
+            logging.error('FCMMessage generate_json_string error. Invalid device tokens: ' + repr(self))
+            raise Exception('FCMMessage generate_json_string error. Invalid device tokens.')
 
         json_dict = {}
         json_dict['registration_ids'] = self.device_tokens
@@ -104,15 +104,15 @@ class GCMConnection:
         self.LOCALHOST = False
         self.SERVER_KEY = Sitevar.get_by_id('gcm.serverKey')
         if self.SERVER_KEY is None:
-            raise Exception("Missing sitevar: gcm.serverKey. Can't send GCM messages.")
+            raise Exception("Missing sitevar: gcm.serverKey. Can't send FCM messages.")
         self.GCM_CONFIG = {'gcm_api_key': self.SERVER_KEY.contents['gcm_key']}
         self.GOOGLE_LOGIN_URL = 'https://www.google.com/accounts/ClientLogin'
         # Can't use https on localhost due to Google cert bug
-        self.GOOGLE_GCM_SEND_URL = 'https://android.apis.google.com/gcm/send'
-        self.GOOGLE_GCM_SEND_URL = 'https://android.googleapis.com/gcm/send'
+        self.GOOGLE_GCM_SEND_URL = 'https://fcm.googleapis.com/fcm'
+        self.GOOGLE_GCM_SEND_URL = 'https://fcm.googleapis.com/fcm'
 
         self.GCM_QUEUE_NAME = 'gcm-retries'
-        self.GCM_QUEUE_CALLBACK_URL = '/gae_python_gcm/send_request'
+        self.GCM_QUEUE_CALLBACK_URL = '/gae_python_fcm/send_request'
 
     # Call this to send a push notification
     def notify_device(self, message, deferred=False):

--- a/templates/admin/authkeys.html
+++ b/templates/admin/authkeys.html
@@ -20,7 +20,7 @@
   <tr><td>Auth Key</td><td><input name="fmsapi_secret" value="{{fmsapi_secret}}" class="form-control"/></td></tr>
 
   <tr><th>Mobile Apps</th></tr>
-  <tr><td>GCM Key</td><td><input name="gcm_key" value="{{gcm_key}}" class="form-control"/></td></tr>
+  <tr><td>FCM Key</td><td><input name="gcm_key" value="{{gcm_key}}" class="form-control"/></td></tr>
   <tr><td>Web Client ID</td><td><input name="web_client_id" value="{{web_client_id}}" class="form-control"/></td></tr>
   <tr><td>Android Client ID</td><td><input name="android_client_id" value="{{android_client_id}}" class="form-control"/></td></tr>
   <tr><td>iOS Client ID</td><td><input name="ios_client_id" value="{{ios_client_id}}" class="form-control"/></td></tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the Google Cloud Messaging send URL used for notifications to the Firebase Cloud Messaging one, since GCM is now deprecated and will go offline during next season.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
GCM is being deprecated, so this is migrating to its successor. If this change is not made then notifications will stop working. Solves issue #2268
I have also changed the authkeys page to reflect that it is now the FCM key, not the GCM key.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Phil tested this with a test version of the Android app and was able to send a test notification to himself with it.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
