### PR TITLE
Add Ping endpoint to myTBA

### DIFF
--- a/controllers/notification_controller.py
+++ b/controllers/notification_controller.py
@@ -1,10 +1,9 @@
 from google.appengine.ext import ndb
 
 from base_controller import LoggedInHandler
-from consts.client_type import ClientType
 from models.account import Account
 from models.mobile_client import MobileClient
-from notifications.ping import PingNotification
+from helpers.notification_helper import NotificationHelper
 
 
 class UserNotificationBroadcast(LoggedInHandler):
@@ -24,12 +23,7 @@ class UserNotificationBroadcast(LoggedInHandler):
             client = MobileClient.get_by_id(int(client_id), parent=ndb.Key(Account, current_user_account_id))
             if client is not None:
                 # This makes sure that the client actually exists and that this user owns it
-                if client.client_type == ClientType.WEBHOOK:
-                    keys = {client.client_type: [(client.messaging_id, client.secret)]}
-                else:
-                    keys = {client.client_type: [client.messaging_id]}
-                notification = PingNotification()
-                notification.send(keys)
+                NotificationHelper.send_ping(client)
             self.redirect('/account')
         else:
             self.redirect('/')

--- a/helpers/notification_helper.py
+++ b/helpers/notification_helper.py
@@ -19,6 +19,7 @@ from notifications.schedule_updated import ScheduleUpdatedNotification
 from notifications.upcoming_match import UpcomingMatchNotification
 from notifications.update_favorites import UpdateFavoritesNotification
 from notifications.update_subscriptions import UpdateSubscriptionsNotification
+from notifications.ping import PingNotification
 from notifications.verification import VerificationNotification
 
 
@@ -150,6 +151,16 @@ class NotificationHelper(object):
         keys = PushHelper.get_client_ids_for_users(users)
 
         notification = BroadcastNotification(title, message, url, app_version)
+        notification.send(keys)
+
+    @classmethod
+    def send_ping(cls, client):
+        if client.client_type == ClientType.WEBHOOK:
+            keys = {client.client_type: [(client.messaging_id, client.secret)]}
+        else:
+            keys = {client.client_type: [client.messaging_id]}
+
+        notification = PingNotification()
         notification.send(keys)
 
     @classmethod

--- a/models/mobile_api_messages.py
+++ b/models/mobile_api_messages.py
@@ -15,6 +15,10 @@ class RegistrationRequest(messages.Message):
     device_uuid = messages.StringField(4, required=True)
 
 
+class PingRequest(messages.Message):
+    mobile_id = messages.StringField(1, required=True)
+
+
 class FavoriteMessage(messages.Message):
     model_key = messages.StringField(1, required=True)
     device_key = messages.StringField(2)  # So we know which device NOT to push sync notification to


### PR DESCRIPTION
Adds a Ping endpoint to myTBA to dispatch a test notification for a user.

## Motivation and Context
This is a next-step in https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/345 which helps users debug information about push notifications. Allowing users to kickoff a push will help us test end-to-end that things are working as expected.

## How Has This Been Tested?
It has not ⚠️  There doesn't seem to be any `NotificationHelper` tests, and I don't believe there's documentation on how to get a push setup locally. This seems fairly low-risk, since it's adding new functionality and not modifying existing functionality.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
