### PR TITLE
Add Event Week to Team Pages

### DIFF
--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -17,7 +17,6 @@ from models.match import Match
 CHAMPIONSHIP_EVENTS_LABEL = 'FIRST Championship'
 TWO_CHAMPS_LABEL = 'FIRST Championship - {}'
 FOC_LABEL = 'FIRST Festival of Champions'
-REGIONAL_EVENTS_LABEL = 'Week {}'
 WEEKLESS_EVENTS_LABEL = 'Other Official Events'
 OFFSEASON_EVENTS_LABEL = 'Offseason'
 PRESEASON_EVENTS_LABEL = 'Preseason'
@@ -80,11 +79,7 @@ class EventHelper(object):
                    (event.start_date.month == 12 and event.start_date.day == 31)):
                     weekless_events.append(event)
                 else:
-                    week = event.week
-                    if event.year == 2016:  # Special case for 2016 week 0.5
-                        label = REGIONAL_EVENTS_LABEL.format(0.5 if week == 0 else week)
-                    else:
-                        label = REGIONAL_EVENTS_LABEL.format(week + 1)
+                    label = event.week_str
                     if label in to_return:
                         to_return[label].append(event)
                     else:

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -66,7 +66,7 @@
           <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
         {% endif %}
         {% if event.start_date %}
-          <span class="glyphicon glyphicon-calendar"></span> <time itemprop="startDate" datetime="{{event.start_date.isoformat()}}">{{ event.start_date|strftime("%B %d") }}{% if event.start_date.date() != event.end_date.date() %}</time> to <time itemprop="endDate" datetime="{{event.end_date.isoformat()}}">{{ event.end_date|strftime("%B %d") }}{% endif %}, {{ event.end_date|strftime("%Y") }}</time> {% if event.week_str %}<span class="badge">{{event.week_str}}</span>{% endif %}
+          <span class="glyphicon glyphicon-calendar"></span> <time itemprop="startDate" datetime="{{event.start_date.isoformat()}}">{{ event.start_date|strftime("%B %d") }}{% if event.start_date.date() != event.end_date.date() %}</time> to <time itemprop="endDate" datetime="{{event.end_date.isoformat()}}">{{ event.end_date|strftime("%B %d") }}{% endif %}, {{ event.end_date|strftime("%Y") }}</time>{% if event.week_str %} <a href="/events/{{event.year}}#{{event.week_str|slugify}}"><span class="badge">{{event.week_str}}</span></a>{% endif %}
         {% endif %}
         {% if event.nl and event.nl.name and event.nl.city_state_country %}
           <br><span class="glyphicon glyphicon-map-marker"></span>

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% import 'match_partials/match_table_macros.html' as mtm %}
+{% import 'event_partials/event_macros.html' as em %}
 
 {% block title %}{{event.name}} ({{event.year}}) - The Blue Alliance{% endblock %}
 
@@ -65,9 +66,7 @@
         {% if parent_event %}
           <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
         {% endif %}
-        {% if event.start_date %}
-          <span class="glyphicon glyphicon-calendar"></span> <time itemprop="startDate" datetime="{{event.start_date.isoformat()}}">{{ event.start_date|strftime("%B %d") }}{% if event.start_date.date() != event.end_date.date() %}</time> to <time itemprop="endDate" datetime="{{event.end_date.isoformat()}}">{{ event.end_date|strftime("%B %d") }}{% endif %}, {{ event.end_date|strftime("%Y") }}</time>{% if event.week_str %} <a href="/events/{{event.year}}#{{event.week_str|slugify}}"><span class="badge">{{event.week_str}}</span></a>{% endif %}
-        {% endif %}
+        {{ em.showEventDates(event) }}
         {% if event.nl and event.nl.name and event.nl.city_state_country %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
           {% if event.nl and event.nl.name %}

--- a/templates_jinja2/event_partials/event_macros.html
+++ b/templates_jinja2/event_partials/event_macros.html
@@ -1,0 +1,5 @@
+{% macro showEventDates(event) %}
+{% if event.start_date %}
+  <span class="glyphicon glyphicon-calendar"></span> <time itemprop="startDate" datetime="{{event.start_date.isoformat()}}">{{ event.start_date|strftime("%B %d") }}{% if event.start_date.date() != event.end_date.date() %}</time> to <time itemprop="endDate" datetime="{{event.end_date.isoformat()}}">{{ event.end_date|strftime("%B %d") }}{% endif %}, {{ event.end_date|strftime("%Y") }}</time>{% if event.week_str %} <a href="/events/{{event.year}}#{{event.week_str|slugify}}"><span class="badge">{{event.week_str}}</span></a>{% endif %}
+{% endif %}
+{% endmacro %}

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% import 'match_partials/match_table_macros.html' as mtm %}
 {% import 'team_partials/blue_banner_macros.html' as bbm %}
+{% import 'event_partials/event_macros.html' as em %}
 
 {% block title %}{% if team.nickname %}{{team.nickname}} - {% endif %}Team {{team.team_number}}{% if not is_canonical %} ({{year}}){% endif %} - The Blue Alliance{% endblock %}
 
@@ -103,7 +104,7 @@
                 <h3><a href="/event/{{ comp.event.key_name }}">{{ comp.event.name }}</a></h3>
                 <p>
                   {% if comp.event.location %}<span class="glyphicon glyphicon-map-marker"></span> in <a href="http://maps.google.com/maps?q={{ comp.event.location }}" target="_blank">{{ comp.event.location }}</a><br />{% endif %}
-                  {% if comp.event.start_date %}<span class="glyphicon glyphicon-calendar"></span> {{ comp.event.start_date|strftime("%B %d") }}{% if comp.event.start_date != comp.event.end_date %} - {{ comp.event.end_date|strftime("%B %d") }}{% endif %}, {{ comp.event.end_date|strftime("%Y") }}{% endif %}
+                  {{ em.showEventDates(comp.event) }}
                 </p>
 
                 {% if comp.wlt or comp.rank or comp.awards or comp.qual_avg or comp.elim_avg %}

--- a/tests/test_event_group_by_week.py
+++ b/tests/test_event_group_by_week.py
@@ -8,7 +8,7 @@ from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
 from consts.event_type import EventType
-from helpers.event_helper import EventHelper, REGIONAL_EVENTS_LABEL, CHAMPIONSHIP_EVENTS_LABEL,\
+from helpers.event_helper import EventHelper, CHAMPIONSHIP_EVENTS_LABEL,\
     WEEKLESS_EVENTS_LABEL, OFFSEASON_EVENTS_LABEL, PRESEASON_EVENTS_LABEL
 from models.event import Event
 
@@ -39,7 +39,7 @@ class TestEventGroupByWeek(unittest2.TestCase):
         week_start = datetime.datetime(2013, 2, 27)
         for i in range(1, 7):  # test for 6 weeks
             for _ in range(state.randint(1, 15)):  # random number of events per week
-                week_label = REGIONAL_EVENTS_LABEL.format(i)
+                week_label = 'Week {}'.format(i)
 
                 start_date = week_start + datetime.timedelta(days=state.randint(0, 6))
                 end_date = start_date + datetime.timedelta(days=state.randint(0, 3))


### PR DESCRIPTION
## Description
- Use `Event.week_str` in `event_helper.py` to de-dupe week string generation.
- Add link to `/events/<year>#<week>` on week badges.
- Refactor code to use same date generation logic on Event and Team pages.

## How Has This Been Tested?
Local dev.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/52971372-3555e780-3385-11e9-8a71-1287a5745cad.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
