### PR TITLE
Correct vagrant version listed in dev docs

### DIFF
--- a/docs/dev-container.md
+++ b/docs/dev-container.md
@@ -5,7 +5,7 @@ We have a development container setup that uses [`vagrant`](https://www.vagrantu
 
 You should be able to install `docker` and `vagrant` from your system's package manager (Homebrew, `apt`, etc.).
 
-Ensure that the version of `vagrant` is at least `1.8.1` (run `vagrant --version` to confirm). Some linux distributions, like Debian, may not always have the newest version available in the repositories. If that's the case, you may need to install `vagrant` from [the website](https://www.vagrantup.com).
+Ensure that the version of `vagrant` is at least `2.1.0` (run `vagrant --version` to confirm). Some linux distributions, like Debian, may not always have the newest version available in the repositories. If that's the case, you may need to install `vagrant` from [the website](https://www.vagrantup.com).
 
 This is optional, but you may also want to configure running `docker` as a non-root user and to automatically start on system boot. You can find instructions [here](https://docs.docker.com/engine/installation/linux/linux-postinstall/).
 


### PR DESCRIPTION
## Description
Vagrant version was listed as 1.8.1, but the actual required version from the Vagrantfile is 2.1.0
## Motivation and Context
Resolves misinformation - Ubuntu 18.04 apt repos install vagrant 2.0.2, which do not work.

## How Has This Been Tested?
Vagrantfile confirms this.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
