### PR TITLE
Separate service for internal mobile API

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -77,7 +77,7 @@ handlers:
 - url: /api/.*
   script: api_main.app
 - url: /_ah/api/.* # Endpoints for internal mobile API
-  script: mobile_main.app
+  script: mobileapi.mobile_main.app
 - url: /_ah/queue/deferred.*
   script: google.appengine.ext.deferred.deferred.application
   login: admin

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -2,7 +2,7 @@ dispatch:
 # Beta PWA
 - url: "beta.thebluealliance.com/*"
   service: pwa-ssr
-  
+
 # Send low-frequency long-running tasks to backend module
 - url: "*/backend-tasks/*"
   module: backend-tasks
@@ -15,6 +15,10 @@ dispatch:
 # Send notification requests to TBANS (The Blue Alliance Notification Service)
 - url: "*/tbans/*"
   service: tbans
+
+# Endpoints for internal mobile API
+- url: "*/mobileapi/*"
+  service: mobileapi
 
 # Send everything else to default module
 - url: "*/"

--- a/mobileapi.yaml
+++ b/mobileapi.yaml
@@ -1,0 +1,28 @@
+service: mobileapi
+
+instance_class: B1
+basic_scaling:
+  max_instances: 1
+
+runtime: python27
+api_version: 1
+threadsafe: true
+
+builtins:
+- appstats: on
+
+libraries:
+- name: pycrypto  # for mobile API
+  version: 2.6
+- name: ssl
+  version: 2.7.11
+
+handlers:
+- url: /mobileapi/.*
+  script: mobileapi.mobile_main.app
+
+includes:
+- app_shared.yaml
+
+env_variables:
+  ENDPOINTS_SERVICE_NAME: tbatv-prod-hrd.appspot.com

--- a/mobileapi/mobile_main.py
+++ b/mobileapi/mobile_main.py
@@ -2,6 +2,7 @@ import endpoints
 import json
 import logging
 
+from google.appengine.api.modules import modules
 from google.appengine.ext import ndb
 
 from protorpc import remote
@@ -59,6 +60,7 @@ if tba_config.DEBUG:
 
 
 @endpoints.api(
+    base_path='/mobileapi/' if modules.get_current_module_name() == 'mobileapi' else None,  # Temporarily support both default and dedicated service
     name='tbaMobile',
     version='v9',
     description="API for TBA Mobile clients",
@@ -79,7 +81,6 @@ if tba_config.DEBUG:
     }
 )
 class MobileAPI(remote.Service):
-
     @endpoints.method(RegistrationRequest, BaseResponse,
                       path='register', http_method='POST',
                       name='register')

--- a/mobileapi/mobile_main.py
+++ b/mobileapi/mobile_main.py
@@ -81,6 +81,12 @@ if tba_config.DEBUG:
     }
 )
 class MobileAPI(remote.Service):
+    @endpoints.method(message_types.VoidMessage, BaseResponse,
+                      path='test', http_method='GET',
+                      name='test')
+    def test(self, request):
+        return BaseResponse(code=200, message="This is a test!")
+
     @endpoints.method(RegistrationRequest, BaseResponse,
                       path='register', http_method='POST',
                       name='register')

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -63,7 +63,7 @@ trap release_lock EXIT INT TERM
 
 echo "Obtained Lock. Deploying $PROJECT:$VERSION"
 # need more permissions for cron.yaml queue.yaml index.yaml, we can come back to them
-for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml cron.yaml dispatch.yaml; do
+for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml cron.yaml dispatch.yaml; do
     with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $config --version $VERSION"
 done
 

--- a/pavement.py
+++ b/pavement.py
@@ -114,7 +114,7 @@ def make():
 
 @task
 def make_endpoints_config():
-    sh("python lib/endpoints/endpointscfg.py get_openapi_spec mobile_main.MobileAPI --hostname tbatv-prod-hrd.appspot.com")
+    sh("python lib/endpoints/endpointscfg.py get_openapi_spec mobileapi.mobile_main.MobileAPI --hostname tbatv-prod-hrd.appspot.com")
 
 
 @task
@@ -128,7 +128,7 @@ def preflight():
 @task
 def run():
     """Run local dev server"""
-    sh("dev_appserver.py dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml")
+    sh("dev_appserver.py dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml")
 
 
 @task
@@ -202,7 +202,7 @@ def bootstrap(options):
 
 @task
 def devserver():
-    sh("dev_appserver.py --skip_sdk_update_check=true --admin_host=0.0.0.0 --host=0.0.0.0 --datastore_path=/datastore/tba.db dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml")
+    sh("dev_appserver.py --skip_sdk_update_check=true --admin_host=0.0.0.0 --host=0.0.0.0 --datastore_path=/datastore/tba.db dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml")
 
 
 def test_function(args):


### PR DESCRIPTION
- Duplicates the current internal mobile API at `/mobileapi/*` under a separate service.
- Adds a `test` endpoint for easier testing.

## Motivation and Context
We are trying to move everything to its own service for better separation of concerns for code and ops. This allows us to test & use the existing internal mobile API with both the old and new service until everything is migrated to point to the new one.

## How Has This Been Tested?
Visiting `/_ah/api/tbaMobile/v9/test` and `/mobileapi/tbaMobile/v9/test` both work in local dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
