### PR TITLE
Added "direct_link" to webcasts type and Removed "rookie_year" as requirement for teams

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -6626,7 +6626,8 @@
               "iframe",
               "html5",
               "rtmp",
-              "livestream"
+              "livestream",
+              "direct_link"
             ]
           },
           "channel": {

--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -3916,7 +3916,6 @@
         "required": [
           "key",
           "name",
-          "rookie_year",
           "team_number"
         ],
         "type": "object",


### PR DESCRIPTION
Fixes issue 
1) TBA API where get_event("2019micmp") returns with a webcast of type "direct_link" which is not an allowed type webcasts

2) TBA API where get_team("frc7") creates error because their rookie_year is None

## Description
Adds "direct_link" to the allowed types for webcasts
Removes "rookie_year" requirement from teams since many teams do not have a rookie year EG : frc326, frc7

## Images
### Webcasts
![event_response_webcast](https://user-images.githubusercontent.com/6640721/60408726-216d8e00-9b8e-11e9-931a-dee8ff2e5ea4.PNG)
![error_using_api](https://user-images.githubusercontent.com/6640721/60408727-216d8e00-9b8e-11e9-99d0-a202c01f826a.PNG)

### Rookie Year
![rookie_year_error](https://user-images.githubusercontent.com/6640721/60524319-5545d200-9cba-11e9-8771-3183b764c62a.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
