### PR TITLE
[wip] Migrate Event Playoff Advancement/Bracket into EventDetails

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -11,7 +11,7 @@ from controllers.admin.admin_contbuild_controller import AdminContbuildControlle
 from controllers.admin.admin_district_controller import AdminDistrictList, AdminDistrictEdit, \
     AdminDistrictCreate
 from controllers.admin.admin_event_controller import AdminEventAddAllianceSelections, AdminEventDeleteTeams, AdminEventAddTeams, AdminEventRemapTeams, AdminEventAddWebcast, AdminEventCreate, AdminEventCreateTest, AdminEventDelete, AdminEventDetail, AdminEventEdit, AdminEventList, \
-    AdminAddAllianceBackup, AdminEventRemoveWebcast, AdminRefetchEventLocation
+    AdminAddAllianceBackup, AdminEventRemoveWebcast, AdminRefetchEventLocation, AdminPlayoffAdvancementAddController
 from controllers.admin.admin_gameday_controller import AdminGamedayDashboard
 from controllers.admin.admin_main_controller import AdminDebugHandler, AdminMain, AdminTasksHandler
 from controllers.admin.admin_award_controller import AdminAwardDashboard, AdminAwardEdit, AdminAwardAdd, \
@@ -101,6 +101,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/migration/backfill_playoff_advancement/(.*)', AdminMigrationPlayoffAdvancement),
                                ('/admin/offseasons', AdminOffseasonScraperController),
                                ('/admin/offseasons/spreadsheet', AdminOffseasonSpreadsheetController),
+                               ('/admin/playoff_advancement/add', AdminPlayoffAdvancementAddController),
                                ('/admin/sitevars', AdminSitevarList),
                                ('/admin/sitevar/create', AdminSitevarCreate),
                                ('/admin/sitevar/edit/(.*)', AdminSitevarEdit),

--- a/admin_main.py
+++ b/admin_main.py
@@ -20,7 +20,10 @@ from controllers.admin.admin_match_controller import AdminVideosAdd, AdminMatchC
 from controllers.admin.admin_media_controller import AdminMediaDashboard, AdminMediaDeleteReference, AdminMediaMakePreferred, AdminMediaRemovePreferred, AdminMediaAdd, \
     AdminMediaInstagramImport
 from controllers.admin.admin_memcache_controller import AdminMemcacheMain
-from controllers.admin.admin_migration_controller import AdminMigration, AdminMigrationCreateEventDetails, AdminMigrationRankings, AdminMigrationAddSurrogates, AdminMigrationBackfillYearDQ, AdminMigrationBackfillEventDQ
+from controllers.admin.admin_migration_controller import AdminMigration,
+    AdminMigrationCreateEventDetails, AdminMigrationRankings, AdminMigrationAddSurrogates, \
+    AdminMigrationBackfillYearDQ, AdminMigrationBackfillEventDQ, \
+    AdminMigrationPlayoffAdvancement, AdminMigrationPlayoffAdvancementAll
 from controllers.admin.admin_mobile_controller import AdminMobile, AdminBroadcast, AdminMobileWebhooks
 from controllers.admin.admin_offseason_scraper_controller import AdminOffseasonScraperController
 from controllers.admin.admin_offseason_spreadsheet_controller import AdminOffseasonSpreadsheetController
@@ -94,6 +97,8 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/migration/add_surrogates/([0-9]*)', AdminMigrationAddSurrogates),
                                ('/admin/migration/backfill_year_dq/([0-9]*)', AdminMigrationBackfillYearDQ),
                                ('/admin/migration/backfill_event_dq/(.*)', AdminMigrationBackfillEventDQ),
+                               ('/admin/migration/backfill_playoff_advancement', AdminMigrationPlayoffAdvancementAll),
+                               ('/admin/migration/backfill_playoff_advancement/(.*)', AdminMigrationPlayoffAdvancement),
                                ('/admin/offseasons', AdminOffseasonScraperController),
                                ('/admin/offseasons/spreadsheet', AdminOffseasonSpreadsheetController),
                                ('/admin/sitevars', AdminSitevarList),

--- a/admin_main.py
+++ b/admin_main.py
@@ -20,7 +20,7 @@ from controllers.admin.admin_match_controller import AdminVideosAdd, AdminMatchC
 from controllers.admin.admin_media_controller import AdminMediaDashboard, AdminMediaDeleteReference, AdminMediaMakePreferred, AdminMediaRemovePreferred, AdminMediaAdd, \
     AdminMediaInstagramImport
 from controllers.admin.admin_memcache_controller import AdminMemcacheMain
-from controllers.admin.admin_migration_controller import AdminMigration,
+from controllers.admin.admin_migration_controller import AdminMigration, \
     AdminMigrationCreateEventDetails, AdminMigrationRankings, AdminMigrationAddSurrogates, \
     AdminMigrationBackfillYearDQ, AdminMigrationBackfillEventDQ, \
     AdminMigrationPlayoffAdvancement, AdminMigrationPlayoffAdvancementAll

--- a/controllers/admin/admin_migration_controller.py
+++ b/controllers/admin/admin_migration_controller.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+from tba_config import MAX_YEAR
 from google.appengine.api import taskqueue
 from google.appengine.ext import ndb
 from google.appengine.ext import deferred
@@ -59,6 +60,26 @@ class AdminMigrationRankings(LoggedInHandler):
         EventDetailsManipulator.createOrUpdate(updated)
 
         self.response.out.write("DONE")
+
+
+class AdminMigrationPlayoffAdvancementAll(LoggedInHandler):
+    def get(self):
+        for year in range(1992, MAX_YEAR + 1):
+                        taskqueue.add(url='/admin/migration/backfill_playoff_advancement/{}'.format(year),
+                                      method='GET')
+        self.response.out.write("Enqueued migrations for 1992 - {}".format(MAX_YEAR))
+
+
+class AdminMigrationPlayoffAdvancement(LoggedInHandler):
+    def get(self, year):
+        self._require_admin()
+
+        event_keys = Event.query(Event.year==int(year)).fetch(keys_only=True)
+        for event_key in event_keys:
+            taskqueue.add(url='/tasks/math/do/playoff_advancement_update/{}'.format(event_key.id()),
+                          method='GET')
+
+        self.response.out.write("Enqueued {} migrations".format(len(event_keys)))
 
 
 class AdminMigrationAddSurrogates(LoggedInHandler):

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import tba_config
+import logging
 
 from google.appengine.api import memcache
 from google.appengine.ext import ndb

--- a/controllers/event_controller.py
+++ b/controllers/event_controller.py
@@ -192,7 +192,16 @@ class EventDetail(CacheableHandler):
             matches_recent = None
             matches_upcoming = None
 
-        bracket_table, playoff_advancement, double_elim_matches, playoff_template = PlayoffAdvancementHelper.generatePlayoffAdvancement(event, matches)
+        bracket_table = event.playoff_bracket
+        playoff_advancement = event.playoff_advancement
+        double_elim_matches = PlayoffAdvancementHelper.getDoubleElimMatches(event, matches)
+        playoff_template = PlayoffAdvancementHelper.getPlayoffTemplate(event)
+
+        # Lazy handle the case when we haven't backfilled the event details
+        if not bracket_table or not playoff_advancement:
+            bracket_table2, playoff_advancement2, _, _ = PlayoffAdvancementHelper.generatePlayoffAdvancement(event, matches)
+            bracket_table = bracket_table or bracket_table2
+            playoff_advancement = playoff_advancement or playoff_advancement2
 
         district_points_sorted = None
         if event.district_key and event.district_points:

--- a/cron_main.py
+++ b/cron_main.py
@@ -12,7 +12,8 @@ from controllers.datafeed_controller import FMSAPIAwardsGet, FMSAPIEventAlliance
 from controllers.datafeed_controller import HallOfFameTeamsGet
 
 from controllers.cron_controller import DistrictPointsCalcEnqueue, DistrictPointsCalcDo, \
-    MatchTimePredictionsEnqueue, MatchTimePredictionsDo, BlueZoneUpdateDo, SuggestionQueueDailyNag, RemapTeamsDo
+    MatchTimePredictionsEnqueue, MatchTimePredictionsDo, BlueZoneUpdateDo, SuggestionQueueDailyNag, RemapTeamsDo, \
+    RebuildPlayoffAdvancementEnqueue, RebuildPlayoffAdvancementDo
 from controllers.cron_controller import DistrictRankingsCalcEnqueue, DistrictRankingsCalcDo
 from controllers.cron_controller import EventTeamStatusCalcEnqueue, EventTeamStatusCalcDo
 from controllers.cron_controller import EventShortNameCalcEnqueue, EventShortNameCalcDo
@@ -64,6 +65,8 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/math/do/final_matches_repair/([0-9]*)', FinalMatchesRepairDo),
                                ('/tasks/math/enqueue/predict_match_times', MatchTimePredictionsEnqueue),
                                ('/tasks/math/do/predict_match_times/(.*)', MatchTimePredictionsDo),
+                               ('/tasks/math/enqueue/playoff_advancement_update/(.*)', RebuildPlayoffAdvancementEnqueue),
+                               ('/tasks/math/do/playoff_advancement_update/(.*)', RebuildPlayoffAdvancementDo),
                                ('/tasks/notifications/upcoming_match', UpcomingNotificationDo),
                                ('/tasks/admin/enqueue/clear_mobile_duplicates', AdminMobileClearEnqueue),
                                ('/tasks/admin/clear_mobile_duplicates', AdminMobileClear),

--- a/datafeeds/csv_advancement_parser.py
+++ b/datafeeds/csv_advancement_parser.py
@@ -1,0 +1,27 @@
+import csv
+import StringIO
+
+from datafeeds.parser_base import ParserBase
+
+
+class CSVAdvancementParser(ParserBase):
+    @classmethod
+    def parse(self, data, matches_per_team):
+        """
+        Parse CSV that contains round robin playoff advancement
+        Format is as follows:
+        alliance_number, cmp_points_m1, cmp_points_m2 ..., tiebreak1_m1, tiebreak2_m2 ...,  tiebreak2_m1, tiebreak2_m2 ..., wins, losses, ties
+        """
+        advancement = []
+        csv_data = list(csv.reader(StringIO.StringIO(data), delimiter=',', skipinitialspace=True))
+        for row in csv_data:
+            advancement.append({
+                'alliance_number': int(row[0]),
+                'cmp_points_matches': [int(row[i]) for i in range(1, 1 + matches_per_team)],
+                'tiebreak1_matches': [int(row[i]) for i in range(1 + matches_per_team, 1 + 2 * matches_per_team)],
+                'tiebreak2_matches': [int(row[i]) for i in range(1 + 2 * matches_per_team, 1 + 3 * matches_per_team)],
+                'wins': int(row[1 + 3 * matches_per_team]),
+                'losses': int(row[2 + 3 * matches_per_team]),
+                'ties': int(row[3 + 3 * matches_per_team]),
+            })
+        return advancement

--- a/helpers/event_details_manipulator.py
+++ b/helpers/event_details_manipulator.py
@@ -74,6 +74,7 @@ class EventDetailsManipulator(ManipulatorBase):
             'predictions',
             'rankings',
             'rankings2',
+            'playoff_advancement'
         ]
 
         old_event_details._updated_attrs = []

--- a/helpers/match_manipulator.py
+++ b/helpers/match_manipulator.py
@@ -119,6 +119,15 @@ class MatchManipulator(ManipulatorBase):
                 logging.error("Error enqueuing event_team_status for {}".format(event_key))
                 logging.error(traceback.format_exc())
 
+            # Enqueue updating playoff advancement
+            try:
+                taskqueue.add(
+                    url='/tasks/math/do/playoff_advancement_update/{}'.format(event_key),
+                    method='GET')
+            except Exception:
+                logging.error("Error enqueuing advancement update for {}".format(event_key))
+                logging.error(traceback.format_exc())
+
     @classmethod
     def updateMerge(self, new_match, old_match, auto_union=True):
         """

--- a/helpers/playoff_advancement_helper.py
+++ b/helpers/playoff_advancement_helper.py
@@ -75,6 +75,42 @@ class PlayoffAdvancementHelper(object):
         return bracket_table, playoff_advancement, double_elim_matches, playoff_template
 
     @classmethod
+    def generatePlayoffAdvancementFromCSV(cls, event, csv_advancement):
+        """
+        Generate properly formatted advancement info from the output of CSVAdvancementParser
+        The output will be of the same format as generatePlayoffAdvancementRoundRobin
+        """
+        if event.playoff_type != PlayoffType.ROUND_ROBIN_6_TEAM:
+            return {}
+
+        advancement = []
+        for alliance_advancement in csv_advancement:
+            alliance = event.alliance_selections[alliance_advancement['alliance_number'] - 1]
+            advancement.append([
+                map(lambda p: int(p[3:]), alliance['picks']),
+                alliance_advancement['cmp_points_matches'],
+                sum(alliance_advancement['cmp_points_matches']),
+                alliance_advancement['tiebreak1_matches'],
+                sum(alliance_advancement['tiebreak1_matches']),
+                alliance_advancement['tiebreak2_matches'],
+                sum(alliance_advancement['tiebreak2_matches']),
+                alliance.get('name'),
+                {
+                    'wins': alliance_advancement['wins'],
+                    'losses': alliance_advancement['losses'],
+                    'ties': alliance_advancement['ties'],
+                }
+            ])
+
+        advancement = sorted(advancement, key=lambda x: -x[6])  # sort by tiebreaker2
+        advancement = sorted(advancement, key=lambda x: -x[4])  # sort by tiebreaker1
+        advancement = sorted(advancement, key=lambda x: -x[2])  # sort by championship points
+        return {
+            "sf": advancement,
+            "sf_complete": True,
+        }
+
+    @classmethod
     def generateBracket(cls, matches, event, alliance_selections=None):
         complete_alliances = []
         bracket_table = defaultdict(lambda: defaultdict(dict))

--- a/models/event.py
+++ b/models/event.py
@@ -129,6 +129,22 @@ class Event(ndb.Model):
         else:
             return self.details.district_points
 
+    @property
+    def playoff_advancement(self):
+        if self.details is None:
+            return None
+        else:
+            return self.details.playoff_advancement.get(
+                "advancement") if self.details.playoff_advancement else None
+
+    @property
+    def playoff_bracket(self):
+        if self.details is None:
+            return None
+        else:
+            return self.details.playoff_advancement.get(
+                "bracket") if self.details.playoff_advancement else None
+
     @ndb.tasklet
     def get_matches_async(self):
         if self._matches is None:

--- a/models/event_details.py
+++ b/models/event_details.py
@@ -15,6 +15,10 @@ class EventDetails(ndb.Model):
     rankings = ndb.JsonProperty()
     rankings2 = ndb.JsonProperty()
 
+    # Based on the output of PlayoffAdvancementHelper.generatePlayoffAdvancement
+    # Dict with keys for: bracket, playoff_advancement
+    playoff_advancement = ndb.JsonProperty()
+
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True)
 

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -180,6 +180,7 @@
   <h2>Math Tasks</h2>
   <div class="btn-group">
     <a href="/tasks/math/do/eventteam_update/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-user"></span> Rebuild EventTeams</a>
+    <a href="/tasks/math/do/playoff_advancement_update/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-user"></span> Rebuild Playoff Advancement</a>
     <a href="/backend-tasks/do/post_event_tasks/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-play"></span> Run Post-Event Tasks</a>
     <a href="/tasks/math/do/district_points_calc/{{event.key_name}}?allow-offseason=true" class="btn btn-warning"><span class="glyphicon glyphicon-tasks"></span> District Points</a>
     <a href="/tasks/math/do/event_team_status/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-stats"></span> Team@Event Status</a>

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -258,6 +258,22 @@
   <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-plus-sign"></span> Add Matches</button>
 </form>
 
+{% if event.playoff_type == 4 %}
+<!-- Round robin -->
+<h2>Add Round Robin Playoff Advancement</h2>
+<p>Add playoff advancement (round robin event types only) formatted as CSV. This requires having alliance data set</p>
+<p>Example:</p>
+<div class="well">
+  <p>alliance_number, cmp_points_m1, cmp_points_m2 ..., tiebreak1_m1, tiebreak2_m2 ...,  tiebreak2_m1, tiebreak2_m2 ..., wins, losses, ties
+</div>
+<form action="/admin/playoff_advancement/add" method="post">
+  <input name="event_key" type="hidden" value="{{ event.key_name }}" />
+  <p>Number of Round Robin matches per team: <input name="num_matches" value="5" /></p>
+  <p><textarea class="form-control" name="advancement_csv"></textarea></p>
+  <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-plus-sign"></span> Add Advancement</button>
+</form>
+{% endif %}
+
 <h2>Add Awards</h2>
 <p>Add awards formatted as a CSV.</p>
 <p>Format:</p>

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -33,6 +33,7 @@
     <li><a href="#webcasts" data-toggle="tab">Webcasts</a></li>
     <li><a href="#rankings" data-toggle="tab">Rankings</a></li>
     <li><a href="#alliances" data-toggle="tab">Alliances</a></li>
+    <li><a href="#advancement" data-toggle="tab">Playoff Advancement</a></li>
     <li><a href="#awards" data-toggle="tab">Awards</a></li>
     <li><a href="#matches" data-toggle="tab">Matches</a></li>
     <li><a href="#media" data-toggle="tab">Media</a></li>
@@ -374,6 +375,26 @@
       <p>No ranking data yet</p>
   {% endfor %}
 </table>
+{% endif %}
+</div>
+</div>
+
+
+<div class="tab-pane" id="advancement">
+<div class="row">
+<h2>Rankings</h2>
+{% if event.details and event.details.playoff_advancement %}
+<h3>Elim Bracket</h3>
+{% autoescape off %}
+  {{elim_bracket_html}}
+{% endautoescape %}
+
+<h3>Playoff Advancement</h3>
+{% autoescape off %}
+  {{advancement_html}}
+{% endautoescape %}
+{% else %}
+  <p>No advancement details yet</p>
 {% endif %}
 </div>
 </div>

--- a/templates_jinja2/bracket_partials/bracket_table.html
+++ b/templates_jinja2/bracket_partials/bracket_table.html
@@ -2,43 +2,45 @@
   <tbody>
     <tr>
       {% if bracket_table.qf %}
-      <td class="leftAlliance {% if bracket_table.qf.1.winning_alliance == 'red' %}winnerL{% endif %}" rowspan="1">
+      <td class="leftAlliance {% if bracket_table.qf.qf1.winning_alliance == 'red' %}winnerL{% endif %}" rowspan="1">
         <div class="alliance_number">1.</div>
-        {% for team in bracket_table.qf.1.red_alliance %}
+        {% for team in bracket_table.qf.qf1.red_alliance %}
             <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
       {% endif %}
       {% if bracket_table.sf %}
-      <td class="leftAlliance {% if bracket_table.sf.1.winning_alliance == 'red' %}winnerL{% endif %}" rowspan="2">
-        {% for team in bracket_table.sf.1.red_alliance %}
+      <td class="leftAlliance {% if bracket_table.sf.sf1.winning_alliance == 'red' %}winnerL{% endif %}" rowspan="2">
+        {% for team in bracket_table.sf.sf1.red_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
       {% endif %}
-      <td class="{% if bracket_table.f.1.winning_alliance == 'red' %}winnerC{% else %}{% if bracket_table.f.1.winning_alliance == 'blue' %}secondC{% endif %}{% endif %}" rowspan="4">
+      {% if bracket_table.f %}
+      <td class="{% if bracket_table.f.f1.winning_alliance == 'red' %}winnerC{% else %}{% if bracket_table.f.f1.winning_alliance == 'blue' %}secondC{% endif %}{% endif %}" rowspan="4">
         <br>
-        {% for team in bracket_table.f.1.red_alliance %}
+        {% for team in bracket_table.f.f1.red_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
-      <td class="{% if bracket_table.f.1.winning_alliance == 'blue' %}winnerC{% else %}{% if bracket_table.f.1.winning_alliance == 'red' %}secondC{% endif %}{% endif %}" rowspan="4">
+      <td class="{% if bracket_table.f.f1.winning_alliance == 'blue' %}winnerC{% else %}{% if bracket_table.f.f1.winning_alliance == 'red' %}secondC{% endif %}{% endif %}" rowspan="4">
         <br>
-        {% for team in bracket_table.f.1.blue_alliance %}
+        {% for team in bracket_table.f.f1.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
+      {% endif %}
       {% if bracket_table.sf %}
-      <td class="rightAlliance {% if bracket_table.sf.2.winning_alliance == 'blue' %}winnerR{% endif %}" rowspan="2">
-        {% for team in bracket_table.sf.2.blue_alliance %}
+      <td class="rightAlliance {% if bracket_table.sf.sf2.winning_alliance == 'blue' %}winnerR{% endif %}" rowspan="2">
+        {% for team in bracket_table.sf.sf2.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
       {% endif %}
       {% if bracket_table.qf %}
-      <td class="rightAlliance {% if bracket_table.qf.4.winning_alliance == 'red' %}winnerR{% endif %}" rowspan="1">
+      <td class="rightAlliance {% if bracket_table.qf.qf4.winning_alliance == 'red' %}winnerR{% endif %}" rowspan="1">
         <div class="alliance_number">3.</div>
-        {% for team in bracket_table.qf.4.red_alliance %}
+        {% for team in bracket_table.qf.qf4.red_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
@@ -46,15 +48,15 @@
     </tr>
     <tr>
       {% if bracket_table.qf %}
-      <td class="leftAlliance {% if bracket_table.qf.1.winning_alliance == 'blue' %}winnerL{% endif %}" rowspan="1">
+      <td class="leftAlliance {% if bracket_table.qf.qf1.winning_alliance == 'blue' %}winnerL{% endif %}" rowspan="1">
         <div class="alliance_number">8.</div>
-        {% for team in bracket_table.qf.1.blue_alliance %}
+        {% for team in bracket_table.qf.qf1.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
-      <td class="rightAlliance {% if bracket_table.qf.4.winning_alliance == 'blue' %}winnerR{% endif %}" rowspan="1">
+      <td class="rightAlliance {% if bracket_table.qf.qf4.winning_alliance == 'blue' %}winnerR{% endif %}" rowspan="1">
         <div class="alliance_number">6.</div>
-        {% for team in bracket_table.qf.4.blue_alliance %}
+        {% for team in bracket_table.qf.qf4.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
@@ -62,29 +64,29 @@
     </tr>
     <tr>
       {% if bracket_table.qf %}
-      <td class="leftAlliance {% if bracket_table.qf.2.winning_alliance == 'red' %}winnerL{% endif %}" rowspan="1">
+      <td class="leftAlliance {% if bracket_table.qf.qf2.winning_alliance == 'red' %}winnerL{% endif %}" rowspan="1">
         <div class="alliance_number">4.</div>
-        {% for team in bracket_table.qf.2.red_alliance %}
+        {% for team in bracket_table.qf.qf2.red_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
       {% endif %}
       {% if bracket_table.sf %}
-      <td class="leftAlliance {% if bracket_table.sf.1.winning_alliance == 'blue' %}winnerL{% endif %}" rowspan="2">
-        {% for team in bracket_table.sf.1.blue_alliance %}
+      <td class="leftAlliance {% if bracket_table.sf.sf1.winning_alliance == 'blue' %}winnerL{% endif %}" rowspan="2">
+        {% for team in bracket_table.sf.sf1.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
-      <td class="rightAlliance {% if bracket_table.sf.2.winning_alliance == 'red' %}winnerR{% endif %}" rowspan="2">
-        {% for team in bracket_table.sf.2.red_alliance %}
+      <td class="rightAlliance {% if bracket_table.sf.sf2.winning_alliance == 'red' %}winnerR{% endif %}" rowspan="2">
+        {% for team in bracket_table.sf.sf2.red_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
       {% endif %}
       {% if bracket_table.qf %}
-      <td class="rightAlliance {% if bracket_table.qf.3.winning_alliance == 'red' %}winnerR{% endif %}" rowspan="1">
+      <td class="rightAlliance {% if bracket_table.qf.qf3.winning_alliance == 'red' %}winnerR{% endif %}" rowspan="1">
         <div class="alliance_number">2.</div>
-        {% for team in bracket_table.qf.3.red_alliance %}
+        {% for team in bracket_table.qf.qf3.red_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
@@ -92,15 +94,15 @@
     </tr>
     <tr>
       {% if bracket_table.qf %}
-      <td class="leftAlliance {% if bracket_table.qf.2.winning_alliance == 'blue' %}winnerL{% endif %}" rowspan="1">
+      <td class="leftAlliance {% if bracket_table.qf.qf2.winning_alliance == 'blue' %}winnerL{% endif %}" rowspan="1">
         <div class="alliance_number">5.</div>
-        {% for team in bracket_table.qf.2.blue_alliance %}
+        {% for team in bracket_table.qf.qf2.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>
-      <td class="rightAlliance {% if bracket_table.qf.3.winning_alliance == 'blue' %}winnerR{% endif %}" rowspan="1">
+      <td class="rightAlliance {% if bracket_table.qf.qf3.winning_alliance == 'blue' %}winnerR{% endif %}" rowspan="1">
         <div class="alliance_number">7.</div>
-        {% for team in bracket_table.qf.3.blue_alliance %}
+        {% for team in bracket_table.qf.qf3.blue_alliance %}
           <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
         {% endfor %}
       </td>

--- a/templates_jinja2/playoff_partials/playoff_round_robin_6_team.html
+++ b/templates_jinja2/playoff_partials/playoff_round_robin_6_team.html
@@ -38,15 +38,15 @@
   <table class="brackettable">
     <tbody>
       <tr>
-        <td class="{% if bracket_table.f.1.winning_alliance == 'red' %}winnerC{% else %}{% if bracket_table.f.1.winning_alliance == 'blue' %}secondC{% endif %}{% endif %}">
+        <td class="{% if bracket_table.f.f1.winning_alliance == 'red' %}winnerC{% else %}{% if bracket_table.f.f1.winning_alliance == 'blue' %}secondC{% endif %}{% endif %}">
           <br>
-          {% for team in bracket_table.f.1.red_alliance %}
+          {% for team in bracket_table.f.f1.red_alliance %}
             <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
           {% endfor %}
         </td>
-        <td class="{% if bracket_table.f.1.winning_alliance == 'blue' %}winnerC{% else %}{% if bracket_table.f.1.winning_alliance == 'red' %}secondC{% endif %}{% endif %}">
+        <td class="{% if bracket_table.f.f1.winning_alliance == 'blue' %}winnerC{% else %}{% if bracket_table.f.f1.winning_alliance == 'red' %}secondC{% endif %}{% endif %}">
           <br>
-          {% for team in bracket_table.f.1.blue_alliance %}
+          {% for team in bracket_table.f.f1.blue_alliance %}
             <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
           {% endfor %}
         </td>

--- a/templates_jinja2/playoff_partials/playoff_table.html
+++ b/templates_jinja2/playoff_partials/playoff_table.html
@@ -75,15 +75,15 @@
   <table class="brackettable">
     <tbody>
       <tr>
-        <td class="{% if bracket_table.f.1.winning_alliance == 'red' %}winnerC{% else %}{% if bracket_table.f.1.winning_alliance == 'blue' %}secondC{% endif %}{% endif %}">
+        <td class="{% if bracket_table.f.f1.winning_alliance == 'red' %}winnerC{% else %}{% if bracket_table.f.f1.winning_alliance == 'blue' %}secondC{% endif %}{% endif %}">
           <br>
-          {% for team in bracket_table.f.1.red_alliance %}
+          {% for team in bracket_table.f.f1.red_alliance %}
             <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
           {% endfor %}
         </td>
-        <td class="{% if bracket_table.f.1.winning_alliance == 'blue' %}winnerC{% else %}{% if bracket_table.f.1.winning_alliance == 'red' %}secondC{% endif %}{% endif %}">
+        <td class="{% if bracket_table.f.f1.winning_alliance == 'blue' %}winnerC{% else %}{% if bracket_table.f.f1.winning_alliance == 'red' %}secondC{% endif %}{% endif %}">
           <br>
-          {% for team in bracket_table.f.1.blue_alliance %}
+          {% for team in bracket_table.f.f1.blue_alliance %}
             <a href="/team/{{team|digits}}/{{event.year}}" title="{{team}}">{{team}}</a><br>
           {% endfor %}
         </td>


### PR DESCRIPTION
We want to be able to support loading arbitrary data into playoff advancement (for offseason events that run their own round robin, for example), so move all this into a datastore model we can expose writes to.

This required changing the format of the bracket data to not have numeric keys (since those don't work with a round trip of json serialization).

Also haven't done cache clearing yet