### PR TITLE
Fixes issues when importing FMS-generated spreadsheets

### DIFF
--- a/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -37,7 +37,7 @@ function getYoutubeId(url) {
 }
 
 function cleanTeamNum(number) {
-    return number.trim().replace("*", "")
+    return number.toString().trim().replace("*", "")
 }
 
 $('#teams-ok').click(function(){
@@ -310,9 +310,9 @@ $('#rankings_file').change(function(){
         //var is_int = [true, true, true, true, true, false, true, true];
 
         // 2017 Headers
-        //var headers = ['Rank', 'Team', 'RS', 'TotalPts', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'W-L-T', 'DQ', 'Played'];
-        //var display_headers = ['Rank', 'Team', 'Ranking Score', 'Match Points', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'Record (W-L-T)', 'DQ', 'Played'];
-        //var is_num = [true, true, true, true, true, true, false, true, true];
+//      var headers = ['Rank', 'Team', 'RS', 'TotalPts', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'W-L-T', 'DQ', 'Played'];
+//      var display_headers = ['Rank', 'Team', 'Ranking Score', 'Match Points', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'Record (W-L-T)', 'DQ', 'Played'];
+//      var is_num = [true, true, true, true, true, true, false, true, true];
 
         // 2018 Headers
         var headers = ['Rank', 'Team', 'RS', 'Endgame', 'Auto', 'Ownership', 'Vault', 'W-L-T', 'DQ', 'Played'];
@@ -347,7 +347,7 @@ $('#rankings_file').change(function(){
             breakdown['dqs'] = parseInt(rank['DQ']);
             for(var j=0; j<request_body['breakdowns'].length; j++){
                 var val = rank[headers[j + 2]];
-                breakdown[request_body['breakdowns'][j]] = is_num[j] ? Number(val.replace(',','')) : val;
+                breakdown[request_body['breakdowns'][j]] = is_num[j] ? Number(val.toString().replace(',','')) : val;
             }
             request_body['rankings'].push(breakdown);
         }

--- a/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -527,7 +527,7 @@ function updateRankings(cell) {
                 teamRank['played'] = rankData[i]['Played'];
                 teamRank['dqs'] = 0;
                 for(var j=0; j<breakdowns.length; j++){
-                    teamRank[display[j]] = Number(rankData[i][breakdowns[j]].replace(',',''));
+                    teamRank[display[j]] = Number(rankData[i][breakdowns[j]].toString().replace(',',''));
                 }
                 request_body['rankings'].push(teamRank);
             }

--- a/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -310,9 +310,9 @@ $('#rankings_file').change(function(){
         //var is_int = [true, true, true, true, true, false, true, true];
 
         // 2017 Headers
-//      var headers = ['Rank', 'Team', 'RS', 'TotalPts', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'W-L-T', 'DQ', 'Played'];
-//      var display_headers = ['Rank', 'Team', 'Ranking Score', 'Match Points', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'Record (W-L-T)', 'DQ', 'Played'];
-//      var is_num = [true, true, true, true, true, true, false, true, true];
+        //var headers = ['Rank', 'Team', 'RS', 'TotalPts', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'W-L-T', 'DQ', 'Played'];
+        //var display_headers = ['Rank', 'Team', 'Ranking Score', 'Match Points', 'Auto', 'Rotor', 'Takeoff', 'kPa', 'Record (W-L-T)', 'DQ', 'Played'];
+        //var is_num = [true, true, true, true, true, true, false, true, true];
 
         // 2018 Headers
         var headers = ['Rank', 'Team', 'RS', 'Endgame', 'Auto', 'Ownership', 'Vault', 'W-L-T', 'DQ', 'Played'];

--- a/templates/eventwizard.html
+++ b/templates/eventwizard.html
@@ -202,7 +202,7 @@
 {% block inline_javascript %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/md5.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-csv/0.71/jquery.csv-0.71.min.js"></script>
-<script src="//unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.14.0/xlsx.full.min.js"></script>
 <script type="text/javascript" src="/javascript/tba_combined_js.eventwizard.min.js"></script>
 
 {% endblock %}

--- a/templates/eventwizard.html
+++ b/templates/eventwizard.html
@@ -202,7 +202,7 @@
 {% block inline_javascript %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/md5.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-csv/0.71/jquery.csv-0.71.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/xlsx/0.8.0/xlsx.core.min.js"></script>
+<script src="//unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
 <script type="text/javascript" src="/javascript/tba_combined_js.eventwizard.min.js"></script>
 
 {% endblock %}

--- a/templates/react-eventwizard.html
+++ b/templates/react-eventwizard.html
@@ -12,5 +12,5 @@
 
 {% block inline_javascript %}
   <script type="text/javascript" src="/javascript/eventwizard.min.js"></script>
-  <script src="//unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.14.0/xlsx.full.min.js"></script>
 {% endblock %}

--- a/templates/react-eventwizard.html
+++ b/templates/react-eventwizard.html
@@ -12,5 +12,5 @@
 
 {% block inline_javascript %}
   <script type="text/javascript" src="/javascript/eventwizard.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/xlsx/0.11.2/xlsx.core.min.js"></script>
+  <script src="//unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Description
This pull request allows the EventWizard to import spreadsheets generated by the FRC FMS.

## Motivation and Context
Previously, when importing spreadsheets generated by the FMS, the Event Wizard could not find any data; however, after re-saving the spreadsheets, everything worked as intended. 

## How Has This Been Tested?
As these changes are very simple, minimal testing was required. I first tested the FMS-generated files, to ensure that my changes worked as intended. Then, to further ensure that everything was working, I tested all of the re-saved files. **(Note: It is necessary to use spreadsheets from 2018 in order for everything to work as intended. I was using 2017 spreadsheets to make sure the loading worked.)**

@tweirtx also tested these changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
