### PR TITLE
Fix team link under social media review

### DIFF
--- a/templates_jinja2/suggestions/suggest_team_social_review.html
+++ b/templates_jinja2/suggestions/suggest_team_social_review.html
@@ -37,7 +37,7 @@
                     </label>
                   </div>
                   <div class="col-xs-5 fitvids">
-                      <p><strong><a href="/team/{{reference.team_number}}/{{suggestion.contents.year}}" target="_blank">Team {{reference.team_number}}{% if reference.nickname %} - {{reference.nickname}}{% endif %} ({{suggestion.contents.year}})</a></strong></p>
+                      <p><strong><a href="/team/{{reference.team_number}}" target="_blank">Team {{reference.team_number}}{% if reference.nickname %} - {{reference.nickname}}{% endif %}</a></strong></p>
                       {{smm.social_media_card(suggestion)}}
                   </div>
                   <div class="col-xs-2">


### PR DESCRIPTION
Social media suggestion items don't have a year, which means all of the team links on the social media suggestion review page end up being `Team XXXX (None)`, and the links don't go anywhere. This removes the year from the link/text formatting to fix the link location.