### PR TITLE
Run backup to bigquery cron weekly

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -98,7 +98,7 @@ cron:
 
 - description: Backup Cron job
   url: /backend-tasks/backup/enqueue
-  schedule: 1 of month 03:00
+  schedule: every monday 03:00
   timezone: America/Los_Angeles
 
 # - description: BlueZone Update


### PR DESCRIPTION
## Description
Increases frequency of backup cron job to publish fresher data to bigquery

## Motivation and Context
People are asking for fresher data

## How Has This Been Tested?
It has not. Please verify this will work as intended. I copied the cron syntax from the "Update Team Search Indexes" job.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
