### PR TITLE
Fix 404ing Tasks from Admin Interface & location_helper API check

### DIFF
--- a/helpers/location_helper.py
+++ b/helpers/location_helper.py
@@ -500,7 +500,7 @@ class LocationHelper(object):
             google_secrets = Sitevar.get_by_id("google.secrets")
             google_api_key = None
             if google_secrets is None:
-                logging.warning("Missing sitevar: google.api_key. API calls rate limited by IP and may be over rate limit.")
+                raise ndb.Return([])
             else:
                 google_api_key = google_secrets.contents['api_key']
 
@@ -510,6 +510,8 @@ class LocationHelper(object):
             }
             if google_api_key:
                 geocode_params['key'] = google_api_key
+            else:
+                raise ndb.Return([])
             geocode_url = 'https://maps.googleapis.com/maps/api/geocode/json?%s' % urllib.urlencode(geocode_params)
             try:
                 geocode_results = yield context.urlfetch(geocode_url)

--- a/templates/admin/tasks.html
+++ b/templates/admin/tasks.html
@@ -218,64 +218,6 @@
 
 <hr>
 
-<h2>Other Cron Tasks</h2>
-
-<h3>Calculate Year Insights</h3>
-<p>Generate Insights by year or overall</p>
-<div class="row">
-    <div class="col-sm-6">
-        <span class="help-block">Enqueue Award Insights</span>
-        <form class="form-inline">
-            <div class="input-group">
-                <input class="form-control" id="enqueue_award_insights_year" type="text" placeholder="2017">
-                <span class="input-group-btn" id="enqueue_award_insights_year_submit">
-                    <button class="btn btn-warning" type="button">Go <span class="glyphicon glyphicon-fast-forward"></span></button>
-                </span>
-            </div>
-        </form>
-        <script>
-        $("#enqueue_award_insights_year_submit").click(function() {
-            window.location = "/tasks/math/enqueue/insights/awards/" + $("#enqueue_award_insights_year").val();
-        });
-        </script>
-    </div>
-    <div class="col-sm-6">
-        <span class="help-block">Enqueue Match Insights</span>
-        <form class="form-inline">
-            <div class="input-group">
-                <input class="form-control" id="enqueue_match_insights_year" type="text" placeholder="2017">
-                <span class="input-group-btn" id="enqueue_match_insights_year_submit">
-                    <button class="btn btn-warning" type="button">Go <span class="glyphicon glyphicon-fast-forward"></span></button>
-                </span>
-            </div>
-        </form>
-        <script>
-        $("#enqueue_match_insights_year_submit").click(function() {
-            window.location = "/tasks/math/enqueue/insights/matches/" + $("#enqueue_match_insights_year").val();
-        });
-        </script>
-    </div>
-</div>
-<h3>Calculate Overall Insights</h3>
-<div class="row">
-    <div class="col-sm-6">
-        <a class="btn btn-warning" href="/tasks/math/enqueue/overallinsights/awards">Enqueue Overall Award Insights</a>
-    </div>
-    <div class="col-sm-6">
-        <a class="btn btn-warning" href="/tasks/math/enqueue/overallinsights/matches">Enqueue Overall Match Insights</a>
-    </div>
-</div>
-
-<h3>Calculate Typeahead</h3>
-<p>Generate TypeaheadEntries</p>
-<div class="row">
-    <div class="col-sm-6">
-        <a class="btn btn-warning" href="/tasks/math/enqueue/typeaheadcalc">Calc Typeahead!</a>
-    </div>
-</div>
-
-<hr>
-
 <h2>Special Tasks<h2>
 <h3>Special Registration Days</h3>
 <div class="row">


### PR DESCRIPTION
First, remove the insights task enqueuing items from the Admin Task interface -- they have long since been removed from the backend. Second, the `location_helper` will attempt to geolocate events even if there is no Google API key present. In the past this was ok, a small number of requests were permitted without a key, but this is no longer the case.

## Motivation and Context
Both are dev instance quality-of-life items.

## How Has This Been Tested?
Tested on local dev instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
