### PR TITLE
Add custom playoff type

### DIFF
--- a/consts/playoff_type.py
+++ b/consts/playoff_type.py
@@ -18,6 +18,9 @@ class PlayoffType(object):
     BO5_FINALS = 6
     BO3_FINALS = 7
 
+    # Custom
+    CUSTOM = 8
+
     BRACKET_TYPES = [BRACKET_8_TEAM, BRACKET_16_TEAM, BRACKET_4_TEAM]
     DOUBLE_ELIM_TYPES = [DOUBLE_ELIM_8_TEAM]
 

--- a/helpers/playoff_advancement_helper.py
+++ b/helpers/playoff_advancement_helper.py
@@ -33,6 +33,9 @@ class PlayoffAdvancementHelper(object):
         playoff_advancement = None
         playoff_template = None
         double_elim_matches = None
+
+        if event.playoff_type == PlayoffType.CUSTOM:
+            playoff_template = 'custom'
         if event.playoff_type == PlayoffType.AVG_SCORE_8_TEAM:
             playoff_advancement = cls.generatePlayoffAdvancement2015(matches, event.alliance_selections)
             playoff_template = 'playoff_table'

--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -176,7 +176,7 @@
               {% if playoff_advancement %}
                 <h3>Playoff Advancement</h3>
                 {% include "playoff_partials/{}.html".format(playoff_template) %}
-              {% else %}
+              {% elif playoff_template != 'custom' %}
                 <h3>{% if event.year >= 2015 %}Playoff{% else %}Elimination{% endif %} Bracket</h3>
                 {% include "bracket_partials/bracket_table.html" %}
               {% endif %}


### PR DESCRIPTION
Creates `PlayoffType.CUSTOM` for events that do not use any of the standard elims brackets that have already been implemented, e.g. `2019bc`.

## Description
For custom playoff types, the standard eliminations bracket is not rendered, and instead, only the elims match list is rendered.

## Motivation and Context
#2540 

## How Has This Been Tested?
Tested on local instance of TBA

## Screenshots (if appropriate):
https://i.imgur.com/Z55pcw6.png

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
