### PR TITLE
Fix 2020+ event sorting

### DIFF
--- a/database/event_query.py
+++ b/database/event_query.py
@@ -10,7 +10,7 @@ from models.team import Team
 
 
 class EventQuery(DatabaseQuery):
-    CACHE_VERSION = 0
+    CACHE_VERSION = 1
     CACHE_KEY_FORMAT = 'event_{}'  # (event_key)
     DICT_CONVERTER = EventConverter
 
@@ -22,7 +22,7 @@ class EventQuery(DatabaseQuery):
 
 
 class EventListQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'event_list_{}'  # (year)
     DICT_CONVERTER = EventConverter
 
@@ -34,7 +34,7 @@ class EventListQuery(DatabaseQuery):
 
 
 class DistrictEventsQuery(DatabaseQuery):
-    CACHE_VERSION = 2
+    CACHE_VERSION = 3
     CACHE_KEY_FORMAT = 'district_events_{}'  # (district_key)
     DICT_CONVERTER = EventConverter
 
@@ -47,7 +47,7 @@ class DistrictEventsQuery(DatabaseQuery):
 
 
 class TeamEventsQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'team_events_{}'  # (team_key)
     DICT_CONVERTER = EventConverter
 
@@ -61,7 +61,7 @@ class TeamEventsQuery(DatabaseQuery):
 
 
 class TeamYearEventsQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'team_year_events_{}_{}'  # (team_key, year)
     DICT_CONVERTER = EventConverter
 
@@ -78,7 +78,7 @@ class TeamYearEventsQuery(DatabaseQuery):
 
 
 class TeamYearEventTeamsQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = 'team_year_eventteams_{}_{}'  # (team_key, year)
 
     @ndb.tasklet
@@ -92,7 +92,7 @@ class TeamYearEventTeamsQuery(DatabaseQuery):
 
 
 class EventDivisionsQuery(DatabaseQuery):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "event_divisions_{}"  # (event_key)
     DICT_CONVERTER = EventConverter
 

--- a/models/event.py
+++ b/models/event.py
@@ -241,8 +241,13 @@ class Event(ndb.Model):
             ).order(Event.start_date).fetch(1, projection=[Event.start_date])
             if e:
                 first_start_date = e[0].start_date
-                diff_from_wed = (first_start_date.weekday() - 2) % 7  # 2 is Wednesday
-                week_start = first_start_date - datetime.timedelta(days=diff_from_wed)
+
+                days_diff = 0
+                # Before 2020, event weeks start on Wednesdays
+                if self.year < 2020:
+                    days_diff = 2  # 2 is Wednesday
+                diff_from_week_start = (first_start_date.weekday() - days_diff) % 7
+                week_start = first_start_date - datetime.timedelta(days=diff_from_week_start)
             else:
                 week_start = None
         context_cache.set(cache_key, week_start)


### PR DESCRIPTION
Confirmed on my staging instance that 2020 events match up properly with what's on frc-events, and that re-scraped 2019 events are still sorted properly

<img width="1026" alt="Screen Shot 2019-09-29 at 5 51 54 PM" src="https://user-images.githubusercontent.com/516458/65840103-a6c62300-e2e2-11e9-97f1-ee1663fc2818.png">

**Edit: Ignore this part - see https://github.com/the-blue-alliance/the-blue-alliance/pull/2584#issuecomment-536346649 - our week sorting is right**
The one exception is this Israeli DCMP which sorts as being Week 10 in our system, but shows up as Week 9 in frc-events. 99% success rate is pretty good I guess.

<img width="1050" alt="Screen Shot 2019-09-29 at 5 58 18 PM" src="https://user-images.githubusercontent.com/516458/65840111-bf363d80-e2e2-11e9-9e40-d93c7d1d99cb.png">

No tests because holy cow it takes so much setup to tests these - I can file a ticket to make sure we get tests