### PR TITLE
Separate clientapi service attempt 2

### DIFF
--- a/clientapi.yaml
+++ b/clientapi.yaml
@@ -1,4 +1,4 @@
-service: mobileapi
+service: clientapi
 
 runtime: python27
 api_version: 1
@@ -21,7 +21,7 @@ libraries:
 
 handlers:
 - url: .*
-  script: mobileapi.mobileapi_service.app
+  script: clientapi.clientapi_service.app
 
 includes:
 - app_shared.yaml

--- a/clientapi/clientapi_service.py
+++ b/clientapi/clientapi_service.py
@@ -52,12 +52,12 @@ def get_current_user_id(headers):
 
 
 @endpoints.api(
-    base_path='/mobileapi/',
-    name='tbaMobile',
+    base_path='/clientapi/',
+    name='tbaClient',
     version='v9',
     description="API for TBA Mobile clients",
 )
-class MobileAPI(remote.Service):
+class ClientAPI(remote.Service):
     def initialize_request_state(self, state):
         self.headers = state.headers
 
@@ -305,4 +305,4 @@ class MobileAPI(remote.Service):
         else:
             return BaseResponse(code=400, message="Bad suggestion url")
 
-app = endpoints.api_server([MobileAPI])
+app = endpoints.api_server([ClientAPI])

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -8,7 +8,9 @@ GoogleAppEngineCloudStorageClient
 
 # Cloud Endpoints Stuff
 oauth2client==3.0.0
+google-auth
 google-endpoints
 google-endpoints-api-management
+requests-toolbelt
 # See https://github.com/urllib3/urllib3/issues/1456
 urllib3==1.23

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -12,13 +12,13 @@ dispatch:
 - url: "*/backend-tasks-b2/*"
   module: backend-tasks-b2
 
+# Endpoints for internal client API
+- url: "*/clientapi/*"
+  service: clientapi
+
 # Send notification requests to TBANS (The Blue Alliance Notification Service)
 - url: "*/tbans/*"
   service: tbans
-
-# Endpoints for internal mobile API
-- url: "*/mobileapi*"
-  service: mobileapi
 
 # Send everything else to default module
 - url: "*/"

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -2,7 +2,7 @@ dispatch:
 # Beta PWA
 - url: "beta.thebluealliance.com/*"
   service: pwa-ssr
-  
+
 # Send low-frequency long-running tasks to backend module
 - url: "*/backend-tasks/*"
   module: backend-tasks
@@ -15,6 +15,10 @@ dispatch:
 # Send notification requests to TBANS (The Blue Alliance Notification Service)
 - url: "*/tbans/*"
   service: tbans
+
+# Endpoints for internal mobile API
+- url: "*/mobileapi*"
+  service: mobileapi
 
 # Send everything else to default module
 - url: "*/"

--- a/mobileapi.yaml
+++ b/mobileapi.yaml
@@ -1,0 +1,30 @@
+service: mobileapi
+
+runtime: python27
+api_version: 1
+threadsafe: true
+
+instance_class: F1
+automatic_scaling:
+  max_idle_instances: 1
+
+builtins:
+- appstats: on
+
+libraries:
+- name: pycrypto  # for Google Cloud Endpoints
+  version: 2.6
+- name: ssl
+  version: 2.7.11
+- name: MySQLdb
+  version: "latest"
+
+handlers:
+- url: .*
+  script: mobileapi.mobileapi_service.app
+
+includes:
+- app_shared.yaml
+
+env_variables:
+  FIREBASE_PROJECT_ID: tbatv-prod-hrd

--- a/mobileapi/mobileapi_service.py
+++ b/mobileapi/mobileapi_service.py
@@ -28,6 +28,7 @@ from models.mobile_api_messages import BaseResponse, FavoriteCollection, Favorit
 from models.mobile_client import MobileClient
 from models.suggestion import Suggestion
 
+# See: https://cloud.google.com/appengine/docs/standard/python/authenticating-users-firebase-appengine
 # See: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/6f5f3bcb81779679a24e0964a6c57c0c7deabfac/appengine/standard/firebase/firenotes/backend/main.py#L27
 requests_toolbelt.adapters.appengine.monkeypatch()
 HTTP_REQUEST = google.auth.transport.requests.Request()

--- a/mobileapi/mobileapi_service.py
+++ b/mobileapi/mobileapi_service.py
@@ -34,7 +34,11 @@ HTTP_REQUEST = google.auth.transport.requests.Request()
 
 
 def get_current_user(headers):
-    id_token = headers['Authorization'].split(' ').pop()
+    auth = headers.get('Authorization')
+    if not auth:
+        return None
+
+    id_token = auth.split(' ').pop()
     try:
         claims = google.oauth2.id_token.verify_firebase_token(id_token, HTTP_REQUEST)
     except ValueError:

--- a/mobileapi/mobileapi_service.py
+++ b/mobileapi/mobileapi_service.py
@@ -1,0 +1,298 @@
+import endpoints
+import json
+import logging
+
+from google.appengine.ext import ndb
+import google.auth.transport.requests
+import google.oauth2.id_token
+from protorpc import remote
+from protorpc import message_types
+import requests_toolbelt.adapters.appengine
+
+import tba_config
+
+from consts.client_type import ClientType
+from helpers.media_helper import MediaParser
+from helpers.push_helper import PushHelper
+from helpers.notification_helper import NotificationHelper
+from helpers.mytba_helper import MyTBAHelper
+from helpers.suggestions.suggestion_creator import SuggestionCreator
+from models.account import Account
+from models.favorite import Favorite
+from models.media import Media
+from models.sitevar import Sitevar
+from models.subscription import Subscription
+from models.mobile_api_messages import BaseResponse, FavoriteCollection, FavoriteMessage, RegistrationRequest, \
+                                       SubscriptionCollection, SubscriptionMessage, ModelPreferenceMessage, \
+                                       MediaSuggestionMessage, PingRequest
+from models.mobile_client import MobileClient
+from models.suggestion import Suggestion
+
+# See: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/6f5f3bcb81779679a24e0964a6c57c0c7deabfac/appengine/standard/firebase/firenotes/backend/main.py#L27
+requests_toolbelt.adapters.appengine.monkeypatch()
+HTTP_REQUEST = google.auth.transport.requests.Request()
+
+
+def get_current_user(headers):
+    id_token = headers['Authorization'].split(' ').pop()
+    try:
+        claims = google.oauth2.id_token.verify_firebase_token(id_token, HTTP_REQUEST)
+    except ValueError:
+        return None
+    return PushHelper.user_email_to_id(claims['email'])
+
+@endpoints.api(
+    base_path='/mobileapi/',
+    name='tbaMobile',
+    version='v9',
+    description="API for TBA Mobile clients",
+)
+class MobileAPI(remote.Service):
+    def initialize_request_state(self, state):
+        self.headers = state.headers
+
+    @endpoints.method(message_types.VoidMessage, BaseResponse,
+                      path='test', http_method='GET',
+                      name='test')
+    def test(self, request):
+        user_id = get_current_user(self.headers)
+        return BaseResponse(code=200, message="User id: {}".format(user_id))
+
+    @endpoints.method(RegistrationRequest, BaseResponse,
+                      path='register', http_method='POST',
+                      name='register')
+    def register_client(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return BaseResponse(code=401, message="Unauthorized to register")
+        gcm_id = request.mobile_id
+        os = ClientType.enums[request.operating_system]
+        name = request.name
+        uuid = request.device_uuid
+
+        query = MobileClient.query(
+                MobileClient.user_id == user_id,
+                MobileClient.device_uuid == uuid,
+                MobileClient.client_type == os)
+        # trying to figure out an elusive dupe bug
+        logging.info("DEBUGGING")
+        logging.info("User ID: {}".format(user_id))
+        logging.info("UUID: {}".format(uuid))
+        logging.info("Count: {}".format(query.count()))
+        if query.count() == 0:
+            # Record doesn't exist yet, so add it
+            MobileClient(
+                parent=ndb.Key(Account, user_id),
+                user_id=user_id,
+                messaging_id=gcm_id,
+                client_type=os,
+                device_uuid=uuid,
+                display_name=name).put()
+            return BaseResponse(code=200, message="Registration successful")
+        else:
+            # Record already exists, update it
+            client = query.fetch(1)[0]
+            client.messaging_id = gcm_id
+            client.display_name = name
+            client.put()
+            return BaseResponse(code=304, message="Client already exists")
+
+    @endpoints.method(RegistrationRequest, BaseResponse,
+                      path='unregister', http_method='POST',
+                      name='unregister')
+    def unregister_client(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return BaseResponse(code=401, message="Unauthorized to unregister")
+        gcm_id = request.mobile_id
+        query = MobileClient.query(MobileClient.messaging_id == gcm_id, ancestor=ndb.Key(Account, user_id))\
+            .fetch(keys_only=True)
+        if len(query) == 0:
+            # Record doesn't exist, so we can't remove it
+            return BaseResponse(code=404, message="User doesn't exist. Can't remove it")
+        else:
+            ndb.delete_multi(query)
+            return BaseResponse(code=200, message="User deleted")
+
+    @endpoints.method(PingRequest, BaseResponse,
+                      path='ping', http_method='POST',
+                      name='ping')
+    def ping_client(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return BaseResponse(code=401, message="Unauthorized to ping client")
+
+        gcm_id = request.mobile_id
+
+        # Find a Client for the current user with the passed GCM ID
+        clients = MobileClient.query(MobileClient.messaging_id == gcm_id, ancestor=ndb.Key(Account, user_id)).fetch(1)
+        if len(clients) == 0:
+            # No Client for user with that push token - bailing
+            return BaseResponse(code=404, message="Invalid push token for user")
+        else:
+            client = clients[0]
+            response = NotificationHelper.send_ping(client)
+            # If we got a response from the send_ping method, it was sent via TBANS
+            # We'll bubble up any errors we got back
+            if response:
+                if response.code == 200:
+                    return BaseResponse(code=200, message="Ping sent")
+                else:
+                    return BaseResponse(code=response.code, message="Error pinging client - {}".format(response.message))
+            else:
+                return BaseResponse(code=200, message="Ping sent")
+
+    @endpoints.method(message_types.VoidMessage, FavoriteCollection,
+                      path='favorites/list', http_method='POST',
+                      name='favorites.list')
+    def list_favorites(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return FavoriteCollection(favorites=[])
+
+        favorites = Favorite.query(ancestor=ndb.Key(Account, user_id)).fetch()
+        output = []
+        for favorite in favorites:
+            output.append(FavoriteMessage(model_key=favorite.model_key, model_type=favorite.model_type))
+        return FavoriteCollection(favorites=output)
+
+    @endpoints.method(ModelPreferenceMessage, BaseResponse,
+                      path="model/setPreferences", http_method="POST",
+                      name="model.setPreferences")
+    def update_model_preferences(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return BaseResponse(code=401, message="Unauthorized to update model preferences")
+        model_key = request.model_key
+        model_type = request.model_type
+        output = {}
+        code = 0
+
+        if request.favorite:
+            fav = Favorite(
+                parent=ndb.Key(Account, user_id),
+                user_id=user_id,
+                model_key=model_key,
+                model_type=model_type
+            )
+            result = MyTBAHelper.add_favorite(fav, request.device_key)
+            if result == 200:
+                output['favorite'] = {"code":    200,
+                                      "message": "Favorite added"}
+                code += 100
+            elif result == 304:
+                output['favorite'] = {"code":    304,
+                                      "message": "Favorite already exists"}
+                code += 304
+            else:
+                output['favorite'] = {"code":    500,
+                                      "message": "Unknown error adding favorite"}
+                code += 500
+        else:
+            result = MyTBAHelper.remove_favorite(user_id, model_key, model_type, request.device_key)
+            if result == 200:
+                output['favorite'] = {"code":    200,
+                                      "message": "Favorite deleted"}
+                code += 100
+            elif result == 404:
+                output['favorite'] = {"code":    404,
+                                      "message": "Favorite not found"}
+                code += 404
+            else:
+                output['favorite'] = {"code":    500,
+                                      "message": "Unknown error removing favorite"}
+                code += 500
+
+        if request.notifications:
+            sub = Subscription(
+                parent=ndb.Key(Account, user_id),
+                user_id=user_id,
+                model_key=model_key,
+                model_type=request.model_type,
+                notification_types=PushHelper.notification_enums_from_string(request.notifications)
+            )
+            result = MyTBAHelper.add_subscription(sub, request.device_key)
+            if result == 200:
+                output['subscription'] = {"code":    200,
+                                          "message": "Subscription updated"}
+                code += 100
+            elif result == 304:
+                output['subscription'] = {"code":    304,
+                                          "message": "Subscription already exists"}
+                code += 304
+            else:
+                output['subscription'] = {"code":    500,
+                                          "message": "Unknown error adding favorite"}
+                code += 500
+        else:
+            result = MyTBAHelper.remove_subscription(user_id, model_key, model_type, request.device_key)
+            if result == 200:
+                output['subscription'] = {"code":    200,
+                                          "message": "Subscription removed"}
+                code += 100
+            elif result == 404:
+                output['subscription'] = {"code":    404,
+                                          "message": "Subscription not found"}
+                code += 404
+            else:
+                output['subscription'] = {"code":    500,
+                                          "message": "Unknown error removing subscription"}
+                code += 500
+
+        return BaseResponse(code=code, message=json.dumps(output))
+
+    @endpoints.method(message_types.VoidMessage, SubscriptionCollection,
+                      path='subscriptions/list', http_method='POST',
+                      name='subscriptions.list')
+    def list_subscriptions(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return SubscriptionCollection(subscriptions=[])
+
+        subscriptions = Subscription.query(ancestor=ndb.Key(Account, user_id)).fetch()
+        output = []
+        for subscription in subscriptions:
+            output.append(SubscriptionMessage(
+                    model_key=subscription.model_key,
+                    notifications=PushHelper.notification_string_from_enums(subscription.notification_types),
+                    model_type=subscription.model_type))
+        return SubscriptionCollection(subscriptions=output)
+
+    @endpoints.method(MediaSuggestionMessage, BaseResponse,
+                      path='team/media/suggest', http_method='POST',
+                      name='team.media.suggestion')
+    def suggest_team_media(self, request):
+        user_id = get_current_user_id(self.headers)
+        if user_id is None:
+            return BaseResponse(code=401, message="Unauthorized to make suggestions")
+
+        # For now, only allow team media suggestions
+        if request.reference_type != "team":
+            # Trying to suggest a media for an invalid model type
+            return BaseResponse(code=400, message="Bad model type")
+
+        # Need to split deletehash out into its own private dict. Don't want that to be exposed via API...
+        private_details_json = None
+        if request.details_json:
+            incoming_details = json.loads(request.details_json)
+            private_details = None
+            if 'deletehash' in incoming_details:
+                private_details = {'deletehash': incoming_details.pop('deletehash')}
+            private_details_json = json.dumps(private_details) if private_details else None
+
+        status = SuggestionCreator.createTeamMediaSuggestion(
+            author_account_key=ndb.Key(Account, user_id),
+            media_url=request.media_url,
+            team_key=request.reference_key,
+            year_str=str(request.year),
+            private_details_json=private_details_json)
+
+        if status != 'bad_url':
+            if status == 'success':
+                return BaseResponse(code=200, message="Suggestion added")
+            else:
+                return BaseResponse(code=304, message="Suggestion already exists")
+        else:
+            return BaseResponse(code=400, message="Bad suggestion url")
+
+app = endpoints.api_server([MobileAPI])

--- a/mobileapi/mobileapi_service.py
+++ b/mobileapi/mobileapi_service.py
@@ -45,6 +45,7 @@ def get_current_user(headers):
         return None
     return PushHelper.user_email_to_id(claims['email'])
 
+
 @endpoints.api(
     base_path='/mobileapi/',
     name='tbaMobile',

--- a/mobileapi/mobileapi_service.py
+++ b/mobileapi/mobileapi_service.py
@@ -33,7 +33,7 @@ requests_toolbelt.adapters.appengine.monkeypatch()
 HTTP_REQUEST = google.auth.transport.requests.Request()
 
 
-def get_current_user(headers):
+def get_current_user_id(headers):
     auth = headers.get('Authorization')
     if not auth:
         return None
@@ -60,7 +60,7 @@ class MobileAPI(remote.Service):
                       path='test', http_method='GET',
                       name='test')
     def test(self, request):
-        user_id = get_current_user(self.headers)
+        user_id = get_current_user_id(self.headers)
         return BaseResponse(code=200, message="User id: {}".format(user_id))
 
     @endpoints.method(RegistrationRequest, BaseResponse,

--- a/mobileapi/mobileapi_service.py
+++ b/mobileapi/mobileapi_service.py
@@ -43,7 +43,11 @@ def get_current_user_id(headers):
         claims = google.oauth2.id_token.verify_firebase_token(id_token, HTTP_REQUEST)
     except ValueError:
         return None
-    return PushHelper.user_email_to_id(claims['email'])
+
+    if not claims:
+        return None
+    else:
+        return PushHelper.user_email_to_id(claims['email'])
 
 
 @endpoints.api(

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -63,7 +63,7 @@ trap release_lock EXIT INT TERM
 
 echo "Obtained Lock. Deploying $PROJECT:$VERSION"
 # need more permissions for cron.yaml queue.yaml index.yaml, we can come back to them
-for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml cron.yaml dispatch.yaml; do
+for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml cron.yaml dispatch.yaml; do
     with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $config --version $VERSION"
 done
 

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -63,7 +63,7 @@ trap release_lock EXIT INT TERM
 
 echo "Obtained Lock. Deploying $PROJECT:$VERSION"
 # need more permissions for cron.yaml queue.yaml index.yaml, we can come back to them
-for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml cron.yaml dispatch.yaml; do
+for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml clientapi.yaml tbans.yaml cron.yaml dispatch.yaml; do
     with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $config --version $VERSION"
 done
 

--- a/pavement.py
+++ b/pavement.py
@@ -128,7 +128,7 @@ def preflight():
 @task
 def run():
     """Run local dev server"""
-    sh("dev_appserver.py dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml")
+    sh("dev_appserver.py dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml clientapi.yaml tbans.yaml")
 
 
 @task
@@ -202,7 +202,7 @@ def bootstrap(options):
 
 @task
 def devserver():
-    sh("dev_appserver.py --skip_sdk_update_check=true --admin_host=0.0.0.0 --host=0.0.0.0 --datastore_path=/datastore/tba.db dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml")
+    sh("dev_appserver.py --skip_sdk_update_check=true --admin_host=0.0.0.0 --host=0.0.0.0 --datastore_path=/datastore/tba.db dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml clientapi.yaml tbans.yaml")
 
 
 def test_function(args):

--- a/pavement.py
+++ b/pavement.py
@@ -128,7 +128,7 @@ def preflight():
 @task
 def run():
     """Run local dev server"""
-    sh("dev_appserver.py dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml")
+    sh("dev_appserver.py dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml")
 
 
 @task
@@ -202,7 +202,7 @@ def bootstrap(options):
 
 @task
 def devserver():
-    sh("dev_appserver.py --skip_sdk_update_check=true --admin_host=0.0.0.0 --host=0.0.0.0 --datastore_path=/datastore/tba.db dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml")
+    sh("dev_appserver.py --skip_sdk_update_check=true --admin_host=0.0.0.0 --host=0.0.0.0 --datastore_path=/datastore/tba.db dispatch.yaml app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml tbans.yaml mobileapi.yaml")
 
 
 def test_function(args):


### PR DESCRIPTION
- Duplicates the current internal mobile API at `/clientapi/*` under a separate service.
- Adds a `test` endpoint for easier testing.
- Handles Firebase authentication ourselves.

## Motivation and Context
We are trying to move everything to its own service for better separation of concerns for code and ops. This allows us to test & use the existing internal client API with both the old and new service until everything is migrated to point to the new one. The new service doesn't use managed endpoints for authentication.

## How Has This Been Tested?
Visiting `/clientapi/tbaClient/v9/test` works in local dev. Adding an `Authorization` header returns the user ID.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
