### PR TITLE
Add Google Analytics ID Sitevar

### DIFF
--- a/notifications/base_notification.py
+++ b/notifications/base_notification.py
@@ -1,11 +1,9 @@
 import logging
 import random
 import tba_config
-import uuid
 
 from google.appengine.ext import deferred
 from google.appengine.api import memcache
-from google.appengine.api import urlfetch
 
 from consts.client_type import ClientType
 from consts.notification_type import NotificationType
@@ -137,16 +135,19 @@ class BaseNotification(object):
         For more information about GAnalytics Protocol Parameters, visit
         https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
         """
-        import urllib
-        analytics_id = Sitevar.get_by_id("google_analytics.id")
-        if analytics_id is None:
+        from sitevars.google_analytics_id import GoogleAnalyticsID
+        google_analytics_id = GoogleAnalyticsID.google_analytics_id()
+        if not google_analytics_id:
             logging.warning("Missing sitevar: google_analytics.id. Can't track API usage.")
         else:
-            GOOGLE_ANALYTICS_ID = analytics_id.contents['GOOGLE_ANALYTICS_ID']
-            params = urllib.urlencode({
+            import uuid
+            cid = uuid.uuid3(uuid.NAMESPACE_X500, str('tba-notification-tracking'))
+
+            from urllib import urlencode
+            params = urlencode({
                 'v': 1,
-                'tid': GOOGLE_ANALYTICS_ID,
-                'cid': uuid.uuid3(uuid.NAMESPACE_X500, str('tba-notification-tracking')),
+                'tid': google_analytics_id,
+                'cid': cid,
                 't': 'event',
                 'ec': 'notification',
                 'ea': NotificationType.type_names[notification_type_enum],
@@ -155,6 +156,7 @@ class BaseNotification(object):
                 'sc': 'end',  # forces tracking session to end
             })
 
+            from google.appengine.api import urlfetch
             analytics_url = 'http://www.google-analytics.com/collect?%s' % params
             urlfetch.fetch(
                 url=analytics_url,

--- a/sitevars/google_analytics_id.py
+++ b/sitevars/google_analytics_id.py
@@ -1,0 +1,15 @@
+import json
+
+from models.sitevar import Sitevar
+
+
+class GoogleAnalyticsID:
+
+    @staticmethod
+    def _default_sitevar():
+        return Sitevar.get_or_insert('google_analytics.id', values_json=json.dumps({'GOOGLE_ANALYTICS_ID': ''}))
+
+    @staticmethod
+    def google_analytics_id():
+        google_analytics_id = GoogleAnalyticsID._default_sitevar()
+        return google_analytics_id.contents.get('GOOGLE_ANALYTICS_ID', '')

--- a/tests/test_google_analytics_id.py
+++ b/tests/test_google_analytics_id.py
@@ -1,0 +1,37 @@
+import json
+import unittest2
+
+from google.appengine.ext import testbed
+from google.appengine.ext import ndb
+
+from models.sitevar import Sitevar
+from sitevars.google_analytics_id import GoogleAnalyticsID
+
+
+class TestNotificationsEnable(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_default_sitevar(self):
+        default_sitevar = GoogleAnalyticsID._default_sitevar()
+        self.assertIsNotNone(default_sitevar)
+
+        default_json = {'GOOGLE_ANALYTICS_ID': ''}
+        self.assertEqual(default_sitevar.values_json, json.dumps(default_json))
+        self.assertEqual(default_sitevar.contents, default_json)
+
+    def test_google_analytics_id(self):
+        self.assertEqual(GoogleAnalyticsID.google_analytics_id(), '')
+
+    def test_google_analytics_id_set(self):
+        test_id = 'abc'
+        Sitevar.get_or_insert('google_analytics.id', values_json=json.dumps({'GOOGLE_ANALYTICS_ID': test_id}))
+        self.assertEqual(GoogleAnalyticsID.google_analytics_id(), test_id)


### PR DESCRIPTION
More cleanup - adds a `GoogleAnalyticsID` sitevar

Tested both the APIv2 and APIv3 controllers - having no `GOOGLE_ANALYTICS_ID` value set properly no-ops/logs having it set does hit the GA API and returns a 200.

I can't confirm that the analytics are showing up properly, since I don't see them in my staging GA, but I don't think there's a change that would break it.