### PR TITLE
Add "OTHER" award type to award helper

### DIFF
--- a/helpers/award_helper.py
+++ b/helpers/award_helper.py
@@ -121,7 +121,7 @@ AWARD_MATCHING_STRINGS = [
     (AwardType.MOST_IMPROVED_TEAM, (["most improved team"], [])),
     (AwardType.WILDCARD, (["wildcard"], [])),
     (AwardType.AUTONOMOUS, (["autonomous"], [])),
-	(AwardType.OTHER, (["other"], ["offseason award"], ["offseason event award"] [])),
+    (AwardType.OTHER, (["other"], ["offseason award"], ["offseason event award"], [])),
 ]
 
 

--- a/helpers/award_helper.py
+++ b/helpers/award_helper.py
@@ -121,6 +121,7 @@ AWARD_MATCHING_STRINGS = [
     (AwardType.MOST_IMPROVED_TEAM, (["most improved team"], [])),
     (AwardType.WILDCARD, (["wildcard"], [])),
     (AwardType.AUTONOMOUS, (["autonomous"], [])),
+	(AwardType.OTHER, (["other"], ["offseason award"], ["offseason event award"] [])),
 ]
 
 

--- a/helpers/award_helper.py
+++ b/helpers/award_helper.py
@@ -121,7 +121,7 @@ AWARD_MATCHING_STRINGS = [
     (AwardType.MOST_IMPROVED_TEAM, (["most improved team"], [])),
     (AwardType.WILDCARD, (["wildcard"], [])),
     (AwardType.AUTONOMOUS, (["autonomous"], [])),
-    (AwardType.OTHER, (["other"], ["offseason award"], ["offseason event award"], [])),
+    (AwardType.OTHER, (["other", "offseason award", "offseason event award"], [])),
 ]
 
 


### PR DESCRIPTION


## Description
Added OTHER award type to the award helper.

## Motivation and Context
Allow submitting other award type from Cheesy Arena

## How Has This Been Tested?
Simple change. 
not tested. 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
