### PR TITLE
Remove notification_update_favorites and notification_update_subscriptions from webhook documentation sidebar

### DIFF
--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -32,8 +32,6 @@
                 <li><a class="smooth-scroll" href="#notification_final_results">Event Final Results</a></li>
                 <li><a class="smooth-scroll" href="#notification_ping">Ping</a></li>
                 <li><a class="smooth-scroll" href="#notification_broadcast">Broadcast</a></li>
-                <li><a class="smooth-scroll" href="#notification_update_favorites">Update Favorites</a></li>
-                <li><a class="smooth-scroll" href="#notification_update_subscriptions">Update Subscriptions</a></li>
                 <li><a class="smooth-scroll" href="#notification_verification">Webhook Verification</a></li>
             </ul></li>
           </ul>


### PR DESCRIPTION
Final bit of cleanup from https://github.com/the-blue-alliance/the-blue-alliance/pull/2530 - we stopped sending myTBA notifications to webhooks and cleaned up the docs, but forgot to remove the links from the sidebar. This just removes the links from the sidebar on the webhooks documentation page.