### PR TITLE
Prevent social media links from line-breaking between icon and text

### DIFF
--- a/static/css/less_css/less/tba/tba_misc.less
+++ b/static/css/less_css/less/tba/tba_misc.less
@@ -14,6 +14,10 @@
   }
 }
 
+.hashtag-link-wrapper {
+  display: inline-block;
+}
+
 .hashtag-link {
   padding-left: 20px;
   background-repeat: no-repeat;

--- a/templates_jinja2/media_partials/social_media_macros.html
+++ b/templates_jinja2/media_partials/social_media_macros.html
@@ -1,5 +1,5 @@
 {% macro social_media_icon_link(media) %}
-<a href="{{ media.social_profile_url }}" target="_blank">
+<a href="{{ media.social_profile_url }}" class="hashtag-link-wrapper" target="_blank">
 {% if media.media_type_enum == 3 %}
   <span class="hashtag-link hashtag-facebook"></span>
 {% elif media.media_type_enum == 4 %}


### PR DESCRIPTION
## Description

Team social media links would sometimes have the icons and text on separate lines. This fixes that.

## How Has This Been Tested?
Local instance

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/3719547/71771732-29780300-2f0e-11ea-9c86-4df5ee325b5c.png)
After:
![image](https://user-images.githubusercontent.com/3719547/71771734-2f6de400-2f0e-11ea-9908-c222eb5996b4.png)
Small screen: 
![image](https://user-images.githubusercontent.com/3719547/71771737-3ac10f80-2f0e-11ea-8655-6540a166f0bb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
