### PR TITLE
Hotfix the CD media links

### DIFF
--- a/templates_jinja2/media_partials/cdphotothread_partial.html
+++ b/templates_jinja2/media_partials/cdphotothread_partial.html
@@ -1,8 +1,8 @@
 <div class="thumbnail cdphotothread-thumbnail">
-  <a href="{{media.image_direct_url}}" class="gallery">
-    <span style="background-image:url('{{media.image_direct_url_med}}')"></span>
+  <a href="https://web.archive.org/web/{{media.image_direct_url}}" class="gallery">
+    <span style="background-image:url('https://web.archive.org/web/{{media.image_direct_url_med}}')"></span>
   </a>
   <div class="caption">
-    <a href="{{media.cdphotothread_thread_url}}" target="_blank">ChiefDelphi Discussion</a>
+    <a href="https://web.archive.org/web/{{media.cdphotothread_thread_url}}" target="_blank">ChiefDelphi Discussion</a>
   </div>
 </div>


### PR DESCRIPTION
## Description
Hotfix the CD images, for now.

## Motivation and Context
CD media is currently entirely foobar'ed on the site, and we're not sure yet when things will be back up, or when the permanent migration/solution will be available.  In the meantime, we can link the images from the Wayback Machine.

## How Has This Been Tested?
Locally, everything is working as intended.  See screenshots below.
I used the following page for testing:
https://www.thebluealliance.com/team/2056/2014

## Screenshots:
Before the fix:
![](https://i.imgur.com/oCYQSWd.png)

After the fix:
![](https://i.imgur.com/2QbLB2Y.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
