### PR TITLE
fixed bracket table incomplete border issue (issue 2481)

### DIFF
--- a/static/css/less_css/less/tba/tba_bracket_table.less
+++ b/static/css/less_css/less/tba/tba_bracket_table.less
@@ -11,6 +11,7 @@
   text-align: center;
   background-color: #eee;
   padding: 0 5px;
+  position: static;
 }
 
 .brackettable .leftAlliance {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have added position: static to .brackettable tr td in tba_bracket_table.less

## Motivation and Context
This is in response to [issue 2481](https://github.com/the-blue-alliance/the-blue-alliance/issues/2481). The bug not only existed in Chrome on Windows, but was also in Chrome on Linux. Firefox in Linux showed no inside borders. Bracket table cells were inheriting a position: relative from the table td styling, but table cells have an undefined behavior when using relative positioning (as defined in the [CSS2.1 Standard](https://www.w3.org/TR/CSS21/visuren.html#choose-position)), so I have added overridden the .brackettable tr td to be statically positioned. The insights page problem is probably a similar issue, but is not addressed in this fix as it should probably be its own issue.

## How Has This Been Tested?
Ran local dev server in Ubuntu Linux. Verified the issue with both Chrome and Firefox. After applying the fix, I checked the issue was resolved at various browser widths (both Firefox and Chrome), and looked for other elements that may have been broken/out of place and saw none.

## Screenshots (if appropriate):
Broken Playoff Bracket in Firefox
![Broken Playoff Bracket in Firefox](https://user-images.githubusercontent.com/1720392/55298397-749f3b80-53fb-11e9-8dfe-48fa57e6b14c.png)

Broken Playoff Bracket in Chrome
![Broken Playoff Bracket in Chrome](https://user-images.githubusercontent.com/1720392/55298403-81bc2a80-53fb-11e9-8ecd-5a045d1caa63.png)


Fixed Playoff Bracket in Firefox
![Fixed Playoff Bracket in Firefox](https://user-images.githubusercontent.com/1720392/55298262-bed3ed00-53fa-11e9-9749-69ab9e1c7364.png)

Fixed Playoff Bracket in Chrome
![Fixed Playoff Bracket in Chrome](https://user-images.githubusercontent.com/1720392/55298271-cc897280-53fa-11e9-8665-fca015fc4bd1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)