### PR TITLE
Change order of service deploys to deploy services before dispatch

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -76,7 +76,7 @@ def main():
             modules = args.modules.split(",")
         else:
             # Full deploy
-            modules = ["app.yaml", "app-backend-tasks-b2.yaml", "app-backend-tasks.yaml", "cron.yaml", "dispatch.yaml", "index.yaml", "queue.yaml", "tbans.yaml"]
+            modules = ["app.yaml", "app-backend-tasks-b2.yaml", "app-backend-tasks.yaml", "tbans.yaml", "cron.yaml", "dispatch.yaml", "index.yaml", "queue.yaml"]
         if args.skip_cron and "cron.yaml" in modules:
             modules.remove("cron.yaml")
         cmd.extend(modules)

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -63,7 +63,7 @@ trap release_lock EXIT INT TERM
 
 echo "Obtained Lock. Deploying $PROJECT:$VERSION"
 # need more permissions for cron.yaml queue.yaml index.yaml, we can come back to them
-for config in dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml cron.yaml tbans.yaml; do
+for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml cron.yaml dispatch.yaml; do
     with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $config --version $VERSION"
 done
 


### PR DESCRIPTION
Attempting to fix the [failed TBANS deploy](https://travis-ci.org/the-blue-alliance/the-blue-alliance/jobs/476013831) by moving `dispatch.yaml` to be the last thing deployed