### PR TITLE
Add location schema.org field to Event locations

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -19,7 +19,6 @@
   {% if event.venue %}<meta property="og:fn" content="{{event.venue}}" />{% endif %}
 {% endblock %}
 
-
 {% block content %}
 {% if event_down %}
   <div id="fixed-alert-container">
@@ -70,18 +69,22 @@
         {% endif %}
         {% if event.nl and event.nl.name and event.nl.city_state_country %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
+          <span itemprop="location">
           {% if event.nl and event.nl.name %}
             <a href="{{event.nl.place_details.url}}" target="_blank">{{event.nl.name}}</a> in {{event.nl.city_state_country}}
           {% else %}
             <a href="//maps.google.com/maps?q={{ event.city_state_country|urlencode }}" target="_blank">{{event.city_state_country}}</a>
           {% endif %}
+          </span>
         {% elif event.location or event.venue_address_safe %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
+          <span itemprop="location">
           {% if event.venue_address_safe %}
             <a href="http://maps.google.com/maps?q={{ event.venue_address_safe|urlencode }}" target="_blank">{{ event.venue_or_venue_from_address }}</a>{% if event.location %} in {{event.location}}{% endif %}
           {% else %}
             <a href="http://maps.google.com/maps?q={{ event.location|urlencode }}" target="_blank">{{event.location}}</a>
           {% endif %}
+          </span>
         {% endif %}
         {% if event.website %}<br><span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
         {% if event.first_eid or event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="{% if event.first_eid %}https://www.firstinspires.org/team-event-search/event?id={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank">firstinspires.org</a>{% endif %}


### PR DESCRIPTION
## Description
Corrects Google Structured Data errors for Events lacking location attributes. Fixes #2313

## Motivation and Context
Improve structured data for search engines.

## How Has This Been Tested?
Compared master and this branch in the https://search.google.com/structured-data/testing-tool/ .

I did not test both codepaths for emitting event locations, since I don't know what causes one or the other to be used, but believe this change covers both.

## Screenshots (if appropriate):

![screenshot 2019-01-12 17 14 44](https://user-images.githubusercontent.com/57101/51079022-b981c480-168d-11e9-8410-71b9c5c46686.png)

![screenshot 2019-01-12 17 13 57](https://user-images.githubusercontent.com/57101/51079023-bbe41e80-168d-11e9-8f21-96964a9bb783.png)


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
