### PR TITLE
 Fix cases where EventDetail types API returns null 

### DIFF
--- a/database/dict_converters/event_details_converter.py
+++ b/database/dict_converters/event_details_converter.py
@@ -31,13 +31,23 @@ class EventDetailsConverter(ConverterBase):
                         normalized_oprs[stat_type][team] = value
 
         event_details.matchstats if event_details else None
+        rankings = {}
+        if event_details:
+            rankings = event_details.renderable_rankings
+        else:
+            rankings = {
+                "extra_stats_info": [],
+                "rankings": None,
+                "sort_order_info": None
+            }
+
         event_details_dict = {
-            'alliances': event_details.alliance_selections if event_details else None,
-            'district_points': event_details.district_points if event_details else None,
-            'insights': event_details.insights if event_details else None,
-            'oprs': normalized_oprs if normalized_oprs else None,  # OPRs, DPRs, CCWMs
-            'predictions': event_details.predictions if event_details else None,
-            'rankings': event_details.renderable_rankings if event_details else None,
+            'alliances': event_details.alliance_selections if event_details else [],
+            'district_points': event_details.district_points if event_details else {},
+            'insights': event_details.insights if event_details else {'qual': {}, 'playoff': {}},
+            'oprs': normalized_oprs if normalized_oprs else {},  # OPRs, DPRs, CCWMs
+            'predictions': event_details.predictions if event_details else {},
+            'rankings': rankings
         }
 
         return event_details_dict

--- a/tba_config.py
+++ b/tba_config.py
@@ -44,7 +44,7 @@ CONFIG["static_resource_version"] = 8
 
 
 def _get_max_year():
-    DEFAULT_YEAR = 2018
+    DEFAULT_YEAR = 2019
     try:
         status_sitevar = Sitevar.get_by_id('apistatus')
         return status_sitevar.contents.get(


### PR DESCRIPTION
## Description
Sometimes we haven't (or can't) computed event details for certain events. In those cases we return null, but actually we should return sensible results like empty objects.

Fixes #2333

## Motivation and Context
#2333 and reasonable API expectations

## How Has This Been Tested?
Locally get yourself an event, and then nuke the EventDetail record from the datastore. This matches what we have in production for an event like `1992cmp`.

`curl -H 'X-TBA-Auth-Key: {}' http://localhost:8080/api/v3/event/1992cmp/rankings`
```
{
  "extra_stats_info": [], 
  "rankings": null, 
  "sort_order_info": null
}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
