### PR TITLE
Updated district ranking link

### DIFF
--- a/templates_jinja2/district_details.html
+++ b/templates_jinja2/district_details.html
@@ -176,8 +176,8 @@
 
           {% if year == 2015 %}
             <p>* District rankings are not official and are calculated using the <a href="http://archive.usfirst.org/sites/default/files/uploadedFiles/Robotics_Programs/FRC/Game_and_Season__Info/2015/FRC_District_Standard_Points_Ranking_System_2015%20Summary.pdf">2015 FRC Standard District Points Ranking System (PDF)</a></p>
-          {% else %}
-            <p>* District rankings are not official and are calculated using the <a href="http://frc-districtrankings.firstinspires.org/">FRC Standard District Points Ranking System</a></p>
+          {% else %} 
+            <p>* District rankings are not official and are calculated using the <a href="https://frc-events.firstinspires.org/{{year}}/districts">FRC Standard District Points Ranking System</a></p>
           {% endif %}
         </div>
         {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
frc-districtrankings.firstinspires.org is being discontinued and replaced with frc-events. There isn't an exactly equivalent page as fair as I can tell so this will at least get to the list of districts.

## Description
On the District Rankings page, we link to the frc-districts site which is being decommissioned. That site shows this banner:
![image](https://user-images.githubusercontent.com/22439365/49782457-46221700-fccb-11e8-8917-a33e33823889.png)
This update should link to the closest to equivalent page. 

## Motivation and Context
Clicking the link gets you to an outdated page. Fine for now but will eventually be problematic.

## How Has This Been Tested?
It hasn't. Also, I don't really know what I'm doing with the {{year}} variables so if someone could check my work that would be nice.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
