### PR TITLE
Make sure webhook url, name, and secret are non-None

### DIFF
--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -260,3 +260,13 @@ class LoggedInHandler(webapp2.RequestHandler):
             TeamAdminAccess.expiration > now).fetch()
         if not existing_access:
             return self.abort(403)
+
+    def _require_user(self):
+        current_user_account_id = self.user_bundle.account.key.id()
+
+        target_account_id = self.request.get('account_id')
+        if not target_account_id:
+            return self.abort(403)
+
+        if target_account_id != current_user_account_id:
+            return self.abort(403)

--- a/controllers/base_controller.py
+++ b/controllers/base_controller.py
@@ -261,7 +261,7 @@ class LoggedInHandler(webapp2.RequestHandler):
         if not existing_access:
             return self.abort(403)
 
-    def _require_user(self):
+    def _require_request_user_is_bundle_user(self):
         current_user_account_id = self.user_bundle.account.key.id()
 
         target_account_id = self.request.get('account_id')

--- a/controllers/webhook_controller.py
+++ b/controllers/webhook_controller.py
@@ -24,13 +24,13 @@ class WebhookAdd(LoggedInHandler):
         self._require_request_user_is_bundle_user()
 
         # Name and URL must be non-None
-        url = self.request.get('url')
-        name = self.request.get('name')
+        url = self.request.get('url', None)
+        name = self.request.get('name', None)
         if not url or not name:
             return self.redirect('/webhooks/add?error=1')
 
         # Secret may be none - but we'll generate a secret for the user
-        secret = self.request.get('secret')
+        secret = self.request.get('secret', None)
         if not secret:
             import uuid
             secret = uuid.uuid4().hex

--- a/controllers/webhook_controller.py
+++ b/controllers/webhook_controller.py
@@ -1,5 +1,4 @@
 import os
-import logging
 
 from google.appengine.ext import ndb
 from google.appengine.ext.webapp import template
@@ -7,7 +6,6 @@ from google.appengine.ext.webapp import template
 from base_controller import LoggedInHandler
 from consts.client_type import ClientType
 from consts.notification_type import NotificationType
-from helpers.tbans_helper import TBANSHelper
 from models.account import Account
 from models.mobile_client import MobileClient
 
@@ -16,56 +14,69 @@ class WebhookAdd(LoggedInHandler):
     def get(self):
         self._require_registration()
 
+        self.template_values['error'] = self.request.get('error')
+
         path = os.path.join(os.path.dirname(__file__), '../templates/webhook_add.html')
         self.response.out.write(template.render(path, self.template_values))
 
     def post(self):
         self._require_registration()
+        self._require_user()
 
-        # Check to make sure that they aren't trying to edit another user
+        # Name and URL must be non-None
+        url = self.request.get('url')
+        name = self.request.get('name')
+        if not url or not name:
+            return self.redirect('/webhooks/add?error=1')
+
+        # Secret may be none - but we'll generate a secret for the user
+        secret = self.request.get('secret')
+        if not secret:
+            import uuid
+            secret = uuid.uuid4().hex
+
         current_user_account_id = self.user_bundle.account.key.id()
-        target_account_id = self.request.get('account_id')
-        if target_account_id == current_user_account_id:
-            url = self.request.get('url')
-            secret_key = self.request.get('secret')
-            query = MobileClient.query(MobileClient.messaging_id == url, ancestor=ndb.Key(Account, current_user_account_id))
-            if query.count() == 0:
-                # Webhook doesn't exist, add it
-                response = TBANSHelper.verify_webhook(url, secret_key)
-                client = MobileClient(
-                    parent=self.user_bundle.account.key,
-                    user_id=current_user_account_id,
-                    messaging_id=url,
-                    display_name = self.request.get('name'),
-                    secret=secret_key,
-                    client_type=ClientType.WEBHOOK,
-                    verified=False,
-                    verification_code=response.verification_key)
-                client.put()
-            else:
-                # Webhook already exists. Update the secret
-                current = query.fetch()[0]
-                current.secret = secret_key
-                current.put()
-            self.redirect('/account')
+        query = MobileClient.query(MobileClient.messaging_id == url, ancestor=ndb.Key(Account, current_user_account_id))
+        if query.count() == 0:
+            # Webhook doesn't exist, add it
+            from helpers.tbans_helper import TBANSHelper
+            response = TBANSHelper.verify_webhook(url, secret)
+
+            client = MobileClient(
+                parent=self.user_bundle.account.key,
+                user_id=current_user_account_id,
+                messaging_id=url,
+                display_name=name,
+                secret=secret,
+                client_type=ClientType.WEBHOOK,
+                verified=False,
+                verification_code=response.verification_key)
+            client.put()
         else:
-            self.redirect('/')
+            # Webhook already exists. Update the secret
+            current = query.fetch()[0]
+            current.secret = secret
+            current.put()
+
+        self.redirect('/account')
 
 
 class WebhookDelete(LoggedInHandler):
     def post(self):
         self._require_registration()
+        self._require_user()
 
-        # Check to make sure that they aren't trying to edit another user
         current_user_account_id = self.user_bundle.account.key.id()
-        target_account_id = self.request.get('account_id')
+        if not current_user_account_id:
+            return self.redirect('/')
+
         client_id = self.request.get('client_id')
-        if target_account_id == current_user_account_id:
-            to_delete = ndb.Key(Account, current_user_account_id, MobileClient, int(client_id))
-            to_delete.delete()
-            self.redirect('/account')
-        else:
-            self.redirect('/')
+        if not client_id:
+            return self.redirect('/')
+
+        to_delete = ndb.Key(Account, current_user_account_id, MobileClient, int(client_id))
+        to_delete.delete()
+        return self.redirect('/account')
 
 
 class WebhookVerify(LoggedInHandler):
@@ -80,45 +91,51 @@ class WebhookVerify(LoggedInHandler):
 
     def post(self, client_id):
         self._require_registration()
+        self._require_user()
 
-        # Check to make sure the user isn't trying to impersonate another
         current_user_account_id = self.user_bundle.account.key.id()
-        target_account_id = self.request.get('account_id')
-        if target_account_id == current_user_account_id:
-            verification = self.request.get('code')
-            webhook = MobileClient.get_by_id(int(client_id), parent=ndb.Key(Account, current_user_account_id))
-            if webhook.client_type == ClientType.WEBHOOK and current_user_account_id == webhook.user_id:
-                if verification == webhook.verification_code:
-                    logging.info("webhook verified")
-                    webhook.verified = True
-                    webhook.put()
-                    self.redirect('/account?webhook_verification_success=1')
-                    return
-                else:  # Verification failed
-                    # Redirect back to the verification page
-                    self.redirect('/webhooks/verify/{}?error=1'.format(webhook.key.id()))
-                    return
-        self.redirect('/')
+        if not current_user_account_id:
+            return self.redirect('/')
+
+        verification = self.request.get('code')
+        if not verification:
+            return self.redirect('/webhooks/verify/{}?error=1'.format(webhook.key.id()))
+
+        webhook = MobileClient.get_by_id(int(client_id), parent=ndb.Key(Account, current_user_account_id))
+        if not webhook or webhook.client_type != ClientType.WEBHOOK or current_user_account_id != webhook.user_id:
+            return self.redirect('/')
+
+        if verification == webhook.verification_code:
+            webhook.verified = True
+            webhook.put()
+            return self.redirect('/account?webhook_verification_success=1')
+        else:
+            # Redirect back to the verification page
+            return self.redirect('/webhooks/verify/{}?error=1'.format(webhook.key.id()))
 
 
 class WebhookVerificationSend(LoggedInHandler):
     def post(self):
         self._require_registration()
+        self._require_user()
 
         current_user_account_id = self.user_bundle.account.key.id()
-        target_account_id = self.request.get('account_id')
-        if target_account_id == current_user_account_id:
-            client_id = self.request.get('client_id')
-            webhook = MobileClient.get_by_id(int(client_id), parent=ndb.Key(Account, current_user_account_id))
-            if webhook.client_type == ClientType.WEBHOOK and current_user_account_id == webhook.user_id:
-                response = TBANSHelper.verify_webhook(webhook.messaging_id, webhook.secret)
-                webhook.verification_code = response.verification_key
-                webhook.verified = False
-                webhook.put()
-                self.redirect('/account')
-                return
-            else:
-                logging.warning("Not webhook, or wrong owner")
-        else:
-            logging.warning("Users don't match. "+current_user_account_id+"/"+target_account_id)
-        self.redirect('/')
+        if not current_user_account_id:
+            return self.redirect('/')
+
+        client_id = self.request.get('client_id')
+        if not client_id:
+            return self.redirect('/')
+
+        webhook = MobileClient.get_by_id(int(client_id), parent=ndb.Key(Account, current_user_account_id))
+        if not webhook or webhook.client_type != ClientType.WEBHOOK or current_user_account_id != webhook.user_id:
+            return self.redirect('/')
+
+        from helpers.tbans_helper import TBANSHelper
+        response = TBANSHelper.verify_webhook(webhook.messaging_id, webhook.secret)
+
+        webhook.verification_code = response.verification_key
+        webhook.verified = False
+        webhook.put()
+
+        return self.redirect('/account')

--- a/controllers/webhook_controller.py
+++ b/controllers/webhook_controller.py
@@ -21,7 +21,7 @@ class WebhookAdd(LoggedInHandler):
 
     def post(self):
         self._require_registration()
-        self._require_user()
+        self._require_request_user_is_bundle_user()
 
         # Name and URL must be non-None
         url = self.request.get('url')
@@ -64,7 +64,7 @@ class WebhookAdd(LoggedInHandler):
 class WebhookDelete(LoggedInHandler):
     def post(self):
         self._require_registration()
-        self._require_user()
+        self._require_request_user_is_bundle_user()
 
         current_user_account_id = self.user_bundle.account.key.id()
         if not current_user_account_id:
@@ -91,7 +91,7 @@ class WebhookVerify(LoggedInHandler):
 
     def post(self, client_id):
         self._require_registration()
-        self._require_user()
+        self._require_request_user_is_bundle_user()
 
         current_user_account_id = self.user_bundle.account.key.id()
         if not current_user_account_id:
@@ -117,7 +117,7 @@ class WebhookVerify(LoggedInHandler):
 class WebhookVerificationSend(LoggedInHandler):
     def post(self):
         self._require_registration()
-        self._require_user()
+        self._require_request_user_is_bundle_user()
 
         current_user_account_id = self.user_bundle.account.key.id()
         if not current_user_account_id:

--- a/templates/webhook_add.html
+++ b/templates/webhook_add.html
@@ -2,10 +2,19 @@
 
 {% block title %}The Blue Alliance - Add Webhook{% endblock %}
 
-{% block meta_description %}Create a webhook so TBA can notify your server on live events.{% endblock %}
-
 {% block content %}
 <div class="container">
+  {% if error %}
+  <div class="row">
+    <div class="col-sm-8 col-sm-offset-2 col-md-offset-2 col-lg-offset-2">
+      <div class="alert alert-danger">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <h4>Error</h4>
+        <p>Missing url or name</p>
+      </div>
+    </div>
+  </div>
+  {% endif %}
   <div class="row">
     <div class="col-sm-8 col-sm-offset-2 col-md-offset-2 col-lg-offset-2">
       <h1>Add Webhook</h1>
@@ -14,11 +23,11 @@
           <tbody>
             <tr>
               <td>URL</td>
-              <td><input class="form-control" type="text" name="url" placeholder="http://yoursite.com"/></td>
+              <td><input class="form-control" type="text" required="required" name="url" placeholder="http://yoursite.com"/></td>
             </tr>
             <tr>
               <td>Name</td>
-              <td><input class="form-control" type="text" name="name" placeholder="My Webhook" /></td>
+              <td><input class="form-control" type="text" required="required" name="name" placeholder="My Webhook" /></td>
             </tr>
             <tr>
               <td>Secret Key</td>

--- a/templates_jinja2/account_overview.html
+++ b/templates_jinja2/account_overview.html
@@ -287,7 +287,7 @@
         <tr>
           <th>Type</th>
           <th>Name</th>
-          <th>ID</td>
+          <th>ID</th>
           <th></th>
           <th></th>
           <th></th>
@@ -296,35 +296,43 @@
             <tr>
               <td>{{ client.type_string }}</td>
               <td> {{ client.display_name }} </td>
-              <td>{% if client.is_webhook %}{{ client.messaging_id }}{% else %}{{ client.short_id }}{% endif %}</td>
+              <td>
+                {% if client.is_webhook %}
+                  URL: {{ client.messaging_id }}
+                  <br/>
+                  Secret: {{ client.secret }}
+                {% else %}
+                  {{ client.short_id }}
+                {% endif %}
+              </td>
               <td><form action="/notifications/broadcast" method="post">
                 <input name="account_id" type="hidden" value="{{user_bundle.account.key.id()}}" />
                 <input name="client_id" type="hidden" value="{{client.key.id()}}" />
                 <button type="submit" class="btn btn-default" {{ping_enabled}}><span class="glyphicon glyphicon-cloud"></span> Ping</button>
               </form></td>
-                <td>
-                  {% if client.is_webhook %}
-                    <form action="/webhooks/delete" method="post">
-                      <input name="account_id" type="hidden" value="{{user_bundle.account.key.id()}}" />
-                      <input name="client_id" type="hidden" value="{{client.key.id()}}" />
-                      <button type="submit" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+              <td>
+                {% if client.is_webhook %}
+                <form action="/webhooks/delete" method="post">
+                  <input name="account_id" type="hidden" value="{{user_bundle.account.key.id()}}" />
+                  <input name="client_id" type="hidden" value="{{client.key.id()}}" />
+                  <button type="submit" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+                </form>
+                {% endif %}
+              </td>
+              <td>
+                {% if client.is_webhook %}
+                  {% if client.verified %}
+                    <p><span class="glyphicon glyphicon-check"></span> Verified</p>
+                  {% else %}
+                    <a href="/webhooks/verify/{{client.key.id()}}"><button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-edit"></span> Verify</button></a>
+                    <form action="/webhooks/send_verification" method="post">
+                    <input name="account_id" type="hidden" value="{{user_bundle.account.key.id()}}" />
+                    <input name="client_id" type="hidden" value="{{client.key.id()}}" />
+                    <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-send"></span> Resend Code</button>
                     </form>
                   {% endif %}
-                </td>
-                <td>
-                  {% if client.is_webhook %}
-                    {% if client.verified %}
-                      <p><span class="glyphicon glyphicon-check"></span> Verified</p>
-                    {% else %}
-                      <a href="/webhooks/verify/{{client.key.id()}}"><button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-edit"></span> Verify</button></a>
-                      <form action="/webhooks/send_verification" method="post">
-                      <input name="account_id" type="hidden" value="{{user_bundle.account.key.id()}}" />
-                      <input name="client_id" type="hidden" value="{{client.key.id()}}" />
-                      <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-send"></span> Resend Code</button>
-                      </form>
-                    {% endif %}
-                  {% endif %}
-                </td>
+                {% endif %}
+              </td>
             </tr>
           {% endfor %}
      {% else %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change to the webhook controller ensures that name, url, and secret are all non-None for webhooks. Closes #2474

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TBANS was assuming webhook secrets were non-None, which doesn't appear to be enforced via during webhook creation. We discussed via Slack generating secrets for users that don't specify secrets so they have a fallback for doing checksums. The next step is to migrate webhook users that don't have secrets set right now and add the validation back in to TBANS.

This also surfaces secrets in the mobile clients UI, since we don't show it right now. There's a lot of diffs, but mostly it's fixing formatting in the HTML/un-nesting the returns in the webhook controller.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in dev

## Screenshots (if appropriate):
<img width="1263" alt="Screen Shot 2019-03-22 at 12 57 49 PM" src="https://user-images.githubusercontent.com/516458/54841278-56bc3300-4ca5-11e9-9714-834ae7450937.png">
<img width="1236" alt="Screen Shot 2019-03-22 at 12 57 39 PM" src="https://user-images.githubusercontent.com/516458/54841281-591e8d00-4ca5-11e9-8eb1-e786b6c3c317.png">
<img width="1187" alt="Screen Shot 2019-03-22 at 1 02 34 PM" src="https://user-images.githubusercontent.com/516458/54841286-5e7bd780-4ca5-11e9-93b9-c00a3889f60b.png">
<img width="997" alt="Screen Shot 2019-03-22 at 1 13 47 PM" src="https://user-images.githubusercontent.com/516458/54841294-62a7f500-4ca5-11e9-947f-d4ba4173e83d.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
