### PR TITLE
Fix parsing match times in event wizard schedule import

### DIFF
--- a/helpers/match_helper.py
+++ b/helpers/match_helper.py
@@ -33,7 +33,7 @@ class MatchHelper(object):
         last_match_time = None
         cur_date = event.end_date + datetime.timedelta(hours=23, minutes=59, seconds=59)  # end_date is specified at midnight of the last day
         for match in matches_reversed:
-            r = re.match(r'(\d+):(\d+) (am|pm)', match.time_string.lower())
+            r = re.search(r'(\d+):(\d+) (am|pm)', match.time_string.lower())
             hour = int(r.group(1))
             minute = int(r.group(2))
             if hour == 12:


### PR DESCRIPTION
This fixes an issue where match times submitted in schedule reports via the event wizard would fail to parse, resulting in "?" placeholder scores being displayed instead of the scheduled match time. (`re.match` only looks for matches at the start of a string, and schedule reports contain strings such as "Sat 11:40 AM", so the weekday was causing issues here.) 

(Note that I based this on #2553 to get schedule imports to work at all, so that should probably be merged first. 0615b3c is the only new commit here.)

## How Has This Been Tested?
Tested uploading schedule reports on a local instance

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/3719547/62182577-13459580-b325-11e9-92a9-dfbf266908e9.png)

After:
![image](https://user-images.githubusercontent.com/3719547/62182587-1c366700-b325-11e9-9ce4-b90451954b82.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
