### PR TITLE
Update PYTHONPATH to look for protorpc library

### DIFF
--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -34,7 +34,6 @@ EXPOSE 22
 
 # Get appengine environment
 ENV GAE_VERSION 1.9.66
-ENV PYTHONPATH /google_appengine
 RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -nv
 RUN unzip -q google_appengine_$GAE_VERSION.zip
 

--- a/ops/dev/vars.sh
+++ b/ops/dev/vars.sh
@@ -5,7 +5,6 @@ NODE_VERSION=8.0.0
 NODE_DIR=${NVM_DIR}/versions/node/v${NODE_VERSION}
 
 # First, configure environment
-export PYTHONPATH="${PYTHONPATH}:${GAE_DIR}"
+export PYTHONPATH="${PYTHONPATH}:${GAE_DIR}:${GAE_DIR}/lib/protorpc-1.0"
 export NODE_PATH="${NODE_DIR}/lib/node_modules"
 export PATH="${PATH}:${GAE_DIR}:${NODE_DIR}/bin"
-


### PR DESCRIPTION
We overwrite the Docker container's `PYTHONPATH` via that `vars.sh` script, which means what we set in our `Dockerfile` isn't respected. The `PYTHONPATH` doesn't need to be set during installs/setup, and we should be fine letting it get set at the end of the script.

This change also adds the `protorpc-1.0` lib to the `PYTHONPATH`, which is something we did on CI to get the TBANS tests running, but never did in the Docker container (I usually do it locally to get the tests to run)