### PR TITLE
Remove extra `{`

### DIFF
--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2019.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2019.html
@@ -411,7 +411,7 @@
         </svg>
         {% endif %}
         {% if match.score_breakdown.red.habDockingRankingPoint %}
-        <svg class="top-left-dot-2" rel="tooltip" title="HAB Docking}">
+        <svg class="top-left-dot-2" rel="tooltip" title="HAB Docking">
           <circle cx="2" cy="2" r="2"/>
         </svg>
         {% endif %}


### PR DESCRIPTION
The HAB Docking tooltip had an extra `{`.  Fixes the typo.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Delete the `{` character.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If the `{` was included it is probably a typo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It has not...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
