### PR TITLE
Fix per-year bugs in redeeming team admin access

### DIFF
--- a/controllers/team_admin_controller.py
+++ b/controllers/team_admin_controller.py
@@ -212,12 +212,6 @@ class TeamAdminRedeem(LoggedInHandler):
         self._require_registration()
         user = self.user_bundle.account.key
 
-        existing_access = TeamAdminAccess.query(
-            TeamAdminAccess.account == user).count(1)
-        if existing_access > 0:
-            self.redirect('/mod/redeem?status=already_linked')
-            return
-
         team_number = self.request.get("team_number")
         if not team_number or not team_number.isdigit():
             self.redirect('/mod/redeem?status=invalid_code')

--- a/templates_jinja2/team_admin_redeem.html
+++ b/templates_jinja2/team_admin_redeem.html
@@ -12,10 +12,6 @@
   <div class="alert alert-danger">
     Invalid auth code!
   </div>
-{% elif status == "alread_linked" %}
-  <div class="alert alert-danger">
-    This account is already linked to a team!
-  </div>
 {% elif status == "code_used" %}
   <div class="alert alert-danger">
     This access code has already been used!
@@ -34,23 +30,22 @@
     {% endfor %}
   </ul>
   <a class="btn btn-primary" href="/mod"><span class="glyphicon glyphicon-eye-open"></span> View Team Admin Dashboard</a>
-{% else %}
-  <p>Redeem an access code to administer your team's media on The Blue Alliance. Having administrative access allows you to manage media linked to your team's TBA profile as well as accept or reject suggestions for additional media links.</p>
-
-  <p>Only one account can be linked per team and the administration access will expire at the end of the competition season. For additional support, please <a href="/contact">contact us</a>.</p>
-  <form class="form-inline" acount="/mod/redeem" method="post" id="redeem">
-    <legend>Redeem</legend>
-    <div class="input-group">
-      <span class="input-group-addon">Team Number: </span>
-      <input class="form-control" size="16" name="team_number">
-    </div>
-    <div class="input-group">
-      <span class="input-group-addon">Admin Code: </span>
-      <input class="form-control" size="16" name="auth_code">
-    </div>
-    <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-link"></span> Link</button>
-  </form>
 {% endif %}
+<p>Redeem an access code to administer your team's media on The Blue Alliance. Having administrative access allows you to manage media linked to your team's TBA profile as well as accept or reject suggestions for additional media links.</p>
+
+<p>Only one account can be linked per team for each year and the administration access will expire at the end of the competition season. For additional support, please <a href="/contact">contact us</a>.</p>
+<form class="form-inline" acount="/mod/redeem" method="post" id="redeem">
+  <legend>Redeem</legend>
+  <div class="input-group">
+    <span class="input-group-addon">Team Number: </span>
+    <input class="form-control" size="16" name="team_number">
+  </div>
+  <div class="input-group">
+    <span class="input-group-addon">Admin Code: </span>
+    <input class="form-control" size="16" name="auth_code">
+  </div>
+  <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-link"></span> Link</button>
+</form>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
No longer fail if the user has redeemed a team admin code for a prior year

## Description
We should be checking the years in here

## Motivation and Context
Fixes #2633 

## How Has This Been Tested?
added unit test