### PR TITLE
Clear team page caches when clearing event page cache

### DIFF
--- a/controllers/admin/admin_event_controller.py
+++ b/controllers/admin/admin_event_controller.py
@@ -430,7 +430,6 @@ class AdminEventDetail(LoggedInHandler):
         self.template_values.update({
             "event": event,
             "medias": event_medias,
-            "cache_key": event_controller.EventDetail('2016nyny').cache_key.format(event.key_name),
             "flushed": self.request.get("flushed"),
             "playoff_types": PlayoffType.type_names,
             "write_auths": api_keys,

--- a/controllers/admin/admin_memcache_controller.py
+++ b/controllers/admin/admin_memcache_controller.py
@@ -4,7 +4,10 @@ from google.appengine.api import memcache
 from google.appengine.ext.webapp import template
 
 from controllers.base_controller import LoggedInHandler
+from controllers.event_controller import EventDetail
+from controllers.team_controller import TeamDetail, TeamCanonical
 from helpers.memcache.memcache_webcast_flusher import MemcacheWebcastFlusher
+from models.event import Event
 
 # Main memcache view.
 
@@ -24,6 +27,23 @@ class AdminMemcacheMain(LoggedInHandler):
         if self.request.get('memcache_key') is not "":
             memcache.delete(self.request.get("memcache_key"))
             flushed.append(self.request.get("memcache_key"))
+
+        if self.request.get('event_key') is not "":
+            # Clear event page and event teams pages
+            event_key = self.request.get('event_key')
+            memcache_keys_to_delete = [EventDetail().cache_key.format(event_key)]
+
+            event = Event.get_by_id(event_key)
+            for team in event.teams:
+                memcache_keys_to_delete.append(
+                    TeamDetail().cache_key.format(team.key.id(), event.year)
+                )
+                memcache_keys_to_delete.append(
+                    TeamCanonical().cache_key.format(team.key.id())
+                )
+
+            # memcache.delete_multi(memcache_keys_to_delete)
+            flushed += memcache_keys_to_delete
 
         if self.request.get('return_url') is not "":
             self.redirect("{}?flushed={}".format(self.request.get('return_url'), flushed))

--- a/controllers/admin/admin_memcache_controller.py
+++ b/controllers/admin/admin_memcache_controller.py
@@ -42,7 +42,7 @@ class AdminMemcacheMain(LoggedInHandler):
                     TeamCanonical().cache_key.format(team.key.id())
                 )
 
-            # memcache.delete_multi(memcache_keys_to_delete)
+            memcache.delete_multi(memcache_keys_to_delete)
             flushed += memcache_keys_to_delete
 
         if self.request.get('return_url') is not "":

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -13,7 +13,7 @@
 </div>
 
 <form action="/admin/memcache" method="post" id="event_cache_clear">
-  <input name="memcache_key" value="{{cache_key}}" type="hidden" />
+  <input name="event_key" value="{{event.key_name}}" type="hidden" />
   <input name="return_url" value="/admin/event/{{ event.key_name }}" type="hidden" />
 </form>
 


### PR DESCRIPTION
## Motivation and Context
Enables clearing of pages for all teams at an event without manually clearing each team.

## How Has This Been Tested?
Locally, clicking "Clear Cache" on the event admin page also clears team page caches.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/61157251-72448700-a4aa-11e9-9c43-9230f62d39f3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
