### PR TITLE
Only send update favorites and update subcriptions notifications to Android clients

### DIFF
--- a/consts/notification_type.py
+++ b/consts/notification_type.py
@@ -22,7 +22,7 @@ class NotificationType(object):
 
     # These aren't notifications, but used for upstream API calls
     UPDATE_FAVORITES = 100
-    UPDATE_SUBSCRIPTION = 101
+    UPDATE_SUBSCRIPTIONS = 101
 
     # This is used for verification that the proper people are in control
     VERIFICATION = 200
@@ -43,7 +43,7 @@ class NotificationType(object):
         EVENT_MATCH_VIDEO: "event_match_video",
 
         UPDATE_FAVORITES: "update_favorites",
-        UPDATE_SUBSCRIPTION: "update_subscriptions",
+        UPDATE_SUBSCRIPTIONS: "update_subscriptions",
 
         VERIFICATION: "verification"
     }
@@ -76,7 +76,7 @@ class NotificationType(object):
         "event_match_video": EVENT_MATCH_VIDEO,
 
         "update_favorites": UPDATE_FAVORITES,
-        "update_subscriptions": UPDATE_SUBSCRIPTION,
+        "update_subscriptions": UPDATE_SUBSCRIPTIONS,
 
         "verification": VERIFICATION
     }

--- a/helpers/notification_helper.py
+++ b/helpers/notification_helper.py
@@ -40,14 +40,14 @@ class NotificationHelper(object):
 
     @classmethod
     def send_favorite_update(cls, user_id, sending_device_key=""):
-        clients = PushHelper.get_client_ids_for_users([user_id])
+        clients = PushHelper.get_client_ids_for_users([user_id], os_types=[ClientType.OS_ANDROID])
 
         notification = UpdateFavoritesNotification(user_id, sending_device_key)
         notification.send(clients)
 
     @classmethod
     def send_subscription_update(cls, user_id, sending_device_key=""):
-        clients = PushHelper.get_client_ids_for_users([user_id])
+        clients = PushHelper.get_client_ids_for_users([user_id], os_types=[ClientType.OS_ANDROID])
 
         notification = UpdateSubscriptionsNotification(user_id, sending_device_key)
         notification.send(clients)

--- a/notifications/update_subscriptions.py
+++ b/notifications/update_subscriptions.py
@@ -16,7 +16,7 @@ class UpdateSubscriptionsNotification(BaseNotification):
 
     @property
     def _type(self):
-        return NotificationType.UPDATE_SUBSCRIPTION
+        return NotificationType.UPDATE_SUBSCRIPTIONS
 
     def _build_dict(self):
         data = {}

--- a/tbans/models/notifications/update_subscriptions.py
+++ b/tbans/models/notifications/update_subscriptions.py
@@ -9,7 +9,7 @@ class UpdateSubscriptionsNotification(Notification):
     @classmethod
     def _type(cls):
         from consts.notification_type import NotificationType
-        return NotificationType.UPDATE_SUBSCRIPTION
+        return NotificationType.UPDATE_SUBSCRIPTIONS
 
     @property
     def platform_config(self):

--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -455,26 +455,6 @@
             <pre class="example-json">
             {"message_data": {"title": "Test", "desc": "Test Broadcast", "url": "http://foo.bar", "app_version": "2.0.0"}, "message_type": "broadcast"}
             </pre>
-        <h3 id="notification_update_favorites">Update Favorites Notification</h3>
-          <p>This notification is sent out to a user's devices when favorites are updated on their account, telling that device to re-sync the list from the server.</p>
-          <h4>Structure</h4>
-            <ul>
-              <li>"message_type": "update_favorites"</li>
-            </ul>
-          <h4>Example JSON</h4>
-            <pre class="example-json">
-            {"message_type": "update_favorites"}
-            </pre>
-        <h3 id="notification_update_subscriptions">Update Subscriptions Notification</h3>
-          <p>This notification is sent out to a user's devices when their subscriptions are updated for the account, telling that device to re-sync the list from the server.</p>
-          <h4>Structure</h4>
-            <ul>
-              <li>"message_type": "update_subscriptions"</li>
-            </ul>
-          <h4>Example JSON</h4>
-            <pre class="example-json">
-            {"message_type": "update_subscriptions"}
-            </pre>
         <h3 id="notification_verification">Webhook Verification Notifications</h3>
           <p>This notification is sent when a new webhook is created. It contains a verification code that needs to be entered in the <a href="/account">Account Overview</a> page for the webhook before it recieves live updates.</p>
           <h4>Structure</h4>

--- a/tests/tbans_tests/models/notifications/test_update_subscriptions.py
+++ b/tests/tbans_tests/models/notifications/test_update_subscriptions.py
@@ -11,7 +11,7 @@ class TestUpdateSubscriptionsNotification(unittest2.TestCase):
         self.notification = UpdateSubscriptionsNotification('abcd')
 
     def test_type(self):
-        self.assertEqual(UpdateSubscriptionsNotification._type(), NotificationType.UPDATE_SUBSCRIPTION)
+        self.assertEqual(UpdateSubscriptionsNotification._type(), NotificationType.UPDATE_SUBSCRIPTIONS)
 
     def test_platform_config(self):
         self.assertEqual(self.notification.platform_config.collapse_key, 'abcd_subscriptions_update')

--- a/tests/test_notification_update_subscriptions.py
+++ b/tests/test_notification_update_subscriptions.py
@@ -23,7 +23,7 @@ class TestUpdateFavoritesNotification(unittest2.TestCase):
 
     def test_build(self):
         expected = {}
-        expected['notification_type'] = NotificationType.type_names[NotificationType.UPDATE_SUBSCRIPTION]
+        expected['notification_type'] = NotificationType.type_names[NotificationType.UPDATE_SUBSCRIPTIONS]
         data = self.notification._build_dict()
 
         self.assertEqual(expected, data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stop sending `UPDATE_FAVORITES` and `UPDATE_SUBSCRIPTIONS` notifications to all non-Android clients (webhooks mostly). Also update the webhook documentation to remove references to these notifications.

Also rename `UPDATE_SUBSCRIPTION` -> `UPDATE_SUBSCRIPTIONS` for parity.

## Motivation and Context
We realized we were dispatching these notifications to webhooks when they can't use them.

## How Has This Been Tested?
This hasn't been tested 🙊 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change API specifications or require data migrations)