### PR TITLE
Removes dead suggestions links in admin console

### DIFF
--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -73,49 +73,43 @@
               <li><a href="/admin/event/create">Create</a></li>
               <li><a href="/admin/offseasons">Scrape USFIRST Offseasons</a></li>
               <li><a href="/admin/offseasons/spreadsheet">Scrape Spreadsheet Offseasons</a></li>
-              
+
               <li>Districts</li>
               <li><a href="/admin/districts">View all</a></li>
               <li><a href="/admin/district/create">Create</a></li>
-              
+
               <li>Matches</li>
               <li><a href="/admin/matches">Edit</a></li>
               <li><a href="/admin/match/cleanup">Cleanup</a></li>
-              
+
               <li>Awards</li>
               <li><a href="/admin/awards">Edit</a></li>
-              
+
               <li>Media</li>
               <li><a href="/admin/gameday">GameDay</a></li>
               <li><a href="/admin/media">Dashboard</a></li>
               <li><a href="/admin/media/import/instagram">Bulk Import from Instagram</a></li>
               <li><a href="/admin/videos/add">Add YouTube Videos</a></li>
-              
+
               <li>Teams</li>
               <li><a href="/admin/media/modcodes/list">View Mods</a></li>
               <li><a href="/admin/teams">View all</a></li>
 
-              
-              <li>Suggestions</li>
-              <li><a href="/admin/suggestions/match/video/review">Match Video Suggestions</a></li>
-              <li><a href="/admin/suggestions/event/webcast/review">Event Webcast Suggestions</a></li>
-              <li><a href="/admin/suggestions/media/review">Media Suggestions</a></li>
-              
               <li>Users</li>
               <li><a href="/admin/user/lookup">Lookup</a></li>
               <li><a href="/admin/users/permissions">Permissions</a></li>
               <li><a href="/admin/users">View all</a></li>
-              
+
               <li>Write API Access<li>
               <li><a href="/admin/api_auth/add">Add Authentication</a></li>
               <li><a href="/admin/api_auth/manage">Manage Authentication</a></li>
-              
+
               <li>Migration</li>
               <li><a href="/admin/migration">Migration Utils</a></li>
-              
+
               <li>Memcache</li>
               <li><a href="/admin/memcache">Stats + Flushing</a></li>
-              
+
               <li>Misc</li>
               <li><a href="/admin/debug">Debug Panel</a></li>
               <li><a href="/admin/sitevars">Sitevars</a></li>


### PR DESCRIPTION
The `/admin/suggestions/...` endpoints got removed in https://github.com/the-blue-alliance/the-blue-alliance/commit/5f4936e53452c261ef646362700ccecf1b6f6d33#diff-e5f3a0e7f1f45ee323be58e611b7d79e but the links in the admin console never got removed. This removes those dead links from the admin console sidebar.