### PR TITLE
Add generated index for landing page effective season

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -40,6 +40,13 @@ indexes:
   properties:
   - name: event_type_enum
   - name: year
+  - name: end_date
+    direction: desc
+
+- kind: Event
+  properties:
+  - name: event_type_enum
+  - name: year
   - name: first_eid
 
 - kind: Event


### PR DESCRIPTION
The changes merged in https://github.com/the-blue-alliance/the-blue-alliance/pull/2597 required us to update the index, but our indexes don't get synced from Docker back to local changes, so I missed this index change.