### PR TITLE
Fix 2006 event pages erroring when events have rankings

### DIFF
--- a/helpers/rankings_helper.py
+++ b/helpers/rankings_helper.py
@@ -143,6 +143,13 @@ class RankingsHelper(object):
              'precision': 2},
             {'name': 'Match Points',
              'precision': 0}],
+        2006: [
+            {'name': 'Qual Score',
+             'precision': 0},
+            {'name': 'Seeding Score',
+             'precision': 2},
+            {'name': 'Match Points',
+             'precision': 0}],
     }
 
     NO_RECORD_YEARS = {2010, 2015}


### PR DESCRIPTION
The `2006nh` is throwing errors on production because we're getting an error when trying to get `sort_order_info[0]['name']`, since the `sort_order_info` for 2006 will always be None, although we do appear to have `extra_stats` for 2006 rankings. This adds a `sort_order_info` and `sort_order` for 2006.

Some old-school FRC people should probably take a look at this one and make sure things look right - I'm not entirely sure abort sort orders and whatnot for 2006. Pulling sort orders for 2006 and 2007, things looked the same, so I copied the setup for 2007 for 2006.

```
2006: u'sort_orders': [0.0, 24.11, 0.0, 0.0, 0.0, 0.0]
2007: u'sort_orders': [0.0, 32.0, 0.0, 0.0, 0.0, 0.0]
```

<img width="1201" alt="Screen Shot 2019-12-05 at 12 09 13 PM" src="https://user-images.githubusercontent.com/516458/70257692-cd785e00-1758-11ea-970f-d1c0221f2ef4.png">

I'm fairly confident the Qual Scores being 0 is an issue with my local env