### PR TITLE
Add noindex header to API and LoggedIn pages. Closes #2302

### DIFF
--- a/controllers/api/api_base_controller.py
+++ b/controllers/api/api_base_controller.py
@@ -66,6 +66,7 @@ class ApiBaseController(CacheableHandler):
         super(ApiBaseController, self).__init__(*args, **kw)
         self.response.headers['content-type'] = 'application/json; charset="utf-8"'
         self.response.headers['Access-Control-Allow-Origin'] = '*'
+        self.response.headers['X-Robots-Tag'] = 'noindex'
 
     def handle_exception(self, exception, debug):
         """

--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -56,6 +56,7 @@ class ApiBaseController(CacheableHandler):
         super(ApiBaseController, self).__init__(*args, **kw)
         self.response.headers['content-type'] = 'application/json; charset="utf-8"'
         self.response.headers['Access-Control-Allow-Origin'] = '*'
+        self.response.headers['X-Robots-Tag'] = 'noindex'
 
         # Set cache key based on class name, version, and kwargs
         kwargs_sorted = sorted([(k, v) for k, v in self.request.route_kwargs.items()], key=lambda x: x[0])

--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -191,6 +191,7 @@ class LoggedInHandler(webapp2.RequestHandler):
         self.response.headers['Pragma'] = 'no-cache'
         self.response.headers['Expires'] = '0'
         self.response.headers['Vary'] = 'Accept-Encoding'
+        self.response.headers['X-Robots-Tag'] = 'noindex'
 
     def _get_login_url(self, target_url):
         return self.user_bundle.create_login_url(target_url)


### PR DESCRIPTION
`robots.txt` doesn't prevent pages from showing up in search engines. Adding this header tag will prevent our API pages and pages that require login from showing in search results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
