### PR TITLE
Show year for non-canonical team shares (closes #2327)

### DIFF
--- a/templates_jinja2/team_partials/team_head_tags.html
+++ b/templates_jinja2/team_partials/team_head_tags.html
@@ -1,4 +1,4 @@
-<meta property="og:title" content="Team {{team.team_number}} - {{team.nickname}}" />
+<meta property="og:title" content="{{team.nickname}} - Team {{team.team_number}}{% if not is_canonical %} ({{year}}){% endif %}" />
 <meta property="og:type" content="sports_team" />
 <meta property="og:url" content="https://www.thebluealliance.com/team/{{team.team_number}}" />
 <meta property="og:image" content="{% if preferred_image_medias %}{{preferred_image_medias[0].image_direct_url_med}}{% else %}https://www.thebluealliance.com/images/logo_square_512.png{% endif %}" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #2327

## Description
Modifies the og:title attributes to 1) match the order of data in the title attribute, and 2) show the year for the team, if we're showing the non-canonical page

## Motivation and Context
#2327, also it makes sense when sharing a year page for a team the social tags show the year

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):
Canonical page
<img width="1290" alt="screen shot 2018-11-18 at 11 10 58 am" src="https://user-images.githubusercontent.com/516458/48675131-185e0e00-eb23-11e8-8272-887dabc7095f.png">

Non-canonical page
<img width="1278" alt="screen shot 2018-11-18 at 11 11 21 am" src="https://user-images.githubusercontent.com/516458/48675134-1e53ef00-eb23-11e8-89ed-96de513787ef.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
