### PR TITLE
Add existing notification models to TBANS

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -391,6 +391,12 @@ class Event(ndb.Model):
         return current_webcasts
 
     @property
+    def online_webcasts(self):
+        current_webcasts = self.current_webcasts
+        WebcastOnlineHelper.add_online_status(current_webcasts)
+        return filter(lambda x: x.get('status', '') != 'offline', current_webcasts if current_webcasts else [])
+
+    @property
     def has_first_official_webcast(self):
         return any([('firstinspires' in w['channel']) for w in self.webcast]) if self.webcast else False
 

--- a/models/match.py
+++ b/models/match.py
@@ -198,6 +198,17 @@ class Match(ndb.Model):
         return self._winning_alliance
 
     @property
+    def losing_alliance(self):
+        winning_alliance = self.winning_alliance
+        # No winning alliance means no losing alliance - either a tie, or 2015
+        if winning_alliance == '':
+            return ''
+
+        alliances = ['red', 'blue']
+        alliances.remove(winning_alliance)
+        return alliances[0]
+
+    @property
     def event_key_name(self):
         return self.event.id()
 
@@ -261,6 +272,10 @@ class Match(ndb.Model):
     @property
     def name(self):
         return "%s" % (self.COMP_LEVELS_VERBOSE[self.comp_level])
+
+    @property
+    def full_name(self):
+        return "%s" % (self.COMP_LEVELS_VERBOSE_FULL[self.comp_level])
 
     @property
     def youtube_videos_formatted(self):

--- a/tbans/models/notifications/alliance_selection.py
+++ b/tbans/models/notifications/alliance_selection.py
@@ -1,0 +1,42 @@
+from tbans.models.notifications.notification import Notification
+
+
+class AllianceSelectionNotification(Notification):
+
+    def __init__(self, event):
+        self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.ALLIANCE_SELECTION
+
+    @property
+    def fcm_notification(self):
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} Alliances Updated'.format(self.event.event_short.upper()),
+            body='{} alliances have been updated.'.format(self.event.normalized_name)
+        )
+
+    @property
+    def platform_config(self):
+        from tbans.consts.fcm.platform_priority import PlatformPriority
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
+    def data_payload(self):
+        from helpers.model_to_dict import ModelToDict
+        return {
+            'event': ModelToDict.eventConverter(self.event),
+            'event_key': self.event.key_name
+        }
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['event_name'] = self.event.name
+        return payload

--- a/tbans/models/notifications/awards.py
+++ b/tbans/models/notifications/awards.py
@@ -1,0 +1,43 @@
+from tbans.models.notifications.notification import Notification
+
+
+class AwardsNotification(Notification):
+
+    def __init__(self, event):
+        self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.AWARDS
+
+    @property
+    def fcm_notification(self):
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} Awards Updated'.format(self.event.event_short.upper()),
+            body='{} awards have been updated.'.format(self.event.normalized_name)
+        )
+
+    @property
+    def platform_config(self):
+        from tbans.consts.fcm.platform_priority import PlatformPriority
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
+    def data_payload(self):
+        from helpers.award_helper import AwardHelper
+        from helpers.model_to_dict import ModelToDict
+        return {
+            'awards': [ModelToDict.awardConverter(award) for award in AwardHelper.organizeAwards(self.event.awards)],
+            'event_key': self.event.key_name
+        }
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['event_name'] = self.event.name
+        return payload

--- a/tbans/models/notifications/broadcast.py
+++ b/tbans/models/notifications/broadcast.py
@@ -1,0 +1,40 @@
+from tbans.models.notifications.notification import Notification
+
+
+class BroadcastNotification(Notification):
+
+    def __init__(self, title, message, url, app_version=''):
+        self.title = title
+        self.message = message
+        self.url = url
+        self.app_version = app_version
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.BROADCAST
+
+    @property
+    def fcm_notification(self):
+        from firebase_admin import messaging
+        return messaging.Notification(title=self.title, body=self.message)
+
+    @property
+    def data_payload(self):
+        payload = {
+            'url': self.url
+        }
+
+        if self.app_version:
+            payload['app_version'] = self.app_version
+        else:
+            payload['app_version'] = None
+
+        return payload
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['title'] = self.title
+        payload['desc'] = self.message
+        return payload

--- a/tbans/models/notifications/district_points.py
+++ b/tbans/models/notifications/district_points.py
@@ -1,0 +1,34 @@
+from tbans.models.notifications.notification import Notification
+
+
+class DistrictPointsNotification(Notification):
+
+    # disrict_key is like <year><enum>
+    # Example: 2014ne
+    def __init__(self, district):
+        self.district = district
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.DISTRICT_POINTS_UPDATED
+
+    @property
+    def fcm_notification(self):
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} District Points Updated'.format(self.district.abbreviation.upper()),
+            body='{} district point calculations have been updated.'.format(self.district.display_name)
+        )
+
+    @property
+    def data_payload(self):
+        return {
+            'district_key': self.district.key_name
+        }
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['district_name'] = self.district.display_name
+        return payload

--- a/tbans/models/notifications/event_level.py
+++ b/tbans/models/notifications/event_level.py
@@ -1,0 +1,58 @@
+import calendar
+import datetime
+
+from tbans.models.notifications.notification import Notification
+
+
+class EventLevelNotification(Notification):
+
+    def __init__(self, match):
+        self.match = match
+        self.event = match.event.get()
+        self._event_feed = self.event.key_name
+        self._district_feed = self.event.event_district_abbrev
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.LEVEL_STARTING
+
+    @property
+    def fcm_notification(self):
+        if self.match.time:
+            time = self.match.time.strftime("%H:%M")
+            ending = 'scheduled for {}.'.format(time)
+        else:
+            ending = 'starting.'
+
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} {} Matches Starting'.format(self.event.event_short.upper(), self.match.full_name),
+            body='{}: {} Matches are {}'.format(self.event.normalized_name, self.match.full_name, ending)
+        )
+
+    @property
+    def platform_config(self):
+        from tbans.consts.fcm.platform_priority import PlatformPriority
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
+    def data_payload(self):
+        payload = {
+            'comp_level': self.match.comp_level,
+            'event_key': self.event.key_name
+        }
+
+        if self.match.time:
+            payload['scheduled_time'] = calendar.timegm(self.match.time.utctimetuple())
+        else:
+            payload['scheduled_time'] = None
+
+        return payload
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['event_name'] = self.event.name
+        return payload

--- a/tbans/models/notifications/event_schedule.py
+++ b/tbans/models/notifications/event_schedule.py
@@ -1,0 +1,61 @@
+import calendar
+
+from tbans.models.notifications.notification import Notification
+
+
+class EventScheduleNotification(Notification):
+
+    def __init__(self, event, next_match=None):
+        self.event = event
+        self._event_feed = event.key_name
+        self._district_feed = event.event_district_abbrev
+
+        if not next_match:
+            from helpers.match_helper import MatchHelper
+            upcoming = MatchHelper.upcomingMatches(event.matches, 1)
+            self.next_match = upcoming[0] if upcoming and len(upcoming) > 0 else None
+        else:
+            self.next_match = next_match
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.SCHEDULE_UPDATED
+
+    @property
+    def fcm_notification(self):
+        body = 'The {} match schedule has been updated.'.format(self.event.normalized_name)
+        if self.next_match and self.next_match.time:
+            time = self.next_match.time.strftime("%H:%M")
+            body += ' The next match starts at {}.'.format(time)
+
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} Schedule Updated'.format(self.event.event_short.upper()),
+            body=body
+        )
+
+    @property
+    def platform_config(self):
+        from tbans.consts.fcm.platform_priority import PlatformPriority
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
+    def data_payload(self):
+        payload = {
+            'event_key': self.event.key_name
+        }
+
+        if self.next_match and self.next_match.time:
+            payload['first_match_time'] = calendar.timegm(self.next_match.time.utctimetuple())
+        else:
+            payload['first_match_time'] = None
+
+        return payload
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['event_name'] = self.event.name
+        return payload

--- a/tbans/models/notifications/match_score.py
+++ b/tbans/models/notifications/match_score.py
@@ -1,0 +1,60 @@
+from tbans.models.notifications.notification import Notification
+
+
+class MatchScoreNotification(Notification):
+
+    def __init__(self, match):
+        self.match = match
+        self.event = match.event.get()
+        self._event_feed = self.event.key_name
+        self._district_feed = self.event.event_district_enum
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.MATCH_SCORE
+
+    @property
+    def fcm_notification(self):
+        winning_alliance = self.match.winning_alliance
+        losing_alliance = self.match.losing_alliance
+
+        alliance_one = self.match.alliances[winning_alliance] if winning_alliance is not '' else self.match.alliances['red']
+        alliance_two = self.match.alliances[losing_alliance] if losing_alliance is not '' else self.match.alliances['blue']
+
+        # [3:] to remove 'frc' prefix
+        alliance_one_teams = ', '.join([team[3:] for team in alliance_one['teams']])
+        alliance_two_teams = ', '.join([team[3:] for team in alliance_two['teams']])
+
+        alliance_one_score = alliance_one['score']
+        alliance_two_score = alliance_two['score']
+        if alliance_one_score == alliance_two_score:
+            action = 'tied with'
+        else:
+            action = 'beat'
+
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} {} Results'.format(self.event.event_short.upper(), self.match.short_name),
+            body='{} {} {} scoring {}-{}.'.format(alliance_one_teams, action, alliance_two_teams, alliance_one_score, alliance_two_score)
+        )
+
+    @property
+    def platform_config(self):
+        from tbans.consts.fcm.platform_priority import PlatformPriority
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
+    def data_payload(self):
+        from helpers.model_to_dict import ModelToDict
+        return {
+            'event_key': self.event.key_name,
+            'match': ModelToDict.matchConverter(self.match)
+        }
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['event_name'] = self.event.name
+        return payload

--- a/tbans/models/notifications/match_upcoming.py
+++ b/tbans/models/notifications/match_upcoming.py
@@ -1,0 +1,74 @@
+import calendar
+
+from tbans.models.notifications.notification import Notification
+
+
+class MatchUpcomingNotification(Notification):
+
+    def __init__(self, match):
+        self.match = match
+        self.event = match.event.get()
+        self._event_feed = self.event.key_name
+        self._district_feed = self.event.event_district_enum
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.UPCOMING_MATCH
+
+    @property
+    def fcm_notification(self):
+        # [3:] to remove 'frc' prefix
+        red_alliance = ', '.join([team[3:] for team in self.match.alliances['red']['teams']])
+        blue_alliance = ', '.join([team[3:] for team in self.match.alliances['blue']['teams']])
+
+        scheduled_time = self.match.time if self.match.predicted_time is None else self.match.predicted_time
+        if scheduled_time:
+            time = scheduled_time.strftime("%H:%M")
+            ending = ', scheduled for {}.'.format(time)
+        else:
+            ending = '.'
+
+        from firebase_admin import messaging
+        return messaging.Notification(
+            title='{} {} Starting Soon'.format(self.event.event_short.upper(), self.match.short_name),
+            body='{} {}: {} will play {}{}'.format(self.event.normalized_name, self.match.verbose_name, red_alliance, blue_alliance, ending)
+        )
+
+    @property
+    def platform_config(self):
+        from tbans.consts.fcm.platform_priority import PlatformPriority
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
+    def data_payload(self):
+        payload = {
+            'event_key': self.event.key_name,
+            'match_key': self.match.key_name,
+            'team_keys': self.match.team_key_names
+        }
+
+        if self.match.time:
+            payload['scheduled_time'] = calendar.timegm(self.match.time.utctimetuple())
+        else:
+            payload['scheduled_time'] = None
+
+        if self.match.predicted_time:
+            payload['predicted_time'] = calendar.timegm(self.match.predicted_time.utctimetuple())
+        else:
+            payload['predicted_time'] = None
+
+        online_webcasts = self.event.online_webcasts
+        if online_webcasts:
+            payload['webcast'] = online_webcasts[0]
+        else:
+            payload['webcast'] = None
+
+        return payload
+
+    @property
+    def webhook_message_data(self):
+        payload = self.data_payload
+        payload['event_name'] = self.event.name
+        return payload

--- a/tbans/models/notifications/update_favorites.py
+++ b/tbans/models/notifications/update_favorites.py
@@ -1,0 +1,17 @@
+from tbans.models.notifications.notification import Notification
+
+
+class UpdateFavoritesNotification(Notification):
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.UPDATE_FAVORITES
+
+    @property
+    def platform_config(self):
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(collapse_key='{}_favorite_update'.format(self.user_id))

--- a/tbans/models/notifications/update_subscriptions.py
+++ b/tbans/models/notifications/update_subscriptions.py
@@ -1,0 +1,17 @@
+from tbans.models.notifications.notification import Notification
+
+
+class UpdateSubscriptionsNotification(Notification):
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+
+    @classmethod
+    def _type(cls):
+        from consts.notification_type import NotificationType
+        return NotificationType.UPDATE_SUBSCRIPTION
+
+    @property
+    def platform_config(self):
+        from tbans.models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(collapse_key='{}_subscriptions_update'.format(self.user_id))

--- a/tests/tbans_tests/models/notifications/test_alliance_selection.py
+++ b/tests/tbans_tests/models/notifications/test_alliance_selection.py
@@ -1,0 +1,66 @@
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.notification_type import NotificationType
+from helpers.event.event_test_creator import EventTestCreator
+from models.team import Team
+
+from tbans.consts.fcm.platform_priority import PlatformPriority
+from tbans.models.notifications.alliance_selection import AllianceSelectionNotification
+
+
+class TestAllianceSelectionNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()
+
+        self.testbed.init_taskqueue_stub(root_path=".")
+
+        for team_number in range(7):
+            Team(id="frc%s" % team_number,
+                 team_number=team_number).put()
+
+        self.event = EventTestCreator.createPresentEvent()
+        self.notification = AllianceSelectionNotification(self.event)
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_type(self):
+        self.assertEqual(AllianceSelectionNotification._type(), NotificationType.ALLIANCE_SELECTION)
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
+    def test_fcm_notification(self):
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Alliances Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'Present Test Event alliances have been updated.')
+
+    def test_fcm_notification_short_name(self):
+        self.notification.event.short_name = 'Arizona North'
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Alliances Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'Arizona North Regional alliances have been updated.')
+
+    def test_data_payload(self):
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 2)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNotNone(payload['event'])
+
+    def test_webhook_message_data(self):
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNotNone(payload['event'])

--- a/tests/tbans_tests/models/notifications/test_awards.py
+++ b/tests/tbans_tests/models/notifications/test_awards.py
@@ -1,0 +1,66 @@
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.notification_type import NotificationType
+from helpers.event.event_test_creator import EventTestCreator
+from models.team import Team
+
+from tbans.consts.fcm.platform_priority import PlatformPriority
+from tbans.models.notifications.awards import AwardsNotification
+
+
+class TestAwardsNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()
+
+        self.testbed.init_taskqueue_stub(root_path=".")
+
+        for team_number in range(7):
+            Team(id="frc%s" % team_number,
+                 team_number=team_number).put()
+
+        self.event = EventTestCreator.createPresentEvent()
+        self.notification = AwardsNotification(self.event)
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_type(self):
+        self.assertEqual(AwardsNotification._type(), NotificationType.AWARDS)
+
+    def test_fcm_notification(self):
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Awards Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'Present Test Event awards have been updated.')
+
+    def test_fcm_notification_short_name(self):
+        self.notification.event.short_name = 'Arizona North'
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Awards Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'Arizona North Regional awards have been updated.')
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
+    def test_data_payload(self):
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 2)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNotNone(payload['awards'])
+
+    def test_webhook_message_data(self):
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNotNone(payload['awards'])

--- a/tests/tbans_tests/models/notifications/test_broadcast.py
+++ b/tests/tbans_tests/models/notifications/test_broadcast.py
@@ -1,0 +1,35 @@
+import unittest2
+
+from consts.notification_type import NotificationType
+
+from tbans.models.notifications.broadcast import BroadcastNotification
+
+
+class TestBroadcastNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.notification = BroadcastNotification('Title Here', 'Some body message ya dig', 'https://thebluealliance.com/')
+
+    def test_type(self):
+        self.assertEqual(BroadcastNotification._type(), NotificationType.BROADCAST)
+
+    def test_fcm_notification(self):
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'Title Here')
+        self.assertEqual(self.notification.fcm_notification.body, 'Some body message ya dig')
+
+    def test_data_payload(self):
+        self.assertEqual(self.notification.data_payload, {'url': 'https://thebluealliance.com/', 'app_version': None})
+
+    def test_data_payload_app_version(self):
+        notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', '1.0.0')
+        self.assertEqual(notification.data_payload, {'url': 'https://thebluealliance.com/', 'app_version': '1.0.0'})
+
+    def test_webhook_message_data(self):
+        payload = {'title': 'Title Here', 'desc': 'Some body message ya dig', 'url': 'https://thebluealliance.com/', 'app_version': None}
+        self.assertEqual(self.notification.webhook_message_data, payload)
+
+    def test_webhook_message_data_app_version(self):
+        notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', '1.0.0')
+        payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/', 'app_version': '1.0.0'}
+        self.assertEqual(notification.webhook_message_data, payload)

--- a/tests/tbans_tests/models/notifications/test_district_points.py
+++ b/tests/tbans_tests/models/notifications/test_district_points.py
@@ -1,0 +1,27 @@
+import unittest2
+
+from consts.notification_type import NotificationType
+from models.district import District
+
+from tbans.models.notifications.district_points import DistrictPointsNotification
+
+
+class TestDistrictPointsNotification(unittest2.TestCase):
+
+    def setUp(self):
+        district = District(id='2015fim', year=2015, abbreviation='fim', display_name='FIRST In Michigan')
+        self.notification = DistrictPointsNotification(district)
+
+    def test_type(self):
+        self.assertEqual(DistrictPointsNotification._type(), NotificationType.DISTRICT_POINTS_UPDATED)
+
+    def test_fcm_notification(self):
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'FIM District Points Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'FIRST In Michigan district point calculations have been updated.')
+
+    def test_data_payload(self):
+        self.assertEqual(self.notification.data_payload, {'district_key': '2015fim'})
+
+    def test_webhook_message_data(self):
+        self.assertEqual(self.notification.webhook_message_data, {'district_key': '2015fim', 'district_name': 'FIRST In Michigan'})

--- a/tests/tbans_tests/models/notifications/test_event_level.py
+++ b/tests/tbans_tests/models/notifications/test_event_level.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.notification_type import NotificationType
+from helpers.event.event_test_creator import EventTestCreator
+from models.team import Team
+
+from tbans.consts.fcm.platform_priority import PlatformPriority
+from tbans.models.notifications.event_level import EventLevelNotification
+
+
+class TestEventLevelNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+        self.testbed.init_taskqueue_stub(root_path=".")
+
+        for team_number in range(7):
+            Team(id="frc%s" % team_number,
+                 team_number=team_number).put()
+
+        self.event = EventTestCreator.createPresentEvent()
+        self.match = self.event.matches[0]
+
+        self.notification = EventLevelNotification(self.match)
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_type(self):
+        self.assertEqual(EventLevelNotification._type(), NotificationType.LEVEL_STARTING)
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
+    def test_fcm_notification(self):
+        # Remove time for testing
+        self.notification.match.time = None
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Qualification Matches Starting')
+        self.assertEqual(self.notification.fcm_notification.body, 'Present Test Event: Qualification Matches are starting.')
+
+    def test_fcm_notification_short_name(self):
+        self.notification.event.short_name = 'Arizona North'
+        # Remove time for testing
+        self.notification.match.time = None
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Qualification Matches Starting')
+        self.assertEqual(self.notification.fcm_notification.body, 'Arizona North Regional: Qualification Matches are starting.')
+
+    def test_fcm_notification_scheduled_time(self):
+        # Set constant scheduled time for testing
+        self.notification.match.time = datetime(2017, 11, 28, 13, 30, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Qualification Matches Starting')
+        self.assertEqual(self.notification.fcm_notification.body, 'Present Test Event: Qualification Matches are scheduled for 13:30.')
+
+    def test_fcm_notification_short_name_scheduled_time(self):
+        self.notification.event.short_name = 'Arizona North'
+        # Set constant scheduled time for testing
+        self.notification.match.time = datetime(2017, 11, 28, 13, 30, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Qualification Matches Starting')
+        self.assertEqual(self.notification.fcm_notification.body, 'Arizona North Regional: Qualification Matches are scheduled for 13:30.')
+
+    def test_data_payload(self):
+        # Remove time for testing
+        self.notification.match.time = None
+
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['comp_level'], 'qm')
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNone(payload['scheduled_time'])
+
+    def test_data_payload_scheduled_time(self):
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['comp_level'], 'qm')
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNotNone(payload['scheduled_time'])
+
+    def test_webhook_message_data(self):
+        # Remove time for testing
+        self.notification.match.time = None
+
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 4)
+        self.assertEqual(payload['comp_level'], 'qm')
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNone(payload['scheduled_time'])
+
+    def test_webhook_message_data_scheduled_time(self):
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 4)
+        self.assertEqual(payload['comp_level'], 'qm')
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNotNone(payload['scheduled_time'])

--- a/tests/tbans_tests/models/notifications/test_event_schedule.py
+++ b/tests/tbans_tests/models/notifications/test_event_schedule.py
@@ -1,0 +1,147 @@
+from datetime import datetime
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.notification_type import NotificationType
+from helpers.event.event_test_creator import EventTestCreator
+from models.team import Team
+
+from tbans.consts.fcm.platform_priority import PlatformPriority
+from tbans.models.notifications.event_schedule import EventScheduleNotification
+
+
+class TestEventScheduleNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+        self.testbed.init_taskqueue_stub(root_path=".")
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def _setup_notification(self):
+        for team_number in range(7):
+            Team(id="frc%s" % team_number,
+                 team_number=team_number).put()
+
+        self.event = EventTestCreator.createPresentEvent()
+        self.notification = EventScheduleNotification(self.event)
+
+    def test_init(self):
+        just_event = EventTestCreator.createPresentEvent(only_event=True)
+        just_event_notification = EventScheduleNotification(just_event)
+        self.assertEqual(just_event_notification.event, just_event)
+        self.assertIsNone(just_event_notification.next_match)
+
+    def test_init_automatic_next(self):
+        self._setup_notification()
+        automatic_event_notification = EventScheduleNotification(self.event)
+        self.assertEqual(automatic_event_notification.event, self.event)
+        self.assertIsNotNone(automatic_event_notification.next_match)
+
+    def test_init_explicit_next(self):
+        self._setup_notification()
+        explicit_match = self.event.matches[1]
+        explicit_event_notification = EventScheduleNotification(self.event, explicit_match)
+        self.assertEqual(explicit_event_notification.event, self.event)
+        self.assertEqual(explicit_event_notification.next_match, explicit_match)
+
+    def test_type(self):
+        self.assertEqual(EventScheduleNotification._type(), NotificationType.SCHEDULE_UPDATED)
+
+    def test_platform_config(self):
+        self._setup_notification()
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
+    def test_fcm_notification(self):
+        self._setup_notification()
+
+        # Remove time for testing
+        self.notification.next_match.time = None
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Schedule Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'The Present Test Event match schedule has been updated.')
+
+    def test_fcm_notification_time(self):
+        self._setup_notification()
+
+        # Set constant scheduled time for testing
+        self.notification.next_match.time = datetime(2017, 11, 28, 13, 30, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Schedule Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'The Present Test Event match schedule has been updated. The next match starts at 13:30.')
+
+    def test_fcm_notification_short_name(self):
+        self._setup_notification()
+
+        self.notification.event.short_name = 'Arizona North'
+        # Remove time for testing
+        self.notification.next_match.time = None
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Schedule Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'The Arizona North Regional match schedule has been updated.')
+
+    def test_fcm_notification_short_name_time(self):
+        self._setup_notification()
+
+        self.notification.event.short_name = 'Arizona North'
+        # Set constant scheduled time for testing
+        self.notification.next_match.time = datetime(2017, 11, 28, 13, 30, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Schedule Updated')
+        self.assertEqual(self.notification.fcm_notification.body, 'The Arizona North Regional match schedule has been updated. The next match starts at 13:30.')
+
+    def test_data_payload(self):
+        self._setup_notification()
+
+        # Remove time for testing
+        self.notification.next_match.time = None
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 2)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNone(payload['first_match_time'])
+
+    def test_data_payload_first_match_time(self):
+        self._setup_notification()
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 2)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNotNone(payload['first_match_time'])
+
+    def test_webhook_message_data(self):
+        self._setup_notification()
+
+        # Remove time for testing
+        self.notification.next_match.time = None
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNone(payload['first_match_time'])
+
+    def test_webhook_message_data_first_match_time(self):
+        self._setup_notification()
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNotNone(payload['first_match_time'])

--- a/tests/tbans_tests/models/notifications/test_match_score.py
+++ b/tests/tbans_tests/models/notifications/test_match_score.py
@@ -1,0 +1,73 @@
+import re
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.notification_type import NotificationType
+from helpers.event.event_test_creator import EventTestCreator
+from models.team import Team
+
+from tbans.consts.fcm.platform_priority import PlatformPriority
+from tbans.models.notifications.match_score import MatchScoreNotification
+
+
+class TestMatchScoreNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+        self.testbed.init_taskqueue_stub(root_path=".")
+
+        for team_number in range(7):
+            Team(id="frc%s" % team_number,
+                 team_number=team_number).put()
+
+        self.event = EventTestCreator.createPresentEvent()
+        self.match = self.event.matches[0]
+
+        self.notification = MatchScoreNotification(self.match)
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_type(self):
+        self.assertEqual(MatchScoreNotification._type(), NotificationType.MATCH_SCORE)
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
+    def test_fcm_notification(self):
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Results')
+        match_regex = re.compile(r'^\d+, \d+, \d+ beat \d+, \d+, \d+ scoring \d+-\d+.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_fcm_notification_tied(self):
+        score = self.notification.match.alliances['red']['score']
+        self.notification.match.alliances['blue']['score'] = score
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Results')
+        match_regex = re.compile(r'^\d+, \d+, \d+ tied with \d+, \d+, \d+ scoring \d+-\d+.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_data_payload(self):
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 2)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertIsNotNone(payload['match'])
+
+    def test_webhook_message_data(self):
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertIsNotNone(payload['match'])

--- a/tests/tbans_tests/models/notifications/test_match_upcoming.py
+++ b/tests/tbans_tests/models/notifications/test_match_upcoming.py
@@ -1,0 +1,334 @@
+from datetime import datetime
+import re
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.notification_type import NotificationType
+from helpers.event.event_test_creator import EventTestCreator
+from models.team import Team
+
+from tbans.consts.fcm.platform_priority import PlatformPriority
+from tbans.models.notifications.match_upcoming import MatchUpcomingNotification
+
+
+class TestMatchUpcomingNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+        self.testbed.init_taskqueue_stub(root_path=".")
+
+        for team_number in range(7):
+            Team(id="frc%s" % team_number,
+                 team_number=team_number).put()
+
+        self.event = EventTestCreator.createPresentEvent()
+        self.match = self.event.matches[0]
+
+        self.notification = MatchUpcomingNotification(self.match)
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_type(self):
+        self.assertEqual(MatchUpcomingNotification._type(), NotificationType.UPCOMING_MATCH)
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
+    def test_fcm_notification(self):
+        # Set times for testing
+        self.notification.match.time = None
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Starting Soon')
+        match_regex = re.compile(r'^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_fcm_notification_predicted_time(self):
+        # Set times for testing
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Starting Soon')
+        match_regex = re.compile(r'^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:30.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_fcm_notification_time(self):
+        # Set times for testing
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Starting Soon')
+        match_regex = re.compile(r'^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:00.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_fcm_notification_short_name(self):
+        self.notification.event.short_name = 'Arizona North'
+        # Set times for testing
+        self.notification.match.time = None
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Starting Soon')
+        match_regex = re.compile(r'^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_fcm_notification_short_name_predicted_time(self):
+        self.notification.event.short_name = 'Arizona North'
+        # Set times for testing
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Starting Soon')
+        match_regex = re.compile(r'^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:30.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_fcm_notification_short_name_time(self):
+        self.notification.event.short_name = 'Arizona North'
+        # Set times for testing
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+
+        self.assertIsNotNone(self.notification.fcm_notification)
+        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Q1 Starting Soon')
+        match_regex = re.compile(r'^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:00.$')
+        match = re.match(match_regex, self.notification.fcm_notification.body)
+        self.assertIsNotNone(match)
+
+    def test_data_payload(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_data_payload_time(self):
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_data_payload_predicted_time(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = None
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_data_payload_no_time(self):
+        self.notification.match.time = None
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_data_payload_no_webcast(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+        self.notification.event._webcast = []
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_data_payload_time_no_webcast(self):
+        self.notification.event._webcast = []
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_data_payload_predicted_time_no_webcast(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = None
+        self.notification.event._webcast = []
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_data_payload_no_time_no_webcast(self):
+        self.notification.match.time = None
+        self.notification.event._webcast = []
+
+        # No `event_name`
+        payload = self.notification.data_payload
+        self.assertEqual(len(payload), 6)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_webhook_message_data(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_webhook_message_data_time(self):
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_webhook_message_data_predicted_time(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = None
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_webhook_message_data_no_time(self):
+        self.notification.match.time = None
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['webcast'])
+
+    def test_webhook_message_data_no_webcast(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
+        self.notification.event._webcast = []
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_webhook_message_data_time_no_webcast(self):
+        self.notification.event._webcast = []
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNotNone(payload['scheduled_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_webhook_message_data_predicted_time_no_webcast(self):
+        self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
+        self.notification.match.time = None
+        self.notification.event._webcast = []
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNotNone(payload['predicted_time'])
+        self.assertIsNone(payload['webcast'])
+
+    def test_webhook_message_data_no_time_no_webcast(self):
+        self.notification.match.time = None
+        self.notification.event._webcast = []
+
+        # Has `event_name`
+        payload = self.notification.webhook_message_data
+        self.assertEqual(len(payload), 7)
+        self.assertEqual(payload['event_key'], '2019testpresent')
+        self.assertEqual(payload['event_name'], 'Present Test Event')
+        self.assertEqual(payload['match_key'], '2019testpresent_qm1')
+        self.assertIsNotNone(payload['team_keys'])
+        self.assertIsNone(payload['scheduled_time'])
+        self.assertIsNone(payload['predicted_time'])
+        self.assertIsNone(payload['webcast'])

--- a/tests/tbans_tests/models/notifications/test_update_favorites.py
+++ b/tests/tbans_tests/models/notifications/test_update_favorites.py
@@ -1,0 +1,17 @@
+import unittest2
+
+from consts.notification_type import NotificationType
+
+from tbans.models.notifications.update_favorites import UpdateFavoritesNotification
+
+
+class TestUpdateFavoritesNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.notification = UpdateFavoritesNotification('abcd')
+
+    def test_type(self):
+        self.assertEqual(UpdateFavoritesNotification._type(), NotificationType.UPDATE_FAVORITES)
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.collapse_key, 'abcd_favorite_update')

--- a/tests/tbans_tests/models/notifications/test_update_subscriptions.py
+++ b/tests/tbans_tests/models/notifications/test_update_subscriptions.py
@@ -1,0 +1,17 @@
+import unittest2
+
+from consts.notification_type import NotificationType
+
+from tbans.models.notifications.update_subscriptions import UpdateSubscriptionsNotification
+
+
+class TestUpdateSubscriptionsNotification(unittest2.TestCase):
+
+    def setUp(self):
+        self.notification = UpdateSubscriptionsNotification('abcd')
+
+    def test_type(self):
+        self.assertEqual(UpdateSubscriptionsNotification._type(), NotificationType.UPDATE_SUBSCRIPTION)
+
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.collapse_key, 'abcd_subscriptions_update')


### PR DESCRIPTION
This adds all existing notification models (other than `MatchVideo` and `EventMatchVideo` - those ones need more thought) to TBANS. 