### PR TITLE
Fixed Broken Instagram Images

### DIFF
--- a/models/media.py
+++ b/models/media.py
@@ -156,6 +156,9 @@ class Media(ndb.Model):
         return self.instagram_url_helper("t")
 
     def instagram_url_helper(self, size):
+        # Supported size values are t (thumbnail), m (medium), l (large)
+        # See the Instagram developer docs for more information:
+        # https://www.instagram.com/developer/embedding/#media_redirect!
         return "{}/media/?size={}".format(self.instagram_url, size)
 
     @property

--- a/models/media.py
+++ b/models/media.py
@@ -145,15 +145,18 @@ class Media(ndb.Model):
 
     @property
     def instagram_direct_url(self):
-        return self.details['thumbnail_url']
+        return self.instagram_url_helper("l")
 
     @property
     def instagram_direct_url_med(self):
-        return self.instagram_direct_url
+        return self.instagram_url_helper("m")
 
     @property
     def instagram_direct_url_sm(self):
-        return self.instagram_direct_url
+        return self.instagram_url_helper("t")
+
+    def instagram_url_helper(self, size):
+        return "{}/media/?size={}".format(self.instagram_url, size)
 
     @property
     def view_image_url(self):

--- a/static/javascript/tba_js/tba.js
+++ b/static/javascript/tba_js/tba.js
@@ -61,6 +61,12 @@ $(document).ready(function(){
 
   // Featherlight Gallery
   $('.gallery').featherlightGallery('image');
+  // NOTE:
+  // Featherlight supports many types of content, but our specific
+  // useage of Instagram returns an unexpected `content-type`, so in
+  // order to not confuse Featherlight, we're explicitly telling it
+  // to expect images only.
+  // https://github.com/noelboss/featherlight#content-filters
 
 	// Converting match time to local time
   var weekday = new Array(7);

--- a/static/javascript/tba_js/tba.js
+++ b/static/javascript/tba_js/tba.js
@@ -60,7 +60,7 @@ $(document).ready(function(){
 	}
 
   // Featherlight Gallery
-  $('.gallery').featherlightGallery();
+  $('.gallery').featherlightGallery('image');
 
 	// Converting match time to local time
   var weekday = new Array(7);


### PR DESCRIPTION
## Description
Move Instagram image presentation to use the suggested (by Instagram) media embedding URLs.

## Motivation and Context
Some Instagram images are broken, due to us saving media URLs that are now outdated.
This fixes #2297.

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate):
The second image in the screenshot is from Instagram:
![](https://i.imgur.com/WjeW8Uy.png)

And the image carousel, with said Instagram image:
![](https://i.imgur.com/BXJK1yB.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
