### PR TITLE
Remove Team motto from APIv2 and APIv3 responses

### DIFF
--- a/database/dict_converters/team_converter.py
+++ b/database/dict_converters/team_converter.py
@@ -3,7 +3,7 @@ from database.dict_converters.converter_base import ConverterBase
 
 class TeamConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        3: 4,
+        3: 5,
     }
 
     @classmethod
@@ -28,7 +28,6 @@ class TeamConverter(ConverterBase):
             'name': team.name if team.name else default_name,
             'website': team.website,
             'rookie_year': team.rookie_year,
-            'motto': None,
             'home_championship': team.championship_location,
         }
         team_dict.update(cls.constructLocation_v3(team))

--- a/helpers/model_to_dict.py
+++ b/helpers/model_to_dict.py
@@ -16,7 +16,6 @@ class ModelToDict(object):
         team_dict["website"] = team.website
         team_dict["location"] = team.location
         team_dict["rookie_year"] = team.rookie_year
-        team_dict["motto"] = None
 
         try:
             team_dict["location"] = team.location

--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account). \n\n A `User-Agent` header may need to be set to prevent a 403 Unauthorized error.",
-    "version": "3.5",
+    "version": "3.6.0",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.5.0 - 3.6.0: Remove motto from Team model. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -1869,7 +1869,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -1933,7 +1933,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -1991,7 +1991,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2050,7 +2050,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2109,7 +2109,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2169,7 +2169,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2224,7 +2224,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2279,7 +2279,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2337,7 +2337,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2392,7 +2392,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2447,7 +2447,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2502,7 +2502,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2557,7 +2557,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2613,7 +2613,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2673,7 +2673,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2733,7 +2733,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2794,7 +2794,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2855,7 +2855,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2914,7 +2914,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -2973,7 +2973,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3033,7 +3033,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3093,7 +3093,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3151,7 +3151,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3206,7 +3206,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3261,7 +3261,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3320,7 +3320,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3378,7 +3378,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3438,7 +3438,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3504,7 +3504,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3565,7 +3565,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3625,7 +3625,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3685,7 +3685,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3746,7 +3746,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3806,7 +3806,7 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-            
+
           }
         },
         "security": [
@@ -3987,10 +3987,6 @@
           "rookie_year": {
             "type": "integer",
             "description": "First year the team officially competed."
-          },
-          "motto": {
-            "type": "string",
-            "description": "Team's motto as provided by FIRST. This field is deprecated and will return null - will be removed at end-of-season in 2019."
           },
           "home_championship": {
             "type": "object",
@@ -6647,7 +6643,7 @@
     "responses": {
       "Unauthorized": {
         "$ref": "#/components/responses/Unauthorized"
-        
+
       },
       "NotModified": {
         "description": "Not Modified - Use Local Cached Value"

--- a/templates/apidocs_v2.html
+++ b/templates/apidocs_v2.html
@@ -192,11 +192,6 @@
             <td>Team's rookie year</td>
             <td>1999</td>
           </tr>
-        <tr>
-            <td>motto</td>
-            <td>Team's Motto</td>
-            <td>Infiltrating Young Minds One Robot at a Time</td>
-        </tr>
         </tbody>
       </table>
 

--- a/tests/test_apiv2_team_controller.py
+++ b/tests/test_apiv2_team_controller.py
@@ -67,7 +67,6 @@ class TestTeamApiController(unittest2.TestCase):
         self.assertEqual(team["region"], "SC")
         self.assertEqual(team["website"], self.team.website)
         self.assertEqual(team["rookie_year"], self.team.rookie_year)
-        self.assertEqual(team["motto"], None)
 
     def test_team_api(self):
         response = self.testapp.get('/frc281', headers={"X-TBA-App-Id": "tba-tests:team-controller-test:v01"})
@@ -207,7 +206,6 @@ class TestDistrictTeamsApiController(unittest2.TestCase):
         self.assertEqual(team["country_name"], "USA")
         self.assertEqual(team["region"], "SC")
         self.assertEqual(team["website"], self.team.website)
-        self.assertEqual(team["motto"], None)
 
     def test_districts_api(self):
         response = self.testapp.get('/ne/2015', headers={"X-TBA-App-Id": "tba-tests:team-districts-controller-test:v01"})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As we've been discussing for a while, this removes `motto` from Team responses in APIv2 and APIv3. This doesn't touch the backing data models/stores or parsers for team mottos.

## Motivation and Context
Second part of https://github.com/the-blue-alliance/the-blue-alliance/pull/2410

## How Has This Been Tested?
#YOLO

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change API specifications or require data migrations)
