### PR TITLE
Add dynamic stop-build dates for homepage

### DIFF
--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -18,6 +18,7 @@ from consts.media_tag import MediaTag
 from consts.media_type import MediaType
 from database import media_query
 from helpers.event_helper import EventHelper
+from helpers.season_helper import SeasonHelper
 from helpers.firebase.firebase_pusher import FirebasePusher
 from models.award import Award
 from models.event import Event
@@ -151,7 +152,7 @@ class MainBuildseasonHandler(CacheableHandler):
     def _render(self, *args, **kw):
         endbuild_datetime_est = datetime.datetime.strptime(
             self.template_values['build_season_end'], "%Y-%m-%dT%H:%M:%S"
-        ) if 'build_season_end' in self.template_values else None
+        ) if 'build_season_end' in self.template_values else SeasonHelper.stop_build_date()
         endbuild_datetime_utc = pytz.utc.localize(
             endbuild_datetime_est + datetime.timedelta(hours=5))
         week_events = EventHelper.getWeekEvents()

--- a/helpers/season_helper.py
+++ b/helpers/season_helper.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime, timedelta
+
+
+class SeasonHelper:
+    """ General season-information helper methods """
+
+    @staticmethod
+    def kickoff_date(year=datetime.now().year):
+        """ Computes the date of Kickoff for a given year. Kickoff is always the first Saturday in January after Jan 2nd. """
+        jan_2nd = date(year, 1, 2)
+        days_ahead = 5 - jan_2nd.weekday()  # Saturday is 5
+        # Kickoff won't occur *on* Jan 2nd if it's a Saturday - it'll be the next Saturday
+        if days_ahead <= 0:
+            days_ahead += 7
+        return jan_2nd + timedelta(days=days_ahead)
+
+    @staticmethod
+    def stop_build_date(year=datetime.now().year):
+        """ Computes day teams are done working on robots. The stop build day is kickoff + 6 weeks + 3 days. Set to 23:59:59 """
+        return datetime.combine(SeasonHelper.kickoff_date(year=year) + timedelta(days=4, weeks=6), datetime.min.time()) - timedelta(seconds=1)

--- a/tests/test_season_helper.py
+++ b/tests/test_season_helper.py
@@ -1,0 +1,32 @@
+import unittest2
+from datetime import date, datetime
+
+from helpers.season_helper import SeasonHelper
+
+
+class TestSeasonHelper(unittest2.TestCase):
+
+    def test_kickoff_date(self):
+        # 2011 - Saturday the 8th (https://en.wikipedia.org/wiki/Logo_Motion)
+        kickoff_2011 = date(2011, 1, 8)
+        self.assertEqual(SeasonHelper.kickoff_date(year=2011), kickoff_2011)
+        # 2010 - Saturday the 9th (https://en.wikipedia.org/wiki/Breakaway_(FIRST))
+        kickoff_2010 = date(2010, 1, 9)
+        self.assertEqual(SeasonHelper.kickoff_date(year=2010), kickoff_2010)
+        # 2009 - Saturday the 3rd (https://en.wikipedia.org/wiki/Lunacy_(FIRST)
+        kickoff_2009 = date(2009, 1, 3)
+        self.assertEqual(SeasonHelper.kickoff_date(year=2009), kickoff_2009)
+
+    def test_stop_build_date(self):
+        # 2019 - Feb 19th, 2019
+        stop_build_2019 = datetime(2019, 2, 19, 23, 59, 59)
+        self.assertEqual(SeasonHelper.stop_build_date(year=2019), stop_build_2019)
+        # 2018 - Feb 20th, 2018
+        stop_build_2018 = datetime(2018, 2, 20, 23, 59, 59)
+        self.assertEqual(SeasonHelper.stop_build_date(year=2018), stop_build_2018)
+        # 2017 - Feb 21th, 2017
+        stop_build_2017 = datetime(2017, 2, 21, 23, 59, 59)
+        self.assertEqual(SeasonHelper.stop_build_date(year=2017), stop_build_2017)
+        # 2016 - Feb 23th, 2016
+        stop_build_2016 = datetime(2016, 2, 23, 23, 59, 59)
+        self.assertEqual(SeasonHelper.stop_build_date(year=2016), stop_build_2016)


### PR DESCRIPTION
Adds dynamic stop build dates for homepage - closes #2381

I'm realizing the lifespan of this code is probably... 43 days 😓 

Prod vs Dev (somehow, one minute off?)

<img width="1527" alt="screen shot 2019-01-07 at 11 48 29 pm" src="https://user-images.githubusercontent.com/516458/50810330-0dc82580-12d7-11e9-8b98-a62f22372fb9.png">
<img width="1487" alt="screen shot 2019-01-07 at 11 48 26 pm" src="https://user-images.githubusercontent.com/516458/50810337-14ef3380-12d7-11e9-8211-29aff477d5ec.png">
