### PR TITLE
Only send to verified webhooks via TBANS

### DIFF
--- a/helpers/tbans_helper.py
+++ b/helpers/tbans_helper.py
@@ -204,6 +204,8 @@ class TBANSHelper:
 
         # Make sure we're only sending to webhook clients
         clients = [client for client in clients if client.client_type == ClientType.WEBHOOK]
+        # Only send to verified webhooks
+        clients = [client for client in clients if client.verified]
 
         from models.notifications.requests.webhook_request import WebhookRequest
         for client in clients:

--- a/tests/helpers_tests/test_tbans_helper.py
+++ b/tests/helpers_tests/test_tbans_helper.py
@@ -603,6 +603,27 @@ class TestTBANSHelper(unittest2.TestCase):
             mock_init.assert_called_once_with(ANY, expected, ANY)
             self.assertEqual(exit_code, 0)
 
+    def test_send_webhook_filter_webhook_clients_verified(self):
+        clients = [
+            MobileClient(
+                parent=ndb.Key(Account, 'user_id'),
+                user_id='user_id',
+                messaging_id='unverified',
+                client_type=ClientType.WEBHOOK,
+                verified=False),
+            MobileClient(
+                parent=ndb.Key(Account, 'user_id'),
+                user_id='user_id',
+                messaging_id='verified',
+                client_type=ClientType.WEBHOOK,
+                verified=True)
+        ]
+
+        with patch('models.notifications.requests.webhook_request.WebhookRequest', autospec=True) as mock_init:
+            exit_code = TBANSHelper._send_webhook(clients, MockNotification())
+            mock_init.assert_called_once_with(ANY, 'verified', ANY)
+            self.assertEqual(exit_code, 0)
+
     def test_send_webhook_multiple(self):
         clients = [MobileClient(
                     parent=ndb.Key(Account, 'user_id'),


### PR DESCRIPTION
Fixing a TBANS oversight where we weren't checking to see if a webhook was verified before sending to it. Luckily we haven't used this codepath yet.