### PR TITLE
Use notification_type instead of message_type for FCM messages

### DIFF
--- a/notifications/alliance_selections.py
+++ b/notifications/alliance_selections.py
@@ -18,7 +18,7 @@ class AllianceSelectionNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_name'] = self.event.name
         data['message_data']['event_key'] = self.event.key_name

--- a/notifications/awards_updated.py
+++ b/notifications/awards_updated.py
@@ -19,7 +19,7 @@ class AwardsUpdatedNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_name'] = self.event.name
         data['message_data']['event_key'] = self.event.key_name

--- a/notifications/base_notification.py
+++ b/notifications/base_notification.py
@@ -93,7 +93,7 @@ class BaseNotification(object):
 
     """
     Subclasses should override this method and return a dict containing the payload of the notification.
-    The dict should have two entries: 'message_type' (should be one of NotificationType, string) and 'message_data'
+    The dict should have two entries: 'notification_type' (should be one of NotificationType, string) and 'message_data'
     """
     def _build_dict(self):
         raise NotImplementedError("Subclasses must implement this method to build JSON data to send")
@@ -111,7 +111,11 @@ class BaseNotification(object):
         return self._render_gcm(ClientType.OS_ANDROID)
 
     def _render_webhook(self):
-        return self._build_dict()
+        # Note: webhooks use `message_type` instead of the `notification_type`
+        data = self._build_dict()
+        message_type = data.pop('notification_type')
+        data['message_type'] = message_type
+        return data
 
     def _render_gcm(self, client_type):
         from controllers.gcm.gcm import GCMMessage

--- a/notifications/broadcast.py
+++ b/notifications/broadcast.py
@@ -18,7 +18,7 @@ class BroadcastNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {
             'title': self.title,
             'desc': self.message,

--- a/notifications/district_points_updated.py
+++ b/notifications/district_points_updated.py
@@ -17,7 +17,7 @@ class DistrictPointsUpdatedNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['district_key'] = self.district_key
         data['message_data']['district_name'] = self.district_name

--- a/notifications/level_starting.py
+++ b/notifications/level_starting.py
@@ -20,7 +20,7 @@ class CompLevelStartingNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_name'] = self.event.name
         data['message_data']['event_key'] = self.event.key_name

--- a/notifications/match_score.py
+++ b/notifications/match_score.py
@@ -19,7 +19,7 @@ class MatchScoreNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_name'] = self.event.name
         data['message_data']['event_key'] = self.event.key_name

--- a/notifications/match_video.py
+++ b/notifications/match_video.py
@@ -14,7 +14,7 @@ class MatchVideoNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_name'] = self.event.name
         data['message_data']['match_key'] = self.match.key.id()
@@ -37,7 +37,7 @@ class EventMatchVideoNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_key'] = self.event.key.id()
         data['message_data']['event_name'] = self.event.name

--- a/notifications/ping.py
+++ b/notifications/ping.py
@@ -12,7 +12,7 @@ class PingNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {'title': "Test Message",
                                 'desc': "This is a test message ensuring your device can recieve push messages from The Blue Alliance."}
         return data

--- a/notifications/schedule_updated.py
+++ b/notifications/schedule_updated.py
@@ -25,7 +25,7 @@ class ScheduleUpdatedNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_key'] = self.event.key_name
         data['message_data']['event_name'] = self.event.name

--- a/notifications/upcoming_match.py
+++ b/notifications/upcoming_match.py
@@ -22,7 +22,7 @@ class UpcomingMatchNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         data['message_data'] = {}
         data['message_data']['event_key'] = self.event.key_name
         data['message_data']['event_name'] = self.event.name

--- a/notifications/update_favorites.py
+++ b/notifications/update_favorites.py
@@ -18,7 +18,7 @@ class UpdateFavoritesNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         return data
 
     def _render_android(self):

--- a/notifications/update_subscriptions.py
+++ b/notifications/update_subscriptions.py
@@ -20,7 +20,7 @@ class UpdateSubscriptionsNotification(BaseNotification):
 
     def _build_dict(self):
         data = {}
-        data['message_type'] = NotificationType.type_names[self._type]
+        data['notification_type'] = NotificationType.type_names[self._type]
         return data
 
     def _render_android(self):

--- a/tests/test_notification_awards.py
+++ b/tests/test_notification_awards.py
@@ -11,7 +11,7 @@ from models.team import Team
 from notifications.awards_updated import AwardsUpdatedNotification
 
 
-class TestAllianceNotification(unittest2.TestCase):
+class TestAwardsNotification(unittest2.TestCase):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
@@ -33,7 +33,7 @@ class TestAllianceNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.AWARDS]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.AWARDS]
         expected['message_data'] = {}
         expected['message_data']['event_name'] = self.event.name
         expected['message_data']['event_key'] = self.event.key_name

--- a/tests/test_notification_base.py
+++ b/tests/test_notification_base.py
@@ -26,8 +26,14 @@ class TestBaseNotification(unittest2.TestCase):
 
     def test_render_webhook(self):
         message = self.notification._render_webhook()
-
-        self.assertEqual(message, self.notification._build_dict())
+        expect = {
+            'message_type': 'ping',
+            'message_data': {
+                'title': 'Test Message',
+                'desc': 'This is a test message ensuring your device can recieve push messages from The Blue Alliance.'
+            }
+        }
+        self.assertEqual(message, expect)
 
     def _test_render_gcm(self, client_type):
         message = self.notification._render_gcm(client_type)

--- a/tests/test_notification_level_starting.py
+++ b/tests/test_notification_level_starting.py
@@ -33,7 +33,7 @@ class TestMatchScoreNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.LEVEL_STARTING]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.LEVEL_STARTING]
         expected['message_data'] = {}
         expected['message_data']['event_name'] = self.event.name
         expected['message_data']['event_key'] = self.event.key_name

--- a/tests/test_notification_ping.py
+++ b/tests/test_notification_ping.py
@@ -18,7 +18,7 @@ class TestUserPingNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.PING]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.PING]
         expected['message_data'] = {'title': "Test Message",
                                     'desc': "This is a test message ensuring your device can recieve push messages from The Blue Alliance."}
 

--- a/tests/test_notification_push.py
+++ b/tests/test_notification_push.py
@@ -24,7 +24,7 @@ class TestUserPingNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.PING]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.PING]
         expected['message_data'] = {'title': "Test Message",
                                     'desc': "This is a test message ensuring your device can recieve push messages from The Blue Alliance."}
 

--- a/tests/test_notification_schedule_updated.py
+++ b/tests/test_notification_schedule_updated.py
@@ -33,7 +33,7 @@ class TestMatchScoreNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.SCHEDULE_UPDATED]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.SCHEDULE_UPDATED]
         expected['message_data'] = {}
         expected['message_data']['event_key'] = self.event.key_name
         expected['message_data']['event_name'] = self.event.name

--- a/tests/test_notification_score.py
+++ b/tests/test_notification_score.py
@@ -33,7 +33,7 @@ class TestMatchScoreNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.MATCH_SCORE]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.MATCH_SCORE]
         expected['message_data'] = {}
         expected['message_data']['event_key'] = self.event.key_name
         expected['message_data']['event_name'] = self.event.name

--- a/tests/test_notification_upcoming_match.py
+++ b/tests/test_notification_upcoming_match.py
@@ -36,7 +36,7 @@ class TestUpcomingMatchNotification(unittest2.TestCase):
     def test_build(self):
         expected = {}
         self.maxDiff = None
-        expected['message_type'] = NotificationType.type_names[NotificationType.UPCOMING_MATCH]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.UPCOMING_MATCH]
         expected['message_data'] = {}
         expected['message_data']['event_key'] = self.event.key_name
         expected['message_data']['event_name'] = self.event.name

--- a/tests/test_notification_update_favorites.py
+++ b/tests/test_notification_update_favorites.py
@@ -23,7 +23,7 @@ class TestUpdateFavoritesNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.UPDATE_FAVORITES]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.UPDATE_FAVORITES]
         data = self.notification._build_dict()
 
         self.assertEqual(expected, data)

--- a/tests/test_notification_update_subscriptions.py
+++ b/tests/test_notification_update_subscriptions.py
@@ -23,7 +23,7 @@ class TestUpdateFavoritesNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['message_type'] = NotificationType.type_names[NotificationType.UPDATE_SUBSCRIPTION]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.UPDATE_SUBSCRIPTION]
         data = self.notification._build_dict()
 
         self.assertEqual(expected, data)


### PR DESCRIPTION
FCM messages are failing to send right now because we're using `message_type` which FCM uses as a reserved keyword. This changes FCM client (Android) notifications to use `notification_type` instead