### PR TITLE
Remove validation on secret for verification notification

### DIFF
--- a/tbans/models/notifications/verification.py
+++ b/tbans/models/notifications/verification.py
@@ -16,12 +16,12 @@ class VerificationNotification(Notification):
             url (string): The URL to send the notification payload to.
             secret (string): The secret to calculate the payload checksum with.
         """
-        from tbans.utils.validation_utils import validate_is_string
-        # Check url, secret
-        for (key, value) in [('url', url), ('secret', secret)]:
-            # Make sure our value exists
-            args = {key: value}
-            validate_is_string(**args)
+        from tbans.utils.validation_utils import validate_is_string, validate_is_type
+        # Check url
+        validate_is_string(url=url)
+
+        # Check secret
+        validate_is_type(basestring, not_empty=False, secret=secret)
 
         self.url = url
         self.secret = secret

--- a/tests/tbans_tests/models/notifications/test_verification.py
+++ b/tests/tbans_tests/models/notifications/test_verification.py
@@ -32,8 +32,8 @@ class TestVerificationNotification(unittest2.TestCase):
             VerificationNotification('https://thebluealliance.com/', 200)
 
     def test_secret_empty(self):
-        with self.assertRaises(ValueError):
-            VerificationNotification('https://thebluealliance.com/', '')
+        # TODO: Migrate existing users, make this throw again
+        VerificationNotification('https://thebluealliance.com/', '')
 
     def test_type(self):
         self.assertEqual(VerificationNotification._type(), NotificationType.VERIFICATION)


### PR DESCRIPTION
Follow up on https://github.com/the-blue-alliance/the-blue-alliance/pull/2473 - we fixed the secret validation in the request but not in the notification (we need both when forming a verification request)