### PR TITLE
Fix 2018 ranking import

### DIFF
--- a/consts/ranking_indexes.py
+++ b/consts/ranking_indexes.py
@@ -2,6 +2,7 @@ class RankingIndexes(object):
     TEAM_NUMBER = 1
 
     MATCHES_PLAYED = {
+        2018: 9,
         2017: 10,
         2016: 8,
         2015: 8,
@@ -16,6 +17,7 @@ class RankingIndexes(object):
     }
 
     CUMULATIVE_RANKING_SCORE = {
+        2018: 2,
         2017: 2,  # In 2017, this is RP/Match
         2016: 2,
         2015: 2,  # In 2015, this is average qual score
@@ -47,4 +49,5 @@ class RankingIndexes(object):
         2015: None,
         2016: 7,
         2017: 8,
+        2018: 7,
     }

--- a/controllers/api/api_trusted_controller.py
+++ b/controllers/api/api_trusted_controller.py
@@ -204,7 +204,7 @@ class ApiTrustedEventRankingsUpdate(ApiTrustedBaseController):
             EventHelper.remapteams_rankings(event_details.rankings, event.remap_teams)
             # TODO: Remap rankings2 directly
 
-        if event_details.year >= 2017:  # TODO: Temporary fix. Should directly parse request into rankings2
+        if event_details.year >= 2018:  # TODO: Temporary fix. Should directly parse request into rankings2
             event_details.rankings2 = RankingsHelper.convert_rankings(event_details)
 
         EventDetailsManipulator.createOrUpdate(event_details)

--- a/helpers/rankings_helper.py
+++ b/helpers/rankings_helper.py
@@ -6,6 +6,7 @@ from models.event_details import EventDetails
 
 class RankingsHelper(object):
     SORT_ORDERS = {
+        2018: [2, 3, 4, 5, 6],
         2017: [2, 3, 4, 5, 6, 7],
         2016: [2, 3, 4, 5, 6],
         2015: [2, 5, 3, 4, 7, 6],

--- a/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -310,14 +310,19 @@ $('#rankings_file').change(function(){
         //var is_int = [true, true, true, true, true, false, true, true];
 
         // 2017 Headers
-        var headers = ['Rank', 'Team', 'RS', 'TotalPts', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'W-L-T', 'DQ', 'Played'];
-        var display_headers = ['Rank', 'Team', 'Ranking Score', 'Match Points', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'Record (W-L-T)', 'DQ', 'Played'];
+        //var headers = ['Rank', 'Team', 'RS', 'TotalPts', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'W-L-T', 'DQ', 'Played'];
+        //var display_headers = ['Rank', 'Team', 'Ranking Score', 'Match Points', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'Record (W-L-T)', 'DQ', 'Played'];
+        //var is_num = [true, true, true, true, true, true, false, true, true];
+
+        // 2018 Headers
+        var headers = ['Rank', 'Team', 'RS', 'Endgame', 'Auto', 'Ownership', 'Vault', 'W-L-T', 'DQ', 'Played'];
+        var display_headers = ['Rank', 'Team', 'Ranking Score', 'End Game', 'Auto', 'Ownership', 'Vault', 'Record (W-L-T)', 'DQ', 'Played'];
         var is_num = [true, true, true, true, true, true, false, true, true];
 
         $('#rankings_preview').empty();
         $('#rankings_preview').html("<tr><th>" + display_headers.join("</th><th>") + "</th></tr>");
 
-        request_body['breakdowns'] = display_headers.slice(2, 9);
+        request_body['breakdowns'] = display_headers.slice(2, 8);
         request_body['rankings'] = [];
 
         for(var i=0; i<rankings.length; i++){


### PR DESCRIPTION
This allows users to import 2018 FMS Ranking Reports

## Motivation and Context
#mordata

## How Has This Been Tested?
It has not been tested.

## Sample report data

Rank | Team | RS | Endgame | Auto | Ownership | Vault | W-L-T | DQ | Played | HRS*
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 5813 | 3.20 | 375 | 167 | 1,186 | 140 | 5-0-0 | 0 | 5 |  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
