### PR TITLE
Track webcast view time in GameDay

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^15.0.1",
     "react-event-listener": "^0.4.0",
     "react-file-input": "^0.2.5",
+    "react-ga": "^2.5.7",
     "react-native-listener": "^1.0.1",
     "react-redux": "^4.4.5",
     "react-select": "^1.0.0-rc.5",
@@ -26,8 +27,8 @@
     "redux": "^3.5.2",
     "redux-thunk": "^2.0.1",
     "reselect": "^2.5.1",
-    "swagger-ui": "3.17.1",
     "swagger-client": "3.8.6",
+    "swagger-ui": "3.17.1",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -110,7 +110,7 @@ export default class VideoCell extends React.Component {
             position={this.props.position}
             onRequestClose={() => this.onRequestCloseSwapPositionDialog()}
           />
-          <VideoCellAnalyticsTracker webcast={this.props.webcast}/>
+          <VideoCellAnalyticsTracker webcast={this.props.webcast} />
         </div>
       )
     }

--- a/react/gameday2/components/VideoCell.js
+++ b/react/gameday2/components/VideoCell.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 import WebcastEmbed from './WebcastEmbed'
+import VideoCellAnalyticsTracker from './VideoCellAnalyticsTracker'
 import LivescoreDisplayContainer from '../containers/LivescoreDisplayContainer'
 import VideoCellToolbarContainer from '../containers/VideoCellToolbarContainer'
 import WebcastSelectionDialogContainer from '../containers/WebcastSelectionDialogContainer'
@@ -109,6 +110,7 @@ export default class VideoCell extends React.Component {
             position={this.props.position}
             onRequestClose={() => this.onRequestCloseSwapPositionDialog()}
           />
+          <VideoCellAnalyticsTracker webcast={this.props.webcast}/>
         </div>
       )
     }

--- a/react/gameday2/components/VideoCellAnalyticsTracker.js
+++ b/react/gameday2/components/VideoCellAnalyticsTracker.js
@@ -14,6 +14,14 @@ export default class VideoCellAnalyticsTracker extends React.Component {
     this.elapsedTime = 0 // In minutes
   }
 
+  componentDidMount() {
+    this.sendTracking()
+    this.interval = setInterval(this.sendTracking.bind(this), 60000)
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
 
   sendTracking() {
     const { id, type, channel, file } = this.props.webcast
@@ -29,15 +37,6 @@ export default class VideoCellAnalyticsTracker extends React.Component {
       value: this.elapsedTime === 0 ? 0 : 1,
     })
     this.elapsedTime += 1
-  }
-
-  componentDidMount() {
-    this.sendTracking()
-    this.interval = setInterval(this.sendTracking.bind(this), 60000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval)
   }
 
   render() {

--- a/react/gameday2/components/VideoCellAnalyticsTracker.js
+++ b/react/gameday2/components/VideoCellAnalyticsTracker.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 import ReactGA from 'react-ga'
 import { webcastPropType } from '../utils/webcastUtils'
 
@@ -9,7 +9,11 @@ export default class VideoCellAnalyticsTracker extends React.Component {
     webcast: webcastPropType,
   }
 
-  elapsedTime = 0 // In minutes
+  constructor(props) {
+    super(props)
+    this.elapsedTime = 0 // In minutes
+  }
+
 
   sendTracking() {
     const { key, type, channel, file } = this.props.webcast
@@ -24,7 +28,7 @@ export default class VideoCellAnalyticsTracker extends React.Component {
       label: this.elapsedTime.toString(),
       value: this.elapsedTime === 0 ? 0 : 1,
     })
-    this.elapsedTime++
+    this.elapsedTime += 1
   }
 
   componentDidMount() {

--- a/react/gameday2/components/VideoCellAnalyticsTracker.js
+++ b/react/gameday2/components/VideoCellAnalyticsTracker.js
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react'
+import ReactGA from 'react-ga'
+import { webcastPropType } from '../utils/webcastUtils'
+
+ReactGA.initialize('UA-1090782-9')
+
+export default class VideoCellAnalyticsTracker extends React.Component {
+  static propTypes = {
+    webcast: webcastPropType,
+  }
+
+  elapsedTime = 0 // In minutes
+
+  sendTracking() {
+    const { key, type, channel, file } = this.props.webcast
+    let action = `${key}::${type}::${channel}`
+    if (file) {
+      action += `::${file}`
+    }
+
+    ReactGA.event({
+      category: 'Webcast View Time',
+      action: action.toLowerCase(),
+      label: this.elapsedTime.toString(),
+      value: this.elapsedTime === 0 ? 0 : 1,
+    })
+    this.elapsedTime++
+  }
+
+  componentDidMount() {
+    this.sendTracking()
+    this.interval = setInterval(this.sendTracking.bind(this), 60000)
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+  render() {
+    return null
+  }
+}

--- a/react/gameday2/components/VideoCellAnalyticsTracker.js
+++ b/react/gameday2/components/VideoCellAnalyticsTracker.js
@@ -16,8 +16,8 @@ export default class VideoCellAnalyticsTracker extends React.Component {
 
 
   sendTracking() {
-    const { key, type, channel, file } = this.props.webcast
-    let action = `${key}::${type}::${channel}`
+    const { id, type, channel, file } = this.props.webcast
+    let action = `${id}::${type}::${channel}`
     if (file) {
       action += `::${file}`
     }


### PR DESCRIPTION
Track how long certain webcasts are open in GameDay in Google Analytics.
Fires every minute.
Tracks in a separate GA property from the website.

## Screenshots
![image](https://user-images.githubusercontent.com/1421884/53690381-824b9d80-3d37-11e9-9f6e-e606d9c07693.png)
![image](https://user-images.githubusercontent.com/1421884/53690395-c50d7580-3d37-11e9-9dbe-a8109f2e179d.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
