### PR TITLE
Add APIv3 endpoints for all teams and all events

### DIFF
--- a/api/apiv3/api_event_controller.py
+++ b/api/apiv3/api_event_controller.py
@@ -30,7 +30,7 @@ class ApiEventListAllController(ApiBaseController):
 
     def _render(self, model_type=None):
         futures = []
-        for year in xrange(1992, tba_config.MAX_YEAR + 1):
+        for year in xrange(tba_config.MIN_YEAR, tba_config.MAX_YEAR + 1):
             futures.append(EventListQuery(year).fetch_async(dict_version=3, return_updated=True))
 
         events = []

--- a/api/apiv3/api_event_controller.py
+++ b/api/apiv3/api_event_controller.py
@@ -1,3 +1,4 @@
+import cloudstorage
 import json
 
 from google.appengine.ext import ndb
@@ -15,6 +16,20 @@ from helpers.match_helper import MatchHelper
 from helpers.playoff_advancement_helper import PlayoffAdvancementHelper
 from models.event_team import EventTeam
 from models.match import Match
+
+
+class ApiEventListAllController(ApiBaseController):
+    CACHE_VERSION = 0
+    CACHE_HEADER_LENGTH = 61
+
+    def _track_call(self):
+        self._track_call_defer('event/list', 'all')
+
+    def _render(self):
+        file = cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-events.json')
+        contents = file.read()
+        file.close()
+        return contents
 
 
 class ApiEventListController(ApiBaseController):

--- a/api/apiv3/api_event_controller.py
+++ b/api/apiv3/api_event_controller.py
@@ -1,5 +1,5 @@
-import cloudstorage
 import json
+import tba_config
 
 from google.appengine.ext import ndb
 
@@ -22,14 +22,27 @@ class ApiEventListAllController(ApiBaseController):
     CACHE_VERSION = 0
     CACHE_HEADER_LENGTH = 61
 
-    def _track_call(self):
-        self._track_call_defer('event/list', 'all')
+    def _track_call(self, model_type=None):
+        action = 'event/list'
+        if model_type:
+            action += '/{}'.format(model_type)
+        self._track_call_defer(action, 'all')
 
-    def _render(self):
-        file = cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-events.json')
-        contents = file.read()
-        file.close()
-        return contents
+    def _render(self, model_type=None):
+        futures = []
+        for year in xrange(1992, tba_config.MAX_YEAR + 1):
+            futures.append(EventListQuery(year).fetch_async(dict_version=3, return_updated=True))
+
+        events = []
+        for future in futures:
+            partial_events, last_modified = future.get_result()
+            events += partial_events
+            if self._last_modified is None or last_modified > self._last_modified:
+                self._last_modified = last_modified
+
+        if model_type is not None:
+            events = filter_event_properties(events, model_type)
+        return json.dumps(events, ensure_ascii=True, indent=True, sort_keys=True)
 
 
 class ApiEventListController(ApiBaseController):

--- a/api/apiv3/api_team_controller.py
+++ b/api/apiv3/api_team_controller.py
@@ -1,3 +1,4 @@
+import cloudstorage
 import datetime
 import json
 
@@ -17,6 +18,19 @@ from helpers.event_team_status_helper import EventTeamStatusHelper
 from models.event_team import EventTeam
 from models.team import Team
 
+
+class ApiTeamListAllController(ApiBaseController):
+    CACHE_VERSION = 0
+    CACHE_HEADER_LENGTH = 61
+
+    def _track_call(self):
+        self._track_call_defer('team/list', 'all')
+
+    def _render(self):
+        file = cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-teams.json')
+        contents = file.read()
+        file.close()
+        return contents
 
 class ApiTeamListController(ApiBaseController):
     """

--- a/api/apiv3/api_team_controller.py
+++ b/api/apiv3/api_team_controller.py
@@ -29,8 +29,12 @@ class ApiTeamListAllController(ApiBaseController):
         self._track_call_defer(action, 'all')
 
     def _render(self, model_type=None):
+        max_team_key = Team.query().order(-Team.team_number).fetch(1, keys_only=True)[0]
+        max_team_num = int(max_team_key.id()[3:])
+        max_team_page = int(max_team_num / 500)
+
         futures = []
-        for page_num in xrange(20):  # TODO: don't hardcode
+        for page_num in xrange(max_team_page + 1):
             futures.append(TeamListQuery(page_num).fetch_async(dict_version=3, return_updated=True))
 
         team_list = []

--- a/api/apiv3/api_team_controller.py
+++ b/api/apiv3/api_team_controller.py
@@ -30,7 +30,7 @@ class ApiTeamListAllController(ApiBaseController):
 
     def _render(self, model_type=None):
         futures = []
-        for page_num in xrange(20):
+        for page_num in xrange(20):  # TODO: don't hardcode
             futures.append(TeamListQuery(page_num).fetch_async(dict_version=3, return_updated=True))
 
         team_list = []
@@ -42,7 +42,6 @@ class ApiTeamListAllController(ApiBaseController):
 
         if model_type is not None:
             team_list = filter_team_properties(team_list, model_type)
-
         return json.dumps(team_list, ensure_ascii=True, indent=2, sort_keys=True)
 
 

--- a/api/apiv3_main.py
+++ b/api/apiv3_main.py
@@ -20,6 +20,8 @@ app = webapp2.WSGIApplication([
     webapp2.Route(r'/api/v3/status',
         asc.ApiStatusController, methods=['GET', 'OPTIONS']),
     # Team List
+    webapp2.Route(r'/api/v3/teams/all',
+        atc.ApiTeamListAllController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/teams/<page_num:([0-9]+)>',
         atc.ApiTeamListController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/teams/<page_num:([0-9]+)>/<model_type:(simple|keys)>',
@@ -83,6 +85,8 @@ app = webapp2.WSGIApplication([
     webapp2.Route(r'/api/v3/suggest/media/team/<team_key:>/<year:([0-9]+)>',
         asgc.ApiSuggestTeamMediaController, methods=['POST', 'OPTIONS']),
     # Event List
+    webapp2.Route(r'/api/v3/events/all',
+        aec.ApiEventListAllController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/events/<year:([0-9]+)>',
         aec.ApiEventListController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/events/<year:([0-9]+)>/<model_type:(simple|keys)>',

--- a/api/apiv3_main.py
+++ b/api/apiv3_main.py
@@ -22,6 +22,8 @@ app = webapp2.WSGIApplication([
     # Team List
     webapp2.Route(r'/api/v3/teams/all',
         atc.ApiTeamListAllController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/teams/all/<model_type:(simple|keys)>',
+        atc.ApiTeamListAllController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/teams/<page_num:([0-9]+)>',
         atc.ApiTeamListController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/teams/<page_num:([0-9]+)>/<model_type:(simple|keys)>',
@@ -86,6 +88,8 @@ app = webapp2.WSGIApplication([
         asgc.ApiSuggestTeamMediaController, methods=['POST', 'OPTIONS']),
     # Event List
     webapp2.Route(r'/api/v3/events/all',
+        aec.ApiEventListAllController, methods=['GET', 'OPTIONS']),
+    webapp2.Route(r'/api/v3/events/all/<model_type:(simple|keys)>',
         aec.ApiEventListAllController, methods=['GET', 'OPTIONS']),
     webapp2.Route(r'/api/v3/events/<year:([0-9]+)>',
         aec.ApiEventListController, methods=['GET', 'OPTIONS']),

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -1,4 +1,3 @@
-import cloudstorage
 import datetime
 import logging
 import os
@@ -15,8 +14,6 @@ from consts.district_type import DistrictType
 from consts.event_type import EventType
 
 from controllers.api.api_status_controller import ApiStatusController
-from database.dict_converters.team_converter import TeamConverter
-from database.dict_converters.event_converter import EventConverter
 from database.district_query import DistrictsInYearQuery
 from database.event_query import DistrictEventsQuery, EventQuery
 from database.match_query import EventMatchesQuery
@@ -470,12 +467,6 @@ class TypeaheadCalcDo(webapp.RequestHandler):
         keys_to_delete = old_entry_keys.difference(new_entry_keys)
         logging.info("Removing the following unused TypeaheadEntries: {}".format([key.id() for key in keys_to_delete]))
         ndb.delete_multi(keys_to_delete)
-
-        # Save APIv3 index to cloudstorage
-        with cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-events.json', 'w') as json_file:
-            json.dump(EventConverter.convert(events, 3), json_file, indent=2, sort_keys=True)
-        with cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-teams.json', 'w') as json_file:
-            json.dump(TeamConverter.convert(teams, 3), json_file, indent=2, sort_keys=True)
 
         template_values = {'results': results}
         path = os.path.join(os.path.dirname(__file__), '../templates/math/typeaheadcalc_do.html')

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -473,9 +473,9 @@ class TypeaheadCalcDo(webapp.RequestHandler):
 
         # Save APIv3 index to cloudstorage
         with cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-events.json', 'w') as json_file:
-            json.dump(EventConverter.convert(events, 3), json_file)
+            json.dump(EventConverter.convert(events, 3), json_file, indent=2, sort_keys=True)
         with cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-teams.json', 'w') as json_file:
-            json.dump(TeamConverter.convert(teams, 3), json_file)
+            json.dump(TeamConverter.convert(teams, 3), json_file, indent=2, sort_keys=True)
 
         template_values = {'results': results}
         path = os.path.join(os.path.dirname(__file__), '../templates/math/typeaheadcalc_do.html')

--- a/controllers/cron_controller.py
+++ b/controllers/cron_controller.py
@@ -1,3 +1,4 @@
+import cloudstorage
 import datetime
 import logging
 import os
@@ -14,6 +15,8 @@ from consts.district_type import DistrictType
 from consts.event_type import EventType
 
 from controllers.api.api_status_controller import ApiStatusController
+from database.dict_converters.team_converter import TeamConverter
+from database.dict_converters.event_converter import EventConverter
 from database.district_query import DistrictsInYearQuery
 from database.event_query import DistrictEventsQuery, EventQuery
 from database.match_query import EventMatchesQuery
@@ -467,6 +470,12 @@ class TypeaheadCalcDo(webapp.RequestHandler):
         keys_to_delete = old_entry_keys.difference(new_entry_keys)
         logging.info("Removing the following unused TypeaheadEntries: {}".format([key.id() for key in keys_to_delete]))
         ndb.delete_multi(keys_to_delete)
+
+        # Save APIv3 index to cloudstorage
+        with cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-events.json', 'w') as json_file:
+            json.dump(EventConverter.convert(events, 3), json_file)
+        with cloudstorage.open('/tbatv-prod-hrd.appspot.com/apiv3-index/all-teams.json', 'w') as json_file:
+            json.dump(TeamConverter.convert(teams, 3), json_file)
 
         template_values = {'results': results}
         path = os.path.join(os.path.dirname(__file__), '../templates/math/typeaheadcalc_do.html')

--- a/tba_config.py
+++ b/tba_config.py
@@ -52,5 +52,5 @@ def _get_max_year():
     except Exception:
         return DEFAULT_YEAR
 
-
+MIN_YEAR = 1992
 MAX_YEAR = _get_max_year()


### PR DESCRIPTION
## Description
Add `/api/v3/teams/all/(simple|keys)` and `/api/v3/events/all/(simple|keys)` endpoints that return ALL teams and events respectively.

## Motivation and Context
Enables apps to download an index of all teams and events without hitting 40+ endpoints.

## How Has This Been Tested?
Local dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
