### PR TITLE
Add event week to myTBA

### DIFF
--- a/templates/mytba_live.html
+++ b/templates/mytba_live.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import 'event_partials/event_macros.html' as em %}
 
 {% block title %}myTBA Dashboard - The Blue Alliance{% endblock %}
 
@@ -57,7 +58,7 @@
           <h3><a href="/event/{{ event.key_name }}">{{ event.name }}</a></h3>
           <p>
             {% if event.city_state_country %}<span class="glyphicon glyphicon-map-marker"></span> in <a href="http://maps.google.com/maps?q={{ event.city_state_country }}" target="_blank">{{ event.city_state_country }}</a><br />{% endif %}
-            {% if event.start_date %}<span class="glyphicon glyphicon-calendar"></span> {{ event.start_date|date:"M d" }}{% if event.start_date|date:"M d" != event.end_date|date:"M d" %} - {{ event.end_date|date:"M d" }}{% endif %}, {{ event.end_date|date:"Y" }}{% endif %}
+            {{ em.showEventDates(event) }}
           </p>
           <table class="table table-striped table-condensed">
             <tr>


### PR DESCRIPTION
Add the event week to the date block on myTBA.

## Description
Uses the macro at `templates_jinja2/event_partials/event_macros.html` to add the event date with the week. Replaces the code for the event date with `{{ em.showEventDates(event) }}`. 

## Motivation and Context
The event week is now listed next to the date in other places, so it should be listed here, too.

## How Has This Been Tested?
I _think_ I did this right but I'm not positive.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/53471908-160d2900-3a1b-11e9-93a4-37fc4fd7e303.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
