### PR TITLE
PYTHONPATH fix

### DIFF
--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -53,3 +53,6 @@ EXPOSE 8080-8089
 
 # Start SSH server
 CMD ["/usr/sbin/sshd", "-D"]
+
+# Add vars to SSH automatically
+RUN echo source /tba/ops/dev/vars.sh >> /root/.bashrc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a step to the provisioning that makes using Paver in the dev container possible (fixed loading the PYTHONPATH)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is required so that Paver bootstrap and other commands requiring the Google App Engine SDK work in the container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Provisioning without the fix causes errors when using paver bootstrap. Provisioning with the fix does not produce the error. Tested on my Ubuntu 18.04 laptop. No other tests have issues.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
