### PR TITLE
Shortcuts for FLL and FTC gameday

### DIFF
--- a/static/javascript/tba_js/gameday.js
+++ b/static/javascript/tba_js/gameday.js
@@ -101,6 +101,24 @@ function setupViews() {
     setupView(8, $("#2016tes-1"));
   }
 
+  var isChamps = urlvars['champs-fll'];
+  if (isChamps != null) {
+    layout_3();
+    setChat(true);
+    setupView(0, $("#fll1-0"));
+    setupView(1, $("#fll2-0"));
+    setupView(2, $("#fll3-0"));
+    setupView(3, $("#fll4-0"));
+  }
+	
+  var isChamps = urlvars['champs-ftc'];
+  if (isChamps != null) {
+    layout_1();
+    setChat(true);
+    setupView(0, $("#jemison-0"));
+    setupView(1, $("#franklin-0"));
+  }
+	
   var isChamps = urlvars['champs'];
   if (isChamps != null) {
     layout_2();


### PR DESCRIPTION
Creates `tba/watch/champs-fll` and `tba/watch/champs-ftc`.
## Description
The FLL view is quad with all four FLL fields and the FTC is a dual view with each division.
## Motivation and Context
There's no pretty URL to watch all FLL or FTC streams

## How Has This Been Tested?
Has not been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
