### PR TITLE
Collapse contents_json for long metadata suggestion types

### DIFF
--- a/templates_jinja2/suggestions/suggest_match_video_review_list.html
+++ b/templates_jinja2/suggestions/suggest_match_video_review_list.html
@@ -46,7 +46,8 @@
                             <li>{{ suggestion.author.get().email }}</li>
                             <li>{{ suggestion.author.get().nickname }}</li>
                             <li>{{ suggestion.target_model }}:{{ suggestion.target_key }}</li>
-                            <li>{{ suggestion.contents_json }}</li>
+                            <li><a href="#{{suggestion.key.id()}}-contents_json" data-toggle="collapse">Show contents_json</a></li>
+                            <li id="{{suggestion.key.id()}}-contents_json" class="collapse"></li>
                         </ul>
                     </div>
                     <div class="clearfix"></div>

--- a/templates_jinja2/suggestions/suggest_team_media_review_list.html
+++ b/templates_jinja2/suggestions/suggest_team_media_review_list.html
@@ -113,7 +113,8 @@
                           <li>{{ suggestion.key.id() }}</a></li>
                           <li>{{ suggestion.author.get().email }}</a></li>
                           <li>{{ suggestion.author.get().nickname }}</a></li>
-                          <li>{{ suggestion.contents_json }}</li>
+                          <li><a href="#{{suggestion.key.id()}}-contents_json" data-toggle="collapse">Show contents_json</a></li>
+                          <li id="{{suggestion.key.id()}}-contents_json" class="collapse">{{ suggestion.contents_json }}</li>
                           <li>{{ suggestion.private_details_json }}</li>
                       </ul>
                   </div>


### PR DESCRIPTION
## Description
Adds a toggle using Bootstrap built-ins to hide contents_json for some suggestions, particularly Team Media, where Instagram is TOO LONG.

## Motivation and Context
Mod quality of life

## How Has This Been Tested?
Screenshots below from my dev instance

## Screenshots (if appropriate):

Before:
<img width="1372" alt="screenshot 2019-02-26 16 18 29" src="https://user-images.githubusercontent.com/57101/53447332-e6dac580-39e2-11e9-8902-15b7ae77ad17.png">


After collapsed:
<img width="1372" alt="screenshot 2019-02-26 16 21 40" src="https://user-images.githubusercontent.com/57101/53447350-ec381000-39e2-11e9-9acc-291ce8d71f2f.png">

After expanded:
<img width="1372" alt="screenshot 2019-02-26 16 21 47" src="https://user-images.githubusercontent.com/57101/53447351-ee01d380-39e2-11e9-8068-57dd33147076.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
