### PR TITLE
Add helper method to log/return 400s in TBANS

### DIFF
--- a/tbans/tbans_service.py
+++ b/tbans/tbans_service.py
@@ -35,6 +35,12 @@ class TBANSService(remote.Service):
 
         return app_identity.get_application_id() == incoming_app_id
 
+    def _application_error(self, message):
+        """ Helper method to log and return a 400 TBANSResponse """
+        # TODO: Monitor these
+        logging.error(message)
+        return TBANSResponse(code=400, message=message)
+
     @remote.method(PingRequest, TBANSResponse)
     def ping(self, request):
         """ Immediately dispatch a Ping to either FCM or a webhook """
@@ -42,7 +48,7 @@ class TBANSService(remote.Service):
             raise remote.ApplicationError('Unauthenticated')
 
         if request.fcm and request.webhook:
-            return TBANSResponse(code=400, message='Cannot ping both FCM and webhook')
+            return self._application_error('Cannot ping both FCM and webhook')
 
         from tbans.models.notifications.ping import PingNotification
         notification = PingNotification()
@@ -64,7 +70,7 @@ class TBANSService(remote.Service):
             logging.info('Ping Response - {}'.format(str(response)))
             return TBANSResponse(code=response.status_code, message=response.content)
         else:
-            return TBANSResponse(code=400, message='Did not specify FCM or webhook to ping')
+            return self._application_error('Did not specify FCM or webhook to ping')
 
     @remote.method(VerificationRequest, VerificationResponse)
     def verification(self, request):


### PR DESCRIPTION
The motivation behind this is if we're sending invalid request to TBANS, the logs look all 200. In the case we start sending invalid requests (maybe someone changes the helper methods), the logs will at least start showing up as red.