### PR TITLE
Use HTTPS for YouTube image URLs

### DIFF
--- a/database/dict_converters/media_converter.py
+++ b/database/dict_converters/media_converter.py
@@ -29,7 +29,7 @@ class MediaConverter(ConverterBase):
             'direct_url': None,
         }
         if media.slug_name == "youtube":
-            dict["direct_url"] = "http://img.youtube.com/vi/{}/hqdefault.jpg".format(media.foreign_key)
+            dict["direct_url"] = "https://img.youtube.com/vi/{}/hqdefault.jpg".format(media.foreign_key)
             dict["view_url"] = media.youtube_url_link
         else:
             dict["direct_url"] = media.image_direct_url

--- a/database/dict_converters/media_converter.py
+++ b/database/dict_converters/media_converter.py
@@ -3,7 +3,7 @@ from database.dict_converters.converter_base import ConverterBase
 
 class MediaConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        3: 3,
+        3: 4,
     }
 
     @classmethod


### PR DESCRIPTION
## Description
The direct image URLs for YouTube videos are currently exposed as HTTP links instead of HTTPS links. This changes switches them to use HTTPS.

## Motivation and Context
The Android app would like to use the media URLs exposed via the API instead of generating those URLs ourselves (see [#885](https://github.com/the-blue-alliance/the-blue-alliance-android/issues/885)). However, as of Android 9 (Pie), cleartext traffic is disabled by default. While we could enable it here, there is no compelling reason to do so instead of just getting HTTPS links to begin with.

## How Has This Been Tested?
I set up a dev environment with this change, and observed no regression on the team pages under media (which makes sense, as it does not appear as though the web site is consuming this- it is exposed for other clients).

The HTTP versions of these URLs redirect to the HTTPS versions anyway.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
