### PR TITLE
Fix FCM Android platform priority

### DIFF
--- a/consts/fcm/platform_priority.py
+++ b/consts/fcm/platform_priority.py
@@ -10,8 +10,8 @@ class PlatformPriority:
 
     # https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidmessagepriority
     _android = {
-        NORMAL: 'NORMAL',
-        HIGH: 'HIGH',
+        NORMAL: 'normal',
+        HIGH: 'high',
     }
 
     # https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1

--- a/tests/consts_tests/fcm/test_platform_priority.py
+++ b/tests/consts_tests/fcm/test_platform_priority.py
@@ -23,8 +23,8 @@ class TestPlatformPriority(unittest2.TestCase):
             PlatformPriority.platform_priority(PlatformType.ANDROID, -1)
 
     def test_platform_priority_android(self):
-        self.assertEqual(PlatformPriority.platform_priority(PlatformType.ANDROID, PlatformPriority.HIGH), 'HIGH')
-        self.assertEqual(PlatformPriority.platform_priority(PlatformType.ANDROID, PlatformPriority.NORMAL), 'NORMAL')
+        self.assertEqual(PlatformPriority.platform_priority(PlatformType.ANDROID, PlatformPriority.HIGH), 'high')
+        self.assertEqual(PlatformPriority.platform_priority(PlatformType.ANDROID, PlatformPriority.NORMAL), 'normal')
 
     def test_platform_priority_apns(self):
         self.assertEqual(PlatformPriority.platform_priority(PlatformType.APNS, PlatformPriority.HIGH), '10')

--- a/tests/models_tests/fcm/test_platform_config.py
+++ b/tests/models_tests/fcm/test_platform_config.py
@@ -55,14 +55,14 @@ class TestPlatformConfig(unittest2.TestCase):
         android_config = config.platform_config(PlatformType.ANDROID)
         self.assertTrue(isinstance(android_config, messaging.AndroidConfig))
         self.assertIsNone(android_config.collapse_key)
-        self.assertEqual(android_config.priority, 'HIGH')
+        self.assertEqual(android_config.priority, 'high')
 
     def test_platform_config_android(self):
         config = PlatformConfig(priority=PlatformPriority.NORMAL, collapse_key='collapse_key')
         android_config = config.platform_config(PlatformType.ANDROID)
         self.assertTrue(isinstance(android_config, messaging.AndroidConfig))
         self.assertEqual(android_config.collapse_key, 'collapse_key')
-        self.assertEqual(android_config.priority, 'NORMAL')
+        self.assertEqual(android_config.priority, 'normal')
 
     def test_platform_config_apns_empty(self):
         config = PlatformConfig()


### PR DESCRIPTION
It was unclear via the FCM documentation, but looking over the code, the library we're using enforces `high` and `normal` for FCM platform priorities. I've double checked the APNS and Webpush platform priorities are correct

https://github.com/firebase/firebase-admin-python/blob/00cf1d34fdd8ca3531ff3556688c2e785db17920/firebase_admin/_messaging_encoder.py#L202