### PR TITLE
Dispatch notifications for iOS, combine notification render methods

### DIFF
--- a/helpers/notification_sender.py
+++ b/helpers/notification_sender.py
@@ -14,10 +14,6 @@ class NotificationSender(object):
         gcm_connection.notify_device(notification)
 
     @classmethod
-    def send_ios(cls, notification):
-        pass
-
-    @classmethod
     def send_webhook(cls, message, keys):
         import urllib2
         payload = json.dumps(message, ensure_ascii=True)

--- a/notifications/update_favorites.py
+++ b/notifications/update_favorites.py
@@ -5,7 +5,7 @@ from notifications.base_notification import BaseNotification
 
 class UpdateFavoritesNotification(BaseNotification):
 
-    _supported_clients = [ClientType.OS_ANDROID, ClientType.WEBHOOK]
+    _supported_clients = [ClientType.OS_ANDROID, ClientType.OS_IOS, ClientType.WEBHOOK]
     _track_call = False
 
     def __init__(self, user_id, sending_device_key):

--- a/notifications/update_subscriptions.py
+++ b/notifications/update_subscriptions.py
@@ -7,7 +7,7 @@ from notifications.base_notification import BaseNotification
 
 class UpdateSubscriptionsNotification(BaseNotification):
 
-    _supported_clients = [ClientType.OS_ANDROID, ClientType.WEBHOOK]
+    _supported_clients = [ClientType.OS_ANDROID, ClientType.OS_IOS, ClientType.WEBHOOK]
     _track_call = False
 
     def __init__(self, user_id, sending_device_key):


### PR DESCRIPTION
Gearing up for the iOS launch, one of the things we want to do is support notifications. This wires up sending the current notifications to iOS through Firebase (which I think is still outstanding if we know if it works or not). This also DRY-s out some of the base notification code, while still allowing overriding render methods.

## How Has This Been Tested?
It has not ⚠️ 