### PR TITLE
Fix 2020 event's weeks after Week 8 being off-by-one

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -254,7 +254,12 @@ class Event(ndb.Model):
 
         if self._week is None and week_start is not None:
             days = (self.start_date - week_start).days
-            self._week = days / 7
+            week = days / 7
+            # In 2020 there's an empty week in between Week 8 and Week 9 - mathmatically it's Week 10, but we treat it
+            # as Week 9 - we should make sure we take that in to account. We look for > 7 because weeks are zero-indexed
+            if self.year == 2020 and week > 7:
+                week -= 1
+            self._week = week
 
         return self._week
 


### PR DESCRIPTION
## Description
Adds a case when figuring out `week` for an event to account for the empty week between Week 8 and Week 9 in 2020

## Motivation and Context
Right now, 2020 events after Week 8 are shown with the wrong week.

<img width="1166" alt="Screen Shot 2019-10-22 at 12 00 57 PM" src="https://user-images.githubusercontent.com/516458/67305632-a1b05a00-f4c3-11e9-9205-f25e34dd8f46.png">

## How Has This Been Tested?
Tested in a staging instance - made sure that `2020cmptx` (although we don't return a week for CMP events) was still being calculated as Week 8, whereas `2020iscmp`/`2020cmpmi` are being calculated as Week 9

## Screenshots (if appropriate):
<img width="1195" alt="Screen Shot 2019-10-22 at 11 51 47 AM" src="https://user-images.githubusercontent.com/516458/67305797-f227b780-f4c3-11e9-8f94-b42ed4731d04.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)