### PR TITLE
Add modcodes to admin nav

### DIFF
--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -73,36 +73,49 @@
               <li><a href="/admin/event/create">Create</a></li>
               <li><a href="/admin/offseasons">Scrape USFIRST Offseasons</a></li>
               <li><a href="/admin/offseasons/spreadsheet">Scrape Spreadsheet Offseasons</a></li>
+              
               <li>Districts</li>
               <li><a href="/admin/districts">View all</a></li>
               <li><a href="/admin/district/create">Create</a></li>
+              
               <li>Matches</li>
               <li><a href="/admin/matches">Edit</a></li>
               <li><a href="/admin/match/cleanup">Cleanup</a></li>
+              
               <li>Awards</li>
               <li><a href="/admin/awards">Edit</a></li>
+              
               <li>Media</li>
               <li><a href="/admin/gameday">GameDay</a></li>
               <li><a href="/admin/media">Dashboard</a></li>
               <li><a href="/admin/media/import/instagram">Bulk Import from Instagram</a></li>
               <li><a href="/admin/videos/add">Add YouTube Videos</a></li>
+              
               <li>Teams</li>
+              <li><a href="/admin/media/modcodes/list">View Mods</a></li>
               <li><a href="/admin/teams">View all</a></li>
+
+              
               <li>Suggestions</li>
               <li><a href="/admin/suggestions/match/video/review">Match Video Suggestions</a></li>
               <li><a href="/admin/suggestions/event/webcast/review">Event Webcast Suggestions</a></li>
               <li><a href="/admin/suggestions/media/review">Media Suggestions</a></li>
+              
               <li>Users</li>
               <li><a href="/admin/user/lookup">Lookup</a></li>
               <li><a href="/admin/users/permissions">Permissions</a></li>
               <li><a href="/admin/users">View all</a></li>
+              
               <li>Write API Access<li>
               <li><a href="/admin/api_auth/add">Add Authentication</a></li>
               <li><a href="/admin/api_auth/manage">Manage Authentication</a></li>
+              
               <li>Migration</li>
               <li><a href="/admin/migration">Migration Utils</a></li>
+              
               <li>Memcache</li>
               <li><a href="/admin/memcache">Stats + Flushing</a></li>
+              
               <li>Misc</li>
               <li><a href="/admin/debug">Debug Panel</a></li>
               <li><a href="/admin/sitevars">Sitevars</a></li>


### PR DESCRIPTION
## Description
Adds modcodes to Team section of admin nav

## Motivation and Context
Had to move a modcode, didn't know we had the tool already built. Now it's there!

## How Has This Been Tested?
Local dev instance

## Screenshots (if appropriate):
<img width="427" alt="screenshot 2019-03-03 11 36 37" src="https://user-images.githubusercontent.com/57101/53698293-bb702600-3da8-11e9-87f7-35f81ed11afc.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
