### PR TITLE
Add support for event key type ahead.

### DIFF
--- a/static/javascript/tba_js/tba_typeahead.js
+++ b/static/javascript/tba_js/tba_typeahead.js
@@ -1,10 +1,10 @@
 $(document).ready(function(){
   // Disable browser autocompletes
   $('.typeahead').attr('autocomplete', 'off');
-  
+
   // Set up Twitter Typeahead
   $('.typeahead').typeahead([
-	  {
+    {
       name: 'teams',
       prefetch: {
         url: '/_/typeahead/teams-all',
@@ -21,18 +21,18 @@ $(document).ready(function(){
       header: '<div class="tba-typeahead-header">Events</div>'
     },
     {
-	    name: 'districts',
+      name: 'districts',
       prefetch: {
         url: '/_/typeahead/districts-all',
         filter: districtFilter
       },
       header: '<div class="tba-typeahead-header">Districts</div>'
     }
-	]);
+  ]);
 
-	// Go to event and team pages on select or autocomplete
-	function goToPage(obj, datum) {
-	  var event_re = datum.value.match(/(\d*).+\[(.+?)\]/);
+  // Go to event and team pages on select or autocomplete
+  function goToPage(obj, datum) {
+    var event_re = datum.value.match(eventkeyRegex());
     if (event_re != null) {
       event_key = (event_re[1] + event_re[2]).toLowerCase();
       url = "/event/" + event_key;
@@ -50,7 +50,7 @@ $(document).ready(function(){
       url = "/team/" + team_key;
       window.location.href = url;
     }
-	}
+  }
 
   $('.typeahead').bind('typeahead:selected', goToPage);
   $('.typeahead').bind('typeahead:autocompleted', goToPage);
@@ -90,12 +90,17 @@ function teamFilter(data) {
   return to_return;
 }
 
+function eventkeyRegex() { return /(\d*).+\[(.+?)\]/; }
+
 function eventFilter(data) {
   var to_return = [];
   for(var i=0; i<data.length; i++) {
+    var event_re = cleanUnicode(data[i]).match(eventkeyRegex());
+    var tokens = cleanUnicode(data[i]).replace('[', '').replace(']', '').split(' ');
+    tokens.push((event_re[1] + event_re[2]));
     to_return.push({
       value: data[i],
-      tokens: cleanUnicode(data[i]).replace('[', '').replace(']', '').split(' ')
+      tokens: tokens
     });
   }
   return to_return;


### PR DESCRIPTION
## Description
Generate type ahead tokens for event keys using the same regex as the selected function.

Includes much removal of real tabs, and general whitespace cleanup.

## Motivation and Context
#2332 
Many want the ability to partially type a partial event key into search and return the results. We already support matching the entire event key, but this just takes it to the next level.


## How Has This Been Tested?
General usage in Chromium 71 on debian (couldn't get local typeahead.js to work on Firefox at all which is for another day).

This makes the assumption that `TypeaheadCalcDo` will always generate event strings in a specific human readable format which may or may not be a good idea :man_shrugging:.

## Screenshots (if appropriate):
![tba-typeahead](https://user-images.githubusercontent.com/168291/50135418-1e4e2880-0262-11e9-9720-f6aee1c88134.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
