### PR TITLE
Schema org markup for Google

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,9 +35,11 @@
   {% block more_head_tags %}
     <meta property="og:title" content="The Blue Alliance" />
     <meta property="og:image" content="https://www.thebluealliance.com/images/logo_square_512.png" />
-    <meta property="og:description" content="Team information, webcasts, results, and more from the FIRST Robotics Competition."/>
+    <meta property="og:description" content="Watch webcasts and get team information, competition results, and more from the FIRST Robotics Competition."/>
     <meta property="og:site_name" content="The Blue Alliance" />
   {% endblock %}
+
+  {% block schema_org_markup %}{% endblock %}
 </head>
 <body>
 

--- a/templates/index_buildseason.html
+++ b/templates/index_buildseason.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}The Blue Alliance{% endblock %}
+{% block schema_org_markup %}{% include "index_partials/schema_org_markup.html" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index_champs.html
+++ b/templates/index_champs.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}The Blue Alliance{% endblock %}
+{% block schema_org_markup %}{% include "index_partials/schema_org_markup.html" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}The Blue Alliance{% endblock %}
+{% block schema_org_markup %}{% include "index_partials/schema_org_markup.html" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index_insights.html
+++ b/templates/index_insights.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}The Blue Alliance{% endblock %}
+{% block schema_org_markup %}{% include "index_partials/schema_org_markup.html" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index_kickoff.html
+++ b/templates/index_kickoff.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}The Blue Alliance{% endblock %}
+{% block schema_org_markup %}{% include "index_partials/schema_org_markup.html" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index_offseason.html
+++ b/templates/index_offseason.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}The Blue Alliance{% endblock %}
+{% block schema_org_markup %}{% include "index_partials/schema_org_markup.html" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index_partials/schema_org_markup.html
+++ b/templates/index_partials/schema_org_markup.html
@@ -1,0 +1,29 @@
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "description": "Watch webcasts and get team information, competition results, and more from the FIRST Robotics Competition.",
+    "email": "contact@thebluealliance.com",
+    "logo": "https://www.thebluealliance.com/images/logo_square_512.png",
+    "name": "The Blue Alliance",
+    "sameAs": [
+      "https://www.facebook.com/thebluealliance",
+      "https://github.com/the-blue-alliance/",
+      "https://www.instagram.com/the_blue_alliance",
+      "https://twitter.com/thebluealliance"
+    ],
+    "url": "https://www.thebluealliance.com"
+  }
+</script>
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "url": "https://www.thebluealliance.com",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://www.thebluealliance.com/search?q={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  }
+</script>


### PR DESCRIPTION
## Description
Adds schema.org markup for:
1. `Organization` to hopefully get us a Knowledge Panel
  * https://developers.google.com/search/docs/guides/enhance-site
  * https://developers.google.com/search/docs/data-types/corporate-contact
2. `WebSite` to tell Google about our search box
  * https://developers.google.com/search/docs/data-types/sitelinks-searchbox

Fixes #1815

## Motivation and Context
Be fancy in search engines

## How Has This Been Tested?
Pasted local HTML into Google structured testing tool.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/57101/51079441-26e52380-1695-11e9-9d52-1d646ec1c33f.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
