### PR TITLE
Add week_str tests

### DIFF
--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -10,6 +10,7 @@ from models.event import Event
 
 
 class TestEvent(unittest2.TestCase):
+
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
@@ -114,3 +115,35 @@ class TestEvent(unittest2.TestCase):
     def test_dates_ends_today(self):
         self.assertFalse(self.event_ends_today.starts_today)
         self.assertTrue(self.event_ends_today.ends_today)
+
+    def test_week_str_none(self):
+        event_week_none = MockEvent(week=None, year=2012)
+        self.assertIsNone(event_week_none.week_str)
+
+    def test_week_str_2016(self):
+        event_week_0_year_2016 = MockEvent(week=0, year=2016)
+        self.assertEqual(event_week_0_year_2016.week_str, "Week 0.5")
+        event_week_1_year_2016 = MockEvent(week=1, year=2016)
+        self.assertEqual(event_week_1_year_2016.week_str, "Week 1")
+
+    def test_week_str_not_2016(self):
+        event_week_0_year_2012 = MockEvent(week=0, year=2012)
+        self.assertEqual(event_week_0_year_2012.week_str, "Week 1")
+        event_week_1_year_2022 = MockEvent(week=1, year=2022)
+        self.assertEqual(event_week_1_year_2022.week_str, "Week 2")
+
+
+class MockEvent(Event):
+
+    def __init__(self, week, year):
+        self._week = week
+        self._year = year
+
+    @property
+    def week(self):
+        print(self._week)
+        return self._week
+
+    @property
+    def year(self):
+        return self._year


### PR DESCRIPTION
Getting `week` setup on an actual object, even for testing, is pretty hard. This approach just subclasses `Event` to a `MockEvent` where we can set the `week`/`year` directly and makes sure the logic we're testing works right Closes #2401