### PR TITLE
Change Name field in Offseason suggest to be Event Name

### DIFF
--- a/templates_jinja2/suggestions/suggest_offseason_event.html
+++ b/templates_jinja2/suggestions/suggest_offseason_event.html
@@ -55,7 +55,7 @@
                         <form action="/suggest/offseason" method="post" id="suggest_offseason">
                             <table class="table table-striped table-hover table-condensed">
                                 <tr>
-                                    <td>Name</td>
+                                    <td>Event Name</td>
                                     <td>
                                         <span{% if 'name' in failures %} class="has-error"{% endif %}>
                                             <input class="form-control" type="text" name="name"  placeholder="BattleCry@WPI"{% if name %} value="{{name}}"{% endif %}/>


### PR DESCRIPTION
A bit of feedback from Slack - change the "Name" field to be "Event Name" in the offseason suggestion form