### PR TITLE
Insights "Elims" --> "Playoffs"

### DIFF
--- a/templates_jinja2/index/index_insights.html
+++ b/templates_jinja2/index/index_insights.html
@@ -82,7 +82,7 @@
         <h3>Average Match Score By Week</h3>
         {% if elim_match_averages_by_week %}
           <div class="chart-key"><div class="color-key blue-color-key"></div><div class="chart-key-text">All Match Averages</div></div>
-          <div class="chart-key"><div class="color-key green-color-key"></div><div class="chart-key-text">Elim Match Averages</div></div>
+          <div class="chart-key"><div class="color-key green-color-key"></div><div class="chart-key-text">Playoff Match Averages</div></div>
           <figure style="width: 90%; height: 300px;" id="elim-match-average-chart"></figure>
           <div id="elim-match-average" class="xcharts-data xcharts-line-data">[{{ match_averages_by_week.data_json|safe }}, {{ elim_match_averages_by_week.data_json|safe }}]</div>
         {% else %}


### PR DESCRIPTION
## Description
Changes the title on the graph from Elims to Playoffs on the insights page.

## Motivation and Context
Elsewhere on the site (and even within insights), we refer to the matches after qualifications as Playoffs. This is the same terminology FIRST uses officially now.

## How Has This Been Tested?
Hasn't.

## Screenshots (if appropriate):
**Current (bottom of current home page):**
![image](https://user-images.githubusercontent.com/22439365/67552485-164fe800-f6c0-11e9-8551-3aea8fa48ef7.png)
**Proposed:**
![image](https://user-images.githubusercontent.com/22439365/67552603-3aabc480-f6c0-11e9-8586-c7871e96a62a.png)

**Currently, [elsewhere on the site](https://www.thebluealliance.com/insights/2019):**
![image](https://user-images.githubusercontent.com/22439365/67552710-72b30780-f6c0-11e9-9657-10501ec6ff17.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
