### PR TITLE
Update event sync years

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,11 +1,11 @@
 cron:
 - description: FIRST event list scraping. Also includes event details/event teams/team details scraping.
-  url: /backend-tasks/get/event_list/2018
+  url: /backend-tasks/get/event_list/2019
   schedule: every day 02:00
   timezone: America/Los_Angeles
 
 - description: FIRST official offseason scraping
-  url: /backend-tasks/get/fms-sync-offseasons/2017
+  url: /backend-tasks/get/fms-sync-offseasons/2018
   schedule: every tuesday,thursday 02:30
   timezone: America/Los_Angeles
 


### PR DESCRIPTION
Actually fetch official 2018 offseasons, start fetching 2019 official events