### PR TITLE
Expand site URL

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -225,7 +225,7 @@ def main(key, url):
         remote_api_stub.ConfigureRemoteApiForOAuth(url, '/_ah/remote_api')
 
     print "Loading data from The Blue Alliance requires an API key"
-    print "Please go to https://thebluealliance.com/account and generate a read API key"
+    print "Please go to https://www.thebluealliance.com/account and generate a read API key"
     apiv3_key = raw_input("Enter your API key: ")
 
     global AUTH_TOKEN

--- a/controllers/suggestions/suggest_apiwrite_controller.py
+++ b/controllers/suggestions/suggest_apiwrite_controller.py
@@ -42,8 +42,8 @@ class SuggestApiWriteController(LoggedInHandler):
         subject = "Trusted API Key Request for {}".format(event_key)
         body = """{} ({}) has made a request for trusted API keys for the event {}.
 
-View the event at https://thebluealliance.com/event/{}
+View the event at https://www.thebluealliance.com/event/{}
 
-Review the request at https://thebluealliance.com/suggest/apiwrite/review
+Review the request at https://www.thebluealliance.com/suggest/apiwrite/review
 """.format(user_bundle.account.display_name, user_bundle.account.email, event_key, event_key)
         return subject, body

--- a/controllers/suggestions/suggest_designs_review_controller.py
+++ b/controllers/suggestions/suggest_designs_review_controller.py
@@ -61,7 +61,7 @@ class SuggestDesignsReviewController(SuggestionsReviewBaseController):
                 if self.request.get('action') == 'accept':
                     self._process_accepted(suggestion.key.id())
                     status = 'accepted'
-                    slack_message = "{0} ({1}) accepted the <https://grabcad.com/library/{2}|suggestion> for team <https://thebluealliance.com/team/{3}/{4}|{3} in {4}>".format(
+                    slack_message = "{0} ({1}) accepted the <https://grabcad.com/library/{2}|suggestion> for team <https://www.thebluealliance.com/team/{3}/{4}|{3} in {4}>".format(
                         self.user_bundle.account.display_name,
                         self.user_bundle.account.email,
                         suggestion.contents['foreign_key'],
@@ -71,7 +71,7 @@ class SuggestDesignsReviewController(SuggestionsReviewBaseController):
                 elif self.request.get('action') == 'reject':
                     self._process_rejected(suggestion.key.id())
                     status = 'rejected'
-                    slack_message = "{0} ({1}) rejected the <https://grabcad.com/library/{2}|suggestion> for team <https://thebluealliance.com/team/{3}/{4}|{3} in {4}>".format(
+                    slack_message = "{0} ({1}) rejected the <https://grabcad.com/library/{2}|suggestion> for team <https://www.thebluealliance.com/team/{3}/{4}|{3} in {4}>".format(
                         self.user_bundle.account.display_name,
                         self.user_bundle.account.email,
                         suggestion.contents['foreign_key'],

--- a/controllers/suggestions/suggest_event_media_controller.py
+++ b/controllers/suggestions/suggest_event_media_controller.py
@@ -54,7 +54,7 @@ class SuggestEventMediaController(LoggedInHandler):
             if slack_sitevar:
                 slack_url = slack_sitevar.contents.get('fun', '')
                 if slack_url:
-                    message_body = "{0} ({1}) has suggested a video for <https://thebluealliance.com/event/{2}|{2}>: https://youtu.be/{3}.\nSee all suggestions at https://www.thebluealliance.com/suggest/event/media/review".format(
+                    message_body = "{0} ({1}) has suggested a video for <https://www.thebluealliance.com/event/{2}|{2}>: https://youtu.be/{3}.\nSee all suggestions at https://www.thebluealliance.com/suggest/event/media/review".format(
                         self.user_bundle.account.display_name,
                         self.user_bundle.account.email,
                         event_key,

--- a/controllers/suggestions/suggest_offseason_event_controller.py
+++ b/controllers/suggestions/suggest_offseason_event_controller.py
@@ -60,6 +60,6 @@ class SuggestOffseasonEventController(LoggedInHandler):
         subject = "New Offseason Event Suggestion: {}".format(event_name)
         body = """A new offseason event suggestion has been submitted with title: {}.
 
-Review the request at https://thebluealliance.com/suggest/offseason/review
+Review the request at https://www.thebluealliance.com/suggest/offseason/review
 """.format(event_name)
         return subject, body

--- a/controllers/suggestions/suggest_offseason_event_review_controller.py
+++ b/controllers/suggestions/suggest_offseason_event_review_controller.py
@@ -69,7 +69,7 @@ class SuggestOffseasonEventReviewController(SuggestionsReviewBaseController):
             subject="[TBA] Offseason Event Suggestion: {}".format(event.name),
             email_body="""Dear {},
 
-Thank you for suggesting an offseason event to The Blue Alliance. Your suggestion has been approved and you can find the event at https://thebluealliance.com/event/{}
+Thank you for suggesting an offseason event to The Blue Alliance. Your suggestion has been approved and you can find the event at https://www.thebluealliance.com/event/{}
 
 If you are the event's organizer and would like to upload teams attending, match videos, or real-time match results to TBA before or during the event, you can do so using the TBA EventWizard - request auth keys here: https://www.thebluealliance.com/request/apiwrite
 

--- a/controllers/suggestions/suggest_team_media_controller.py
+++ b/controllers/suggestions/suggest_team_media_controller.py
@@ -78,7 +78,7 @@ class SuggestTeamMediaController(LoggedInHandler):
                 slack_url = slack_sitevar.contents.get('tbablog', '')
                 if slack_url:
                     model_details = json.loads(suggestion.contents['details_json'])
-                    message_body = "{0} ({1}) has suggested a CAD model for team <https://thebluealliance.com/team/{2}/{3}|{2} in {3}>.".format(
+                    message_body = "{0} ({1}) has suggested a CAD model for team <https://www.thebluealliance.com/team/{2}/{3}|{2} in {3}>.".format(
                         self.user_bundle.account.display_name,
                         self.user_bundle.account.email,
                         team_key[3:],

--- a/docs/dev-container.md
+++ b/docs/dev-container.md
@@ -27,7 +27,7 @@ If you make changes to javascript or css files, you may have to recompile them. 
 
 ## Bootstrapping Data
 
-Inside the container, you can run `paver bootstrap` from within the `tba` directory to load production data into your development instance. This will load the 2016 New England District Championship by default (which you can access at localhost:8080/event/2016necmp). You can load a different event by passing it's event key (e.g. `2016necmp`) to `paver bootstrap` (e.g. `paver bootstrap --key=2016necmp`). You will need to provide your TBA APIv3 key in order to load data, you can generate one at https://thebluealliance.com/account.
+Inside the container, you can run `paver bootstrap` from within the `tba` directory to load production data into your development instance. This will load the 2016 New England District Championship by default (which you can access at localhost:8080/event/2016necmp). You can load a different event by passing it's event key (e.g. `2016necmp`) to `paver bootstrap` (e.g. `paver bootstrap --key=2016necmp`). You will need to provide your TBA APIv3 key in order to load data, you can generate one at https://www.thebluealliance.com/account.
 
 If you have any third-party API keys (such as for the FRC API), you can input them at localhost:8080/admin/authkeys. You can also request FRC API keys [here](https://usfirst.collab.net/sf/projects/first_community_developers/).
 

--- a/react/gameday2/components/AppBar.js
+++ b/react/gameday2/components/AppBar.js
@@ -55,7 +55,7 @@ const AppBar = (props) => {
       style={tbaBrandingButtonStyle}
       tooltip="Go to The Blue Alliance"
       tooltipPosition="bottom-right"
-      href="https://thebluealliance.com"
+      href="https://www.thebluealliance.com"
     >
       <LampIcon
         width={props.muiTheme.layout.appBarHeight}

--- a/react/gameday2/components/NoWebcasts.js
+++ b/react/gameday2/components/NoWebcasts.js
@@ -6,7 +6,7 @@ export default () => (
     <h1>No webcasts found</h1>
     <p>Looks like there aren&apos;t any events with webcasts this week. Check on The Blue Alliance for upcoming events!</p>
     <RaisedButton
-      href="https://thebluealliance.com"
+      href="https://www.thebluealliance.com"
       label="Go to The Blue Alliance"
     />
   </div>


### PR DESCRIPTION
## Description
Update all URLs to use the www host as a stopgap measure. It will
also save the 302 redirect once #2298 gets fixed.

## Motivation and Context
Due to #2298, links that resolve to thebluealliance.com are redirected
to www.thebluealliance.com without the remainder of the path intact.

## How Has This Been Tested?
4 character addition per instance, not tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
