### PR TITLE
Update modtools FAQ for Expiration

### DIFF
--- a/templates_jinja2/team_admin_dashboard.html
+++ b/templates_jinja2/team_admin_dashboard.html
@@ -195,28 +195,32 @@
   <div class="row">
     <h2>Team Administration Frequently Asked Questions</h2>
 
-    <h5>I'm a Mentor for Two Different Teams, How Can I Administer Both?</h5>
+    <h4>I'm a Mentor for Two Different Teams, How Can I Administer Both?</h4>
     <p>Currently, accounts can only administer one team per season. We know this is important for several teams and
     mentors. In the meantime, we do not restrict users to one account, so if you have multiple TBA accounts you can
     administer other teams, one per additional account.</p>
 
-    <h5>Our Website URL Has Changed. How Do I Change it on TBA?</h5>
+    <h4>Our Website URL Has Changed. How Do I Change it on TBA?</h4>
     <p>Your website link is another piece of data we get directly from <i>FIRST</i> and therefore do not allow you to edit.</p>
 
-    <h5>How Do I Change the Information TBA Gets from <i>FIRST</i>?</h5>
+    <h4>How Do I Change the Information TBA Gets from <i>FIRST</i>?</h4>
     <p>Nearly all of the information The Blue Alliance receives from <i>FIRST</i>, excluding event and match data, is
     editable by the team's Lead Mentor 1 or 2 on the
     <a href="https://my.firstinspires.org/Dashboard/"><i>FIRST</i> Inspires Dashboard</a> for the team. If you are
     having difficulty locating the information to change on the <i>FIRST</i> Inspires Dashboard, please have a Lead
     Mentor contact <i>FIRST</i> directly.</p>
 
-    <h5>I Have a Great Picture of Just My Team Members, Why Can't I Approve It?</h5>
+    <h4>I Have a Great Picture of Just My Team Members, Why Can't I Approve It?</h4>
     <p>We understand you have an awesome picture of your team and want to share it and help "Make It Loud." The Blue
     Alliance is focused on event data, match data, and robots. Due to the way pictures are used on The Blue Alliance,
     most often to represent your robot, we do not allow pictures without the robot. Feel free to feature your team
     members in other media on The Blue Alliance, like team videos or social media, instead.</p>
 
-    <h3>Question Not Answered Here?</h3>
+    <h4>How Long is My Access Good For? When Does it Expire?</h4>
+    <p>Team Administrators will have access through the competition season, and all access will automatically
+    expire at the beginning of July each year.</p>
+
+    <h4>Question Not Answered Here?</h4>
     <p>For additional support, please <a href="/contact">contact us</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
Updated the modtools FAQ page to include a blurb on expiration of access. (Figure it may save some emails after 7/1 See https://github.com/the-blue-alliance/the-blue-alliance/blob/master/controllers/admin/admin_team_media_mod.py#L90 for current expiration setting.)

Also bumped up the `h5` tags to `h4` for the Q's on the FAQ page to make them a bit more visible.

## Motivation and Context
Trying to avoid "Hey - where'd my access go?" emails & CD posts.

## How Has This Been Tested?
`#WeTestInProd`

(HTML only change)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
