### PR TITLE
Migrate to Cloud Endpoints v2 (yet again)

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,10 +16,10 @@ libraries:
   version: "1.5"
 - name: numpy
   version: "1.6.1"
-- name: endpoints
-  version: "1.0"
 - name: pycrypto  # for mobile API
   version: "2.6"
+- name: ssl
+  version: 2.7.11
 - name: jinja2
   version: "2.6"
 - name: pytz
@@ -72,7 +72,7 @@ handlers:
   script: apiv3_main.app
 - url: /api/.*
   script: api_main.app
-- url: /_ah/spi/.* # Endpoints for internal mobile API
+- url: /_ah/api/.* # Endpoints for internal mobile API
   script: mobile_main.app
 - url: .*
   script: main.app

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -5,3 +5,4 @@ google-api-python-client==1.6.2
 google-cloud-bigquery==0.25.0
 beautifulsoup4
 GoogleAppEngineCloudStorageClient
+google-endpoints

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -9,7 +9,7 @@ set -e
 
 KEYFILE=ops/tbatv-prod-hrd-deploy.json
 PROJECT=tbatv-prod-hrd
-VERSION=prod-1
+VERSION=prod-2
 DEPLOY_LOCK=tbatv-prod-hrd-deploy-lock
 
 BASE='https://dl.google.com/dl/cloudsdk/channels/rapid/'


### PR DESCRIPTION
## Description
Followed migration guide:
https://cloud.google.com/endpoints/docs/frameworks/python/migrating

I think the problem last time was that we didn't deploy a new GAE version. So let's try that now

Closes https://github.com/the-blue-alliance/the-blue-alliance/issues/2277

## Motivation and Context
Google will deprecate this in August....

## How Has This Been Tested?
yolo