### PR TITLE
Fix issues with importing 2019 FMS schedule reports

### DIFF
--- a/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -107,20 +107,27 @@ $('#schedule_file').change(function(){
             var match = matches[i];
 
             // check for invalid match
-            if(!match['Match'] || !match['Red 1']){
+            if(!match['Description'] || !match['Red 1']){
                 continue;
             }
 
-            var compLevel, setNumber, matchNumber, matchKey;
+            var compLevel, setNumber, matchNumber, rawMatchNumber, matchKey;
             var has_octo = $('input[name="alliance-count-schedule"]:checked').val() == "16";
-            matchNumber = parseInt(match['Match']);
+            if (match['Match']) {
+                rawMatchNumber = parseInt(match['Match']);
+            } else if (match['Description'].indexOf('#') >= 0) {
+                rawMatchNumber = parseInt(match['Description'].split('#')[1]);
+            } else {
+                rawMatchNumber = parseInt(match['Description'].split(' ')[1]);
+            }
             if(!match.hasOwnProperty('Description') || match['Description'].indexOf("Qualification") == 0){
+                matchNumber = parseInt(match['Description'].split(' ')[1]);
                 compLevel = "qm";
                 setNumber = 1;
                 matchKey = "qm" + matchNumber;
             }else{
-                compLevel = playoffTypeFromNumber(matchNumber, has_octo);
-                var setAndMatch = playoffMatchAndSet(matchNumber, has_octo);
+                compLevel = playoffTypeFromNumber(rawMatchNumber, has_octo);
+                var setAndMatch = playoffMatchAndSet(rawMatchNumber, has_octo);
                 setNumber = setAndMatch[0];
                 matchNumber = setAndMatch[1];
                 matchKey = compLevel + setNumber + "m" + matchNumber;
@@ -134,7 +141,7 @@ $('#schedule_file').change(function(){
             var row = $('<tr>');
             row.append($('<td>').html(match['Time']));
             row.append($('<td>').html(match['Description']));
-            row.append($('<td>').html(match['Match']));
+            row.append($('<td>').html(rawMatchNumber));
             row.append($('<td>').html($('#event_key').val() + "_" + matchKey));
             row.append($('<td>').html(cleanTeamNum(match['Blue 1'])));
             row.append($('<td>').html(cleanTeamNum(match['Blue 2'])));


### PR DESCRIPTION
This adds support for schedule reports exported from 2019 FMS. These reports dropped the "Match" column from last year and added that information to the "Description" column for playoff matches, so attempting to import them would result in a "No matches found in the file" message.

Fixes #2548

Match result reports seem to work as expected without changes.

## How Has This Been Tested?
Tested in a local instance with both qualification and playoff schedule reports from 2019MIBB and 2018MIBB, which were recognized and uploaded successfully. (I'm unsure if some people are still using 2018-style reports, so I have retained support for those as well.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
