### PR TITLE
New custom webhooks

### DIFF
--- a/controllers/test_notification_controller.py
+++ b/controllers/test_notification_controller.py
@@ -31,11 +31,6 @@ class TestNotificationController(LoggedInHandler):
         district_key = self.request.get('district_key')
         user_id = self.user_bundle.account.key.id()
 
-        if event_key == "":
-            logging.info("No event key")
-            self.response.out.write("No event key specified!")
-            return
-
         logging.info("Sending for {}".format(type))
         try:
             type = int(type)
@@ -44,15 +39,20 @@ class TestNotificationController(LoggedInHandler):
             logging.info("Invalid number passed")
             return
 
-        event = Event.get_by_id(event_key)
+        event = None
 
-        if event is None:
-            logging.info("Invalid event key passed")
-            self.response.out.write("Invalid event key!")
-            return
+        if type != NotificationType.DISTRICT_POINTS_UPDATED:
+            if event_key == "":
+                logging.info("No event key")
+                self.response.out.write("No event key specified!")
+                return
 
-        # match = Match.get_by_id('2014necmp_f1m1')
-        # district = District.get_by_id('2014ne')
+            event = Event.get_by_id(event_key)
+
+            if event is None:
+                logging.info("Invalid event key passed")
+                self.response.out.write("Invalid event key!")
+                return
 
         if type == NotificationType.UPCOMING_MATCH:
             if match_key == "":

--- a/controllers/test_notification_controller.py
+++ b/controllers/test_notification_controller.py
@@ -24,9 +24,17 @@ incoming notifications
 
 
 class TestNotificationController(LoggedInHandler):
-    def get(self, type):
+    def post(self, type):
         self._require_registration('/account/')
+        event_key = self.request.get('event_key')
+        match_key = self.request.get('match_key')
+        district_key = self.request.get('district_key')
         user_id = self.user_bundle.account.key.id()
+
+        if event_key == "":
+            logging.info("No event key")
+            self.response.out.write("No event key specified!")
+            return
 
         logging.info("Sending for {}".format(type))
         try:
@@ -34,18 +42,59 @@ class TestNotificationController(LoggedInHandler):
         except ValueError:
             # Not passed a valid int, just stop here
             logging.info("Invalid number passed")
-            self.redirect('/apidocs/webhooks')
             return
 
-        event = Event.get_by_id('2014necmp')
-        match = Match.get_by_id('2014necmp_f1m1')
-        district = District.get_by_id('2014ne')
+        event = Event.get_by_id(event_key)
+
+        if event is None:
+            logging.info("Invalid event key passed")
+            self.response.out.write("Invalid event key!")
+            return
+
+        # match = Match.get_by_id('2014necmp_f1m1')
+        # district = District.get_by_id('2014ne')
 
         if type == NotificationType.UPCOMING_MATCH:
+            if match_key == "":
+                logging.info("No match key")
+                self.response.out.write("No match key specified!")
+                return
+
+            match = Match.get_by_id(match_key)
+
+            if match is None:
+                logging.info("Invalid match key passed")
+                self.response.out.write("Invalid match key!")
+                return
+
             notification = UpcomingMatchNotification(match, event)
         elif type == NotificationType.MATCH_SCORE:
+            if match_key == "":
+                logging.info("No match key")
+                self.response.out.write("No match key specified!")
+                return
+
+            match = Match.get_by_id(match_key)
+
+            if match is None:
+                logging.info("Invalid match key passed")
+                self.response.out.write("Invalid match key!")
+                return
+
             notification = MatchScoreNotification(match)
         elif type == NotificationType.LEVEL_STARTING:
+            if match_key == "":
+                logging.info("No match key")
+                self.response.out.write("No match key specified!")
+                return
+
+            match = Match.get_by_id(match_key)
+
+            if match is None:
+                logging.info("Invalid match key passed")
+                self.response.out.write("Invalid match key!")
+                return
+
             notification = CompLevelStartingNotification(match, event)
         elif type == NotificationType.ALLIANCE_SELECTION:
             notification = AllianceSelectionNotification(event)
@@ -55,19 +104,65 @@ class TestNotificationController(LoggedInHandler):
             # Not implemented yet
             pass
         elif type == NotificationType.DISTRICT_POINTS_UPDATED:
+            if district_key == "":
+                logging.info("No district key")
+                self.response.out.write("No district key specified!")
+                return
+
+            district = District.get_by_id(district_key)
+
+            if district is None:
+                logging.info("Invalid district key passed")
+                self.response.out.write("Invalid district key!")
+                return
             notification = DistrictPointsUpdatedNotification(district)
         elif type == NotificationType.SCHEDULE_UPDATED:
+            if match_key == "":
+                logging.info("No match key")
+                self.response.out.write("No match key specified!")
+                return
+
+            match = Match.get_by_id(match_key)
+
+            if match is None:
+                logging.info("Invalid match key passed")
+                self.response.out.write("Invalid match key!")
+                return
+
             notification = ScheduleUpdatedNotification(event, match)
         elif type == NotificationType.FINAL_RESULTS:
             # Not implemented yet
             pass
         elif type == NotificationType.MATCH_VIDEO:
+            if match_key == "":
+                logging.info("No match key")
+                self.response.out.write("No match key specified!")
+                return
+
+            match = Match.get_by_id(match_key)
+
+            if match is None:
+                logging.info("Invalid match key passed")
+                self.response.out.write("Invalid match key!")
+                return
+
             notification = MatchVideoNotification(match)
         elif type == NotificationType.EVENT_MATCH_VIDEO:
+            if match_key == "":
+                logging.info("No match key")
+                self.response.out.write("No match key specified!")
+                return
+
+            match = Match.get_by_id(match_key)
+
+            if match is None:
+                logging.info("Invalid match key passed")
+                self.response.out.write("Invalid match key!")
+                return
+
             notification = EventMatchVideoNotification(match)
         else:
             # Not passed a valid int, return
-            self.redirect('/apidocs/webhooks')
             return
 
         keys = PushHelper.get_client_ids_for_users([user_id])
@@ -77,4 +172,4 @@ class TestNotificationController(LoggedInHandler):
             # Nor should its notifications be tracked in analytics
             notification.send(keys, push_firebase=False, track_call=False)
 
-        self.redirect('/apidocs/webhooks')
+        self.response.out.write("ok")

--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -84,7 +84,36 @@
             </pre>
         {% if types.upcoming_match in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.upcoming_match}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Upcoming Match</a>
+            <form method="POST"
+                  action="/notifications/test/{{types.upcoming_match}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="upcomingNotificationEvent" class="col-sm-2 control-label">Event Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp" name="event_key" id="upcomingNotificationEvent">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="upcomingNotificationMatch" class="col-sm-2 control-label">Match Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp_f1m1" name="match_key" id="upcomingNotificationMatch">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test Upcoming Match</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
+{#            <a href="/notifications/test/{{types.upcoming_match}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Upcoming Match</a>#}
         {% endif %}
 
         <h3 id="notification_match_score">Match Score Notification</h3>
@@ -102,7 +131,36 @@
             </pre>
         {% if types.match_score in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.match_score}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Match Score</a>
+            <form method="POST"
+                  action="/notifications/test/{{types.match_score}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="upcomingNotificationEvent" class="col-sm-2 control-label">Event Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp" name="event_key" id="upcomingNotificationEvent">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="upcomingNotificationMatch" class="col-sm-2 control-label">Match Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp_f1m1" name="match_key" id="upcomingNotificationMatch">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test Match Score</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
+{#            <a href="/notifications/test/{{types.match_score}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Match Score</a>#}
         {% endif %}
 
         <h3 id="notification_level_starting">Competition Level Starting Notification</h3>
@@ -122,7 +180,36 @@
             </pre>
         {% if types.starting_comp_level in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.starting_comp_level}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Level Starting</a>
+            <form method="POST"
+                  action="/notifications/test/{{types.starting_comp_level}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="upcomingNotificationEvent" class="col-sm-2 control-label">Event Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp" name="event_key" id="upcomingNotificationEvent">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="upcomingNotificationMatch" class="col-sm-2 control-label">Match Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp_f1m1" name="match_key" id="upcomingNotificationMatch">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test Level Starting</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
+{#            <a href="/notifications/test/{{types.starting_comp_level}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Level Starting</a>#}
         {% endif %}
 
         <h3 id="notification_alliance_selection">Alliance Selection Notification</h3>
@@ -139,7 +226,30 @@
             </pre>
         {% if types.alliance_selection in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.alliance_selection}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Alliance Selection</a>
+            <form method="POST"
+                  action="/notifications/test/{{types.alliance_selection}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="upcomingNotificationEvent" class="col-sm-2 control-label">Event Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp" name="event_key" id="upcomingNotificationEvent">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test Alliance Selection</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
+{#            <a href="/notifications/test/{{types.alliance_selection}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Alliance Selection</a>#}
         {% endif %}
 
         <h3 id="notification_awards">Awards Posted Notification</h3>
@@ -160,7 +270,31 @@
             </pre>
         {% if types.awards_posted in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.awards_posted}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Awards</a>
+            <form method="POST"
+                  action="/notifications/test/{{types.awards_posted}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="upcomingNotificationEvent" class="col-sm-2 control-label">Event Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp" name="event_key"
+                                   id="upcomingNotificationEvent">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test Awards</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
+{#            <a href="/notifications/test/{{types.awards_posted}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Awards</a>#}
         {% endif %}
 
         <h3 id="notification_media_posted">Team Media Posted Notification</h3>
@@ -179,7 +313,8 @@
             </pre>
         {% if types.media_posted in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.media_posted}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Media</a>
+            {# LeoCodes21 - media_posted is unimplemented so there is nothing here for now. #}
+{#            <a href="/notifications/test/{{types.media_posted}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Media</a>#}
         {% endif %}
 
         <h3 id="notification_district_points">District Points Updated Notification</h3>
@@ -197,7 +332,8 @@
             </pre>
         {% if types.disrict_points_updated in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.district_points_updated}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test District Points</a>
+            {# LeoCodes21 - disrict_points_updated is unimplemented so there is nothing here for now. #}
+{#            <a href="/notifications/test/{{types.district_points_updated}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test District Points</a>#}
         {% endif %}
 
         <h3 id="notification_schedule_updated">Event Schedule Updated</h3>
@@ -216,7 +352,36 @@
             </pre>
         {% if types.schedule_updated in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.schedule_updated}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Schedule Update</a>
+            <form method="POST"
+                  action="/notifications/test/{{types.schedule_updated}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="upcomingNotificationEvent" class="col-sm-2 control-label">Event Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp" name="event_key" id="upcomingNotificationEvent">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="upcomingNotificationMatch" class="col-sm-2 control-label">Match Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014necmp_f1m1" name="match_key" id="upcomingNotificationMatch">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test Schedule Update</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
+{#            <a href="/notifications/test/{{types.schedule_updated}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Schedule Update</a>#}
         {% endif %}
 
         <h3 id="notification_final_results">Final Results Notification</h3>
@@ -236,7 +401,8 @@
           </pre>
         {% if types.final_results in enabled %}
         <h4>Test Notification</h4>
-            <a href="/notifications/test/{{types.final_results}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Final Results</a>
+            {# LeoCodes21 - final_results is unimplemented so there is nothing here for now. #}
+{#            <a href="/notifications/test/{{types.final_results}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Final Results</a>#}
         {% endif %}
 
         <h3 id="notification_ping">Ping Notification</h3>
@@ -312,6 +478,41 @@ $( document ).ready(function() {
         var stringified = JSON.stringify(jsonObject, null, 2)
         $(this).html(stringified);
     });
+
+    $('.webhook-send-btn').click(function(e){
+        e.preventDefault();
+        $(this).attr('disabled', true);
+        $(this).addClass('disabled');
+        $(this.form).find('.webhook-alert').css('display', 'none');
+        $(this.form).find('.webhook-alert').removeClass('alert-success');
+        $(this.form).find('.webhook-alert').removeClass('alert-danger');
+
+        console.log(this.form);
+
+        $.post(this.form.action, $(this.form).serialize()).done(function (data) {
+            if (data === "ok") {
+                $(this.form).find('.webhook-alert').addClass('alert-success');
+            } else {
+                $(this.form).find('.webhook-alert').addClass('alert-danger');
+            }
+
+            $(this.form).find('.webhook-alert').css('display', 'block');
+            $(this.form).find('.webhook-alert').text(data === "ok" ? "Sent webhook!" : data);
+
+            $(this).attr('disabled', false);
+            $(this).removeClass('disabled');
+
+            setTimeout(function() {
+                $(this.form).find('.webhook-alert').css('display', 'none');
+            }.bind(this), 5000)
+        }.bind(this)).fail(function () {
+            alert('Something went horribly wrong. Try again.');
+            $(this).attr('disabled', false);
+            $(this).removeClass('disabled');
+        });
+    });
+
+    $('.webhook-alert').hide();
 });
 </script>
 {% endblock %}

--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -312,7 +312,7 @@
             Not yet implemented
             </pre>
         {% if types.media_posted in enabled %}
-        <h4>Test Notification</h4>
+{#        <h4>Test Notification</h4>#}
             {# LeoCodes21 - media_posted is unimplemented so there is nothing here for now. #}
 {#            <a href="/notifications/test/{{types.media_posted}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Media</a>#}
         {% endif %}
@@ -327,13 +327,34 @@
                 <li>“district_name”</li></ul></li>
             </ul>
           <h4>Example JSON</h4>
-            <pre>
-            Not yet implemented
+            <pre class="example-json">
+            {"message_data": {"district_key": "2014ne", "district_name": "New England"}, "message_type": "district_points_updated"}
             </pre>
         {% if types.disrict_points_updated in enabled %}
         <h4>Test Notification</h4>
-            {# LeoCodes21 - disrict_points_updated is unimplemented so there is nothing here for now. #}
-{#            <a href="/notifications/test/{{types.district_points_updated}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test District Points</a>#}
+            <form method="POST"
+                  action="/notifications/test/{{types.disrict_points_updated}}"
+                  class="form-horizontal"
+                  role="form"
+                  onsubmit="event.preventDefault()">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="pointsUpdateDistrict" class="col-sm-2 control-label">District Key</label>
+                        <div class="col-sm-10">
+                            <input type="text" class="form-control" required value="2014ne" name="district_key" id="pointsUpdateDistrict">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm-10">
+                            <button class="btn btn-info webhook-send-btn" type="submit">Send Test District Points</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="alert webhook-alert"></div>
+                </div>
+            </form>
         {% endif %}
 
         <h3 id="notification_schedule_updated">Event Schedule Updated</h3>
@@ -400,7 +421,7 @@
             <i>Not yet implemented</i>
           </pre>
         {% if types.final_results in enabled %}
-        <h4>Test Notification</h4>
+{#        <h4>Test Notification</h4>#}
             {# LeoCodes21 - final_results is unimplemented so there is nothing here for now. #}
 {#            <a href="/notifications/test/{{types.final_results}}" class="btn btn-default"><span class="glyphicon glyphicon-envelope"></span> Send Test Final Results</a>#}
         {% endif %}
@@ -486,8 +507,6 @@ $( document ).ready(function() {
         $(this.form).find('.webhook-alert').css('display', 'none');
         $(this.form).find('.webhook-alert').removeClass('alert-success');
         $(this.form).find('.webhook-alert').removeClass('alert-danger');
-
-        console.log(this.form);
 
         $.post(this.form.action, $(this.form).serialize()).done(function (data) {
             if (data === "ok") {


### PR DESCRIPTION
## Description
This pull request reworks the webhook documentation page to allow test webhooks to be sent for events and matches other than those from `2014necmp` (2014 New England championship). The original test buttons have been replaced with forms that allow custom TBA keys to be specified, defaulting to `2014necmp` for consistency with the original implementation.

## Motivation and Context
This is intended as a quality-of-life feature. When developing and testing applications that need to process data coming through TBA webhooks, it can be irritating to only be able to receive test data from the 2014 season, which has no FMS data available. By allowing for custom TBA keys to be used, webhook-based client testing and development can be made far easier than before.

## How Has This Been Tested?
Multiple tests were conducted, with various inputs. TBA key validation is included, as well as client-side error display.
@tweirtx provided assistance in testing.

## Screenshots (if appropriate):
"Upcoming Match Notification" being sent for the 2018 Greater Pittsburgh Regional finals
![image](https://user-images.githubusercontent.com/25068027/48162277-a841c380-e2aa-11e8-855a-f592fee193f9.png)
![image](https://user-images.githubusercontent.com/25068027/48162296-b099fe80-e2aa-11e8-8f5b-7af2a6721479.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
