### PR TITLE
Update valid match breakdowns for 2019

### DIFF
--- a/helpers/match_helper.py
+++ b/helpers/match_helper.py
@@ -239,6 +239,22 @@ class MatchHelper(object):
             'teleopOwnershipPoints', 'vaultPoints', 'endgamePoints', 'teleopPoints',
             'autoQuestRankingPoint', 'faceTheBossRankingPoint', 'foulCount', 'techFoulCount',
             'adjustPoints', 'foulPoints', 'rp', 'totalPoints', 'tba_gameData']),
+        2019: set([
+            'adjustPoints', 'autoPoints', 'bay1', 'bay2', 'bay3', 'bay4',
+            'bay5', 'bay6', 'bay7', 'bay8', 'cargoPoints',
+            'completeRocketRankingPoint', 'completedRocketFar',
+            'completedRocketNear', 'endgameRobot1', 'endgameRobot2',
+            'endgameRobot3', 'foulCount', 'foulPoints', 'habClimbPoints',
+            'habDockingRankingPoint', 'habLineRobot1', 'habLineRobot2',
+            'habLineRobot3', 'hatchPanelPoints', 'lowLeftRocketFar',
+            'lowLeftRocketNear', 'lowRightRocketFar', 'lowRightRocketNear',
+            'midLeftRocketFar', 'midLeftRocketNear', 'midRightRocketFar',
+            'midRightRocketNear', 'preMatchBay1', 'preMatchBay2',
+            'preMatchBay3', 'preMatchBay6', 'preMatchBay7', 'preMatchBay8',
+            'preMatchLevelRobot1', 'preMatchLevelRobot2', 'preMatchLevelRobot3',
+            'rp', 'sandStormBonusPoints', 'techFoulCount', 'teleopPoints',
+            'topLeftRocketFar', 'topLeftRocketNear', 'topRightRocketFar',
+            'topRightRocketNear', 'totalPoints']),
     }
 
     @classmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows 2019 match breakdowns to be uploaded via the write API. 
## Motivation and Context
Currently, any attempts to do this result in this error:
```
Valid score breakdowns for 2019 are: set([])
```
I would like for this to be fixed before one of my upcoming events, and I'm pretty sure this is the only place that needs to change. (I'm not sure if the rankings endpoint needs to be updated or not, though.)

## How Has This Been Tested?
I haven't gotten Docker to work locally so it hasn't been. But I did run this file through the Python interpreter to make sure there aren't any syntax errors (there aren't). The field list is taken from https://www.thebluealliance.com/api/v3/match/2019micmp1_qm1, which I believe is complete.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
