### PR TITLE
Update Docker Ubuntu version to 19.04

### DIFF
--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:19.04
 MAINTAINER The Blue Alliance
 
 # Set debconf to run non-interactively
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 # Configure ssh server
 RUN mkdir /var/run/sshd
 RUN echo 'root:tba' | chpasswd
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile


### PR DESCRIPTION
This fixes the locale error issue I have when installing system-wide dependencies inside the container via pip, as well as gives us a version of Python 3.7 inside our dev container (I know we're still a little ways off from any upgrading)