### PR TITLE
Added more types to webcast types

### DIFF
--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -6626,7 +6626,11 @@
               "html5",
               "rtmp",
               "livestream",
-              "direct_link"
+              "direct_link",
+              "mms",
+              "justin",
+              "stemtv",
+              "dacast"
             ]
           },
           "channel": {


### PR DESCRIPTION
Turns out there were actually a bunch of different types that were not allowed and broke things when you called events containing them through the API.

<!--- Provide a general summary of your changes in the Title above -->
Added a couple more webcast types that are left out in the API but present in the data set. This information was gathered by examining every webcast type across all years (1992-2019)


## Screenshots (if appropriate):
![webcast_types](https://user-images.githubusercontent.com/6640721/60853707-489a1000-a1cb-11e9-9bb4-e04bebca2046.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
