### PR TITLE
Fix UpcomingMatch notification to send predicted_time

### DIFF
--- a/notifications/upcoming_match.py
+++ b/notifications/upcoming_match.py
@@ -28,11 +28,15 @@ class UpcomingMatchNotification(BaseNotification):
         data['message_data']['event_name'] = self.event.name
         data['message_data']['match_key'] = self.match.key_name
         data['message_data']['team_keys'] = self.match.team_key_names
+
         if self.match.time:
             data['message_data']['scheduled_time'] = calendar.timegm(self.match.time.utctimetuple())
-            data['message_data']['predicted_time'] = calendar.timegm(self.match.time.utctimetuple())  # TODO Add in some time predictions
         else:
             data['message_data']['scheduled_time'] = None
+
+        if self.match.predicted_time:
+            data['message_data']['predicted_time'] = calendar.timegm(self.match.predicted_time.utctimetuple())
+        else:
             data['message_data']['predicted_time'] = None
 
         current_webcasts = self.event.current_webcasts

--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -75,8 +75,8 @@
               <li>“match_key”</li>
               <li>“event_name”</li>
               <li>“team_keys”: list of keys for all teams participating in the match</li>
-              <li>“scheduled_time”: time that the match was originally scheduled for, in UNIX UTC</li>
-              <li>“predicted_time”: time that the match is predicted to start at based on the times that scores were posted for previous events, in UNIX UTC</li></ul></li>
+              <li>“scheduled_time”: time that the match was originally scheduled for, in UNIX UTC. Will be null if the match does not have a scheduled start time.</li>
+              <li>“predicted_time”: time that the match is predicted to start at based on the times that scores were posted for previous events, in UNIX UTC. Will be null if the match start time cannot be predicted.</li></ul></li>
             </ul>
           <h4>Example JSON</h4>
             <pre class="example-json">

--- a/tests/test_notification_upcoming_match.py
+++ b/tests/test_notification_upcoming_match.py
@@ -25,7 +25,9 @@ class TestUpcomingMatchNotification(unittest2.TestCase):
                  team_number=team_number).put()
 
         self.event = EventTestCreator.createPresentEvent()
+
         self.match = self.event.matches[0]
+        self.match.predicted_time = self.match.time
         self.notification = UpcomingMatchNotification(self.match, self.event)
 
     def tearDown(self):
@@ -40,12 +42,14 @@ class TestUpcomingMatchNotification(unittest2.TestCase):
         expected['message_data']['event_name'] = self.event.name
         expected['message_data']['match_key'] = self.match.key_name
         expected['message_data']['team_keys'] = self.match.team_key_names
+
         if self.match.time:
             expected['message_data']['scheduled_time'] = calendar.timegm(self.match.time.utctimetuple())
-            expected['message_data']['predicted_time'] = calendar.timegm(self.match.time.utctimetuple())
         else:
             expected['message_data']['scheduled_time'] = None
-            expected['message_data']['predicted_time'] = None
+
+        expected['message_data']['predicted_time'] = expected['message_data']['scheduled_time']
+
         expected['message_data']['webcast'] = {
             'channel': '6540154',
             'status': 'unknown',


### PR DESCRIPTION
Fixes #2254 to properly send `predicted_time` in the `UpcomingMatchNotification`. Also updates the documentation to better clarify when these fields will or won't have data.

I updated the tests in `UpcomingMatchNotification` as well, but we never predict times for matches in our tests, so the `predicted_time` isn't really tested and will always be `None`. If anyone feels strongly about adding some way to add predictions to matches in `MatchTestCreator`, I'm more than willing to do that work.