### PR TITLE
Match details page naming consistency

### DIFF
--- a/templates_jinja2/match_details.html
+++ b/templates_jinja2/match_details.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% import "match_partials/match_table_macros.html" as mtm %}
 
-{% block title %}{{match.verbose_name}} - {{event.year}} {{event.name}} - The Blue Alliance{% endblock %}
+{% block title %}{{match.verbose_name}} - {{event.name}} {{event.year}} - The Blue Alliance{% endblock %}
 
 {% block meta_description %}Match results and video for {{match.verbose_name}} at the {{event.year}} {{event.name}} FIRST Robotics Competition in {{event.location}}.{% endblock %}
 
@@ -27,7 +27,7 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-12">
-      <h1>{{match.verbose_name}} <small><a href="/event/{{event.key_name}}">{{ event.year }} {{ event.name }}</a></small></h1>
+      <h1>{{match.verbose_name}} <small><a href="/event/{{event.key_name}}">{{ event.name }} {{ event.year }}</a></small></h1>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
Changes the match detail page.
## Description
Now, on the match details page, the title will follow (Event) (Year) rather than (Year) (Event). For example, a match will now say Beach Blitz 2019 instead of 2019 Beach Blitz.

## Motivation and Context
Elsewhere on the site (such as on an [event page](https://github.com/the-blue-alliance/the-blue-alliance/blob/master/templates_jinja2/event_details.html)), the format (Event) (Year) is followed. When clicking on a match from an event page, the inconsistency in header is clear.

## How Has This Been Tested?
It hasn't.

## Screenshots (if appropriate):
**Current:**
![image](https://user-images.githubusercontent.com/22439365/67310249-3b6f0b80-f4b2-11e9-8c58-4e95a0716d35.png)
**New:**
![image](https://user-images.githubusercontent.com/22439365/67310363-76713f00-f4b2-11e9-90f9-e5aada5856c4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
