### PR TITLE
Add blacklist website button to Team admin page

### DIFF
--- a/backend_main.py
+++ b/backend_main.py
@@ -9,7 +9,7 @@ from controllers.admin.admin_cron_controller import AdminPostEventTasksDo, Admin
 from controllers.backup_controller import DatastoreBackupFull, BigQueryImportEnqueue, \
     BigQueryImportEntity, MainBackupsEnqueue, DatastoreBackupArchive, DatastoreBackupArchiveFile
 from controllers.datafeed_controller import EventListEnqueue, EventDetailsEnqueue
-from controllers.datafeed_controller import EventListGet, EventDetailsGet, TeamDetailsGet, TeamAvatarGet, OffseasonEventListGet, DistrictListGet, DistrictRankingsGet
+from controllers.datafeed_controller import EventListGet, EventDetailsGet, TeamDetailsGet, TeamAvatarGet, OffseasonEventListGet, DistrictListGet, DistrictRankingsGet, TeamBlacklistWebsiteDo
 
 
 app = webapp2.WSGIApplication([('/backend-tasks/enqueue/event_list/([0-9]*)', EventListEnqueue),
@@ -19,6 +19,7 @@ app = webapp2.WSGIApplication([('/backend-tasks/enqueue/event_list/([0-9]*)', Ev
                                ('/backend-tasks/get/event_details/(.*)', EventDetailsGet),
                                ('/backend-tasks/get/team_details/(.*)', TeamDetailsGet),
                                ('/backend-tasks/get/team_avatar/(.*)', TeamAvatarGet),
+                               ('/backend-tasks/do/team_blacklist_website/(.*)', TeamBlacklistWebsiteDo),
                                ('/backend-tasks/get/district_rankings/(.*)', DistrictRankingsGet),
                                ('/backend-tasks/get/fms-sync-offseasons/(.*)', OffseasonEventListGet),
                                ('/backend-tasks/do/post_event_tasks/(.*)', AdminPostEventTasksDo),

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -42,6 +42,8 @@ from models.robot import Robot
 from models.sitevar import Sitevar
 from models.team import Team
 
+from sitevars.website_blacklist import WebsiteBlacklist
+
 
 class FMSAPIAwardsEnqueue(webapp.RequestHandler):
     """
@@ -787,3 +789,16 @@ class HallOfFameTeamsGet(webapp.RequestHandler):
         if 'X-Appengine-Taskname' not in self.request.headers:  # Only write out if not in taskqueue
             path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/hall_of_fame_teams_get.html')
             self.response.out.write(template.render(path, template_values))
+
+
+class TeamBlacklistWebsiteDo(webapp.RequestHandler):
+    """
+    Blacklist the current website for a team
+    """
+    def get(self, key_name):
+        team = Team.get_by_id(key_name)
+
+        if team.website:
+            WebsiteBlacklist.blacklist(team.website)
+
+        self.redirect('/backend-tasks/get/team_details/{}'.format(key_name))

--- a/sitevars/website_blacklist.py
+++ b/sitevars/website_blacklist.py
@@ -10,3 +10,13 @@ class WebsiteBlacklist(object):
         website_blacklist_sitevar = Sitevar.get_or_insert('website_blacklist', values_json=json.dumps({'websites': []}))
         website_blacklist = website_blacklist_sitevar.contents.get('websites', [])
         return website in website_blacklist
+
+    @staticmethod
+    def blacklist(website):
+        website_blacklist_sitevar = Sitevar.get_or_insert('website_blacklist', values_json=json.dumps({'websites': []}))
+        website_blacklist = website_blacklist_sitevar.contents.get('websites', [])
+        if website in website_blacklist:
+            return
+        website_blacklist.append(website)
+        website_blacklist_sitevar.contents = {'websites': website_blacklist}
+        website_blacklist_sitevar.put()

--- a/templates/admin/team_details.html
+++ b/templates/admin/team_details.html
@@ -9,6 +9,7 @@
 <div class="btn-group">
     <a href="/team/{{team.team_number}}" class="btn btn-default"><span class="glyphicon glyphicon-eye-open"></span> View on TBA</a>
     <a href="/backend-tasks/get/team_details/{{team.key.id}}" class="btn btn-default"><span class="glyphicon glyphicon-refresh"></span> Refresh from FIRST</a>
+    <a href="/backend-tasks/do/team_blacklist_website/{{team.key.id}}" class="btn btn-danger"><span class="glyphicon glyphicon-remove"></span> Blacklist website</a>
 </div>
 <hr>
 

--- a/tests/test_sitevar_website_blacklist.py
+++ b/tests/test_sitevar_website_blacklist.py
@@ -20,6 +20,13 @@ class TestWebsiteBlacklist(unittest2.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
 
-    def test_blacklist(self):
+    def test_is_blacklisted(self):
         self.assertTrue(self.website_blacklist.is_blacklisted('http://blacklist.com/'))
         self.assertFalse(self.website_blacklist.is_blacklisted('https://www.thebluealliance.com/'))
+
+    def test_blacklist(self):
+        website = 'https://www.thebluealliance.com/'
+        self.assertFalse(self.website_blacklist.is_blacklisted(website))
+        self.website_blacklist.blacklist(website)
+        self.assertTrue(self.website_blacklist.is_blacklisted(website))
+        self.assertTrue(self.website_blacklist.is_blacklisted('http://blacklist.com/'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a "Blacklist Website" button to the Team admin page to blacklist a team's current website

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Blacklisting websites right now involves modifying a sitevar, which is pretty gross.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a staging instance

## Screenshots (if appropriate):
(Before - with the button)
<img width="1207" alt="Screen Shot 2019-05-21 at 11 23 18 PM" src="https://user-images.githubusercontent.com/516458/58145536-7679c400-7c20-11e9-9438-7cde9e1ec0af.png">
(After - automatically re-scrapes the team)
<img width="1245" alt="Screen Shot 2019-05-21 at 11 27 06 PM" src="https://user-images.githubusercontent.com/516458/58145546-8396b300-7c20-11e9-81ae-7da150045cbd.png">
(Blacklist sitevar - automatically updated)
<img width="1053" alt="Screen Shot 2019-05-21 at 11 26 58 PM" src="https://user-images.githubusercontent.com/516458/58145548-898c9400-7c20-11e9-9c23-d3fbdec688f3.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
