### PR TITLE
Modify "Add Video" buttons

### DIFF
--- a/templates/index_buildseason.html
+++ b/templates/index_buildseason.html
@@ -50,7 +50,7 @@
         {% endwith %}
         <div>
           <a class="btn btn-default" href="/webcasts"><span class="glyphicon glyphicon-info-sign"></span> Add Webcasts</a>
-          <a class="btn btn-default" href="/contact"><span class="glyphicon glyphicon-upload"></span> Add YouTube Videos</a>
+          <a class="btn btn-default" href="/add-data"><span class="glyphicon glyphicon-upload"></span> Add YouTube Videos</a>
         </div>
       {% endif %}
       <br>

--- a/templates/index_competitionseason.html
+++ b/templates/index_competitionseason.html
@@ -41,7 +41,7 @@
                 {% endwith %}
                 <div>
                   <a class="btn btn-default" href="/webcasts"><span class="glyphicon glyphicon-info-sign"></span> Add Webcasts</a>
-                  <a class="btn btn-default" href="/contact"><span class="glyphicon glyphicon-upload"></span> Add YouTube Videos</a>
+                  <a class="btn btn-default" href="/add-data"><span class="glyphicon glyphicon-upload"></span> Add YouTube Videos</a>
                 </div>
               </div>
             </div>

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -208,7 +208,7 @@
       <div class="row">
         <div class="col-sm-12">
           {% if has_time_predictions %}<p>Match times listed with a <em>*</em> are unofficial predicted times computed by The Blue Alliance for your convenience.</p>{% endif %}
-          <p><a class="btn btn-default" href="/contact"><span class="glyphicon glyphicon-upload"></span> Tell us about YouTube videos</a></p>
+          <p><a class="btn btn-default" href="/suggest/event/video?event_key={{event.key_name}}"><span class="glyphicon glyphicon-upload"></span> Tell us about YouTube videos</a></p>
           <p><a class="btn btn-default" href="/event/{{ event.key_name }}/feed"><span class="glyphicon glyphicon-barcode"></span> Matches in RSS</a></p>
         </div>
       </div>


### PR DESCRIPTION
Updates the URL tied to three different buttons on the site.

## Description

- Changes the <img src="https://user-images.githubusercontent.com/22439365/54663586-02476680-4a9f-11e9-90a6-d2f01f834b27.png" width="125px"></img> button to link to `/add-data` on both `index_buildseason` and `index_competitionseason`.
- Changes the <img src="https://user-images.githubusercontent.com/22439365/54663720-7c77eb00-4a9f-11e9-93eb-284192f70e0a.png" width="125px"></img> button on `event` pages to go to the same URL as the <img src="https://user-images.githubusercontent.com/22439365/54663777-9f0a0400-4a9f-11e9-8da7-64af7e78bc0f.png" width="100px"></img> button on top of the `event` page.

## Motivation and Context
Currently, the Add button on the homepage just links to the Contact page. However, once on the contact page, there is a section about adding data (including match videos) which links to the Add Data page. So, it seems more appropriate to link there. As of right now, there is no generic page to add match video for an arbitrary event -- if leaving the `match_key` or `event_key` parameter blank at `/suggest/event/video?match_key=xxx` or `/suggest/event/video?event_key=xxx`, the user is redirected back to `index`. I think since there is no generic "Add Video" page, the Add Data page is the closest thing we have.

Also, currently on an event page there are two CTAs for adding video. There is a green button on the top which links to the video suggestion page for the event and there is a plain button on the bottom which links to the contact page. I'm not sure why there are two distinctive buttons to begin with but this change will make them both link to the same place. Perhaps we want to make them more uniform or remove one altogether but leaving that open to see if anyone has context on why we have two in the first place.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
