### PR TITLE
Automatically deploy endpoints config

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -82,4 +82,3 @@ includes:
 
 env_variables:
   ENDPOINTS_SERVICE_NAME: tbatv-prod-hrd.appspot.com
-  ENDPOINTS_SERVICE_VERSION: 2018-05-29r6

--- a/controllers/apiv3/api_admin_controller.py
+++ b/controllers/apiv3/api_admin_controller.py
@@ -30,12 +30,14 @@ class ApiAdminSetBuildInfo(ApiAdminController):
         commit_time = data.get('commit_time', '')
         deploy_time = data.get('deploy_time', '')
         travis_job = data.get('travis_job', '')
+        endpoints_sha = data.get('endpoints_sha', '')
 
         web_info = {
             'current_commit': current_commit_sha,
             'commit_time': commit_time,
             'deploy_time': deploy_time,
             'travis_job': travis_job,
+            'endpoints_sha': endpoints_sha,
         }
 
         status_sitevar = Sitevar.get_or_insert('apistatus', values_json='{}')

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -49,10 +49,16 @@ echo "Obtaining deploy lock..."
 lock $DEPLOY_LOCK
 
 echo "Obtained Lock. Deploying $PROJECT:$VERSION"
-# need more permissiosn for cron.yaml queue.yaml index.yaml, we can come back to them
+# need more permissions for cron.yaml queue.yaml index.yaml, we can come back to them
 for config in dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml cron.yaml; do
     with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $config --version $VERSION"
 done
+
+# Check if we need to deploy our Endpoints config - cleanup afterwards so it's not in our web deploy
+paver make_endpoints_config
+if check_deploy_endpoints_config; then
+    with_python27 "$GCLOUD endpoints services deploy tbaMobilev9openapi.json"
+fi
 
 echo "Updating build info..."
 update_build_info


### PR DESCRIPTION
During the deploy phase in Travis, check if our endpoints configuration has changed, and deploy the new configuration if necessary.

We shouldn't need to specify the `ENDPOINTS_SERVICE_VERSION` - endpoints will default to using the latest deployed version https://github.com/cloudendpoints/endpoints-management-python/pull/69

Note: this does move the `should_deploy` check to later, after setting up Python and gcloud and whatnot.

## Motivation and Context
Automate something that's currently manual and requires keys