### PR TITLE
Changes to app banners on narrower screens

### DIFF
--- a/static/css/less_css/less/tba/tba_base.less
+++ b/static/css/less_css/less/tba/tba_base.less
@@ -30,20 +30,6 @@ body {
   margin-bottom: 25px;
 }
 
-.app-store-row {
-  height: 60px;
-}
-
-.app-store-col {
-  .col-xs-6;
-  padding: 5px;
-  height: 100%;
-}
-
-.app-store-image {
-  height: 100%;
-}
-
 .sponsor-image {
   padding: 10px;
 }

--- a/templates/index_partials/apps.html
+++ b/templates/index_partials/apps.html
@@ -1,12 +1,8 @@
-<div class="app-store-row">
-  <div class="app-store-col">
-    <a href="https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient">
-      <img class="app-store-image" src="/images/google_play.svg" alt="Download Android app from Google Play">
-    </a>
-  </div>
-  <div class="app-store-col">
-    <a href="https://itunes.apple.com/us/app/apple-store/id1441973916?mt=8">
-      <img class="app-store-image" src="/images/app_store.svg" alt="Download iOS app from the App Store">
-    </a>
-  </div>
+<div class="text-center">
+  <a href="https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient">
+    <img src="/images/google_play.svg" alt="Download Android app from Google Play">
+  </a>
+  <a href="https://itunes.apple.com/us/app/apple-store/id1441973916?mt=8">
+    <img src="/images/app_store.svg" alt="Download iOS app from the App Store">
+  </a>
 </div>


### PR DESCRIPTION
## Description
Makes the app install banner icons narrower, centered. Fixes issues on smaller screens.

## Motivation and Context
They used to overlap clownily.

## How Has This Been Tested?
Local instance

## Screenshots (if appropriate):

Before
<img width="885" alt="screenshot 2019-03-04 16 36 09" src="https://user-images.githubusercontent.com/57101/53764614-c9eb3a00-3e9b-11e9-954f-89c8c746ffa5.png">
<img width="672" alt="screenshot 2019-03-04 16 36 21" src="https://user-images.githubusercontent.com/57101/53764622-cbb4fd80-3e9b-11e9-98fb-0bce4c8e2081.png">


After
<img width="885" alt="screenshot 2019-03-04 16 35 06" src="https://user-images.githubusercontent.com/57101/53764624-ce175780-3e9b-11e9-8965-26df2ab1c573.png">
<img width="672" alt="screenshot 2019-03-04 16 36 29" src="https://user-images.githubusercontent.com/57101/53764631-cfe11b00-3e9b-11e9-9cb1-eca3f0e50d6c.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
