### PR TITLE
Fix missing app_identity import in TBANS

### DIFF
--- a/tbans/tbans_service.py
+++ b/tbans/tbans_service.py
@@ -1,6 +1,8 @@
 import logging
 import tba_config
 
+from google.appengine.api.app_identity import app_identity
+
 from protorpc import remote
 from protorpc.wsgi import service
 


### PR DESCRIPTION
We're seeing errors right now being thrown because of a missing import in TBANS. This code path is only executed on prod which is why I didn't catch is 😓 