### PR TITLE
DO NOT MERGE – Towards not allowing illegal youtube channel urls

### DIFF
--- a/consts/media_type.py
+++ b/consts/media_type.py
@@ -13,6 +13,7 @@ class MediaType(object):
     INSTAGRAM_IMAGE = 10
     EXTERNAL_LINK = 11
     AVATAR = 12
+    YOUTUBE_CHANNEL_ILLEGAL = 13
 
     type_names = {
         YOUTUBE_VIDEO: 'YouTube Video',
@@ -28,6 +29,7 @@ class MediaType(object):
         INSTAGRAM_IMAGE: 'Instagram Image',
         EXTERNAL_LINK: 'External Link',
         AVATAR: 'Avatar',
+        YOUTUBE_CHANNEL_ILLEGAL: 'YouTube Channel without custom URL'
     }
 
     image_types = [

--- a/helpers/suggestions/suggestion_creator.py
+++ b/helpers/suggestions/suggestion_creator.py
@@ -20,7 +20,10 @@ from models.suggestion import Suggestion
 class SuggestionCreator(object):
     @classmethod
     def createTeamMediaSuggestion(cls, author_account_key, media_url, team_key, year_str, private_details_json=None, is_social=False, default_preferred=False):
-        """Create a Team Media Suggestion. Returns status (success, suggestion_exists, media_exists, bad_url)"""
+        """Create a Team Media Suggestion. Returns status (success, illegal_media_type, suggestion_exists, media_exists, bad_url)"""
+
+        if MediaParser.media_type_from_url(media_url) in MediaParser.ILLEGAL_MEDIA_TYPES:
+            return 'illegal_media_type', None
 
         media_dict = MediaParser.partial_media_dict_from_url(media_url)
         if media_dict is not None:

--- a/templates_jinja2/suggestions/suggest_team_social_media.html
+++ b/templates_jinja2/suggestions/suggest_team_social_media.html
@@ -9,7 +9,7 @@
 <div class="container">
   {% if status %}
   <div class="row">
-    <div class="col-xs-12 col-lg-6 col-lg-offset-3">
+    <div class="col-xs-12 col-lg-8 col-lg-offset-2">
       {% if status == 'success' %}
       <div class="alert alert-success">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
@@ -28,6 +28,12 @@
         <h4>Thanks!</h4>
         <p>The URL you submitted is already pending review!</p>
       </div>
+      {% elif status == 'illegal_media_type' %}
+      <div class="alert alert-warning">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <h4>Uh oh!</h4>
+        <p>The URL you submitted is not the right type for the service you submitted. See below for currently supported formats.</p>
+      </div>
       {% else %}
       <div class="alert alert-danger">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
@@ -39,7 +45,7 @@
   </div>
   {% endif %}
   <div class="row">
-    <div class="col-xs-12 col-lg-6 col-lg-offset-3">
+    <div class="col-xs-12 col-lg-8 col-lg-offset-2">
       <div class="panel panel-default">
         <div class="panel-heading">
           <h1 class="panel-title">Help others by adding social media!</h1>
@@ -69,6 +75,7 @@
               <p>Please note that we can only accept YouTube channels with custom urls, if you do not have one, please create one by following <a href="https://support.google.com/youtube/answer/2657968?hl=en" target="_blank">these instructions</a>.</p>
               <ul>
                 <li>Example: <code>https://www.youtube.com/user/Uberbots1124</code></li>
+                <li>Invalid Example: <code><strike>https://www.youtube.com/channel/UCweoyLIzRXPS_JOrwpxX5tA</strike></code></li>
               </ul>
             </li>
             <li>GitHub Accounts

--- a/tests/suggestions/test_suggest_team_media_controller.py
+++ b/tests/suggestions/test_suggest_team_media_controller.py
@@ -170,7 +170,7 @@ class TestSuggestTeamSocialMediaController(unittest2.TestCase):
         response = response.follow(expect_errors=True)
         self.assertEqual(response.request.path, '/')
 
-    def test_suggest_team(self):
+    def test_suggest_team_github(self):
         self.loginUser()
         self.storeTeam()
         form = self.getSuggestionForm('frc1124')
@@ -183,3 +183,31 @@ class TestSuggestTeamSocialMediaController(unittest2.TestCase):
 
         suggestion = Suggestion.get_by_id('media_None_team_frc1124_github-profile_frc1124')
         self.assertIsNotNone(suggestion)
+
+    def test_suggest_team_youtube(self):
+        self.loginUser()
+        self.storeTeam()
+        form = self.getSuggestionForm('frc177')
+        form['media_url'] = 'https://www.youtube.com/user/bobcatrobotics'
+        response = form.submit().follow()
+        self.assertEqual(response.status_int, 200)
+
+        request = response.request
+        self.assertEqual(request.GET.get('status'), 'success')
+
+        suggestion = Suggestion.get_by_id('media_None_team_frc177_youtube-channel_bobcatrobotics')
+        self.assertIsNotNone(suggestion)
+
+    def test_suggest_team_youtube_illegal(self):
+        self.loginUser()
+        self.storeTeam()
+        form = self.getSuggestionForm('frc5507')
+        form['media_url'] = 'https://www.youtube.com/channel/UCweoyLIzRXPS_JOrwpxX5tA'
+        response = form.submit().follow()
+        self.assertEqual(response.status_int, 200)
+
+        request = response.request
+        self.assertEqual(request.GET.get('status'), 'illegal_media_type')
+
+        suggestion = Suggestion.get_by_id('media_None_team_frc5507_youtube-channel_channelucweoylizrxps_jorwpxx5ta')
+        self.assertIsNone(suggestion)


### PR DESCRIPTION
DO NOT MERGE

## Description
Errors if people attempt to submit a non-custom URL YouTube Channel.

## Motivation and Context
People submit youtube channels that do not have pretty URLs. We do not allow this, but they go to suggestion queues, and approving them would put a broken URL on the team page.

We could fix this in two ways:
1. Allow these non-pretty URLs and display just generic links like "YouTube Profile"
2. Disallow submitting these.

This is towards doing #2.

## How Has This Been Tested?
* Local dev instance
* New tests

## Screenshots (if appropriate):
Allowed YouTube channel
![Screenshot 2019-03-30 14 53 53](https://user-images.githubusercontent.com/57101/55280471-77ffcd80-52fc-11e9-95b8-ee3ebe16545a.png)

Illegal YouTube channel
![Screenshot 2019-03-30 14 53 40](https://user-images.githubusercontent.com/57101/55280470-759d7380-52fc-11e9-85b8-d65657f8ed2c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
