### PR TITLE
Add back Instagram links in nav bar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -89,6 +89,7 @@
 
       <div class="social-icons">
         <a href="https://www.facebook.com/thebluealliance" title="Like us on Facebook"><i class="fa fa-facebook fa-fw fa-lg"></i></a>
+        <a href="https://www.twitter.com/thebluealliance" title="Follow us on Twitter"><i class="fa fa-twitter fa-fw fa-lg"></i></a>
         <a href="https://www.instagram.com/the_blue_alliance" title="Follow us on Instagram"><i class="fa fa-instagram fa-fw fa-lg"></i></a>
       </div>
     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -89,8 +89,7 @@
 
       <div class="social-icons">
         <a href="https://www.facebook.com/thebluealliance" title="Like us on Facebook"><i class="fa fa-facebook fa-fw fa-lg"></i></a>
-        <!--<a href="https://instagram.com/the_blue_alliance" title="Follow us on Instagram"><i class="fa fa-instagram fa-fw fa-lg"></i></a>
-        <a href="https://twitter.com/thebluealliance" title="Follow us on Twitter"><i class="fa fa-twitter fa-fw fa-lg"></i></a>-->
+        <a href="https://www.instagram.com/the_blue_alliance" title="Follow us on Instagram"><i class="fa fa-instagram fa-fw fa-lg"></i></a>
       </div>
     </div>
   </div>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -85,6 +85,7 @@
 
       <div class="social-icons">
         <a href="https://www.facebook.com/thebluealliance" title="Like us on Facebook"><i class="fa fa-facebook fa-fw fa-lg"></i></a>
+        <a href="https://www.twitter.com/thebluealliance" title="Follow us on Twitter"><i class="fa fa-twitter fa-fw fa-lg"></i></a>
         <a href="https://www.instagram.com/the_blue_alliance" title="Follow us on Instagram"><i class="fa fa-instagram fa-fw fa-lg"></i></a>
       </div>
     </div>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -85,8 +85,7 @@
 
       <div class="social-icons">
         <a href="https://www.facebook.com/thebluealliance" title="Like us on Facebook"><i class="fa fa-facebook fa-fw fa-lg"></i></a>
-        <!--<a href="https://instagram.com/the_blue_alliance" title="Follow us on Instagram"><i class="fa fa-instagram fa-fw fa-lg"></i></a>
-        <a href="https://twitter.com/thebluealliance" title="Follow us on Twitter"><i class="fa fa-twitter fa-fw fa-lg"></i></a>-->
+        <a href="https://www.instagram.com/the_blue_alliance" title="Follow us on Instagram"><i class="fa fa-instagram fa-fw fa-lg"></i></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
Not entirely sure why it was commented out, 51c5ebfdf0ab8b89cac7e81c9d082a61ed953e59 isn't really clear about that. This brings it back.

## Motivation and Context
#2345 

## How Has This Been Tested?
:eye: chromium 71, firefox 60.4, iOS safari
 
## Screenshots (if appropriate):
![instagram-lists](https://user-images.githubusercontent.com/168291/50323394-7b86eb80-04a7-11e9-9b34-19e82452a7c8.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
