### PR TITLE
Add 8000-level page to team list

### DIFF
--- a/controllers/team_controller.py
+++ b/controllers/team_controller.py
@@ -13,7 +13,7 @@ from template_engine import jinja2_engine
 
 
 class TeamList(CacheableHandler):
-    VALID_PAGES = [1, 2, 3, 4, 5, 6, 7, 8]
+    VALID_PAGES = range(1, (8000 // 1000) + 2)
     CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "team_list_{}"  # (page)
 

--- a/controllers/team_controller.py
+++ b/controllers/team_controller.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 import os
 
 from google.appengine.ext import ndb
@@ -13,7 +14,9 @@ from template_engine import jinja2_engine
 
 
 class TeamList(CacheableHandler):
-    VALID_PAGES = range(1, (8000 // 1000) + 2)
+    MAX_TEAM_NUMBER = 8999
+    TEAMS_PER_PAGE = 1000
+    VALID_PAGES = range(1, int(math.ceil(float(MAX_TEAM_NUMBER) / TEAMS_PER_PAGE) + 1))
     CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "team_list_{}"  # (page)
 
@@ -37,7 +40,7 @@ class TeamList(CacheableHandler):
             if curPage == 1:
                 label = '1-999'
             else:
-                label = "{}'s".format((curPage - 1) * 1000)
+                label = "{}'s".format((curPage - 1) * self.TEAMS_PER_PAGE)
             page_labels.append(label)
             if curPage == page:
                 cur_page_label = label


### PR DESCRIPTION
## Description
This adds a "8000's" tab to the team list, and hopefully makes it a bit easier to change in the future.

## Motivation and Context
https://www.thebluealliance.com/teams/9 (8000s) currently 404s. This makes it work.

## How Has This Been Tested?
Locally, by importing 2020milak (which currently has 8126 registered)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3719547/65993564-7d7ed180-e45f-11e9-8624-e4bc565ec71c.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
