### PR TITLE
Migrate secretless webhooks

### DIFF
--- a/controllers/admin/admin_cron_controller.py
+++ b/controllers/admin/admin_cron_controller.py
@@ -153,6 +153,31 @@ class AdminWebhooksClear(LoggedInHandler):
         self.response.out.write(template.render(path, template_values))
 
 
+class AdminWebhooksMigrateSecretlessEnqueue(LoggedInHandler):
+    """
+    Generate secret keys for webhooks without secrets.
+    """
+    def get(self):
+        self._require_admin()
+        taskqueue.add(
+            queue_name='admin',
+            url='/tasks/admin/migrate_secretless_webhooks',
+            method='GET')
+        self.response.out.write("Migrate secretless webhook task enqueued")
+
+
+class AdminWebhooksMigrateSecretless(LoggedInHandler):
+    def get(self):
+        webhooks = MobileClient.query(MobileClient.client_type == ClientType.WEBHOOK, MobileClient.secret == "").fetch()
+
+        import uuid
+        for webhook in webhooks:
+            webhook.secret = uuid.uuid4().hex
+            webhook.put()
+
+        self.response.out.write("Migrated {} secretless webhooks.".format(len(webhooks)))
+
+
 class AdminCreateDistrictTeamsEnqueue(LoggedInHandler):
     """
     Trying to Enqueue a task to rebuild old district teams from event teams.

--- a/cron_main.py
+++ b/cron_main.py
@@ -23,8 +23,8 @@ from controllers.cron_controller import UpcomingNotificationDo
 from controllers.cron_controller import UpdateLiveEventsDo
 
 from controllers.admin.admin_cron_controller import AdminMobileClearEnqueue, AdminMobileClear, AdminSubsClearEnqueue, AdminSubsClear, \
-    AdminWebhooksClearEnqueue, AdminWebhooksClear, AdminRegistrationDayEnqueue, \
-    AdminClearEventTeamsDo
+    AdminWebhooksClearEnqueue, AdminWebhooksClear, AdminWebhooksMigrateSecretlessEnqueue, \
+    AdminWebhooksMigrateSecretless, AdminRegistrationDayEnqueue, AdminClearEventTeamsDo
 from controllers.admin.admin_cron_controller import AdminRunPostUpdateHooksEnqueue, AdminRunPostUpdateHooksDo, AdminRunEventPostUpdateHookDo, AdminRunTeamPostUpdateHookDo, \
     AdminUpdateAllTeamSearchIndexEnqueue, AdminUpdateAllTeamSearchIndexDo, AdminUpdateTeamSearchIndexDo
 
@@ -71,6 +71,8 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/admin/clear_old_subs', AdminSubsClear),
                                ('/tasks/admin/enqueue/clear_old_webhooks', AdminWebhooksClearEnqueue),
                                ('/tasks/admin/clear_old_webhooks', AdminWebhooksClear),
+                               ('/tasks/admin/enqueue/migrate_secretless_webhooks', AdminWebhooksMigrateSecretlessEnqueue),
+                               ('/tasks/admin/migrate_secretless_webhooks', AdminWebhooksMigrateSecretless),
                                ('/tasks/admin/enqueue/registration_day', AdminRegistrationDayEnqueue),
                                ('/tasks/admin/enqueue/run_post_update_hooks/(.*)', AdminRunPostUpdateHooksEnqueue),
                                ('/tasks/admin/do/clear_eventteams/(.*)', AdminClearEventTeamsDo),

--- a/templates/admin/mobile_dashboard.html
+++ b/templates/admin/mobile_dashboard.html
@@ -27,6 +27,9 @@
     <a href="/tasks/admin/enqueue/clear_old_subs" class="btn btn-warning"><span class="glyphicon glyphicon-remove"></span> Remove Past Year Subscriptions</a>
     <a href="/tasks/admin/enqueue/clear_old_webhooks" class="btn btn-warning"><span class="glyphicon glyphicon-remove"></span> Remove Broken Webhooks</a>
 </div>
+<div class="btn-group">
+    <a href="/tasks/admin/enqueue/migrate_secretless_webhooks" class="btn">Migrate Secretless Webhooks</a>
+</div>
 <br />
 
 <h2>Enable Notifications</h2>


### PR DESCRIPTION
## Description
Adds an endpoint and admin console button to migrate webhooks without secrets set. Will revert once migration is complete.

## Motivation and Context
Follow up to https://github.com/the-blue-alliance/the-blue-alliance/pull/2476 and closes #2487 - there are currently 40 webhooks without secrets. We've added validation when creating a webhook that a webhook must have a secret set (we'll generate one by default if the user does not supply one). This will allow us to revert 52744f6e93b8a68a3ab2d9060e43673caf238eb6 and ee567385489627c76167b197fb6b9543e53565b6

## How Has This Been Tested?
Tested on a dev instance.

Before:
<img width="603" alt="Screen Shot 2019-04-20 at 7 37 01 PM" src="https://user-images.githubusercontent.com/516458/56463538-67df8900-63a4-11e9-8fdf-2a110613a8ca.png">

After:
<img width="776" alt="Screen Shot 2019-04-20 at 7 38 58 PM" src="https://user-images.githubusercontent.com/516458/56463540-6b731000-63a4-11e9-91f0-00d40b8d1618.png">

## Screenshots (if appropriate):
<img width="1033" alt="Screen Shot 2019-04-20 at 7 37 12 PM" src="https://user-images.githubusercontent.com/516458/56463536-60b87b00-63a4-11e9-825c-981376376ca6.png">