### PR TITLE
Add Broadcast notifications to TBANS

### DIFF
--- a/consts/client_type.py
+++ b/consts/client_type.py
@@ -1,4 +1,3 @@
-
 class ClientType:
 
     # Operating System types for MobileClient.client_type

--- a/controllers/admin/admin_mobile_controller.py
+++ b/controllers/admin/admin_mobile_controller.py
@@ -8,7 +8,7 @@ from google.appengine.ext.webapp import template
 
 from consts.client_type import ClientType
 from controllers.base_controller import LoggedInHandler
-from helpers.notification_helper import NotificationHelper
+from helpers.tbans_helper import TBANSHelper
 from models.mobile_client import MobileClient
 from sitevars.notifications_enable import NotificationsEnable
 
@@ -80,7 +80,7 @@ class AdminBroadcast(LoggedInHandler):
         self._require_admin()
 
         error = ""
-        if self.request.get('error') == "clients":
+        if self.request.get('error') == "client_types":
             error = "You must select at least one client type"
         elif self.request.get('error') == "title":
             error = "You must supply a title"
@@ -93,6 +93,7 @@ class AdminBroadcast(LoggedInHandler):
             'OS_ANDROID': ClientType.OS_ANDROID,
             'OS_IOS': ClientType.OS_IOS,
             'WEBHOOK': ClientType.WEBHOOK,
+            'WEB': ClientType.WEB,
             'error': error,
         })
 
@@ -103,15 +104,15 @@ class AdminBroadcast(LoggedInHandler):
         self._require_admin()
 
         user_id = self.user_bundle.account.key.id()
-        clients = self.request.get_all('client_types')
+        client_types = self.request.get_all('client_types')
         title = self.request.get('title')
         message = self.request.get('message')
         url = self.request.get('url')
         app_version = self.request.get('app_version')
 
         error = ""
-        if not clients:
-            error = "clients"
+        if not client_types:
+            error = "client_types"
         elif not title:
             error = "title"
         elif not message:
@@ -121,8 +122,8 @@ class AdminBroadcast(LoggedInHandler):
             return
 
         try:
-            clients = [int(c) for c in clients]
-            deferred.defer(NotificationHelper.send_broadcast, clients, title, message, url, app_version, _queue="admin")
+            client_types = [int(c) for c in client_types]
+            deferred.defer(TBANSHelper.broadcast, client_types, title, message, url, app_version, _queue="admin")
             logging.info('User {} sent broadcast'.format(user_id))
         except Exception, e:
             logging.error("Error sending broadcast: {}".format(str(e)))

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -7,7 +7,7 @@ beautifulsoup4
 GoogleAppEngineCloudStorageClient
 
 # TBANS
-firebase-admin==3.2.1
+firebase-admin==3.2.1 # DO NOT BUMP - 3.2.1 is the last version that supports Python 2
 
 # Cloud Endpoints Stuff
 oauth2client==3.0.0

--- a/helpers/notification_helper.py
+++ b/helpers/notification_helper.py
@@ -13,7 +13,6 @@ from models.sitevar import Sitevar
 
 from notifications.alliance_selections import AllianceSelectionNotification
 from notifications.level_starting import CompLevelStartingNotification
-from notifications.broadcast import BroadcastNotification
 from notifications.match_score import MatchScoreNotification
 from notifications.match_video import MatchVideoNotification, EventMatchVideoNotification
 from notifications.awards_updated import AwardsUpdatedNotification
@@ -21,7 +20,6 @@ from notifications.schedule_updated import ScheduleUpdatedNotification
 from notifications.upcoming_match import UpcomingMatchNotification
 from notifications.update_favorites import UpdateFavoritesNotification
 from notifications.update_subscriptions import UpdateSubscriptionsNotification
-from notifications.ping import PingNotification
 
 
 class NotificationHelper(object):
@@ -145,11 +143,3 @@ class NotificationHelper(object):
         else:
             user_keys = PushHelper.get_client_ids_for_users(users)
             EventMatchVideoNotification(match).send(user_keys)
-
-    @classmethod
-    def send_broadcast(cls, client_types, title, message, url, app_version=''):
-        users = PushHelper.get_all_mobile_clients(client_types)
-        keys = PushHelper.get_client_ids_for_users(users)
-
-        notification = BroadcastNotification(title, message, url, app_version)
-        notification.send(keys)

--- a/helpers/tbans_helper.py
+++ b/helpers/tbans_helper.py
@@ -3,6 +3,13 @@ import logging
 
 from consts.client_type import ClientType
 
+from google.appengine.ext import deferred
+
+from models.mobile_client import MobileClient
+
+
+MAXIMUM_BACKOFF = 32
+
 
 def _firebase_app():
     try:
@@ -19,6 +26,45 @@ class TBANSHelper:
     """
     Helper class for sending push notifications via the FCM HTTPv1 API and sending data payloads to webhooks
     """
+
+    @classmethod
+    def broadcast(cls, client_types, title, message, url=None, app_version=None):
+        from models.notifications.broadcast import BroadcastNotification
+        notification = BroadcastNotification(title, message, url, app_version)
+
+        # Send to FCM clients
+        fcm_client_types = [ct for ct in client_types if ct in ClientType.FCM_CLIENTS]
+        if fcm_client_types:
+            clients = MobileClient.query(MobileClient.client_type.IN(fcm_client_types)).fetch()
+            if clients:
+                deferred.defer(
+                    cls._send_fcm,
+                    clients,
+                    notification,
+                    _queue="push-notifications",
+                    _url='/_ah/queue/deferred_notification_send'
+                )
+
+        # Send to webhooks
+        if ClientType.WEBHOOK in client_types:
+            clients = MobileClient.query(MobileClient.client_type == ClientType.WEBHOOK).fetch()
+            if clients:
+                deferred.defer(
+                    cls._send_webhook,
+                    clients,
+                    notification,
+                    _queue="push-notifications",
+                    _url='/_ah/queue/deferred_notification_send'
+                )
+
+        if ClientType.OS_ANDROID in client_types:
+            from helpers.push_helper import PushHelper
+            users = PushHelper.get_all_mobile_clients([ClientType.OS_ANDROID])
+            keys = PushHelper.get_client_ids_for_users(users)
+
+            from notifications.broadcast import BroadcastNotification
+            notification = BroadcastNotification(title, message, url, app_version)
+            notification.send(keys)
 
     @staticmethod
     def ping(client):
@@ -84,3 +130,99 @@ class TBANSHelper:
         logging.info('Verification Key - {}'.format(notification.verification_key))
 
         return notification.verification_key
+
+    @classmethod
+    def _send_fcm(cls, clients, notification, backoff_iteration=0):
+        # Only send to FCM clients if notifications are enabled
+        if not cls._notifications_enabled():
+            return 1
+
+        # Only allow so many retries
+        backoff_time = 2 ** backoff_iteration
+        if backoff_time > MAXIMUM_BACKOFF:
+            return 2
+
+        # Make sure we're only sending to FCM clients
+        clients = [client for client in clients if client.client_type in ClientType.FCM_CLIENTS]
+
+        from models.notifications.requests.fcm_request import FCMRequest, MAXIMUM_TOKENS
+        # We can only send to so many FCM clients at a time - send to our clients across several requests
+        for subclients in [clients[i:i + MAXIMUM_TOKENS] for i in range(0, len(clients), MAXIMUM_TOKENS)]:
+            fcm_request = FCMRequest(firebase_app, notification, tokens=[client.messaging_id for client in subclients])
+            logging.info(str(fcm_request))
+
+            batch_response = fcm_request.send()
+            retry_clients = []
+
+            # Handle our failed sends - this might include logging/alerting, removing old clients, or retrying sends
+            from firebase_admin.exceptions import InvalidArgumentError, InternalError, UnavailableError
+            from firebase_admin.messaging import QuotaExceededError, SenderIdMismatchError, ThirdPartyAuthError, UnregisteredError
+            for index, response in enumerate([response for response in batch_response.responses if not response.success]):
+                client = subclients[index]
+                if isinstance(response.exception, UnregisteredError):
+                    logging.info('Deleting unregistered client with ID: {}'.format(client.messaging_id))
+                    MobileClient.delete_for_messaging_id(client.messaging_id)
+                elif isinstance(response.exception, SenderIdMismatchError):
+                    logging.info('Deleting mismatched client with ID: {}'.format(client.messaging_id))
+                    MobileClient.delete_for_messaging_id(client.messaging_id)
+                elif isinstance(response.exception, QuotaExceededError):
+                    logging.error('Qutoa exceeded - retrying client...')
+                    retry_clients.append(client)
+                elif isinstance(response.exception, ThirdPartyAuthError):
+                    logging.critical('Third party error sending to FCM - {}'.format(response.exception))
+                elif isinstance(response.exception, InvalidArgumentError):
+                    logging.critical('Invalid argument when sending to FCM - {}'.format(response.exception))
+                elif isinstance(response.exception, InternalError):
+                    logging.error('Interal FCM error - retrying client...')
+                    retry_clients.append(client)
+                elif isinstance(response.exception, UnavailableError):
+                    logging.error('FCM unavailable - retrying client...')
+                    retry_clients.append(client)
+                else:
+                    debug_string = cls._debug_string(response.exception)
+                    logging.error('Unhandled FCM error for {} - {}'.format(client.messaging_id, debug_string))
+
+            if retry_clients:
+                # Try again, with exponential backoff
+                deferred.defer(
+                    cls._send_fcm,
+                    retry_clients,
+                    notification,
+                    backoff_iteration + 1,
+                    _countdown=backoff_time,
+                    _queue="push-notifications",
+                    _url='/_ah/queue/deferred_notification_send'
+                )
+
+        return 0
+
+    @classmethod
+    def _send_webhook(cls, clients, notification):
+        # Only send to webhooks if notifications are enabled
+        if not cls._notifications_enabled():
+            return 1
+
+        # Make sure we're only sending to webhook clients
+        clients = [client for client in clients if client.client_type == ClientType.WEBHOOK]
+
+        from models.notifications.requests.webhook_request import WebhookRequest
+        for client in clients:
+            webhook_request = WebhookRequest(notification, client.messaging_id, client.secret)
+            logging.info(str(webhook_request))
+
+            webhook_request.send()
+
+        return 0
+
+    # Returns a list of debug strings for a FirebaseException
+    @classmethod
+    def _debug_string(cls, exception):
+        debug_strings = [exception.code, exception.message]
+        if exception.http_response:
+            debug_strings.append(str(exception.http_response.json()))
+        return ' / '.join(debug_strings)
+
+    @classmethod
+    def _notifications_enabled(cls):
+        from sitevars.notifications_enable import NotificationsEnable
+        return NotificationsEnable.notifications_enabled()

--- a/models/mobile_client.py
+++ b/models/mobile_client.py
@@ -42,3 +42,31 @@ class MobileClient(ndb.Model):
     @property
     def short_id(self):
         return self.messaging_id if len(self.messaging_id)<=50 else self.messaging_id[0:50]+'...'
+
+    @staticmethod
+    def fcm_messaging_ids(user_id):
+        """
+        Get messaging IDs for FCM clients for a given user.
+
+        Args:
+            user_id (string): The User ID to fetch device tokens for.
+
+        Returns:
+            list (string): List of device tokens for the user.
+        """
+        from models.account import Account
+        clients = MobileClient.query(
+            MobileClient.client_type.IN(ClientType.FCM_CLIENTS),
+            ancestor=ndb.Key(Account, user_id)
+        ).fetch(projection=[MobileClient.messaging_id])
+        return [c.messaging_id for c in clients]
+
+    @staticmethod
+    def delete_for_messaging_id(messaging_id):
+        """
+        Delete the mobile client(s) with the associated messaging_id.
+        Args:
+            messaging_id (string): The messaging_id to filter for.
+        """
+        to_delete = MobileClient.query(MobileClient.messaging_id == messaging_id).fetch(keys_only=True)
+        ndb.delete_multi(to_delete)

--- a/models/notifications/broadcast.py
+++ b/models/notifications/broadcast.py
@@ -3,7 +3,7 @@ from models.notifications.notification import Notification
 
 class BroadcastNotification(Notification):
 
-    def __init__(self, title, message, url, app_version=''):
+    def __init__(self, title, message, url=None, app_version=None):
         self.title = title
         self.message = message
         self.url = url
@@ -21,9 +21,11 @@ class BroadcastNotification(Notification):
 
     @property
     def data_payload(self):
-        payload = {
-            'url': self.url
-        }
+        payload = {}
+        if self.url:
+            payload['url'] = self.url
+        else:
+            payload['url'] = None
 
         if self.app_version:
             payload['app_version'] = self.app_version

--- a/templates/admin/send_broadcast.html
+++ b/templates/admin/send_broadcast.html
@@ -23,6 +23,7 @@
         <option value="{{OS_ANDROID}}">Android</option>
         <option value="{{OS_IOS}}">iOS</option>
         <option value="{{WEBHOOK}}">Webhook</option>
+        <option value="{{WEB}}">Web</option>
       </select></td>
     </tr>
     <tr>

--- a/tests/helpers_tests/test_tbans_helper.py
+++ b/tests/helpers_tests/test_tbans_helper.py
@@ -1,15 +1,25 @@
 from firebase_admin import messaging
-from firebase_admin.exceptions import FirebaseError
-from mock import patch
+from firebase_admin.exceptions import FirebaseError, InvalidArgumentError, InternalError, UnavailableError
+from firebase_admin.messaging import QuotaExceededError, SenderIdMismatchError, ThirdPartyAuthError, UnregisteredError
+
+from mock import patch, Mock, ANY
 import unittest2
 
+from google.appengine.api.taskqueue import taskqueue
+from google.appengine.ext import deferred
 from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
 from consts.client_type import ClientType
+import helpers.tbans_helper
 from helpers.tbans_helper import TBANSHelper, _firebase_app
 from models.account import Account
 from models.mobile_client import MobileClient
+from models.notifications.broadcast import BroadcastNotification
+from models.notifications.requests.fcm_request import FCMRequest
+from models.notifications.requests.webhook_request import WebhookRequest
+
+from tests.mocks.notifications.mock_notification import MockNotification
 
 
 class TestTBANSHelper(unittest2.TestCase):
@@ -18,6 +28,10 @@ class TestTBANSHelper(unittest2.TestCase):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
         self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        self.testbed.init_app_identity_stub()
+        self.testbed.init_taskqueue_stub(root_path='.')
+        self.taskqueue_stub = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
     def tearDown(self):
@@ -35,6 +49,127 @@ class TestTBANSHelper(unittest2.TestCase):
         # Should be the same object
         self.assertEqual(app_one, app_two)
 
+    def test_broadcast_none(self):
+        from notifications.base_notification import BaseNotification
+        with patch.object(BaseNotification, 'send') as mock_send:
+            TBANSHelper.broadcast([], 'Broadcast', 'Test broadcast')
+            # Make sure we didn't send to Android
+            mock_send.assert_not_called()
+
+        # Make sure we didn't send to FCM or webhooks
+        tasks = self.taskqueue_stub.GetTasks('push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_broadcast_fcm_empty(self):
+        from notifications.base_notification import BaseNotification
+
+        for client_type in ClientType.FCM_CLIENTS:
+            with patch.object(BaseNotification, 'send') as mock_send:
+                TBANSHelper.broadcast([client_type], 'Broadcast', 'Test broadcast')
+                # Make sure we didn't send to Android
+                mock_send.assert_not_called()
+
+            # Make sure we didn't send to FCM or webhooks
+            tasks = self.taskqueue_stub.GetTasks('push-notifications')
+            self.assertEqual(len(tasks), 0)
+
+    def test_broadcast_fcm(self):
+        from notifications.base_notification import BaseNotification
+
+        for client_type in ClientType.FCM_CLIENTS:
+            client = MobileClient(
+                parent=ndb.Key(Account, 'user_id'),
+                user_id='user_id',
+                messaging_id='token',
+                client_type=client_type,
+                device_uuid='uuid',
+                display_name='Phone')
+            client_key = client.put()
+
+            with patch.object(BaseNotification, 'send') as mock_send:
+                TBANSHelper.broadcast([client_type], 'Broadcast', 'Test broadcast')
+                # Make sure we didn't send to Android
+                mock_send.assert_not_called()
+
+            # Make sure we'll send to FCM clients
+            tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+            self.assertEqual(len(tasks), 1)
+
+            # Make sure our taskqueue tasks execute what we expect
+            with patch.object(TBANSHelper, '_send_fcm') as mock_send_fcm:
+                deferred.run(tasks[0].payload)
+                mock_send_fcm.assert_called_once_with([client], ANY)
+                # Make sure the notification is a BroadcastNotification
+                notification = mock_send_fcm.call_args[0][1]
+                self.assertTrue(isinstance(notification, BroadcastNotification))
+
+            self.taskqueue_stub.FlushQueue('push-notifications')
+
+            client_key.delete()
+
+    def test_broadcast_webhook_empty(self):
+        from notifications.base_notification import BaseNotification
+
+        with patch.object(BaseNotification, 'send') as mock_send:
+            TBANSHelper.broadcast([ClientType.WEBHOOK], 'Broadcast', 'Test broadcast')
+            # Make sure we didn't send to Android
+            mock_send.assert_not_called()
+
+        # Make sure we didn't send to FCM or webhooks
+        tasks = self.taskqueue_stub.GetTasks('push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_broadcast_webhook(self):
+        from notifications.base_notification import BaseNotification
+
+        client = MobileClient(
+            parent=ndb.Key(Account, 'user_id'),
+            user_id='user_id',
+            messaging_id='token',
+            client_type=ClientType.WEBHOOK,
+            device_uuid='uuid',
+            display_name='Phone')
+        client_key = client.put()
+
+        with patch.object(BaseNotification, 'send') as mock_send:
+            TBANSHelper.broadcast([ClientType.WEBHOOK], 'Broadcast', 'Test broadcast')
+            # Make sure we didn't send to Android
+            mock_send.assert_not_called()
+
+        # Make sure we'll send to FCM clients
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 1)
+
+        # Make sure our taskqueue tasks execute what we expect
+        with patch.object(TBANSHelper, '_send_webhook') as mock_send_webhook:
+            deferred.run(tasks[0].payload)
+            mock_send_webhook.assert_called_once_with([client], ANY)
+            # Make sure the notification is a BroadcastNotification
+            notification = mock_send_webhook.call_args[0][1]
+            self.assertTrue(isinstance(notification, BroadcastNotification))
+
+    def test_broadcast_android(self):
+        client_type = ClientType.OS_ANDROID
+        messaging_id = 'token'
+
+        client = MobileClient(
+            parent=ndb.Key(Account, 'user_id'),
+            user_id='user_id',
+            messaging_id=messaging_id,
+            client_type=client_type,
+            device_uuid='uuid',
+            display_name='Phone')
+        client.put()
+
+        from notifications.base_notification import BaseNotification
+        with patch.object(BaseNotification, 'send') as mock_send:
+            TBANSHelper.broadcast([client_type], 'Broadcast', 'Test broadcast')
+            mock_send.assert_called_once_with({client_type: [messaging_id]})
+
+        # Make sure we didn't send to FCM or webhooks
+        tasks = self.taskqueue_stub.GetTasks('push-notifications')
+        self.assertEqual(len(tasks), 0)
+
     def test_ping_client(self):
         client = MobileClient(
             parent=ndb.Key(Account, 'user_id'),
@@ -46,8 +181,8 @@ class TestTBANSHelper(unittest2.TestCase):
 
         with patch.object(TBANSHelper, '_ping_client', return_value=True) as mock_ping_client:
             success = TBANSHelper.ping(client)
-        mock_ping_client.assert_called_once_with(client)
-        self.assertTrue(success)
+            mock_ping_client.assert_called_once_with(client)
+            self.assertTrue(success)
 
     def test_ping_webhook(self):
         client = MobileClient(
@@ -60,8 +195,8 @@ class TestTBANSHelper(unittest2.TestCase):
 
         with patch.object(TBANSHelper, '_ping_webhook', return_value=True) as mock_ping_webhook:
             success = TBANSHelper.ping(client)
-        mock_ping_webhook.assert_called_once_with(client)
-        self.assertTrue(success)
+            mock_ping_webhook.assert_called_once_with(client)
+            self.assertTrue(success)
 
     def test_ping_fcm(self):
         client = MobileClient(
@@ -73,11 +208,10 @@ class TestTBANSHelper(unittest2.TestCase):
             display_name='Phone')
 
         batch_response = messaging.BatchResponse([messaging.SendResponse({'name': 'abc'}, None)])
-        from models.notifications.requests.fcm_request import FCMRequest
         with patch.object(FCMRequest, 'send', return_value=batch_response) as mock_send:
             success = TBANSHelper._ping_client(client)
-        mock_send.assert_called_once()
-        self.assertTrue(success)
+            mock_send.assert_called_once()
+            self.assertTrue(success)
 
     def test_ping_fcm_fail(self):
         client = MobileClient(
@@ -89,11 +223,10 @@ class TestTBANSHelper(unittest2.TestCase):
             display_name='Phone')
 
         batch_response = messaging.BatchResponse([messaging.SendResponse(None, FirebaseError(500, 'testing'))])
-        from models.notifications.requests.fcm_request import FCMRequest
         with patch.object(FCMRequest, 'send', return_value=batch_response) as mock_send:
             success = TBANSHelper._ping_client(client)
-        mock_send.assert_called_once()
-        self.assertFalse(success)
+            mock_send.assert_called_once()
+            self.assertFalse(success)
 
     def test_ping_android(self):
         client_type = ClientType.OS_ANDROID
@@ -110,8 +243,8 @@ class TestTBANSHelper(unittest2.TestCase):
         from notifications.base_notification import BaseNotification
         with patch.object(BaseNotification, 'send') as mock_send:
             success = TBANSHelper._ping_client(client)
-        mock_send.assert_called_once_with({client_type: [messaging_id]})
-        self.assertTrue(success)
+            mock_send.assert_called_once_with({client_type: [messaging_id]})
+            self.assertTrue(success)
 
     def test_ping_fcm_unsupported(self):
         client = MobileClient(
@@ -137,8 +270,8 @@ class TestTBANSHelper(unittest2.TestCase):
         from models.notifications.requests.webhook_request import WebhookRequest
         with patch.object(WebhookRequest, 'send', return_value=True) as mock_send:
             success = TBANSHelper._ping_webhook(client)
-        mock_send.assert_called_once()
-        self.assertTrue(success)
+            mock_send.assert_called_once()
+            self.assertTrue(success)
 
     def test_ping_webhook_failure(self):
         client = MobileClient(
@@ -152,12 +285,345 @@ class TestTBANSHelper(unittest2.TestCase):
         from models.notifications.requests.webhook_request import WebhookRequest
         with patch.object(WebhookRequest, 'send', return_value=False) as mock_send:
             success = TBANSHelper._ping_webhook(client)
-        mock_send.assert_called_once()
-        self.assertFalse(success)
+            mock_send.assert_called_once()
+            self.assertFalse(success)
 
     def test_verification(self):
         from models.notifications.requests.webhook_request import WebhookRequest
         with patch.object(WebhookRequest, 'send') as mock_send:
             verification_key = TBANSHelper.verify_webhook('https://thebluealliance.com', 'secret')
-        mock_send.assert_called_once()
-        self.assertIsNotNone(verification_key)
+            mock_send.assert_called_once()
+            self.assertIsNotNone(verification_key)
+
+    def test_send_fcm_disabled(self):
+        from sitevars.notifications_enable import NotificationsEnable
+        NotificationsEnable.enable_notifications(False)
+
+        with patch.object(NotificationsEnable, 'notifications_enabled', wraps=NotificationsEnable.notifications_enabled) as mock_check_enabled:
+            exit_code = TBANSHelper._send_fcm([], MockNotification())
+            mock_check_enabled.assert_called_once()
+            self.assertEqual(exit_code, 1)
+
+    def test_send_fcm_maximum_backoff(self):
+        for i in range(0, 6):
+            exit_code = TBANSHelper._send_fcm([], MockNotification(), backoff_iteration=i)
+            self.assertEqual(exit_code, 0)
+
+        # Backoff should start failing at 6
+        exit_code = TBANSHelper._send_fcm([], MockNotification(), backoff_iteration=6)
+        self.assertEqual(exit_code, 2)
+
+    def test_send_fcm_filter_fcm_clients(self):
+        expected = ['client_type_{}'.format(client_type) for client_type in ClientType.FCM_CLIENTS]
+        clients = [MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='client_type_{}'.format(client_type),
+                    client_type=client_type) for client_type in ClientType.names.keys()]
+
+        with patch('models.notifications.requests.fcm_request.FCMRequest', autospec=True) as mock_init:
+            exit_code = TBANSHelper._send_fcm(clients, MockNotification())
+            mock_init.assert_called_once_with(ANY, ANY, expected)
+            self.assertEqual(exit_code, 0)
+
+    def test_send_fcm_batch(self):
+        clients = [MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='{}'.format(i),
+                    client_type=ClientType.OS_IOS) for i in range(3)]
+
+        batch_response = messaging.BatchResponse([])
+        with patch('models.notifications.requests.fcm_request.MAXIMUM_TOKENS', 2), patch.object(FCMRequest, 'send', return_value=batch_response) as mock_send:
+            exit_code = TBANSHelper._send_fcm(clients, MockNotification())
+            self.assertEqual(mock_send.call_count, 2)
+            self.assertEqual(exit_code, 0)
+
+    def test_send_fcm_unregister_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, UnregisteredError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), \
+            patch.object(MobileClient, 'delete_for_messaging_id', wraps=MobileClient.delete_for_messaging_id) as mock_delete, \
+                patch('logging.info') as mock_info:
+                    exit_code = TBANSHelper._send_fcm([client], MockNotification())
+                    mock_delete.assert_called_once_with('messaging_id')
+                    self.assertEqual(exit_code, 0)
+                    mock_info.assert_called_with('Deleting unregistered client with ID: messaging_id')
+
+        # TODO: Check logging?
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), [])
+
+        # Make sure we haven't queued for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_send_fcm_sender_id_mismatch_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, SenderIdMismatchError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), \
+            patch.object(MobileClient, 'delete_for_messaging_id', wraps=MobileClient.delete_for_messaging_id) as mock_delete, \
+                patch('logging.info') as mock_info:
+                    exit_code = TBANSHelper._send_fcm([client], MockNotification())
+                    mock_delete.assert_called_once_with('messaging_id')
+                    self.assertEqual(exit_code, 0)
+                    mock_info.assert_called_with('Deleting mismatched client with ID: messaging_id')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), [])
+
+        # Make sure we haven't queued for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_send_fcm_quota_exceeded_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, QuotaExceededError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.error') as mock_error:
+            exit_code = TBANSHelper._send_fcm([client], MockNotification())
+            self.assertEqual(exit_code, 0)
+            mock_error.assert_called_once_with('Qutoa exceeded - retrying client...')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        # Check that we queue'd for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 1)
+
+        # Make sure our taskqueue tasks execute what we expect
+        with patch.object(TBANSHelper, '_send_fcm') as mock_send_fcm:
+            deferred.run(tasks[0].payload)
+            mock_send_fcm.assert_called_once_with([client], ANY, 1)
+
+    def test_send_fcm_third_party_auth_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, ThirdPartyAuthError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.critical') as mock_critical:
+            exit_code = TBANSHelper._send_fcm([client], MockNotification())
+            self.assertEqual(exit_code, 0)
+            mock_critical.assert_called_once_with('Third party error sending to FCM - code')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        # Make sure we haven't queued for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_send_fcm_invalid_argument_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, InvalidArgumentError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.critical') as mock_critical:
+            exit_code = TBANSHelper._send_fcm([client], MockNotification())
+            self.assertEqual(exit_code, 0)
+            mock_critical.assert_called_once_with('Invalid argument when sending to FCM - code')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        # Make sure we haven't queued for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_send_fcm_internal_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, InternalError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.error') as mock_error:
+            exit_code = TBANSHelper._send_fcm([client], MockNotification())
+            self.assertEqual(exit_code, 0)
+            mock_error.assert_called_once_with('Interal FCM error - retrying client...')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        # Check that we queue'd for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 1)
+
+        # Make sure our taskqueue tasks execute what we expect
+        with patch.object(TBANSHelper, '_send_fcm') as mock_send_fcm:
+            deferred.run(tasks[0].payload)
+            mock_send_fcm.assert_called_once_with([client], ANY, 1)
+
+    def test_send_fcm_unavailable_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, UnavailableError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.error') as mock_error:
+            exit_code = TBANSHelper._send_fcm([client], MockNotification())
+            self.assertEqual(exit_code, 0)
+            mock_error.assert_called_once_with('FCM unavailable - retrying client...')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        # Check that we queue'd for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 1)
+
+        # Make sure our taskqueue tasks execute what we expect
+        with patch.object(TBANSHelper, '_send_fcm') as mock_send_fcm:
+            deferred.run(tasks[0].payload)
+            mock_send_fcm.assert_called_once_with([client], ANY, 1)
+
+    def test_send_fcm_unhandled_error(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, FirebaseError('code', 'message'))])
+        with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.error') as mock_error:
+            exit_code = TBANSHelper._send_fcm([client], MockNotification())
+            self.assertEqual(exit_code, 0)
+            mock_error.assert_called_once_with('Unhandled FCM error for messaging_id - code / message')
+
+        # Sanity check
+        self.assertEqual(MobileClient.fcm_messaging_ids('user_id'), ['messaging_id'])
+
+        # Check that we didn't queue for a retry
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+        self.assertEqual(len(tasks), 0)
+
+    def test_send_fcm_retry_backoff_time(self):
+        client = MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='messaging_id',
+                    client_type=ClientType.OS_IOS)
+        client.put()
+
+        import time, math
+
+        batch_response = messaging.BatchResponse([messaging.SendResponse(None, QuotaExceededError('code', 'message'))])
+        for i in range(0, 6):
+            with patch.object(FCMRequest, 'send', return_value=batch_response), patch('logging.error'):
+                call_time = time.time()
+                TBANSHelper._send_fcm([client], MockNotification(), i)
+
+                # Check that we queue'd for a retry with the proper countdown time
+                tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='push-notifications')
+                self.assertEqual(math.ceil(tasks[0].eta_posix - call_time), 2 ** i)
+
+                # Make sure our taskqueue tasks execute what we expect
+                with patch.object(TBANSHelper, '_send_fcm') as mock_send_fcm:
+                    deferred.run(tasks[0].payload)
+                    mock_send_fcm.assert_called_once_with([client], ANY, i + 1)
+
+                self.taskqueue_stub.FlushQueue('push-notifications')
+
+    def test_send_webhook_disabled(self):
+        from sitevars.notifications_enable import NotificationsEnable
+        NotificationsEnable.enable_notifications(False)
+
+        with patch.object(NotificationsEnable, 'notifications_enabled', wraps=NotificationsEnable.notifications_enabled) as mock_check_enabled:
+            exit_code = TBANSHelper._send_webhook([], MockNotification())
+            mock_check_enabled.assert_called_once()
+            self.assertEqual(exit_code, 1)
+
+    def test_send_webhook_filter_webhook_clients(self):
+        expected = 'client_type_{}'.format(ClientType.WEBHOOK)
+        clients = [MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='client_type_{}'.format(client_type),
+                    client_type=client_type) for client_type in ClientType.names.keys()]
+
+        with patch('models.notifications.requests.webhook_request.WebhookRequest', autospec=True) as mock_init:
+            exit_code = TBANSHelper._send_webhook(clients, MockNotification())
+            mock_init.assert_called_once_with(ANY, expected, ANY)
+            self.assertEqual(exit_code, 0)
+
+    def test_send_webhook_multiple(self):
+        clients = [MobileClient(
+                    parent=ndb.Key(Account, 'user_id'),
+                    user_id='user_id',
+                    messaging_id='{}'.format(i),
+                    client_type=ClientType.WEBHOOK) for i in range(3)]
+
+        batch_response = messaging.BatchResponse([])
+        with patch.object(WebhookRequest, 'send', return_value=batch_response) as mock_send:
+            exit_code = TBANSHelper._send_webhook(clients, MockNotification())
+            self.assertEqual(mock_send.call_count, 3)
+            self.assertEqual(exit_code, 0)
+
+    def test_debug_string(self):
+        exception = FirebaseError('code', 'message')
+        self.assertEqual(TBANSHelper._debug_string(exception), 'code / message')
+
+    def test_debug_string_response(self):
+        class MockResponse:
+            def json(self):
+                import json
+                return json.dumps({'mock': 'mock'})
+        exception = FirebaseError('code', 'message', None, MockResponse())
+        self.assertEqual(TBANSHelper._debug_string(exception), 'code / message / {"mock": "mock"}')

--- a/tests/models_tests/notifications/requests/test_fcm_request.py
+++ b/tests/models_tests/notifications/requests/test_fcm_request.py
@@ -8,7 +8,7 @@ from google.appengine.ext import testbed
 from consts.fcm.platform_priority import PlatformPriority
 from models.fcm.platform_config import PlatformConfig
 from models.notifications.requests.request import Request
-from models.notifications.requests.fcm_request import FCMRequest
+from models.notifications.requests.fcm_request import FCMRequest, MAXIMUM_TOKENS
 from sitevars.notifications_enable import NotificationsEnable
 
 from tests.mocks.notifications.mock_notification import MockNotification
@@ -41,6 +41,11 @@ class TestFCMRequest(unittest2.TestCase):
         with self.assertRaises(TypeError):
             FCMRequest(self.app, notification=MockNotification())
 
+    def test_init_delivery_too_many_tokens(self):
+        with self.assertRaises(ValueError) as ex:
+            FCMRequest(self.app, notification=MockNotification(), tokens=['a' for i in range(MAXIMUM_TOKENS + 1)])
+        self.assertEqual(str(ex.exception), 'FCMRequest tokens must contain less than {} tokens'.format(MAXIMUM_TOKENS))
+
     def test_str(self):
         request = FCMRequest(self.app, notification=MockNotification(), tokens=['abc'])
         self.assertEqual("FCMRequest(tokens=['abc'], notification=MockNotification())", str(request))
@@ -71,15 +76,6 @@ class TestFCMRequest(unittest2.TestCase):
         mock_send.assert_called_once()
         mock_track.assert_called_once_with(1)
         self.assertEqual(response, batch_response)
-
-    def test_send_disabled(self):
-        NotificationsEnable.enable_notifications(False)
-
-        request = FCMRequest(app=self.app, notification=MockNotification(), tokens=['abc'])
-        with patch.object(messaging, 'send_multicast') as mock_send, patch.object(request, 'defer_track_notification') as mock_track:
-            request.send()
-        mock_send.assert_not_called()
-        mock_track.assert_not_called()
 
     def test_fcm_message_empty(self):
         request = FCMRequest(self.app, notification=MockNotification(), tokens=['abc'])
@@ -134,6 +130,18 @@ class TestFCMRequest(unittest2.TestCase):
     def test_fcm_message_data_payload(self):
         platform_config = PlatformConfig(priority=PlatformPriority.HIGH, collapse_key='collapse_key')
         request = FCMRequest(self.app, notification=MockNotification(data_payload={'some_data': 'some test data'}), tokens=['abc'])
+        message = request._fcm_message()
+        self.assertIsNotNone(message)
+        self.assertEqual(message.data, {'notification_type': 'verification', 'some_data': 'some test data'})
+        self.assertIsNone(message.notification)
+        self.assertIsNone(message.android)
+        self.assertIsNone(message.apns)
+        self.assertIsNone(message.webpush)
+        self.assertEqual(message.tokens, ['abc'])
+
+    def test_fcm_message_data_payload_none(self):
+        platform_config = PlatformConfig(priority=PlatformPriority.HIGH, collapse_key='collapse_key')
+        request = FCMRequest(self.app, notification=MockNotification(data_payload={'some_data': 'some test data', 'some_none': None}), tokens=['abc'])
         message = request._fcm_message()
         self.assertIsNotNone(message)
         self.assertEqual(message.data, {'notification_type': 'verification', 'some_data': 'some test data'})

--- a/tests/models_tests/notifications/test_broadcast.py
+++ b/tests/models_tests/notifications/test_broadcast.py
@@ -8,7 +8,7 @@ from models.notifications.broadcast import BroadcastNotification
 class TestBroadcastNotification(unittest2.TestCase):
 
     def setUp(self):
-        self.notification = BroadcastNotification('Title Here', 'Some body message ya dig', 'https://thebluealliance.com/')
+        self.notification = BroadcastNotification('Title Here', 'Some body message ya dig')
 
     def test_type(self):
         self.assertEqual(BroadcastNotification._type(), NotificationType.BROADCAST)
@@ -19,17 +19,35 @@ class TestBroadcastNotification(unittest2.TestCase):
         self.assertEqual(self.notification.fcm_notification.body, 'Some body message ya dig')
 
     def test_data_payload(self):
-        self.assertEqual(self.notification.data_payload, {'url': 'https://thebluealliance.com/', 'app_version': None})
+        self.assertEqual(self.notification.data_payload, {'url': None, 'app_version': None})
+
+    def test_data_payload_url(self):
+        notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/')
+        self.assertEqual(notification.data_payload, {'url': 'https://thebluealliance.com/', 'app_version': None})
 
     def test_data_payload_app_version(self):
         notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', '1.0.0')
         self.assertEqual(notification.data_payload, {'url': 'https://thebluealliance.com/', 'app_version': '1.0.0'})
 
+    def test_data_payload_url_app_version(self):
+        notification = BroadcastNotification('T', 'B', None, '1.0.0')
+        self.assertEqual(notification.data_payload, {'url': None, 'app_version': '1.0.0'})
+
     def test_webhook_message_data(self):
-        payload = {'title': 'Title Here', 'desc': 'Some body message ya dig', 'url': 'https://thebluealliance.com/', 'app_version': None}
+        payload = {'title': 'Title Here', 'desc': 'Some body message ya dig', 'url': None, 'app_version': None}
         self.assertEqual(self.notification.webhook_message_data, payload)
 
+    def test_webhook_message_data_url(self):
+        notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', None)
+        payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/', 'app_version': None}
+        self.assertEqual(notification.webhook_message_data, payload)
+
     def test_webhook_message_data_app_version(self):
+        notification = BroadcastNotification('T', 'B', None, '1.0.0')
+        payload = {'title': 'T', 'desc': 'B', 'url': None, 'app_version': '1.0.0'}
+        self.assertEqual(notification.webhook_message_data, payload)
+
+    def test_webhook_message_data_url_app_version(self):
         notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', '1.0.0')
         payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/', 'app_version': '1.0.0'}
         self.assertEqual(notification.webhook_message_data, payload)

--- a/tests/models_tests/test_mobile_client.py
+++ b/tests/models_tests/test_mobile_client.py
@@ -1,0 +1,89 @@
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.client_type import ClientType
+from models.account import Account
+from models.mobile_client import MobileClient
+
+
+class TestMobileClient(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_fcm_messaging_ids(self):
+        user_id_one = 'user_id_one'
+        token_one = 'token1'
+        token_two = 'token2'
+
+        user_id_two = 'user_id_two'
+        token_three = 'token3'
+
+        user_id_three = 'user_id_three'
+
+        for (user_id, tokens) in [(user_id_one, [token_one, token_two]), (user_id_two, [token_three])]:
+            for token in tokens:
+                MobileClient(
+                    parent=ndb.Key(Account, user_id),
+                    user_id=user_id,
+                    messaging_id=token,
+                    client_type=ClientType.OS_IOS,
+                    device_uuid=token[::-1],
+                    display_name='Phone').put()
+
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_one), [token_one, token_two])
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_two), [token_three])
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_three), [])
+
+    def test_fcm_messaging_ids_unsupported_type(self):
+        user_id = 'user_id'
+
+        for (token, os) in [('a', ClientType.OS_ANDROID), ('b', ClientType.OS_IOS), ('c', ClientType.WEBHOOK), ('d', ClientType.WEB)]:
+            MobileClient(
+                parent=ndb.Key(Account, user_id),
+                user_id=user_id,
+                messaging_id=token,
+                client_type=os,
+                device_uuid=token,
+                display_name=token).put()
+
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id), ['b', 'd'])
+
+    def test_delete_for_messaging_id(self):
+        user_id_one = 'user_id_one'
+        messaging_id_one = 'messaging_id1'
+        messaging_id_two = 'messaging_id2'
+
+        user_id_two = 'user_id_two'
+        messaging_id_three = 'messaging_id3'
+
+        for (user_id, messaging_ids) in [(user_id_one, [messaging_id_one, messaging_id_two]), (user_id_two, [messaging_id_three])]:
+            for messaging_id in messaging_ids:
+                MobileClient(
+                    parent=ndb.Key(Account, user_id),
+                    user_id=user_id,
+                    messaging_id=messaging_id,
+                    client_type=ClientType.OS_IOS,
+                    device_uuid=messaging_id[::-1],
+                    display_name='Phone').put()
+
+        MobileClient.delete_for_messaging_id(messaging_id_one)
+
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_one), [messaging_id_two])
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_two), [messaging_id_three])
+
+        MobileClient.delete_for_messaging_id(messaging_id_two)
+
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_one), [])
+        self.assertEqual(MobileClient.fcm_messaging_ids(user_id_two), [messaging_id_three])
+
+        MobileClient.delete_for_messaging_id('does_not_exist')


### PR DESCRIPTION
Adds support for the the Broadcast notification for FCM clients, moves the Broadcast webhooks to be handled by TBANS, and consolidates Android notification calling code to exist in TBANS.

This also wires up the batch sending/retrying of FCM messages, which has through tests. Under proper failure conditions, we'll attempt to resend to failed FCM clients up to 5 additional times using exponential backoff between 1 and 32 seconds. Logging is in place for deletions, errors, and critical paths. Errors and critical logs will get alerting metrics.