### PR TITLE
Pin mysqlclient version to fix dev_appserver import error

### DIFF
--- a/travis_requirements.txt
+++ b/travis_requirements.txt
@@ -13,4 +13,4 @@ pyOpenSSL
 ndg-httpsclient
 pyasn1
 httpie
-mysqlclient
+mysqlclient==1.3.14


### PR DESCRIPTION
I don't have a great way to prove this works - unless someone wants to pull, destroy their Docker instance, and fire up a new one. 1.3.14 was the latest version that didn't error out with `dev_appserver.py`. Fixes #2398.