### PR TITLE
Experimental APIv3 feature to guarantee a fresh response

### DIFF
--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -64,7 +64,6 @@ class ApiBaseController(CacheableHandler):
         self._partial_cache_key = '_'.join([
             'v{}_{}'.format(self.API_VERSION, self.__class__.__name__)] +
             [x[1] for x in kwargs_sorted])
-
         self._cache_expiration = self.CACHE_HEADER_LENGTH
 
     def handle_exception(self, exception, debug):

--- a/controllers/apiv3/api_base_controller.py
+++ b/controllers/apiv3/api_base_controller.py
@@ -152,7 +152,7 @@ class ApiBaseController(CacheableHandler):
                 self.auth_owner = 'The Blue Alliance'
             else:
                 self._errors = {"Error": "X-TBA-Auth-Key is a required header or URL param. Please get an access key at http://www.thebluealliance.com/account."}
-                self.abort(401)
+                self.abort(400)
 
         if self.auth_owner:
             logging.info("Auth owner: {}, LOGGED IN".format(self.auth_owner))


### PR DESCRIPTION
I don't know if this actually works.

## Description
APIv3 now checks for a `?time=<epoch>` param. If it is within the last minute, the cache header is extended to 1 hour.
Assumption: Edge caches treat differing query strings as unique

## Motivation and Context
To enable a way to get a fresh API response without completely destroying caching. This isn't meant to be a public API, just a way for clients to get fresh data while hitting the same URL with a time provided by Firebase.

## How Has This Been Tested?
Tested locally:
1) Without a time param and verified that the cache header behaved normally.
2) With a time param within the last minute and verified that the `_partial_cache_key` was properly updated and cache header was extended
3) With a time param outside a valid range and verified that the response returned a 400 Bad Request.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
