### PR TITLE
Convert  keyword in service configs to

### DIFF
--- a/app-backend-tasks-b2.yaml
+++ b/app-backend-tasks-b2.yaml
@@ -1,4 +1,4 @@
-module: backend-tasks-b2
+service:backend-tasks-b2
 
 runtime: python27
 api_version: 1

--- a/app-backend-tasks.yaml
+++ b/app-backend-tasks.yaml
@@ -1,4 +1,4 @@
-module: backend-tasks
+service:backend-tasks
 
 runtime: python27
 api_version: 1

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -9,12 +9,12 @@ dispatch:
 
 # Send low-frequency long-running tasks to backend module
 - url: "*/backend-tasks/*"
-  module: backend-tasks
+  service:backend-tasks
 
 # Send low-frequency long-running tasks to backend module
 # Uses B2 instance for higher CPU/memory limits
 - url: "*/backend-tasks-b2/*"
-  module: backend-tasks-b2
+  service:backend-tasks-b2
 
 # Endpoints for internal client API
 # - url: "*/clientapi/*"
@@ -30,4 +30,4 @@ dispatch:
 
 # Send everything else to default module
 - url: "*/"
-  module: default
+  service:default


### PR DESCRIPTION
We're getting warnings during deploying that `module` is deprecated (which it is) and that we should use `service` instead. This doesn't require any migration or anything on our backend services, just changing the names works fine.