### PR TITLE
Fix TBANS webhook requests failing to deliver (revert #2422)

### DIFF
--- a/tbans/requests/webhook_request.py
+++ b/tbans/requests/webhook_request.py
@@ -47,8 +47,7 @@ class WebhookRequest(Request):
         headers['X-TBA-Checksum'] = self._generate_webhook_checksum(message_json)
 
         from google.appengine.api import urlfetch
-        rpc = urlfetch.create_rpc()
-        return urlfetch.make_fetch_call(rpc, self.url, payload=message_json, method=urlfetch.POST, headers=headers)
+        urlfetch.fetch(url=self.url, payload=message_json, method=urlfetch.POST, headers=headers)
 
     def _json_string(self):
         """ JSON string representation of an WebhookRequest object.

--- a/tbans/requests/webhook_request.py
+++ b/tbans/requests/webhook_request.py
@@ -47,7 +47,7 @@ class WebhookRequest(Request):
         headers['X-TBA-Checksum'] = self._generate_webhook_checksum(message_json)
 
         from google.appengine.api import urlfetch
-        urlfetch.fetch(url=self.url, payload=message_json, method=urlfetch.POST, headers=headers)
+        return urlfetch.fetch(url=self.url, payload=message_json, method=urlfetch.POST, headers=headers)
 
     def _json_string(self):
         """ JSON string representation of an WebhookRequest object.

--- a/tests/tbans_tests/requests/test_webhook_request.py
+++ b/tests/tbans_tests/requests/test_webhook_request.py
@@ -78,12 +78,10 @@ class TestWebhookRequest(unittest2.TestCase):
     def test_send(self):
         message = WebhookRequest(MockNotification(webhook_message_data={'data': 'value'}), 'https://www.thebluealliance.com/', 'secret')
         response = message.send()
-        result = response.get_result()
-        self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.content, 'Some content here')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'Some content here')
 
     def test_send_fail(self):
         message = WebhookRequest(MockNotification(webhook_message_data={'data': 'some new value value'}), 'https://somenewwebsite.com', 'somenewsecret')
-        response = message.send()
         with self.assertRaises(AssertionError):
-            response.get_result()
+            response = message.send()


### PR DESCRIPTION
Webhook verifies and pings are failing if the user doesn't get the first request on a TBANS instance. My guess is that our end-to-end requests are succeeding too fast, and the request gets killed/canceled/never executed (I'm seeing 5ms-20ms in the logs for non-first-process requests). Post-change requests look to be a more reasonable length (~100-200ms).

This reverts #2422, which made webhook reqeusts async. If a server doesn't reply to a ping or to a verification within the time allotted (it's 10s end-to-end, with a little overhead in web), showing a 500 in web seems fine. I think the real solution here is to work on some debug messaging for users, as opposed to showing a 500. But we can handle that later, once we get webhook requests working again.