### PR TITLE
[modtools] Implement Team Media Management

### DIFF
--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -235,3 +235,19 @@ class LoggedInHandler(webapp2.RequestHandler):
                 '/account/register?redirect={}'.format(urllib.quote(redirect_url)),
                 abort=True
             )
+
+    def _require_team_admin_access(self, team_number, redirect_url=None):
+        self._require_login(redirect_url)
+        if self.user_bundle.is_current_user_admin:
+            # Admins have this granted
+            return
+
+        user = self.user_bundle.account.key
+
+        existing_access = existing_access = TeamAdminAccess.query(
+            TeamAdminAccess.account == user, TeamAdminAccess.team_number == team_number).fetch()
+        if not existing_access:
+            return self.redirect(
+                "/",
+                abort=True
+            )

--- a/controllers/team_admin_controller.py
+++ b/controllers/team_admin_controller.py
@@ -1,19 +1,96 @@
+import logging
 import tba_config
+from collections import defaultdict
 
 from base_controller import CacheableHandler, LoggedInHandler
 from google.appengine.ext import ndb
+from helpers.media_manipulator import MediaManipulator
+from models.media import Media
+from models.suggestion import Suggestion
 from models.team import Team
 from models.team_admin_access import TeamAdminAccess
 from template_engine import jinja2_engine
 
 
 class TeamAdminDashboard(LoggedInHandler):
+    ALLOWED_SUGGESTION_TYPES = ["media", "social-media", "robot"]
+
     def get(self):
         self._require_registration()
+        user = self.user_bundle.account.key
+
+        existing_access = TeamAdminAccess.query(
+            TeamAdminAccess.account == user).fetch()
+        team_keys = [
+            ndb.Key(Team, "frc{}".format(access.team_number))
+            for access in existing_access
+        ]
+        teams_future = ndb.get_multi_async(team_keys)
+        team_medias_future = Media.query(
+            Media.references.IN(team_keys)).fetch_async(50)
+        suggestions_future = Suggestion.query().filter(
+            Suggestion.review_state == Suggestion.REVIEW_PENDING).filter(
+                Suggestion.target_model.IN(self.ALLOWED_SUGGESTION_TYPES),
+                Suggestion.target_key.IN(
+                    [k.id() for k in team_keys])).fetch_async(limit=50)
+
+        team_num_to_team = {
+            team.get_result().team_number: team.get_result()
+            for team in teams_future
+        }
+        team_medias = defaultdict(list)
+        for media in team_medias_future.get_result():
+            for reference in media.references:
+                if reference in team_keys:
+                    team_num = reference.id()[3:]
+                    team_medias[int(team_num)].append(media)
+
+        suggestions_by_team = defaultdict(list)
+        for suggestion in suggestions_future.get_result():
+            # Assume all the keys are team keys
+            team_num = suggestion.target_key[3:]
+            suggestions_by_team[int(team_num)].append(suggestion)
+
+        self.template_values.update({
+            "existing_access": existing_access,
+            "teams": team_num_to_team,
+            "team_medias": team_medias,
+            "suggestions_by_team": suggestions_by_team,
+        })
 
         self.response.out.write(
             jinja2_engine.render('team_admin_dashboard.html',
                                  self.template_values))
+
+    def post(self):
+        team_number = self.request.get("team_number")
+        if not team_number:
+            self.abort(400)
+        team_number = int(team_number)
+        self._require_team_admin_access(team_number)
+
+        media_key_name = self.request.get("media_key_name")
+        media = Media.get_by_id(media_key_name)
+        if not media:
+            self.abort(400)
+        team_ref = Media.create_reference('team', 'frc{}'.format(team_number))
+        action = self.request.get('action')
+        if action == "remove_media_reference":
+            if team_ref in media.references:
+                media.references.remove(team_ref)
+            if team_ref in media.preferred_references:
+                media.preferred_references.remove(team_ref)
+        elif action == "remove_media_preferred":
+            if team_ref in media.preferred_references:
+                media.preferred_references.remove(team_ref)
+        elif action == "add_media_preferred":
+            if team_ref not in media.preferred_references:
+                media.preferred_references.append(team_ref)
+        else:
+            self.abort(400)
+
+        MediaManipulator.createOrUpdate(media, auto_union=False)
+        self.redirect('/mod/')
 
 
 class TeamAdminRedeem(LoggedInHandler):

--- a/models/team_admin_access.py
+++ b/models/team_admin_access.py
@@ -1,6 +1,7 @@
 
 from google.appengine.ext import ndb
 from models.account import Account
+from models.team import Team
 
 
 class TeamAdminAccess(ndb.Model):
@@ -24,6 +25,10 @@ class TeamAdminAccess(ndb.Model):
     @property
     def key_name(self):
         return self.renderKeyName(self.team_number, self.year)
+
+    @property
+    def team_key(self):
+        return ndb.Key(Team, "frc{}".format(self.team_number))
 
     @classmethod
     def renderKeyName(cls, teamNumber, year):

--- a/templates_jinja2/media_partials/media_display_partial.html
+++ b/templates_jinja2/media_partials/media_display_partial.html
@@ -11,4 +11,7 @@
     {% include "media_partials/grabcad_partial.html" %}
 {% elif media.media_type_enum == 10 %}
     {% include "media_partials/instagram_partial.html" %}
+{% elif media.media_type_enum == 12 %}
+    <!-- Team Avatar -->
+    <img class="team-avatar" src='{{media.avatar_image_source}}'/>
 {% endif %}

--- a/templates_jinja2/team_admin_dashboard.html
+++ b/templates_jinja2/team_admin_dashboard.html
@@ -7,8 +7,90 @@
 {% block content %}
 <div class="container">
 <h1>Team Admin Dashboard</h1>
-<p>Coming soon :)</p>
-<p><a class="btn btn-info" href="/mod/help">Help</a></p>
-<p><a class="btn btn-primary" href="mod/redeem">Redeem</a></p>
+<p>
+  <a class="btn btn-info" href="/mod/help">Help</a>
+  <a class="btn btn-primary" href="mod/redeem">Redeem</a>
+</p>
+<h3>Hi {{user_bundle.account.display_name}}, you have moderator access for {{teams|length}} team{% if teams|length > 1%}s{%endif%}</h3>
+
+<div class="row">
+<div class="col-sm-12">
+<ul class="nav nav-tabs">
+  <li class="active"><a href="#queue" data-toggle="tab">Suggestion Queue</a></li>
+  {% for team_link in existing_access %}
+    <li><a href="#frc{{team_link.team_number}}" data-toggle="tab">Team {{team_link.team_number}} - {{teams[team_link.team_number].nickname}}</a></li>
+  {% endfor %}
+</ul>
+</div>
+</div>
+
+<div class="tab-content">
+<div class="tab-pane active" id="queue">
+<div class="row">
+  {% for team_link in existing_access %}
+    <h2><a href="/team/{{team_link.team_number}}">Team {{team_link.team_number}}</a> - Pending Suggestions</h2>
+    {% for suggestion in suggestions_by_team[team_link.team_number] %}
+    {% else %}
+      <p>No suggestions found!</p>
+    {% endfor %}
+  {% endfor %}
+</div>
+</div>
+
+{% for team_link in existing_access %}
+  <div class="tab-pane" id="frc{{team_link.team_number}}">
+  <div class="row">
+    <h2><a href="/team/{{team_link.team_number}}">Team {{team_link.team_number}}</a> - {{team_link.year}} Media</h2>
+    <table class="table table-striped table-hover table-condensed">
+    <tr><th>Type</th><th>Media</th><th>Tags</th><th>Actions</th></tr>
+    {% for media in team_medias[team_link.team_number] %}
+      <tr>
+        <td>{{media.slug_name}}</td>
+        <td>
+          {% include "media_partials/media_display_partial.html" %}
+        </td>
+        <td>
+          <ul>
+            {% for tag_name in media.tag_names %}
+            <li>{{tag_name}}</li>
+            {%else%}
+              <p>--</p>
+            {% endfor %}
+          </ul>
+        </td>
+        <td>
+          <form id="remove_media_{{media.key_name}}" method="post">
+            <input name="action" type="hidden" value="remove_media_reference" />
+            <input name="team_number" type="hidden" value="{{team_link.team_number}}" />
+            <input name="media_key_name" type="hidden" value="{{media.key_name}}" />
+            <button class="btn btn-danger" type="submit">Remove media reference</button>
+          </form>
+
+          {% if media.is_image %}
+            {% if team_link.team_key in media.preferred_references %}
+            <form id="remove_preferred_{{media.key_name}}" method="post">
+              <input name="action" type="hidden" value="remove_media_preferred" />
+              <input name="team_number" type="hidden" value="{{team_link.team_number}}" />
+              <input name="media_key_name" type="hidden" value="{{media.key_name}}" />
+              <button class="btn btn-warning" type="submit">Remove Preferred</button>
+            </form>
+            {% else %}
+            <form id="add_preferred_{{media.key_name}}" method="post">
+              <input name="action" type="hidden" value="add_media_preferred" />
+              <input name="team_number" type="hidden" value="{{team_link.team_number}}" />
+              <input name="media_key_name" type="hidden" value="{{media.key_name}}" />
+              <button class="btn btn-info" type="submit">Make Preferred</button>
+            {% endif %}
+          {% endif %}
+        </td>
+    {% else %}
+      <tr><td>No media found!</td></tr>
+    {% endfor %}
+    </table>
+  </div>
+  </div>
+{% endfor %}
+
+</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Give team media moderators the ability to remove/make preferred media.

## Description
Does a few things:
 - skeleton out team mod dashboard
 - hook up removing references/managing preferred-ness

This does not yet deal with social media or the suggestion queue. It should probably also implement a modal confirmation before doing writes. And we should also have logging for admin actions...

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2754863/50061056-ebc10480-0169-11e9-9743-19478beaba93.png)