### PR TITLE
Fix spelling error in about template

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -15,7 +15,7 @@
       involved in the <em>FIRST</em> Robotics Competition (FRC) with scouting data and match videos.
       Since then, the project has grown to include developers from within the <em>FIRST</em> community from
       various teams all over the world. We continually strive to make The Blue Alliance an even more valuable
-      resource for our users.  Other additions to The Blue Alliance include match prediction and anaytics,
+      resource for our users.  Other additions to The Blue Alliance include match prediction and analytics,
       hosting of CAD models, and The Blue Alliance Blog.</p>
 
       <div class="hidden-xs">


### PR DESCRIPTION
Change 'anaytics' to 'analytics' in templates/about.html

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a public-facing spelling error
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Not tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
