### PR TITLE
Update Award_Recipient docs to list that awardee and team_key may be null

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -5728,7 +5728,7 @@
             "instagram-image",
             "external-link",
             "avatar"
-          ] 
+          ]
         },
         "foreign_key": {
           "type": "string",
@@ -5839,7 +5839,7 @@
         },
         "recipient_list": {
           "type": "array",
-          "description": "A list of recipients of the award at the event. Either team_key and/or awardee for individual awards.",
+          "description": "A list of recipients of the award at the event. May have either a team_key or an awardee, both, or neither (in the case the award wasn't awarded at the event).",
           "items": {
             "$ref": "#/definitions/Award_Recipient"
           }


### PR DESCRIPTION
I'm open to fixing the wording on this one - just want to make sure we call out that both fields may be null in some cases, since the current docs don't say that.