### PR TITLE
Fix failing webhook requests due to hmac errors

### DIFF
--- a/helpers/notification_sender.py
+++ b/helpers/notification_sender.py
@@ -31,7 +31,7 @@ class NotificationSender(object):
             ch.update(payload)
             checksum = ch.hexdigest()
 
-            mac = hmac.new(secret, payload, hashlib.sha256).hexdigest()
+            mac = hmac.new(str(secret), str(payload), hashlib.sha256).hexdigest()
 
             request = urllib2.Request(url, payload)
             request.add_header("Content-Type", 'application/json; charset="utf-8"')


### PR DESCRIPTION
We're seeing errors in `helpers/notification_sender.py` when sending to webhooks due to `secret` being a unicode string when generating a HMAC for `X-TBA-HMAC`. This should ensure both values used to generate the HMAC are strings.