### PR TITLE
Calculate effective season when generating landing pages

### DIFF
--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -124,12 +124,13 @@ class MainKickoffHandler(CacheableHandler):
 
     def _render(self, *args, **kw):
         special_webcasts = FirebasePusher.get_special_webcasts()
+        effective_season_year = SeasonHelper.effective_season_year()
 
         self.template_values.update({
             'events': EventHelper.getWeekEvents(),
             'is_kickoff': SeasonHelper.is_kickoff_at_least_one_day_away(),
-            'kickoff_datetime_est': SeasonHelper.kickoff_datetime_est(),
-            'kickoff_datetime_utc': SeasonHelper.kickoff_datetime_utc(),
+            'kickoff_datetime_est': SeasonHelper.kickoff_datetime_est(effective_season_year),
+            'kickoff_datetime_utc': SeasonHelper.kickoff_datetime_utc(effective_season_year),
             "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
             "special_webcasts": special_webcasts,
         })
@@ -146,9 +147,11 @@ class MainBuildseasonHandler(CacheableHandler):
         self._cache_expiration = 60 * 5
 
     def _render(self, *args, **kw):
+        effective_season_year = SeasonHelper.effective_season_year()
+
         self.template_values.update({
-            'endbuild_datetime_est': SeasonHelper.stop_build_datetime_est(),
-            'endbuild_datetime_utc': SeasonHelper.stop_build_datetime_utc(),
+            'endbuild_datetime_est': SeasonHelper.stop_build_datetime_est(effective_season_year),
+            'endbuild_datetime_utc': SeasonHelper.stop_build_datetime_utc(effective_season_year),
             'events': EventHelper.getWeekEvents(),
         })
 
@@ -262,10 +265,11 @@ class MainOffseasonHandler(CacheableHandler):
 
     def _render(self, *args, **kw):
         special_webcasts = FirebasePusher.get_special_webcasts()
+        effective_season_year = SeasonHelper.effective_season_year()
 
         self.template_values.update({
             "events": EventHelper.getWeekEvents(),
-            'kickoff_datetime_utc': SeasonHelper.kickoff_datetime_utc(),
+            'kickoff_datetime_utc': SeasonHelper.kickoff_datetime_utc(effective_season_year),
             "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
             "special_webcasts": special_webcasts,
         })

--- a/helpers/season_helper.py
+++ b/helpers/season_helper.py
@@ -1,5 +1,10 @@
-from datetime import datetime, timedelta, tzinfo
+from calendar import monthrange
+from datetime import datetime, timedelta, tzinfo, date
+from google.appengine.ext import ndb
 from pytz import timezone, UTC
+
+from consts.event_type import EventType
+from models.event import Event
 
 
 EST = timezone('EST')
@@ -7,6 +12,32 @@ EST = timezone('EST')
 
 class SeasonHelper:
     """ General season-information helper methods """
+
+    @staticmethod
+    def effective_season_year(date=datetime.now()):
+        """
+        Given a date, find the "effective season" year for the date. If all official events have been played, it's
+        effectively next season.
+        """
+        effective_season_year = date.year
+        last_event_end_date = None
+
+        last_event_list = Event.query(
+            Event.year==int(date.year),
+            Event.event_type_enum.IN(EventType.SEASON_EVENT_TYPES)
+        ).order(-Event.end_date).fetch(1, projection=[Event.end_date])
+        if last_event_list:
+            last_event = last_event_list[0]
+            last_event_end_date = last_event.end_date
+
+        if last_event_end_date is None:
+            # No events for year - assume current year is effective season year
+            return effective_season_year
+
+        if date > last_event_end_date:
+            # All events for current season have been played - effective season is next year
+            return effective_season_year + 1
+        return effective_season_year
 
     @staticmethod
     def is_kickoff_at_least_one_day_away(date=datetime.now(UTC), year=datetime.now().year):

--- a/tests/test_season_helper.py
+++ b/tests/test_season_helper.py
@@ -1,12 +1,95 @@
-from mock import patch
-import unittest2
 from datetime import datetime, timedelta
 from pytz import timezone, UTC
+import unittest2
 
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.event_type import EventType
 from helpers.season_helper import SeasonHelper
+from models.event import Event
 
 
 class TestSeasonHelper(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_effective_season_year_no_events(self):
+        now = datetime.now()
+        self.assertEqual(SeasonHelper.effective_season_year(), now.year)
+
+    def test_effective_season_year_this_year(self):
+        # Effective season should be this year
+        today = datetime.today()
+        Event(
+            id="{}testendstomorrow".format(today.year),
+            end_date=today + timedelta(days=1),
+            event_short="testendstomorrow",
+            event_type_enum=EventType.REGIONAL,
+            first_eid="5561",
+            name="Test Event (Ends Tomorrow)",
+            start_date=today,
+            year=today.year,
+            venue_address="123 Fake Street, Anytown, MI, USA",
+            website="http://www.google.com"
+        ).put()
+        self.assertEqual(SeasonHelper.effective_season_year(), today.year)
+
+    def test_effective_season_year_next_year(self):
+        # Effective season should be next year
+        today = datetime.today()
+        Event(
+            id="{}testended".format(today.year),
+            end_date=today - timedelta(days=1),
+            event_short="testended",
+            event_type_enum=EventType.REGIONAL,
+            first_eid="5561",
+            name="Test Event (Ends Tomorrow)",
+            start_date=today - timedelta(days=2),
+            year=today.year,
+            venue_address="123 Fake Street, Anytown, MI, USA",
+            website="http://www.google.com"
+        ).put()
+        self.assertEqual(SeasonHelper.effective_season_year(), today.year + 1)
+
+    def test_effective_season_year_next_year_ignore_non_official(self):
+        # Effective season should be next year
+        today = datetime.today()
+        # Insert an event that has already happened - otherwise we'll default to the current season
+        # This is to simulate offseason
+        Event(
+            id="{}testended".format(today.year),
+            end_date=today - timedelta(days=1),
+            event_short="testended",
+            event_type_enum=EventType.REGIONAL,
+            first_eid="5561",
+            name="Test Event (Ends Tomorrow)",
+            start_date=today - timedelta(days=2),
+            year=today.year,
+            venue_address="123 Fake Street, Anytown, MI, USA",
+            website="http://www.google.com"
+        ).put()
+        Event(
+            id="{}testendstomorrow".format(today.year),
+            end_date=today + timedelta(days=1),
+            event_short="testendstomorrow",
+            event_type_enum=EventType.OFFSEASON,
+            first_eid="5561",
+            name="Test Event (Ends Tomorrow)",
+            start_date=today,
+            year=today.year,
+            venue_address="123 Fake Street, Anytown, MI, USA",
+            website="http://www.google.com"
+        ).put()
+        self.assertEqual(SeasonHelper.effective_season_year(), today.year + 1)
 
     def test_is_kickoff_at_least_one_day_away(self):
         a = datetime(2020, 1, 3, 14, 30, 00, tzinfo=UTC)  # False - over one day


### PR DESCRIPTION
Fixes the issue we were seeing with https://github.com/the-blue-alliance/the-blue-alliance/pull/2589 - since we're now using programmatic dates for kickoff/offseason, the templates were defaulting to using the current year dates. This is wrong, since if we want to show the kickoff template in December, we'll show the wrong year. Additionally, showing the offseason template will show the current year kickoff date, not the next year kickoff date.

This figures out the "effective year" to show for the index templates - if all official events have been played for a season, the effective season is next season