### PR TITLE
Clean up Onshape verbiage

### DIFF
--- a/templates_jinja2/suggestions/suggest_team_media.html
+++ b/templates_jinja2/suggestions/suggest_team_media.html
@@ -61,9 +61,9 @@
             <li><strong>Instagram photos and videos</strong>, like <code>https://www.instagram.com/p/BUnZiriBYre</code></li>
             <li><strong>YouTube videos</strong>, like <code>https://www.youtube.com/watch?v=DojyJ9bZ4fk</code></li>
             <li><strong>GrabCAD files</strong>, like <code>https://grabcad.com/library/cad-stuff</code></li>
-            <li><strong>Onshape documents that are publically accessible via link</strong>, like <code>https://cad.onshape.com/documents/cfb3e7b1e271d7a73b4fb21e<br>/w/d7248be0d0967489a13c9fd1/e/53d949eaf719f64b688351ad</code>
+            <li><strong>Onshape documents that are publically accessible via link</strong>, like <code>https://cad.onshape.com/documents/robot<br>/w/cad/e/stuff</code>
             <br>
-            Onshape documents that are public but require an onshape account are not supported at this moment. To make them publically accessible via link, select <code>Share</code>, <code>Link Sharing</code>, then <code>Turn on link sharing</code>.
+            Onshape documents that are public but require an Onshape account are not yet supported. To make them accessible, select <code>Share</code>, <code>Link Sharing</code>, then <code>Turn on link sharing</code>.
             </li>
           </ul>
 


### PR DESCRIPTION

A few minor things with the current verbiage about Onshape on the media suggestion page. F
## Description
Fixed the following:
- Uniform capitalization of "Onshape"
- Shorten sample URL. Onshape URLs are just too dang long. Followed a path similar to GrabCAD example link.
- Shortened help text about uploading Onshape video. Removed some unnecessary words.

## Motivation and Context
On the suggestions page, Onshape is dominating for no good reason - it's just taking up too much room to say not a whole lot, imo.

## How Has This Been Tested?
Hasn't.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
