### PR TITLE
Change all user-facing notifications to be high priority

### DIFF
--- a/models/notifications/broadcast.py
+++ b/models/notifications/broadcast.py
@@ -20,6 +20,12 @@ class BroadcastNotification(Notification):
         return messaging.Notification(title=self.title, body=self.message)
 
     @property
+    def platform_config(self):
+        from consts.fcm.platform_priority import PlatformPriority
+        from models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
     def data_payload(self):
         payload = {}
         if self.url:

--- a/models/notifications/district_points.py
+++ b/models/notifications/district_points.py
@@ -22,6 +22,12 @@ class DistrictPointsNotification(Notification):
         )
 
     @property
+    def platform_config(self):
+        from consts.fcm.platform_priority import PlatformPriority
+        from models.fcm.platform_config import PlatformConfig
+        return PlatformConfig(priority=PlatformPriority.HIGH)
+
+    @property
     def data_payload(self):
         return {
             'district_key': self.district.key_name

--- a/tests/models_tests/notifications/test_broadcast.py
+++ b/tests/models_tests/notifications/test_broadcast.py
@@ -18,6 +18,9 @@ class TestBroadcastNotification(unittest2.TestCase):
         self.assertEqual(self.notification.fcm_notification.title, 'Title Here')
         self.assertEqual(self.notification.fcm_notification.body, 'Some body message ya dig')
 
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
     def test_data_payload(self):
         self.assertEqual(self.notification.data_payload, {'url': None, 'app_version': None})
 

--- a/tests/models_tests/notifications/test_broadcast.py
+++ b/tests/models_tests/notifications/test_broadcast.py
@@ -1,5 +1,6 @@
 import unittest2
 
+from consts.fcm.platform_priority import PlatformPriority
 from consts.notification_type import NotificationType
 
 from models.notifications.broadcast import BroadcastNotification

--- a/tests/models_tests/notifications/test_district_points.py
+++ b/tests/models_tests/notifications/test_district_points.py
@@ -1,8 +1,9 @@
 import unittest2
 
+from consts.fcm.platform_priority import PlatformPriority
 from consts.notification_type import NotificationType
-from models.district import District
 
+from models.district import District
 from models.notifications.district_points import DistrictPointsNotification
 
 

--- a/tests/models_tests/notifications/test_district_points.py
+++ b/tests/models_tests/notifications/test_district_points.py
@@ -20,6 +20,9 @@ class TestDistrictPointsNotification(unittest2.TestCase):
         self.assertEqual(self.notification.fcm_notification.title, 'FIM District Points Updated')
         self.assertEqual(self.notification.fcm_notification.body, 'FIRST In Michigan district point calculations have been updated.')
 
+    def test_platform_config(self):
+        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
+
     def test_data_payload(self):
         self.assertEqual(self.notification.data_payload, {'district_key': '2015fim'})
 


### PR DESCRIPTION
Right now broadcast and district points notifications deliver somewhat silently (no vibration). Setting them to delivery at a high priority should make them act more like regular notifications.