### PR TITLE
Only show & count one Championship Woodie Flowers banner

### DIFF
--- a/helpers/insights_helper.py
+++ b/helpers/insights_helper.py
@@ -569,7 +569,7 @@ class InsightsHelper(object):
         blue_banner_winners = defaultdict(int)
         for award_future in award_futures:
             award = award_future.get_result()
-            if award.award_type_enum in AwardType.BLUE_BANNER_AWARDS:
+            if award.award_type_enum in AwardType.BLUE_BANNER_AWARDS and award.count_banner:
                 for team_key in award.team_list:
                     team_key_name = team_key.id()
                     blue_banner_winners[team_key_name] += 1

--- a/models/award.py
+++ b/models/award.py
@@ -51,12 +51,14 @@ class Award(ndb.Model):
     def count_banner(self):
         if (self.award_type_enum == AwardType.WOODIE_FLOWERS and
                 self.event_type_enum == EventType.CMP_FINALS and
-                self.year >= 2017 and
-                self.event.id()[4:] != 'cmptx'):
+                self.year >= 2017):
             # Only count WFA banner from the first Championship
-            # Logic will need updating if CMPTX isn't the first Championship
-            # -fangeugene 2019-04-30
-            return False
+            cmp_event_keys = Event.query(
+                Event.year == self.year,
+                Event.event_type_enum == EventType.CMP_FINALS
+            ).order(Event.start_date).fetch(keys_only=True)
+            if cmp_event_keys and cmp_event_keys[0] != self.event:
+                return False
         return True
 
     @property

--- a/models/award.py
+++ b/models/award.py
@@ -3,6 +3,7 @@ import json
 from google.appengine.ext import ndb
 
 from consts.award_type import AwardType
+from consts.event_type import EventType
 from models.event import Event
 from models.team import Team
 
@@ -45,6 +46,18 @@ class Award(ndb.Model):
     @property
     def is_blue_banner(self):
         return self.award_type_enum in AwardType.BLUE_BANNER_AWARDS
+
+    @property
+    def count_banner(self):
+        if (self.award_type_enum == AwardType.WOODIE_FLOWERS and
+                self.event_type_enum == EventType.CMP_FINALS and
+                self.year >= 2017 and
+                self.event.id()[4:] != 'cmptx'):
+            # Only count WFA banner from the first Championship
+            # Logic will need updating if CMPTX isn't the first Championship
+            # -fangeugene 2019-04-30
+            return False
+        return True
 
     @property
     def normalized_name(self):

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -86,7 +86,7 @@
             {% for comp in participation %}
               {% if comp.event.is_season_event and comp.awards %}
                 {% for award in comp.awards %}
-                  {% if award.is_blue_banner %}
+                  {% if award.is_blue_banner and award.count_banner %}
                     {% for team_number, _ in award.recipient_dict.items() %}
                       {% if team_number|string == team.team_number|string %}
                         {{bbm.blue_banner(award, comp.event)}}

--- a/templates_jinja2/team_history.html
+++ b/templates_jinja2/team_history.html
@@ -76,7 +76,7 @@
           {% for event, awards in event_awards|reverse %}
             {% if event.is_season_event and awards %}
               {% for award in awards %}
-                {% if award.is_blue_banner %}
+                {% if award.is_blue_banner and award.count_banner %}
                   {% for team_number, _ in award.recipient_dict.items() %}
                     {% if team_number|string == team.team_number|string %}
                       {{bbm.blue_banner(award, event)}}

--- a/templates_jinja2/team_partials/blue_banner_macros.html
+++ b/templates_jinja2/team_partials/blue_banner_macros.html
@@ -1,3 +1,18 @@
 {% macro blue_banner(award, event, hidden=False) %}
-<div class="banner{% if hidden %} hidden-banner hidden{% endif %}"><img src="{% if event.event_type_enum == 6 %}/images/first_foc_trophy_icon.svg{% else %}/images/first_icon.svg{% endif %}"><div class="award-name{% if award.normalized_name|length > 18 %}-long{% endif %}"><span>{{award.normalized_name}}</span></div><div class="{% if event.normalized_name|length < 30 %}award-event{% else %}award-event-long{% endif %}"><span>{{award.year}} {{event.normalized_name}}</span></div></div>
+<div class="banner{% if hidden %} hidden-banner hidden{% endif %}">
+    <img src="{% if event.event_type_enum == 6 %}/images/first_foc_trophy_icon.svg{% else %}/images/first_icon.svg{% endif %}"/>
+    <div class="award-name{% if award.normalized_name|length > 18 %}-long{% endif %}">
+        <span>{{award.normalized_name}}</span>
+    </div>
+    {% if event.event_type_enum == 4 and award.award_type_enum == 3 %}
+    {# Only one WFA for both Championsihps #}
+    <div class="award-event">
+        <span>{{award.year}} Championship</span>
+    </div>
+    {% else %}
+    <div class="{% if event.normalized_name|length < 30 %}award-event{% else %}award-event-long{% endif %}">
+        <span>{{award.year}} {{event.normalized_name}}</span>
+    </div>
+    {% endif %}
+</div>
 {% endmacro %}


### PR DESCRIPTION
## How Has This Been Tested?
Verified locally that only one blue banner for WFA shows up for 3847 in 2019.
Verified locally that insights counts 3 total banners for 3847 in 2019, not 4.

## Screenshots (if appropriate):
Before
![image](https://user-images.githubusercontent.com/1421884/56991521-dde2ad80-6b65-11e9-95c2-63a7166fb586.png)

After
![image](https://user-images.githubusercontent.com/1421884/56991536-e89d4280-6b65-11e9-96f6-14e03e3052ed.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
