### PR TITLE
Attempt to fix web deploys

### DIFF
--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -2,6 +2,7 @@
 set -e
 . $(pwd)/ops/travis/should-deploy.sh
 . $(pwd)/ops/gcslock.sh
+export BOTO_CONFIG=/dev/null # Hack to fix https://github.com/travis-ci/travis-ci/issues/7940
 
 # Deploy to GAE from travis CI
 # Basically an implementation of:


### PR DESCRIPTION
Web deploys have been stuck since https://github.com/the-blue-alliance/the-blue-alliance/commit/893056fe0f3a17ab9107d9363c18a0f4c0fbeaaf - it looks like this is a problem others using Travis have fixed via this `BOTO_CONFIG` hack

As noted in Slack, it looks like what changed is we upgraded from Cloud SDK 226.0.0 -> Cloud SDK 227.0.0 and this broke