### PR TITLE
Fix playoff type messing up qual numbering

### DIFF
--- a/consts/playoff_type.py
+++ b/consts/playoff_type.py
@@ -84,12 +84,15 @@ class PlayoffType(object):
 
     @classmethod
     def get_set_match_number(cls, playoff_type, comp_level, match_number):
+        if comp_level == 'qm':
+            return 1, match_number
+
         if playoff_type == cls.AVG_SCORE_8_TEAM:
             if comp_level == 'sf':
                 return 1, match_number - 8
             elif comp_level == 'f':
                 return 1, match_number - 14
-            else:  # qm, qf
+            else:  # qf
                 return 1, match_number
         if playoff_type == cls.ROUND_ROBIN_6_TEAM:
             # Einstein 2017 for example. 15 round robin matches from sf1-1 to sf1-15, then finals
@@ -99,21 +102,15 @@ class PlayoffType(object):
             else:
                 return 1, match_number
         elif playoff_type == cls.DOUBLE_ELIM_8_TEAM:
-            if comp_level in {'ef', 'qf', 'sf', 'f'}:
-                level, set, match = cls.DOUBLE_ELIM_MAPPING.get(match_number)
-                return set, match
-            else:  # qual
-                return 1, match_number
+            level, set, match = cls.DOUBLE_ELIM_MAPPING.get(match_number)
+            return set, match
         elif playoff_type == cls.BO3_FINALS or playoff_type == cls.BO5_FINALS:
             return 1, match_number
         else:
-            if playoff_type == cls.BRACKET_4_TEAM and comp_level != 'qm' and match_number <= 12:
+            if playoff_type == cls.BRACKET_4_TEAM and match_number <= 12:
                 match_number += 12
-            if comp_level in {'ef', 'qf', 'sf', 'f'}:
-                return cls.BRACKET_OCTO_ELIM_MAPPING[match_number] if playoff_type == cls.BRACKET_16_TEAM \
-                    else cls.BRACKET_ELIM_MAPPING[match_number]
-            else:  # qm
-                return 1, match_number
+            return cls.BRACKET_OCTO_ELIM_MAPPING[match_number] if playoff_type == cls.BRACKET_16_TEAM \
+                else cls.BRACKET_ELIM_MAPPING[match_number]
 
     # Determine if a match is in the winner or loser bracket
     @classmethod

--- a/tests/test_playoff_type.py
+++ b/tests/test_playoff_type.py
@@ -1,0 +1,106 @@
+import unittest2
+
+from consts.playoff_type import PlayoffType
+
+
+class TestPlayoffType(unittest2.TestCase):
+    def test_BRACKET_8_TEAM(self):
+        playoff_type = PlayoffType.BRACKET_8_TEAM
+
+        # Qual
+        for i in xrange(50):
+            self.assertEqual(
+                PlayoffType.get_comp_level(playoff_type, 'Qualification', i + 1),
+                'qm'
+            )
+            self.assertEqual(
+                PlayoffType.get_set_match_number(playoff_type, 'qm', i + 1),
+                (1, i + 1)
+            )
+
+        # Playoff
+        expected = [
+            'qf', 'qf', 'qf',
+            'qf', 'qf', 'qf',
+            'qf', 'qf', 'qf',
+            'qf', 'qf', 'qf',
+            'sf', 'sf', 'sf',
+            'sf', 'sf', 'sf',
+            'f', 'f', 'f',
+        ]
+        for i in xrange(21):
+            self.assertEqual(
+                PlayoffType.get_comp_level(playoff_type, 'Playoff', i + 1),
+                expected[i]
+            )
+
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'qf', 1),
+            (1, 1)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'qf', 12),
+            (4, 3)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'sf', 13),
+            (1, 1)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'sf', 18),
+            (2, 3)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'f', 19),
+            (1, 1)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'f', 21),
+            (1, 3)
+        )
+
+    def test_ROUND_ROBIN_6_TEAM(self):
+        playoff_type = PlayoffType.ROUND_ROBIN_6_TEAM
+
+        # Qual
+        for i in xrange(50):
+            self.assertEqual(
+                PlayoffType.get_comp_level(playoff_type, 'Qualification', i + 1),
+                'qm'
+            )
+            self.assertEqual(
+                PlayoffType.get_set_match_number(playoff_type, 'qm', i + 1),
+                (1, i + 1)
+            )
+
+        # Playoff
+        expected = [
+            'sf', 'sf', 'sf',
+            'sf', 'sf', 'sf',
+            'sf', 'sf', 'sf',
+            'sf', 'sf', 'sf',
+            'sf', 'sf', 'sf',
+            'f', 'f', 'f',
+        ]
+        for i in xrange(18):
+            self.assertEqual(
+                PlayoffType.get_comp_level(playoff_type, 'Playoff', i + 1),
+                expected[i]
+            )
+
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'sf', 1),
+            (1, 1)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'sf', 15),
+            (1, 15)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'f', 16),
+            (1, 1)
+        )
+        self.assertEqual(
+            PlayoffType.get_set_match_number(playoff_type, 'f', 18),
+            (1, 3)
+        )


### PR DESCRIPTION
Playoff type for `ROUND_ROBIN_6_TEAM` was messing up qual numbering. This wasn't caught before because Einstein doesn't have qual matches.

## Description
Short circuit `get_set_match_number` for qual matches.

## How Has This Been Tested?
Local dev on `2019pascs`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
