### PR TITLE
Fix Subscription (Instance ID) model init errors

### DIFF
--- a/tbans/consts/platform_payload_priority.py
+++ b/tbans/consts/platform_payload_priority.py
@@ -1,5 +1,4 @@
-
-class PlatformPayloadPriority(object):
+class PlatformPayloadPriority:
     """
     Constants regarding the priority of a push notification
     """

--- a/tbans/consts/platform_payload_type.py
+++ b/tbans/consts/platform_payload_type.py
@@ -1,5 +1,4 @@
-
-class PlatformPayloadType(object):
+class PlatformPayloadType:
     """
     Constants for the type of platform payloads
     https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages

--- a/tbans/models/subscriptions/subscription_batch_response.py
+++ b/tbans/models/subscriptions/subscription_batch_response.py
@@ -44,8 +44,8 @@ class SubscriptionBatchResponse(SubscriptionResponse):
         if invalid_str:
             raise ValueError('SubscriptionBatchResponse tokens must be non-empty strings.')
 
-        results = self.data.get('results')
-        if not isinstance(results, list) or not results:
+        results = self.data.get('results', [])
+        if not isinstance(results, list) or (not results and not self.error):
             raise ValueError('SubscriptionBatchResponse results must be a non-empty list.')
 
         self.subscribers = [Subscriber(token, result) for token, result in zip(tokens, results)]

--- a/tbans/models/subscriptions/subscription_response.py
+++ b/tbans/models/subscriptions/subscription_response.py
@@ -10,6 +10,9 @@ class SubscriptionResponse(object):
             response (object, content/status_code/headers): response from urlfetch Instance ID API call (https://cloud.google.com/appengine/docs/standard/python/refdocs/google.appengine.api.urlfetch)
             error (string): Directly pass an error instead of trying to parse the error from the JSON response.
         """
+        if not response and not error:
+            raise ValueError('SubscriptionResponse must be initilized with either a response or an error')
+
         # Check that response looks right
         if response:
             if response.content:
@@ -70,7 +73,7 @@ class SubscriptionResponse(object):
         if self._error:
             return IIDError.UNKNOWN_ERROR
         # If we have a non-200 error code, pull the corresponding IID Error
-        elif status_code is not 200:
+        elif status_code and status_code is not 200:
             return IIDError.ERROR_CODES.get(status_code, IIDError.UNKNOWN_ERROR)
         # Otherwise, no error at all
         else:
@@ -89,7 +92,7 @@ class SubscriptionResponse(object):
         if self._error:
             return self._error
         # If we have a non-200 error code, get the error from the JSON (if possible).
-        elif status_code is not 200:
+        elif status_code and status_code is not 200:
             raw_json = self._raw_data
             json_error = raw_json.pop('error', None)
             if json_error:

--- a/tbans/models/subscriptions/subscription_status.py
+++ b/tbans/models/subscriptions/subscription_status.py
@@ -32,7 +32,13 @@ class SubscriptionStatus(SubscriptionResponse):
         super(SubscriptionStatus, self).__init__(response=response, error=error)
 
         relations = self.data.get('rel', {})
+        if not isinstance(relations, dict):
+            raise ValueError('SubscriptionStatus relations must be a dict.')
+
         topics = relations.get('topics', {})
+        if not isinstance(topics, dict):
+            raise ValueError('SubscriptionStatus topics must be a dict.')
+
         self.subscriptions = [str(topic) for topic in topics]
 
     def __str__(self):

--- a/tests/tbans_tests/models/subscriptions/test_subscription_batch_response.py
+++ b/tests/tbans_tests/models/subscriptions/test_subscription_batch_response.py
@@ -28,6 +28,13 @@ class TestSubscriptionBatchResponse(unittest2.TestCase):
         with self.assertRaises(ValueError):
             SubscriptionBatchResponse(tokens=['abc'], response=response)
 
+    def test_result_type_error(self):
+        # init with an empty results but with an error is valid
+        response = MockResponse(400, '{"error": "some error"}')
+        batch_response = SubscriptionBatchResponse(tokens=['abc'], response=response)
+        self.assertEqual(batch_response.error, "some error")
+        self.assertEqual(batch_response.subscribers, [])
+
     def test_init(self):
         response = MockResponse(200, '{"results": [{}]}')
         batch_response = SubscriptionBatchResponse(tokens=['abc'], response=response)

--- a/tests/tbans_tests/models/subscriptions/test_subscription_response.py
+++ b/tests/tbans_tests/models/subscriptions/test_subscription_response.py
@@ -7,6 +7,10 @@ from tests.tbans_tests.mocks.mock_response import MockResponse
 
 class TestSubscriptionResponse(unittest2.TestCase):
 
+    def test_response_none(self):
+        with self.assertRaises(ValueError):
+            SubscriptionResponse()
+
     def test_data_response_none_data(self):
         subscription_response = SubscriptionResponse(response=None, error="error")
         self.assertEqual(subscription_response.data, {})

--- a/tests/tbans_tests/models/subscriptions/test_subscription_status.py
+++ b/tests/tbans_tests/models/subscriptions/test_subscription_status.py
@@ -7,6 +7,16 @@ from tests.tbans_tests.mocks.mock_response import MockResponse
 
 class TestSubscriptionStatus(unittest2.TestCase):
 
+    def test_init_wrong_rel(self):
+        response = MockResponse(200, '{"rel":"abc"}')
+        with self.assertRaises(ValueError):
+            SubscriptionStatus(response=response)
+
+    def test_init_wrong_topics(self):
+        response = MockResponse(200, '{"rel":{"topics": "abc"}}')
+        with self.assertRaises(ValueError):
+            SubscriptionStatus(response=response)
+
     def test_init_topics(self):
         response = MockResponse(200, '{"rel":{"topics":{"broadcasts":{"addDate":"2019-02-15"}}}}')
         subscription_status = SubscriptionStatus(response=response)
@@ -28,3 +38,9 @@ class TestSubscriptionStatus(unittest2.TestCase):
         response = MockResponse(400, '{"error":"some error"}')
         subscription_status = SubscriptionStatus(response=response)
         self.assertEqual(str(subscription_status), "SubscriptionStatus(subscriptions=[], iid_error=invalid-argument, error=some error)")
+
+    def test_error(self):
+        response = MockResponse(400, '{"error":"some error"}')
+        subscription_status = SubscriptionStatus(response=response)
+        self.assertEqual(subscription_status.error, "some error")
+        self.assertEqual(subscription_status.subscriptions, [])


### PR DESCRIPTION
Fixed some initialization weirdness with the Instance ID model classes. `SubscriptionBatchResponse` shouldn't throw an error if we have an empty `results`, because we got back error JSON.

Additionally, this just adds another level of validation that a `SubscriptionResponse` gets initialized with either an error or a response, which means we can check for an error or a status code when looking for an error (because one or the other will be right). In it's current implementation if we init an empty object (which is currently possible) we'll get an unknown error, even though we didn't get an error back from the server.

And finally, `SubscriptionStatus` didn't have validation on the JSON and the rest of the classes do, so I added it, along with a test to make sure it can be initialized properly with an error like `SubscriptionBatchResponse`