### PR TITLE
Change build season to count down to first event

### DIFF
--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -150,8 +150,7 @@ class MainBuildseasonHandler(CacheableHandler):
         effective_season_year = SeasonHelper.effective_season_year()
 
         self.template_values.update({
-            'endbuild_datetime_est': SeasonHelper.stop_build_datetime_est(effective_season_year),
-            'endbuild_datetime_utc': SeasonHelper.stop_build_datetime_utc(effective_season_year),
+            'seasonstart_datetime_utc': SeasonHelper.first_event_datetime_utc(effective_season_year),
             'events': EventHelper.getWeekEvents(),
         })
 

--- a/helpers/season_helper.py
+++ b/helpers/season_helper.py
@@ -4,6 +4,7 @@ from google.appengine.ext import ndb
 from pytz import timezone, UTC
 
 from consts.event_type import EventType
+from database import event_query
 from models.event import Event
 
 
@@ -74,3 +75,16 @@ class SeasonHelper:
     def stop_build_datetime_utc(year=datetime.now().year):
         """ Converts stop_build_date to a UTC datetime """
         return SeasonHelper.stop_build_datetime_est(year).astimezone(UTC)
+
+    @staticmethod
+    def first_event_datetime_utc(year=datetime.now().year):
+        """ Computes day the first in-season event begins """
+        events = event_query.EventListQuery(year).fetch()
+        earliest_start = None
+        timezone = None
+        for event in events:
+            if event.is_season_event and (earliest_start is None or event.start_date < earliest_start):
+                earliest_start = event.start_date
+                timezone = event.timezone_id
+        print earliest_start, timezone
+        return earliest_start

--- a/helpers/season_helper.py
+++ b/helpers/season_helper.py
@@ -66,17 +66,6 @@ class SeasonHelper:
         return SeasonHelper.kickoff_datetime_est(year).astimezone(UTC)
 
     @staticmethod
-    def stop_build_datetime_est(year=datetime.now().year):
-        """ Computes day teams are done working on robots. The stop build day is kickoff + 6 weeks + 3 days. Set to 23:59:59 """
-        stop_build_date = datetime.combine(SeasonHelper.kickoff_datetime_est(year).date() + timedelta(days=4, weeks=6), datetime.min.time()) - timedelta(seconds=1)
-        return EST.localize(stop_build_date)  # Make our timezone unaware datetime timezone aware
-
-    @staticmethod
-    def stop_build_datetime_utc(year=datetime.now().year):
-        """ Converts stop_build_date to a UTC datetime """
-        return SeasonHelper.stop_build_datetime_est(year).astimezone(UTC)
-
-    @staticmethod
     def first_event_datetime_utc(year=datetime.now().year):
         """ Computes day the first in-season event begins """
         events = event_query.EventListQuery(year).fetch()

--- a/templates_jinja2/index/index_buildseason.html
+++ b/templates_jinja2/index/index_buildseason.html
@@ -12,14 +12,11 @@
     </div>
     <div class="col-sm-7 col-lg-8">
       <h2>
-        <div id="countdown-finish-time">{{endbuild_datetime_utc|isoformat}}</div>
-        <span class="countdown-number countdown-days">--</span><span class="countdown-label day-label">D </span>
-        <span class="countdown-number countdown-hours">--</span><span class="countdown-label">H </span>
-        <span class="countdown-number countdown-minutes">--</span><span class="countdown-label">M </span>
-        <span class="countdown-number countdown-seconds">--</span><span class="countdown-label">S</span>
-       Left to Build!
+        <div id="countdown-finish-time">{{seasonstart_datetime_utc|isoformat}}</div>
+        <span class="countdown-number countdown-days">--</span><span class="countdown-label day-label"> Days </span>
+        Until Week 1 Starts!
        <br>
-       <small>Build Season ends {{endbuild_datetime_est|strftime("%B %-d%t %H:%-M")}} EST</small></h2>
+       <small>Official events start on {{seasonstart_datetime_utc|strftime("%B %-d%t")}}</small></h2>
       <div class="btn-group game-manual">
         <a class="btn btn-default" href="http://www.firstinspires.org/resource-library/frc/competition-manual-qa-system" target="_blank"><span class="glyphicon glyphicon-file"></span> {{game_name}} Game Manual and Materials</a>
       </div>

--- a/tests/test_season_helper.py
+++ b/tests/test_season_helper.py
@@ -118,25 +118,3 @@ class TestSeasonHelper(unittest2.TestCase):
         kickoff_2009_utc = kickoff_2009.astimezone(UTC)
         self.assertEqual(SeasonHelper.kickoff_datetime_est(year=2009), kickoff_2009)
         self.assertEqual(SeasonHelper.kickoff_datetime_utc(year=2009), kickoff_2009_utc)
-
-    def test_stop_build_date(self):
-        # 2019 - Feb 19th, 2019
-        stop_build_2019 = datetime(2019, 2, 19, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2019_utc = stop_build_2019.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2019), stop_build_2019)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2019), stop_build_2019_utc)
-        # 2018 - Feb 20th, 2018
-        stop_build_2018 = datetime(2018, 2, 20, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2018_utc = stop_build_2018.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2018), stop_build_2018)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2018), stop_build_2018_utc)
-        # 2017 - Feb 21th, 2017
-        stop_build_2017 = datetime(2017, 2, 21, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2017_utc = stop_build_2017.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2017), stop_build_2017)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2017), stop_build_2017_utc)
-        # 2016 - Feb 23th, 2016
-        stop_build_2016 = datetime(2016, 2, 23, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2016_utc = stop_build_2016.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2016), stop_build_2016)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2016), stop_build_2016_utc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Display countdown to the first official event of the season.

## Motivation and Context
Stop build day no longer exists

## How Has This Been Tested?
Local dev

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/71650565-99e31200-2ccb-11ea-8598-d320bcc9652b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
