### PR TITLE
Unpack num_played in 2015 advancement template

### DIFF
--- a/templates_jinja2/playoff_partials/playoff_table.html
+++ b/templates_jinja2/playoff_partials/playoff_table.html
@@ -10,7 +10,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for alliance, scores, average_score in playoff_advancement.ef %}
+      {% for alliance, scores, average_score, num_played in playoff_advancement.ef %}
         <tr>
           <td>{{loop.index}}</td>
           <td>{% for team in alliance %}<a href="/team/{{ team|digits }}/{{ event.year }}">{{ team }}</a>{% if not loop.last %}, {% endif %}{% endfor %}</td>
@@ -34,7 +34,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for alliance, scores, average_score in playoff_advancement.qf %}
+      {% for alliance, scores, average_score, num_played in playoff_advancement.qf %}
         <tr>
           <td>{{loop.index}}</td>
           <td>{% for team in alliance %}<a href="/team/{{ team|digits }}/{{ event.year }}">{{ team }}</a>{% if not loop.last %}, {% endif %}{% endfor %}</td>
@@ -58,7 +58,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for alliance, scores, average_score in playoff_advancement.sf %}
+      {% for alliance, scores, average_score, num_played in playoff_advancement.sf %}
         <tr>
           <td>{{loop.index}}</td>
           <td>{% for team in alliance %}<a href="/team/{{ team|digits }}/{{ event.year }}">{{ team }}</a>{% if not loop.last %}, {% endif %}{% endfor %}</td>


### PR DESCRIPTION
Phil's change in https://github.com/the-blue-alliance/the-blue-alliance/commit/a04fe4ad9c687ced4ec125a7f8f9b7dc4d0ae147 added a `num_played` field to the results of `generatePlayoffAdvancement2015`, but we weren't unpacking that value in the templates. This updates the templates to unpack that value and fix the 500s for 2015 events.