### PR TITLE
Only report successful notification sends to GA

### DIFF
--- a/models/notifications/requests/fcm_request.py
+++ b/models/notifications/requests/fcm_request.py
@@ -40,8 +40,10 @@ class FCMRequest(Request):
         from sitevars.notifications_enable import NotificationsEnable
         if not NotificationsEnable.notifications_enabled():
             return messaging.BatchResponse([])
-        self.defer_track_notification(len(self.tokens))
-        return messaging.send_multicast(self._fcm_message(), app=self._app)
+        response = messaging.send_multicast(self._fcm_message(), app=self._app)
+        if response.success_count > 0:
+            self.defer_track_notification(response.success_count)
+        return response
 
     def _fcm_message(self):
         platform_config = self.notification.platform_config

--- a/models/notifications/requests/webhook_request.py
+++ b/models/notifications/requests/webhook_request.py
@@ -48,8 +48,8 @@ class WebhookRequest(Request):
         # https://github.com/the-blue-alliance/the-blue-alliance/issues/2576
         valid_url = True
         try:
-            self.defer_track_notification(1)
             urllib2.urlopen(request)
+            self.defer_track_notification(1)
         except urllib2.HTTPError, e:
             if e.code == 400:
                 logging.warning('400, Bad request for URL: {}'.format(self.url))

--- a/tests/models_tests/notifications/requests/test_fcm_request.py
+++ b/tests/models_tests/notifications/requests/test_fcm_request.py
@@ -54,6 +54,24 @@ class TestFCMRequest(unittest2.TestCase):
         mock_track.assert_called_once_with(1)
         self.assertEqual(response, batch_response)
 
+    def test_send_failed(self):
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, 'a')])
+        request = FCMRequest(app=self.app, notification=MockNotification(), tokens=['abc', 'def'])
+        with patch.object(messaging, 'send_multicast', return_value=batch_response) as mock_send, patch.object(request, 'defer_track_notification') as mock_track:
+            response = request.send()
+        mock_send.assert_called_once()
+        mock_track.assert_not_called()
+        self.assertEqual(response, batch_response)
+
+    def test_send_failed_partial(self):
+        batch_response = messaging.BatchResponse([messaging.SendResponse({'name': 'abc'}, None), messaging.SendResponse(None, 'a')])
+        request = FCMRequest(app=self.app, notification=MockNotification(), tokens=['abc', 'def'])
+        with patch.object(messaging, 'send_multicast', return_value=batch_response) as mock_send, patch.object(request, 'defer_track_notification') as mock_track:
+            response = request.send()
+        mock_send.assert_called_once()
+        mock_track.assert_called_once_with(1)
+        self.assertEqual(response, batch_response)
+
     def test_send_disabled(self):
         NotificationsEnable.enable_notifications(False)
 

--- a/tests/models_tests/notifications/requests/test_request.py
+++ b/tests/models_tests/notifications/requests/test_request.py
@@ -16,6 +16,9 @@ class TestRequest(unittest2.TestCase):
         self.testbed.init_taskqueue_stub(root_path='.')
         self.taskqueue_stub = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
 
+    def tearDown(self):
+        self.testbed.deactivate()
+
     def test_init(self):
         Request(MockNotification())
 

--- a/tests/models_tests/notifications/requests/test_webhook_request.py
+++ b/tests/models_tests/notifications/requests/test_webhook_request.py
@@ -20,6 +20,9 @@ class TestWebhookRequest(unittest2.TestCase):
         self.testbed.init_taskqueue_stub(root_path='.')
         self.taskqueue_stub = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
 
+    def tearDown(self):
+        self.testbed.deactivate()
+
     def test_subclass(self):
         request = WebhookRequest(MockNotification(), 'https://www.thebluealliance.com', 'secret')
         self.assertTrue(isinstance(request, Request))
@@ -88,7 +91,7 @@ class TestWebhookRequest(unittest2.TestCase):
             with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
                 success = message.send()
             mock_urlopen.assert_called_once()
-            mock_track.assert_called_once_with(1)
+            mock_track.assert_not_called()
             self.assertTrue(success)
 
     def test_send_error_unknown(self):
@@ -100,7 +103,7 @@ class TestWebhookRequest(unittest2.TestCase):
         with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
             success = message.send()
         mock_urlopen.assert_called_once()
-        mock_track.assert_called_once_with(1)
+        mock_track.assert_not_called()
         self.assertTrue(success)
 
     def test_send_fail_404(self):
@@ -112,7 +115,7 @@ class TestWebhookRequest(unittest2.TestCase):
         with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
             success = message.send()
         mock_urlopen.assert_called_once()
-        mock_track.assert_called_once_with(1)
+        mock_track.assert_not_called()
         self.assertFalse(success)
 
     def test_send_fail_url_error(self):
@@ -124,7 +127,7 @@ class TestWebhookRequest(unittest2.TestCase):
         with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
             success = message.send()
         mock_urlopen.assert_called_once()
-        mock_track.assert_called_once_with(1)
+        mock_track.assert_not_called()
         self.assertFalse(success)
 
     def test_send_error_other(self):
@@ -136,5 +139,5 @@ class TestWebhookRequest(unittest2.TestCase):
         with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
             success = message.send()
         mock_urlopen.assert_called_once()
-        mock_track.assert_called_once_with(1)
+        mock_track.assert_not_called()
         self.assertTrue(success)


### PR DESCRIPTION
This is a bit in preparation for doing retries on FCM sends - if we attempt to send a notification to some mobile clients and only some of the sends succeed, we should only report the successful sends. The idea being - if we try the sends again later and they succeed, we'll report them. Otherwise we'll clean up the old clients. This should make this metric a little more clear - if we don't see any notifications being reported, or it's lower than usual, that gives us a signal something is probably wrong