### PR TITLE
Fix error when showing avatar button on build page

### DIFF
--- a/templates_jinja2/index/index_buildseason.html
+++ b/templates_jinja2/index/index_buildseason.html
@@ -40,7 +40,7 @@
       {% endif %}
       {% if build_handler_show_avatars == 'True' %}
       <div>
-        <a class="btn btn-lg btn-block btn-primary" href="/avatars/{{endbuild_datetime_est|strftime("%Y")}}"><span class="glyphicon glyphicon-user"></span> View All {{endbuild_datetime_est|strftime("%Y")}} Team Avatars</a>
+        <a class="btn btn-lg btn-block btn-primary" href="/avatars/{{seasonstart_datetime_utc|strftime("%Y")}}"><span class="glyphicon glyphicon-user"></span> View All {{seasonstart_datetime_utc|strftime("%Y")}} Team Avatars</a>
       </div>
       {% endif %}
 


### PR DESCRIPTION
The template never got updated to use `seasonstart_datetime_utc` when we removed `endbuild_datetime_est` in https://github.com/the-blue-alliance/the-blue-alliance/pull/2637