### PR TITLE
Fixed playoff type selection in React eventwizard being under other elements

### DIFF
--- a/react/eventwizard/eventwizard.less
+++ b/react/eventwizard/eventwizard.less
@@ -1,1 +1,5 @@
 @import (inline) "../../node_modules/react-select/dist/react-select.css";
+
+#team_mappings_list {
+  z-index: 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Lowered the `z-index` of the re-mapping section so that the playoff drop down would be over it.

## Motivation and Context
It was annoying, and made the wizard harder to use.
See #2322

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
Before:
![](https://i.imgur.com/oOD1KYP.png)

After:
![](https://i.imgur.com/7Ca1Bnv.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
