### PR TITLE
Fix task enqueue URLs for insights

### DIFF
--- a/templates/admin/debug.html
+++ b/templates/admin/debug.html
@@ -61,8 +61,8 @@
               <li><a href="/tasks/math/enqueue/event_matchstats/{{cur_year}}">Update Matchstats (OPR/DPR/CCWM)</a> or <a href="/tasks/math/do/event_matchstats/2010cmp">Update One Event's Matchstats (OPR/DPR/CCWM)</a>, to recalculate Matchstats.</li>
               <li><a href="/tasks/math/enqueue/insights/matches/{{cur_year}}">Calculate Match insights</a> for a particular year.</li>
               <li><a href="/tasks/math/enqueue/insights/awards/{{cur_year}}">Calculate Award insights</a> for a particular year.</li>
-              <li><a href="/tasks/math/enqueue/overallinsights/matches">Calculate overall Match insights</a>.</li>
-              <li><a href="/tasks/math/enqueue/overallinsights/awards">Calculate overall Award insights</a>.</li>
+              <li><a href="/backend-tasks-b2/math/enqueue/overallinsights/matches">Calculate overall Match insights</a>.</li>
+              <li><a href="/backend-tasks-b2/math/enqueue/overallinsights/awards">Calculate overall Award insights</a>.</li>
             </ol>
         </div>
 

--- a/templates/admin/tasks.html
+++ b/templates/admin/tasks.html
@@ -235,7 +235,7 @@
         </form>
         <script>
         $("#enqueue_award_insights_year_submit").click(function() {
-            window.location = "/tasks/math/enqueue/insights/awards/" + $("#enqueue_award_insights_year").val();
+            window.location = "/backend-tasks-b2/math/enqueue/insights/awards/" + $("#enqueue_award_insights_year").val();
         });
         </script>
     </div>
@@ -251,7 +251,7 @@
         </form>
         <script>
         $("#enqueue_match_insights_year_submit").click(function() {
-            window.location = "/tasks/math/enqueue/insights/matches/" + $("#enqueue_match_insights_year").val();
+            window.location = "/backend-tasks-b2/math/enqueue/insights/matches/" + $("#enqueue_match_insights_year").val();
         });
         </script>
     </div>
@@ -259,10 +259,10 @@
 <h3>Calculate Overall Insights</h3>
 <div class="row">
     <div class="col-sm-6">
-        <a class="btn btn-warning" href="/tasks/math/enqueue/overallinsights/awards">Enqueue Overall Award Insights</a>
+        <a class="btn btn-warning" href="/backend-tasks-b2/math/enqueue/overallinsights/awards">Enqueue Overall Award Insights</a>
     </div>
     <div class="col-sm-6">
-        <a class="btn btn-warning" href="/tasks/math/enqueue/overallinsights/matches">Enqueue Overall Match Insights</a>
+        <a class="btn btn-warning" href="/backend-tasks-b2.yaml/math/enqueue/overallinsights/matches">Enqueue Overall Match Insights</a>
     </div>
 </div>
 


### PR DESCRIPTION
The buttons on the admin console for launching tasks related to generating insights were broken.

## Description
I found URLs that work in `cron.yaml`, so I just replaced the 404ing URLs with the corresponding ones from there.

## Motivation and Context
Makes dev lives easier

## How Has This Been Tested?
Manually tested, you should probably test it on your own as well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
