### PR TITLE
Adds validation utils to TBANS, updates imports

### DIFF
--- a/tbans/models/notifications/notification.py
+++ b/tbans/models/notifications/notification.py
@@ -1,10 +1,7 @@
-
 class Notification(object):
-
     """
-    Base notification classs - represents message, data, and platform config payloads for notifications
+    Base notification classs - represents message, data, and platform config payloads for notifications.
     """
-
     def __str__(self):
         values = [ value for value in
             [(self.data_payload, 'data_payload'),

--- a/tbans/models/notifications/payloads/notification_payload.py
+++ b/tbans/models/notifications/payloads/notification_payload.py
@@ -1,8 +1,6 @@
-
 class NotificationPayload(object):
-
     """
-    Basic notification template to use across all platforms
+    Basic notification template to use across all platforms.
 
     https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Notification
 
@@ -10,27 +8,20 @@ class NotificationPayload(object):
         title (string): Title for the notification.
         body (string): Body message for the notification.
     """
-
     def __init__(self, title, body):
         """
         Args:
             title (string): Title for the notification.
             body (string): Body message for the notification.
         """
+        from tbans.utils.validation_utils import validate_is_string
+
         # Check that we have a title
-        if title is None:
-            raise ValueError('NotificationPayload requires a title')
-        # Check that our title looks right
-        if not isinstance(title, basestring):
-            raise TypeError('NotificationPayload title must be a string')
+        validate_is_string(title=title)
         self.title = title
 
         # Check that we have a body
-        if body is None:
-            raise ValueError('NotificationPayload requires a body')
-        # Check that our body looks right
-        if not isinstance(body, basestring):
-            raise TypeError('NotificationPayload body must be a string')
+        validate_is_string(body=body)
         self.body = body
 
     def __str__(self):

--- a/tbans/models/notifications/payloads/payload.py
+++ b/tbans/models/notifications/payloads/payload.py
@@ -1,10 +1,7 @@
-
 class Payload(object):
-
     """
-    Abstract class to be subclassed by payload parts for notifications
+    Abstract class to be subclassed by payload parts for notifications.
     """
-
     @property
     def payload_dict(self):
         raise NotImplementedError("Payload subclass must implement payload_dict")

--- a/tbans/models/notifications/payloads/platform_payload.py
+++ b/tbans/models/notifications/payloads/platform_payload.py
@@ -4,9 +4,8 @@ from tbans.models.notifications.payloads.payload import Payload
 
 
 class PlatformPayload(Payload):
-
     """
-    Represents platform-specific push notification configuration options
+    Represents platform-specific push notification configuration options.
 
     https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages
 
@@ -15,7 +14,6 @@ class PlatformPayload(Payload):
         priority (int): Priority for push notification - may be None.
         collapse_key (string): Collapse key for push notification - may be None.
     """
-
     # TODO: Add ttl
     def __init__(self, platform_type=None, priority=None, collapse_key=None):
         """
@@ -24,24 +22,24 @@ class PlatformPayload(Payload):
             priority (int): Priority for push notification - may be None.
             collapse_key (string): Collapse key for push notification - may be None.
         """
+        from tbans.utils.validation_utils import validate_is_string, validate_is_type
+
         # Check that our platform_type looks right
         if platform_type:
-            if not isinstance(platform_type, int):
-                raise TypeError('PlatformPayload platform_type must be a PlatformPayloadType constant')
+            validate_is_type(int, not_empty=False, platform_type=platform_type)
             PlatformPayload._validate_platform_type(platform_type)
         self.platform_type = platform_type
 
         # Check that our priority looks right
         if priority:
-            if not isinstance(priority, int):
-                raise TypeError('PlatformPayload priority must be a PlatformPayloadPriority constant')
+            validate_is_type(int, not_empty=False, priority=priority)
             if priority not in PlatformPayloadPriority.types:
                 raise TypeError("Unsupported PlatformPayload priority: {}".format(priority))
         self.priority = priority
 
         # Check that our collapse key looks right
-        if collapse_key and not isinstance(collapse_key, basestring):
-            raise TypeError('PlatformPayload collapse_key must be a string')
+        if collapse_key:
+            validate_is_string(collapse_key=collapse_key)
         self.collapse_key = collapse_key
 
     def __str__(self):

--- a/tbans/models/notifications/ping.py
+++ b/tbans/models/notifications/ping.py
@@ -1,6 +1,4 @@
-from consts.notification_type import NotificationType
 from tbans.models.notifications.notification import Notification
-from tbans.models.notifications.payloads.notification_payload import NotificationPayload
 
 
 class PingNotification(Notification):
@@ -11,10 +9,12 @@ class PingNotification(Notification):
 
     @staticmethod
     def _type():
+        from consts.notification_type import NotificationType
         return NotificationType.PING
 
     @property
     def notification_payload(self):
+        from tbans.models.notifications.payloads.notification_payload import NotificationPayload
         return NotificationPayload(title=self._title, body=self._body)
 
     @property

--- a/tbans/models/notifications/update_favorites.py
+++ b/tbans/models/notifications/update_favorites.py
@@ -1,4 +1,3 @@
-from consts.notification_type import NotificationType
 from tbans.models.notifications.update_mytba import UpdateMyTBANotification
 
 
@@ -10,4 +9,5 @@ class UpdateFavoritesNotification(UpdateMyTBANotification):
 
     @staticmethod
     def _type():
+        from consts.notification_type import NotificationType
         return NotificationType.UPDATE_FAVORITES

--- a/tbans/models/notifications/update_mytba.py
+++ b/tbans/models/notifications/update_mytba.py
@@ -1,8 +1,6 @@
 from tbans.models.notifications.notification import Notification
-from tbans.models.notifications.payloads.platform_payload import PlatformPayload
 
 
-# Base notification class for myTBA update models
 class UpdateMyTBANotification(Notification):
     """ Base notification class for myTBA update notifications - ex: favorites and subscriptions
 
@@ -19,14 +17,12 @@ class UpdateMyTBANotification(Notification):
             user_id (string): User/account ID that we're sending notifications for - used for collapse key.
             sending_device_key (string): The FCM token for the device that triggered the notification.
         """
+        from tbans.utils.validation_utils import validate_is_string
         # Check type_name, user_id, and sending_device_key
         for (value, name) in [(type_name, 'type_name'), (user_id, 'user_id'), (sending_device_key, 'sending_device_key')]:
             # Make sure our value exists
-            if value is None:
-                raise ValueError('UpdateMyTBANotification requires a {}'.format(name))
-            # Check that our value looks right
-            if not isinstance(value, basestring):
-                raise TypeError('UpdateMyTBANotification {} must be an string'.format(name))
+            args = {name: value}
+            validate_is_string(**args)
 
         self.type_name = type_name
         self.user_id = user_id
@@ -45,6 +41,7 @@ class UpdateMyTBANotification(Notification):
 
     @property
     def platform_payload(self):
+        from tbans.models.notifications.payloads.platform_payload import PlatformPayload
         return PlatformPayload(collapse_key='{}_{}_update'.format(self.user_id, self.type_name))
 
     def _additional_logging_values(self):

--- a/tbans/models/notifications/update_subscriptions.py
+++ b/tbans/models/notifications/update_subscriptions.py
@@ -1,4 +1,3 @@
-from consts.notification_type import NotificationType
 from tbans.models.notifications.update_mytba import UpdateMyTBANotification
 
 
@@ -10,4 +9,5 @@ class UpdateSubscriptionsNotification(UpdateMyTBANotification):
 
     @staticmethod
     def _type():
+        from consts.notification_type import NotificationType
         return NotificationType.UPDATE_SUBSCRIPTION

--- a/tbans/models/notifications/verification.py
+++ b/tbans/models/notifications/verification.py
@@ -1,7 +1,3 @@
-import hashlib
-import time
-
-from consts.notification_type import NotificationType
 from tbans.models.notifications.notification import Notification
 
 
@@ -20,21 +16,21 @@ class VerificationNotification(Notification):
             url (string): The URL to send the notification payload to.
             secret (string): The secret to calculate the payload checksum with.
         """
+        from tbans.utils.validation_utils import validate_is_string
         # Check url, secret
-        for (value, name) in [(url, 'url'), (secret, 'secret')]:
+        for (key, value) in [('url', url), ('secret', secret)]:
             # Make sure our value exists
-            if value is None:
-                raise ValueError('VerificationNotification requires a {}'.format(name))
-            # Check that our value looks right
-            if not isinstance(value, basestring):
-                raise TypeError('VerificationNotification {} must be an string'.format(name))
+            args = {key: value}
+            validate_is_string(**args)
 
         self.url = url
         self.secret = secret
         self._generate_key()
 
     def _generate_key(self):
+        import hashlib
         ch = hashlib.sha1()
+        import time
         ch.update(str(time.time()))
         ch.update(self.url)
         ch.update(self.secret)
@@ -42,6 +38,7 @@ class VerificationNotification(Notification):
 
     @staticmethod
     def _type():
+        from consts.notification_type import NotificationType
         return NotificationType.VERIFICATION
 
     # Only webhook payload is defined - because we'll only ever send verification to webhooks

--- a/tbans/models/requests/notifications/notification_request.py
+++ b/tbans/models/requests/notifications/notification_request.py
@@ -1,6 +1,3 @@
-from tbans.models.notifications.notification import Notification
-
-
 class NotificationRequest(object):
     """ Base class used for requests to represent a notification payload.
 
@@ -13,11 +10,10 @@ class NotificationRequest(object):
         Args:
             notification (Notification): The Notification to send.
         """
-        class_name = self.__class__.__name__
-        if notification is None:
-            raise ValueError('{} notification cannot be None'.format(class_name))
-        if not isinstance(notification, Notification):
-            raise TypeError('{} notification must be a Notification subclass'.format(class_name))
+        from tbans.models.notifications.notification import Notification
+        from tbans.utils.validation_utils import validate_is_type
+
+        validate_is_type(Notification, notification=notification)
         self.notification = notification
 
     def json_string(self):

--- a/tbans/models/requests/notifications/notification_response.py
+++ b/tbans/models/requests/notifications/notification_response.py
@@ -12,18 +12,15 @@ class NotificationResponse(object):
             status_code (int): The stauts code from the HTTP response
             content (string): The content from the HTTP response - may be None
         """
+        from tbans.utils.validation_utils import validate_is_string, validate_is_type
+
         # Check that we have a status_code
-        if status_code is None:
-            raise ValueError('NotificationResponse requires a status_code')
-        # Check that our status_code looks right
-        if not isinstance(status_code, int):
-            raise TypeError('NotificationResponse status_code must be an int')
+        validate_is_type(int, not_empty=False, status_code=status_code)
         self.status_code = status_code
 
         # Check that content looks right
         if content:
-            if not isinstance(content, basestring):
-                raise TypeError('NotificationResponse content must be a string')
+            validate_is_string(content=content)
         self.content = content
 
     def __str__(self):

--- a/tbans/models/requests/subscriptions/subscription_batch_response.py
+++ b/tbans/models/requests/subscriptions/subscription_batch_response.py
@@ -1,6 +1,4 @@
 from tbans.models.requests.subscriptions.subscription_response import SubscriptionResponse
-from tbans.models.subscriptions.subscriber import Subscriber
-from tbans.utils.json_utils import json_string_to_dict
 
 
 class SubscriptionBatchResponse(SubscriptionResponse):
@@ -37,9 +35,10 @@ class SubscriptionBatchResponse(SubscriptionResponse):
         """
         super(SubscriptionBatchResponse, self).__init__(response=response, error=error)
 
+        from tbans.utils.validation_utils import validate_is_type
+
         # Ensure our tokens are right - non-empty strings, in a list
-        if not isinstance(tokens, list) or not tokens:
-            raise ValueError('SubscriptionBatchResponse tokens must be a non-empty list of strings.')
+        validate_is_type(list, tokens=tokens)
         invalid_str = [t for t in tokens if not isinstance(t, basestring) or not t]
         if invalid_str:
             raise ValueError('SubscriptionBatchResponse tokens must be non-empty strings.')
@@ -48,6 +47,7 @@ class SubscriptionBatchResponse(SubscriptionResponse):
         if not isinstance(results, list) or (not results and not self.error):
             raise ValueError('SubscriptionBatchResponse results must be a non-empty list.')
 
+        from tbans.models.subscriptions.subscriber import Subscriber
         self.subscribers = [Subscriber(token, result) for token, result in zip(tokens, results)]
 
     def __str__(self):

--- a/tbans/models/requests/subscriptions/subscription_response.py
+++ b/tbans/models/requests/subscriptions/subscription_response.py
@@ -1,7 +1,3 @@
-from tbans.consts.iid_error import IIDError
-from tbans.utils.json_utils import json_string_to_dict
-
-
 class SubscriptionResponse(object):
     """ Base response object for Instance ID API responses. """
     def __init__(self, response=None, error=None):
@@ -13,27 +9,24 @@ class SubscriptionResponse(object):
         if not response and not error:
             raise ValueError('SubscriptionResponse must be initilized with either a response or an error')
 
+        from tbans.utils.validation_utils import validate_is_string, validate_is_type
+
         # Check that response looks right
         if response:
             if response.content:
-                if not isinstance(response.content, basestring):
-                    raise TypeError('SubscriptionResponse content must be a string')
+                validate_is_string(content=response.content)
             # Check that we have a status_code
-            if response.status_code is None:
-                raise ValueError('SubscriptionResponse response.status_code cannot be None')
-            # Check that our status_code looks right
-            if not isinstance(response.status_code, int):
-                raise TypeError('SubscriptionResponse response.status_code must be an int')
+            validate_is_type(int, not_empty=False, status_code=response.status_code)
         self._response = response
 
         # Check that error looks right
         if error:
-            if not isinstance(error, basestring):
-                raise TypeError('SubscriptionResponse error must be a string')
+            validate_is_string(error=error)
         self._error = error
 
     @property
     def _raw_data(self):
+        from tbans.utils.json_utils import json_string_to_dict
         if self._response:
             return json_string_to_dict(self._response.content)
         return {}
@@ -70,6 +63,7 @@ class SubscriptionResponse(object):
         """
         status_code = self._status_code
         # If we pass an error - we consider this an unknown error, since it probably wasn't caused by the IID API
+        from tbans.consts.iid_error import IIDError
         if self._error:
             return IIDError.UNKNOWN_ERROR
         # If we have a non-200 error code, pull the corresponding IID Error

--- a/tbans/models/requests/subscriptions/subscription_status_request.py
+++ b/tbans/models/requests/subscriptions/subscription_status_request.py
@@ -1,11 +1,6 @@
-from google.appengine.api import urlfetch
-
-from tbans.models.requests.subscriptions.subscription_status_response import SubscriptionStatusResponse
-from tbans.utils.auth_utils import get_firebase_messaging_access_token
-
-
 class SubscriptionStatusRequest:
-    """ Represents a request to Firebase's Instance ID API to get the subscription status for a subscriber
+    """
+    Represents a request to Firebase's Instance ID API to get the subscription status for a subscriber.
 
     https://developers.google.com/instance-id/reference/server#get_information_about_app_instances
 
@@ -18,9 +13,9 @@ class SubscriptionStatusRequest:
         Args:
             token (string): The Instance ID token for the subscriber - this is the same token as FCM tokens.
         """
-        if not isinstance(token, basestring):
-            raise ValueError('SubscriptionStatusRequest token option must be a string')
+        from tbans.utils.validation_utils import validate_is_string
 
+        validate_is_string(token=token)
         self.token = token
 
     def __str__(self):
@@ -36,6 +31,10 @@ class SubscriptionStatusRequest:
         Return:
             SubscriptionStatusResponse
         """
+        from google.appengine.api import urlfetch
+        from tbans.models.requests.subscriptions.subscription_status_response import SubscriptionStatusResponse
+        from tbans.utils.auth_utils import get_firebase_messaging_access_token
+
         headers = {
             'Authorization': 'Bearer ' + get_firebase_messaging_access_token(),
         }

--- a/tbans/models/requests/subscriptions/subscription_status_response.py
+++ b/tbans/models/requests/subscriptions/subscription_status_response.py
@@ -31,13 +31,13 @@ class SubscriptionStatusResponse(SubscriptionResponse):
         """
         super(SubscriptionStatusResponse, self).__init__(response=response, error=error)
 
+        from tbans.utils.validation_utils import validate_is_type
+
         relations = self.data.get('rel', {})
-        if not isinstance(relations, dict):
-            raise ValueError('SubscriptionStatusResponse relations must be a dict.')
+        validate_is_type(dict, not_empty=False, relations=relations)
 
         topics = relations.get('topics', {})
-        if not isinstance(topics, dict):
-            raise ValueError('SubscriptionStatusResponse topics must be a dict.')
+        validate_is_type(dict, not_empty=False, topics=topics)
 
         self.subscriptions = [str(topic) for topic in topics]
 

--- a/tbans/models/subscriptions/subscriber.py
+++ b/tbans/models/subscriptions/subscriber.py
@@ -12,13 +12,12 @@ class Subscriber:
             token (string): Instance ID for the subscriber.
             result (dict): Dictionary result for the subscriber.
         """
+        from tbans.utils.validation_utils import validate_is_string, validate_is_type
+
         # Check that token looks right.
-        if not isinstance(token, basestring) or not token:
-            raise ValueError('Subscriber token must be a non-empty string.')
+        validate_is_string(token=token)
         self.token = token
 
         # Check that result looks right.
-        if not isinstance(result, dict):
-            raise TypeError('Subscriber result must be a dictionary.')
-
+        validate_is_type(dict, not_empty=False, result=result)
         self.error = result.get('error', None)

--- a/tbans/utils/validation_utils.py
+++ b/tbans/utils/validation_utils.py
@@ -1,0 +1,104 @@
+import logging
+
+
+def validate_is_type(obj_type, not_empty=True, **kwargs):
+    """
+    Validates that a value is a not-None type.
+
+    Examples:
+        >>> validate_is_type(int, counter=1)
+        # no throw
+        >>> validate_is_type(basestring, some_key="")
+        # will throw
+        >>> validate_is_type(basestring, not_empty=False, some_key="")
+        # no throw
+
+    Args:
+        obj_type (type): The type the kwarg value should be.
+        not_empty (bool): If we should validate the kwarg value equates to None.
+        kwargs: key/value pairs for the name/value of the strings to validate.
+
+    Raises:
+        Exception: If more than one kwarg is supplied.
+        TypeError: If a param is not a string.
+        ValueError: If a param is not a non-None string.
+    """
+    if len(kwargs) is not 1:
+        raise Exception("validate_is_type may only have one kwarg")
+
+    key, value = kwargs.items()[0]
+    if not isinstance(value, obj_type):
+        raise TypeError("{} must be a {} - got {}".format(key, obj_type.__name__, _type_name(value)))
+    if not value and not_empty:
+        raise ValueError("{} must not be empty".format(key))
+
+
+def validate_is_string(**kwargs):
+    """
+    Validates that pararms are a non-empty strings.
+
+    Examples:
+        >>> validate_is_string(abc="abc")
+        # no throw
+        >>> validate_is_string(abc="")
+        # will throw
+        >>> validate_is_string(abc=1)
+        # will throw
+
+    Args:
+        kwargs (string): key/value pairs for the name/value of the strings to validate.
+
+    Raises:
+        TypeError: If a param is not a string.
+        ValueError: If a param is not a non-None string.
+    """
+    for key, value in kwargs.items():
+        arg = {key: value}
+        validate_is_type(basestring, **arg)
+
+
+def validate_model_params(model_type, model_key, notification_types):
+    """
+    Method to DRY out validation for model_type, model_key, notification_types
+
+    Args:
+        model_type (int): ModelType constant from monorepo - Event, Team, Match, etc.
+        model_key (string): Key for the model.
+        notification_types (list, int): A list of NotificationType constants to get topics for.
+    """
+    # Ensure our model_type looks right.
+    validate_is_type(int, not_empty=False, model_type=model_type)
+    # Kick the model_key/notification_types validation out to a shared method.
+    validate_model_key_and_notification_types(model_key, notification_types)
+
+
+def validate_model_key_and_notification_types(model_key, notification_types):
+    """
+    Method to DRY out validation for keys/notification_types.
+
+    Args:
+        model_key (string): A key to validate.
+        notification_types (list, int): A list of NotificationType constants to validate.
+    """
+    # Ensure our model_key looks right.
+    validate_is_string(model_key=model_key)
+
+    # Ensure our notification_types looks right.
+    validate_is_type(list, not_empty=False, notification_types=notification_types)
+
+    invalid_notification_types = [nt for nt in notification_types if not isinstance(nt, int)]
+    if invalid_notification_types:
+        raise ValueError('notification_types items must be ints')
+
+
+def _type_name(typed_obj):
+    """
+    Get the name for a type for a given value.
+
+    Args:
+        typed_obj (any): The value to get the type for.
+
+    Returns:
+        string: Name of the type for the given value.
+    """
+    return type(typed_obj).__name__

--- a/tests/tbans_tests/models/notifications/payloads/test_notification_payload.py
+++ b/tests/tbans_tests/models/notifications/payloads/test_notification_payload.py
@@ -10,20 +10,28 @@ class TestNotificationPayload(unittest2.TestCase):
         self.assertEqual(str(payload), 'NotificationPayload(title="Title Here" body="Body here")')
 
     def test_payload_title_none(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             NotificationPayload(title=None, body='abc')
 
     def test_payload_title_type(self):
         with self.assertRaises(TypeError):
             NotificationPayload(title=False, body='abc')
 
-    def test_payload_body_none(self):
+    def test_payload_title_empty(self):
         with self.assertRaises(ValueError):
+            NotificationPayload(title="", body='abc')
+
+    def test_payload_body_none(self):
+        with self.assertRaises(TypeError):
             NotificationPayload(title='abc', body=None)
 
     def test_payload_body_type(self):
         with self.assertRaises(TypeError):
             NotificationPayload(title='abc', body=False)
+
+    def test_payload_body_empty(self):
+        with self.assertRaises(ValueError):
+            NotificationPayload(title='abc', body="")
 
     def test_payload_dict(self):
         payload_one = NotificationPayload(title='Title Here', body='Body here')

--- a/tests/tbans_tests/models/notifications/test_update_mytba.py
+++ b/tests/tbans_tests/models/notifications/test_update_mytba.py
@@ -15,28 +15,40 @@ class TestUpdateMyTBANotification(unittest2.TestCase):
         self.assertEquals(str(notification), 'MockUpdateMyTBANotification(data_payload={\'sending_device_key\': \'efgh\'} platform_payload=PlatformPayload(platform_type=None priority=None collapse_key="abcd_typezor_update") type_name=typezor user_id=abcd sending_device_key=efgh)')
 
     def test_type_name(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             UpdateMyTBANotification(None, 'abcd', 'efgh')
 
     def test_type_name_type(self):
         with self.assertRaises(TypeError):
             UpdateMyTBANotification(200, 'abcd', 'efgh')
 
-    def test_user_id(self):
+    def test_type_name_empty(self):
         with self.assertRaises(ValueError):
+            UpdateMyTBANotification('', 'abcd', 'efgh')
+
+    def test_user_id(self):
+        with self.assertRaises(TypeError):
             UpdateMyTBANotification('abc', None, 'efgh')
 
     def test_user_id_type(self):
         with self.assertRaises(TypeError):
             UpdateMyTBANotification('abc', 200, 'efgh')
 
-    def test_sending_device_key(self):
+    def test_user_id_empty(self):
         with self.assertRaises(ValueError):
+            UpdateMyTBANotification('abc', '', 'efgh')
+
+    def test_sending_device_key(self):
+        with self.assertRaises(TypeError):
             UpdateMyTBANotification('abc', 'def', None)
 
     def test_sending_device_key_type(self):
         with self.assertRaises(TypeError):
             UpdateMyTBANotification('abc', 'def', 200)
+
+    def test_sending_device_key_empty(self):
+        with self.assertRaises(ValueError):
+            UpdateMyTBANotification('abc', 'def', '')
 
     def test_data_payload(self):
         notification = UpdateMyTBANotification('typezor', 'abcd', 'efgh')

--- a/tests/tbans_tests/models/notifications/test_verification.py
+++ b/tests/tbans_tests/models/notifications/test_verification.py
@@ -12,20 +12,28 @@ class TestVerificationNotification(unittest2.TestCase):
         self.assertTrue("{'verification_key': " in str(notification))
 
     def test_url(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             VerificationNotification(None, 'password')
 
     def test_url_type(self):
         with self.assertRaises(TypeError):
             VerificationNotification(200, 'password')
 
-    def test_secret(self):
+    def test_url_empty(self):
         with self.assertRaises(ValueError):
+            VerificationNotification('', 'password')
+
+    def test_secret(self):
+        with self.assertRaises(TypeError):
             VerificationNotification('https://thebluealliance.com/', None)
 
     def test_secret_type(self):
         with self.assertRaises(TypeError):
             VerificationNotification('https://thebluealliance.com/', 200)
+
+    def test_secret_empty(self):
+        with self.assertRaises(ValueError):
+            VerificationNotification('https://thebluealliance.com/', '')
 
     def test_type(self):
         self.assertEqual(VerificationNotification._type(), NotificationType.VERIFICATION)

--- a/tests/tbans_tests/models/requests/notifications/test_notification_request.py
+++ b/tests/tbans_tests/models/requests/notifications/test_notification_request.py
@@ -8,7 +8,7 @@ from tests.tbans_tests.mocks.notifications.mock_notification import MockNotifica
 class TestNotificationRequest(unittest2.TestCase):
 
     def test_init_notification_none(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             NotificationRequest(notification=None)
 
     def test_init_notification_value(self):

--- a/tests/tbans_tests/models/requests/notifications/test_notification_response.py
+++ b/tests/tbans_tests/models/requests/notifications/test_notification_response.py
@@ -6,12 +6,15 @@ from tbans.models.requests.notifications.notification_response import Notificati
 class TestNotificationResponse(unittest2.TestCase):
 
     def test_status_code(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             NotificationResponse(status_code=None)
 
     def test_status_code_type(self):
         with self.assertRaises(TypeError):
             NotificationResponse(status_code='abc')
+
+    def test_status_code_zero(self):
+        NotificationResponse(status_code=0)
 
     def test_content_type(self):
         with self.assertRaises(TypeError):
@@ -31,3 +34,6 @@ class TestNotificationResponse(unittest2.TestCase):
     def test_str_content(self):
         response = NotificationResponse(status_code=400, content='Some content here')
         self.assertEqual(str(response), 'NotificationResponse(code=400 content="Some content here")')
+
+    def test_init_empty(self):
+        NotificationResponse(status_code=0, content='')

--- a/tests/tbans_tests/models/requests/notifications/test_webhook_request.py
+++ b/tests/tbans_tests/models/requests/notifications/test_webhook_request.py
@@ -32,20 +32,28 @@ class TestWebhookRequest(unittest2.TestCase):
         self.assertTrue(isinstance(request, NotificationRequest))
 
     def test_url(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             WebhookRequest(MockNotification(), None, 'secret')
 
     def test_url_type(self):
         with self.assertRaises(TypeError):
             WebhookRequest(MockNotification(), 200, 'secret')
 
-    def test_secret(self):
+    def test_url_empty(self):
         with self.assertRaises(ValueError):
+            WebhookRequest(MockNotification(), '', 'secret')
+
+    def test_secret(self):
+        with self.assertRaises(TypeError):
             WebhookRequest(MockNotification(), 'https://www.thebluealliance.com/', None)
 
     def test_secret_type(self):
         with self.assertRaises(TypeError):
             WebhookRequest(MockNotification(), 'https://www.thebluealliance.com/', 200)
+
+    def test_secret_empty(self):
+        with self.assertRaises(ValueError):
+            WebhookRequest(MockNotification(), 'https://www.thebluealliance.com/', '')
 
     def test_str(self):
         message_str = WebhookRequest(MockNotification(), 'https://www.thebluealliance.com/', 'secret')

--- a/tests/tbans_tests/models/requests/subscriptions/test_subscription_batch_request.py
+++ b/tests/tbans_tests/models/requests/subscriptions/test_subscription_batch_request.py
@@ -42,8 +42,16 @@ class TestSubscriptionBatchRequest(unittest2.TestCase):
             SubscriptionBatchRequest([], 'broadcasts', SubscriptionActionType.ADD)
 
     def test_tokens_type(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionBatchRequest(2, 'broadcasts', SubscriptionActionType.ADD)
+
+    def test_token_value_none(self):
+        with self.assertRaises(TypeError):
+            SubscriptionBatchRequest(None, 'broadcasts', SubscriptionActionType.ADD)
+
+    def test_tokens_type(self):
+        with self.assertRaises(ValueError):
+            SubscriptionBatchRequest([], 'broadcasts', SubscriptionActionType.ADD)
 
     def test_token_value(self):
         with self.assertRaises(ValueError):
@@ -59,10 +67,6 @@ class TestSubscriptionBatchRequest(unittest2.TestCase):
             SubscriptionBatchRequest(['abc' for _ in xrange(max + 1)], 'broadcasts', SubscriptionActionType.ADD)
         SubscriptionBatchRequest(['abc' for _ in xrange(max)], 'broadcasts', SubscriptionActionType.ADD)
 
-    def test_token_value_none(self):
-        with self.assertRaises(ValueError):
-            SubscriptionBatchRequest(None, 'broadcasts', SubscriptionActionType.ADD)
-
     def test_topic_fixed(self):
         request = SubscriptionBatchRequest('abc', 'broadcasts', SubscriptionActionType.ADD)
         self.assertEqual(request.topic, '/topics/broadcasts')
@@ -72,12 +76,16 @@ class TestSubscriptionBatchRequest(unittest2.TestCase):
         self.assertEqual(request.topic, '/topics/broadcasts')
 
     def test_topic_type(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionBatchRequest('abc', 1, SubscriptionActionType.ADD)
 
     def test_topic_none(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionBatchRequest('abc', None, SubscriptionActionType.ADD)
+
+    def test_topic_empty(self):
+        with self.assertRaises(ValueError):
+            SubscriptionBatchRequest('abc', '', SubscriptionActionType.ADD)
 
     def test_action_type(self):
         SubscriptionBatchRequest('abc', 'broadcasts', SubscriptionActionType.ADD)

--- a/tests/tbans_tests/models/requests/subscriptions/test_subscription_response.py
+++ b/tests/tbans_tests/models/requests/subscriptions/test_subscription_response.py
@@ -27,13 +27,17 @@ class TestSubscriptionResponse(unittest2.TestCase):
 
     def test_response_status_code(self):
         response = MockResponse(None, '')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionResponse(response=response)
 
     def test_response_status_code_type(self):
         response = MockResponse('', '')
         with self.assertRaises(TypeError):
             SubscriptionResponse(response=response)
+
+    def test_response_empty(self):
+        response = MockResponse(0, '')
+        SubscriptionResponse(response=response)
 
     def test_init_error(self):
         response = MockResponse(500, '{"error": "not the same error"}')
@@ -66,6 +70,13 @@ class TestSubscriptionResponse(unittest2.TestCase):
 
     def test_init_garbage(self):
         response = MockResponse(200, 'abcd')
+        subscription_response = SubscriptionResponse(response=response)
+        self.assertEqual(subscription_response.error, None)
+        self.assertEqual(subscription_response.iid_error, None)
+        self.assertEqual(subscription_response.data, {})
+
+    def test_init_empty(self):
+        response = MockResponse(200, '')
         subscription_response = SubscriptionResponse(response=response)
         self.assertEqual(subscription_response.error, None)
         self.assertEqual(subscription_response.iid_error, None)

--- a/tests/tbans_tests/models/requests/subscriptions/test_subscription_status_request.py
+++ b/tests/tbans_tests/models/requests/subscriptions/test_subscription_status_request.py
@@ -1,5 +1,3 @@
-# test_tbans_subscription_status_request.py
-
 import unittest2
 import uuid
 
@@ -44,8 +42,12 @@ class TestSubscriptionStatusRequest(unittest2.TestCase):
             SubscriptionStatusRequest()
 
     def test_init_token_type(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionStatusRequest(token=1)
+
+    def test_init_token_empty(self):
+        with self.assertRaises(ValueError):
+            SubscriptionStatusRequest(token='')
 
     def test_str(self):
         request = SubscriptionStatusRequest(token=self.token)

--- a/tests/tbans_tests/models/requests/subscriptions/test_subscription_status_response.py
+++ b/tests/tbans_tests/models/requests/subscriptions/test_subscription_status_response.py
@@ -9,13 +9,21 @@ class TestSubscriptionStatusResponse(unittest2.TestCase):
 
     def test_init_wrong_rel(self):
         response = MockResponse(200, '{"rel":"abc"}')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionStatusResponse(response=response)
 
-    def test_init_wrong_topics(self):
+    def test_init_rel_empty(self):
+        response = MockResponse(200, '{"rel":{}}')
+        SubscriptionStatusResponse(response=response)
+
+    def test_init_topics_type(self):
         response = MockResponse(200, '{"rel":{"topics": "abc"}}')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             SubscriptionStatusResponse(response=response)
+
+    def test_init_topics_empty(self):
+        response = MockResponse(200, '{"rel":{"topics": {}}}')
+        SubscriptionStatusResponse(response=response)
 
     def test_init_topics(self):
         response = MockResponse(200, '{"rel":{"topics":{"broadcasts":{"addDate":"2019-02-15"}}}}')

--- a/tests/tbans_tests/models/subscriptions/test_subscriber.py
+++ b/tests/tbans_tests/models/subscriptions/test_subscriber.py
@@ -7,11 +7,11 @@ from tbans.models.subscriptions.subscriber import Subscriber
 class TestSubscriber(unittest2.TestCase):
 
     def test_token_type(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Subscriber(token=1, result={})
 
     def test_token_none(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Subscriber(token=None, result={})
 
     def test_token_empty(self):

--- a/tests/tbans_tests/utils/test_validation_utils.py
+++ b/tests/tbans_tests/utils/test_validation_utils.py
@@ -1,0 +1,67 @@
+import unittest2
+
+from consts.model_type import ModelType
+from consts.notification_type import NotificationType
+
+from tbans.utils.validation_utils import *
+
+
+class TestValidationUtils(unittest2.TestCase):
+
+    def test_validate_is_type_multiple(self):
+        with self.assertRaises(Exception):
+            validate_is_type(obj_type=str, ac="a", abc="abc")
+
+    def test_validate_is_type_type(self):
+        with self.assertRaises(TypeError):
+            validate_is_type(obj_type=str, ac=1)
+
+    def test_validate_is_type_none(self):
+        with self.assertRaises(ValueError):
+            validate_is_type(obj_type=str, ac="")
+
+    def test_validate_is_type_valid(self):
+        validate_is_type(obj_type=str, ac="abc")
+
+    def test_validate_is_type_valid_none(self):
+        validate_is_type(obj_type=str, not_empty=False, ac="")
+
+    def test_validate_is_string_none(self):
+        with self.assertRaises(TypeError):
+            validate_is_string(efg=None)
+
+    def test_validate_is_string_empty(self):
+        with self.assertRaises(ValueError):
+            validate_is_string(efg="")
+
+    def test_validate_is_string_multiple(self):
+        validate_is_string(abc="abc", ab="def")
+
+    def test_validate_is_string(self):
+        validate_is_string(efg="abc")
+
+    def test_validate_model_params_model_type(self):
+        with self.assertRaises(TypeError):
+            validate_model_params("", "frc7332", [NotificationType.UPCOMING_MATCH, NotificationType.AWARDS])
+
+    def test_validate_model_params_model_key_type(self):
+        with self.assertRaises(TypeError):
+            validate_model_params(ModelType.TEAM, 1, [NotificationType.UPCOMING_MATCH, NotificationType.AWARDS])
+
+    def test_validate_model_params_model_key(self):
+        with self.assertRaises(ValueError):
+            validate_model_params(ModelType.TEAM, "", [NotificationType.UPCOMING_MATCH, NotificationType.AWARDS])
+
+    def test_validate_model_params_notification_types_type(self):
+        with self.assertRaises(TypeError):
+            validate_model_params(ModelType.TEAM, "frc7332", 1)
+
+    def test_validate_model_params_notification_types_list_type(self):
+        with self.assertRaises(ValueError):
+            validate_model_params(ModelType.TEAM, "frc7332", ["", NotificationType.UPCOMING_MATCH])
+
+    def test_validate_model_params_notification_types_empty(self):
+        validate_model_params(ModelType.TEAM, "frc7332", [])
+
+    def test_validate_model_params(self):
+        validate_model_params(ModelType.EVENT, "frc7332", [NotificationType.UPCOMING_MATCH, NotificationType.AWARDS])


### PR DESCRIPTION
More code being pulled out of #2432 - TBANS does a lot of validation to make sure things look right (we do a lot of parsing JSON, using values from users, etc). This PR creates a set of validation utility methods that get used throughout TBANS.

`validate_is_string` = Is a string a string and is it not-empty (we don't want empty strings anywhere)
`validate_is_type` = Is some value the type we think it should be, and optionally, is it not-empty

The `validate_model_params` and `validate_model_key_and_notification_types` are both for validating the the elements that make up a subscription (a model type, a model key, and notification types) look how we expect. These aren't used in this PR, but I'm going to add them in this one, along with the tests for them.

Also re: our conversation in Slack, I took a pass at doing imports when necessary, since we do a pretty good job of doing that on the surface (in `tbans_service.py`) but not elsewhere (in our subscription models, for example).