### PR TITLE
Fix #2507.

### DIFF
--- a/database/match_query.py
+++ b/database/match_query.py
@@ -7,7 +7,7 @@ from models.match import Match
 
 
 class MatchQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'match_{}'  # (match_key)
     DICT_CONVERTER = MatchConverter
 
@@ -19,7 +19,7 @@ class MatchQuery(DatabaseQuery):
 
 
 class EventMatchesQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'event_matches_{}'  # (event_key)
     DICT_CONVERTER = MatchConverter
 
@@ -32,7 +32,7 @@ class EventMatchesQuery(DatabaseQuery):
 
 
 class TeamEventMatchesQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'team_event_matches_{}_{}'  # (team_key, event_key)
     DICT_CONVERTER = MatchConverter
 
@@ -48,7 +48,7 @@ class TeamEventMatchesQuery(DatabaseQuery):
 
 
 class TeamYearMatchesQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'team_year_matches_{}_{}'  # (team_key, year)
     DICT_CONVERTER = MatchConverter
 

--- a/models/match.py
+++ b/models/match.py
@@ -137,6 +137,8 @@ class Match(ndb.Model):
                 # add dqs if not present
                 if 'dqs' not in self._alliances[color]:
                     self._alliances[color]['dqs'] = []
+                if len(self._alliances[color]['dqs']) != 0 and self.comp_level in self.ELIM_LEVELS:
+                    self._alliances[color]['dqs'] = self._alliances[color]['teams']
 
         return self._alliances
 

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -487,7 +487,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(match.alliances['red']['teams'], ['frc1', 'frc2', 'frc3'])
         self.assertEqual(match.alliances['red']['score'], 250)
         self.assertEqual(match.alliances['red']['surrogates'], ['frc1'])
-        self.assertEqual(match.alliances['red']['dqs'], ['frc2'])
+        self.assertEqual(match.alliances['red']['dqs'], ['frc1', 'frc2', 'frc3'])
         self.assertEqual(match.score_breakdown['red']['truss+catch'], 20)
         self.assertEqual(match.alliances['blue']['teams'], ['frc4', 'frc5', 'frc6'])
         self.assertEqual(match.alliances['blue']['score'], 260)

--- a/tests/test_api_trusted.py
+++ b/tests/test_api_trusted.py
@@ -856,7 +856,7 @@ class TestApiTrustedController(unittest2.TestCase):
                 'red': {'teams': ['frc1', 'frc2', 'frc3'],
                         'score': 250,
                         'surrogates': ['frc1'],
-                        'dqs': ['frc2']},
+                        'dqs': ['frc1', 'frc2', 'frc3']},
                 'blue': {'teams': ['frc4', 'frc5', 'frc6'],
                          'score': 260,
                          'surrogates': [],
@@ -882,7 +882,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(match.alliances['red']['teams'], ['frc101B', 'frc102B', 'frc102C'])
         self.assertEqual(match.alliances['red']['score'], 250)
         self.assertEqual(match.alliances['red']['surrogates'], ['frc101B'])
-        self.assertEqual(match.alliances['red']['dqs'], ['frc102B'])
+        self.assertEqual(match.alliances['red']['dqs'], ['frc101B', 'frc102B', 'frc102C'])
         self.assertEqual(match.score_breakdown['red']['truss+catch'], 20)
         self.assertEqual(match.alliances['blue']['teams'], ['frc104', 'frc5', 'frc6'])
         self.assertEqual(match.alliances['blue']['score'], 260)
@@ -974,7 +974,7 @@ class TestApiTrustedController(unittest2.TestCase):
                 'red': {'teams': ['frc1', 'frc2', 'frc3'],
                         'score': 250,
                         'surrogates': ['frc1'],
-                        'dqs': ['frc2']},
+                        'dqs': ['frc1', 'frc2', 'frc3']},
                 'blue': {'teams': ['frc4', 'frc5', 'frc6'],
                          'score': 260,
                          'surrogates': [],
@@ -1064,7 +1064,7 @@ class TestApiTrustedController(unittest2.TestCase):
         self.assertEqual(match.alliances['red']['teams'], ['frc101B', 'frc102B', 'frc102C'])
         self.assertEqual(match.alliances['red']['score'], 250)
         self.assertEqual(match.alliances['red']['surrogates'], ['frc101B'])
-        self.assertEqual(match.alliances['red']['dqs'], ['frc102B'])
+        self.assertEqual(match.alliances['red']['dqs'], ['frc101B', 'frc102B', 'frc102C'])
         self.assertEqual(match.score_breakdown['red']['truss+catch'], 20)
         self.assertEqual(match.alliances['blue']['teams'], ['frc104', 'frc5', 'frc6'])
         self.assertEqual(match.alliances['blue']['score'], 260)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Correctly indicate disqualification status for eliminations.

## Description
<!--- Describe your changes in detail -->

See diff.  It's pretty minor.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We currently do not correctly indicate that elimination alliances are
disqualified together.  We currently only mark the middle team as
disqualified.

<!--- If it fixes an open issue, please link to the issue here. -->

See #2507.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)