### PR TITLE
Remove auth from ping endpoint

### DIFF
--- a/mobile_main.py
+++ b/mobile_main.py
@@ -143,15 +143,10 @@ class MobileAPI(remote.Service):
                       path='ping', http_method='POST',
                       name='ping')
     def ping_client(self, request):
-        current_user = endpoints.get_current_user()
-        if current_user is None:
-            return BaseResponse(code=401, message="Unauthorized to ping client")
-
-        user_id = PushHelper.user_email_to_id(current_user.email())
         gcm_id = request.mobile_id
 
         # Find a Client for the current user with the passed GCM ID
-        clients = MobileClient.query(MobileClient.messaging_id == gcm_id, ancestor=ndb.Key(Account, user_id)).fetch(1)
+        clients = MobileClient.query(MobileClient.messaging_id == gcm_id).fetch(1)
         if len(clients) == 0:
             # No Client for user with that push token - bailing
             return BaseResponse(code=404, message="Invalid push token for user")


### PR DESCRIPTION
We can't seem to get auth working for the ping endpoint added in https://github.com/the-blue-alliance/the-blue-alliance/pull/2334 - this removes that authentication