### PR TITLE
Add variant to mobile API messages to fix IntegerField being serialized as strings

### DIFF
--- a/models/mobile_api_messages.py
+++ b/models/mobile_api_messages.py
@@ -4,7 +4,7 @@ from protorpc import messages
 
 
 class BaseResponse(messages.Message):
-    code = messages.IntegerField(1, default=200)
+    code = messages.IntegerField(1, default=200, variant=messages.Variant.INT32)
     message = messages.StringField(2, default='')
 
 
@@ -18,7 +18,7 @@ class RegistrationRequest(messages.Message):
 class FavoriteMessage(messages.Message):
     model_key = messages.StringField(1, required=True)
     device_key = messages.StringField(2)  # So we know which device NOT to push sync notification to
-    model_type = messages.IntegerField(3, required=True)
+    model_type = messages.IntegerField(3, required=True, variant=messages.Variant.INT32)
 
 
 class FavoriteCollection(messages.Message):
@@ -29,7 +29,7 @@ class SubscriptionMessage(messages.Message):
     model_key = messages.StringField(1, required=True)
     notifications = messages.StringField(2, repeated=True)
     device_key = messages.StringField(3)  # So we know which device NOT to push sync notifications to
-    model_type = messages.IntegerField(4, required=True)
+    model_type = messages.IntegerField(4, required=True, variant=messages.Variant.INT32)
 
 
 class SubscriptionCollection(messages.Message):
@@ -41,12 +41,12 @@ class ModelPreferenceMessage(messages.Message):
     notifications = messages.StringField(2, repeated=True)
     device_key = messages.StringField(3)  # So we know which device NOT to push sync notifications to
     favorite = messages.BooleanField(4, required=True)
-    model_type = messages.IntegerField(5, required=True)
+    model_type = messages.IntegerField(5, required=True, variant=messages.Variant.INT32)
 
 
 class MediaSuggestionMessage(messages.Message):
     reference_key = messages.StringField(1, required=True)
     reference_type = messages.StringField(2, required=True)
-    year = messages.IntegerField(3, required=True)
+    year = messages.IntegerField(3, required=True, variant=messages.Variant.INT32)
     media_url = messages.StringField(4, required=True)
     details_json = messages.StringField(5, default="")


### PR DESCRIPTION
## Description
In the mobile API messages, all values being set in `IntegerField` classes were being serialized and sent to clients as strings. This adds a specific `variant` field to the `IntegerField` instances that forces them to be serialized as integers (example of this [here](https://stackoverflow.com/a/30737750/537341))

## Motivation and Context
This fixes incorrect functionality in the mobile API

## How Has This Been Tested?
Deployed my changes to a GCP and consumed the modified endpoint functionality to ensure codes were being sent back as integers, as opposed to strings

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change API specifications or require data migrations)
