### PR TITLE
Base RPs and unicorn matches off of match breakdowns

### DIFF
--- a/helpers/event_insights_helper.py
+++ b/helpers/event_insights_helper.py
@@ -188,8 +188,9 @@ class EventInsightsHelper(object):
                     hatch_panel_points += alliance_breakdown['hatchPanelPoints']
                     cargo_points += alliance_breakdown['cargoPoints']
 
-                    alliance_rocket_rp_achieved = alliance_breakdown['completeRocketRankingPoint']
-                    alliance_climb_rp_achieved = alliance_breakdown['habDockingRankingPoint']
+                    completed_rocket = alliance_breakdown['completedRocketNear'] or alliance_breakdown['completedRocketFar']
+                    alliance_rocket_rp_achieved = alliance_breakdown['completeRocketRankingPoint'] or completed_rocket
+                    alliance_climb_rp_achieved = alliance_breakdown['habDockingRankingPoint'] or (alliance_breakdown['habClimbPoints'] >= 15)
                     rocket_rp_achieved += 1 if alliance_rocket_rp_achieved else 0
                     climb_rp_achieved += 1 if alliance_climb_rp_achieved else 0
                     alliance_win = alliance_color == match.winning_alliance


### PR DESCRIPTION
This allows these objectives to be recorded and analyzed for playoff matches.

On the other hand, it's a bit confusing to note RP being scored in playoff matches, so we should discuss whether that needs to be clarified in the template text.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the logic for calculating rocket and hab RPs to be when the FIRST API reported RP _or_ when the match breakdown indicates RP criteria was met.

The FMS can report RPs that aren't met by match breakdown, e.g. G5/G16 for rocket RP. This differs from previous years where RP requirements would have been satisfied by the causing the component events to be scored, hence the explicit RP indications in the FIRST API.

## Motivation and Context
This allows for rocket RP, hab RP, and unicorn match analysis on playoff matches, which @jaredhasenklein requested.
Fixes #2489.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Spot checks on events showed that this didn't break any quals counts. That said, I haven't exhaustively checked that the RP flag was set in the FIRST API in every case that the criteria were met by the new standards.

It's a pretty self-contained change, and only affects the event insights, not any of the core logic or data.

## Screenshots (if appropriate):

<img width="1178" alt="Screenshot showing both qualification and playoff objective statistics with new change." src="https://user-images.githubusercontent.com/2940350/56709185-b9ee1a80-66d4-11e9-975f-61a3dd3f5436.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)