### PR TITLE
Pin httpie version to fix Travis deploys

### DIFF
--- a/travis_requirements.txt
+++ b/travis_requirements.txt
@@ -12,7 +12,7 @@ requests[security]
 pyOpenSSL
 ndg-httpsclient
 pyasn1
-httpie
+httpie==1.0.3
 mysqlclient==1.3.14
 openapi-spec-validator
 mock==3.0.5


### PR DESCRIPTION
Travis deploys are failing at the end when we're updating web config information - the `httpie` version changed from underneath us. We should pin the version for now.