### PR TITLE
Fix crash when generating endpoints configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
 - travis_retry ./ops/travis/travis-install.sh $JOB
 - export PYTHONPATH=${PYTHONPATH}:${HOME}/google_appengine
+- export ENDPOINTS_GAE_SDK=$(gcloud info --format="value(installation.sdk_root)")
 before_script:
 - ./ops/travis/travis-before.sh $JOB
 script:

--- a/mobile_main.py
+++ b/mobile_main.py
@@ -66,7 +66,6 @@ if tba_config.DEBUG:
     audiences={
         'firebase': ['tbatv-prod-hrd'],
         'google_id_token': [ANDROID_AUDIENCE],
-        ANDROID_AUDIENCE: True,  # Hack to get Android auth working
     },
     issuers={
         'firebase': endpoints.Issuer(

--- a/ops/travis/travis-worker.sh
+++ b/ops/travis/travis-worker.sh
@@ -13,7 +13,7 @@ case "$1" in
         paver test
         ;;
     "LINT")
-	echo "Linting python..."
+        echo "Linting python..."
         if test "$TRAVIS_BRANCH" != "" ; then
             echo "Linting all changes between HEAD and $TRAVIS_BRANCH"
             paver lint --base $TRAVIS_BRANCH
@@ -23,12 +23,16 @@ case "$1" in
         fi
 
         # Lint Javascript
-	echo "Linting javascript..."
+        echo "Linting javascript..."
         npm run lint -s
 
-	# Lint swagger files
-	echo "Linting swagger specs..."
-	find $(pwd)/static/swagger -type f -name "*.json" | xargs -n 1 swagger-cli validate
+        # Lint swagger files
+        echo "Linting swagger specs..."
+        find $(pwd)/static/swagger -type f -name "*.json" | xargs -n 1 swagger-cli validate
+
+        # Test we can generate our mobile API configuration - needed for deploys
+        echo "Verifying our endpoints configuration..."
+        paver make_endpoints_config
         ;;
     "PYBUILD")
         echo "Building all python files"


### PR DESCRIPTION
https://github.com/the-blue-alliance/the-blue-alliance/commit/19034851d81767de972dd6c93a41e03a0a779768 broke deploys (well, only the last half of deploys - we're still successfully deploying to the web), because we're running in to an error when generating the endpoints configuration. That `ANDROID_AUDIENCE: True` line is the problem - the endpoints config script complains about a missing issuer

```
TypeError: Missing issuer 
```

I'm not entirely sure what it's looking for here, since from what I can tell, that `ANDROID_AUDIENCE` value isn't going to be one of the values in our issuers. Additionally, I can't find any documentation about what that line is actually doing.

Finally, I added a step to the `LINT` job that generates our endpoints configuration (and cleaned up the formatting), since it's fairly cheap, and we should probably make sure that works before merging PRs 😄 