### PR TITLE
Remove explicit platform priority from TBANS notifications

### DIFF
--- a/models/notifications/alliance_selection.py
+++ b/models/notifications/alliance_selection.py
@@ -20,12 +20,6 @@ class AllianceSelectionNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         from helpers.model_to_dict import ModelToDict
         return {

--- a/models/notifications/awards.py
+++ b/models/notifications/awards.py
@@ -20,12 +20,6 @@ class AwardsNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         from helpers.award_helper import AwardHelper
         from helpers.model_to_dict import ModelToDict

--- a/models/notifications/broadcast.py
+++ b/models/notifications/broadcast.py
@@ -20,12 +20,6 @@ class BroadcastNotification(Notification):
         return messaging.Notification(title=self.title, body=self.message)
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         payload = {}
         if self.url:

--- a/models/notifications/district_points.py
+++ b/models/notifications/district_points.py
@@ -22,12 +22,6 @@ class DistrictPointsNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         return {
             'district_key': self.district.key_name

--- a/models/notifications/event_level.py
+++ b/models/notifications/event_level.py
@@ -30,12 +30,6 @@ class EventLevelNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         payload = {
             'comp_level': self.match.comp_level,

--- a/models/notifications/event_schedule.py
+++ b/models/notifications/event_schedule.py
@@ -34,12 +34,6 @@ class EventScheduleNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         payload = {
             'event_key': self.event.key_name

--- a/models/notifications/match_score.py
+++ b/models/notifications/match_score.py
@@ -38,12 +38,6 @@ class MatchScoreNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         from helpers.model_to_dict import ModelToDict
         return {

--- a/models/notifications/match_upcoming.py
+++ b/models/notifications/match_upcoming.py
@@ -34,12 +34,6 @@ class MatchUpcomingNotification(Notification):
         )
 
     @property
-    def platform_config(self):
-        from consts.fcm.platform_priority import PlatformPriority
-        from models.fcm.platform_config import PlatformConfig
-        return PlatformConfig(priority=PlatformPriority.HIGH)
-
-    @property
     def data_payload(self):
         payload = {
             'event_key': self.event.key_name,

--- a/tests/models_tests/notifications/test_alliance_selection.py
+++ b/tests/models_tests/notifications/test_alliance_selection.py
@@ -7,7 +7,6 @@ from consts.notification_type import NotificationType
 from helpers.event.event_test_creator import EventTestCreator
 from models.team import Team
 
-from consts.fcm.platform_priority import PlatformPriority
 from models.notifications.alliance_selection import AllianceSelectionNotification
 
 
@@ -34,9 +33,6 @@ class TestAllianceSelectionNotification(unittest2.TestCase):
 
     def test_type(self):
         self.assertEqual(AllianceSelectionNotification._type(), NotificationType.ALLIANCE_SELECTION)
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_fcm_notification(self):
         self.assertIsNotNone(self.notification.fcm_notification)

--- a/tests/models_tests/notifications/test_awards.py
+++ b/tests/models_tests/notifications/test_awards.py
@@ -7,7 +7,6 @@ from consts.notification_type import NotificationType
 from helpers.event.event_test_creator import EventTestCreator
 from models.team import Team
 
-from consts.fcm.platform_priority import PlatformPriority
 from models.notifications.awards import AwardsNotification
 
 
@@ -46,9 +45,6 @@ class TestAwardsNotification(unittest2.TestCase):
         self.assertIsNotNone(self.notification.fcm_notification)
         self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Awards Updated')
         self.assertEqual(self.notification.fcm_notification.body, 'Arizona North Regional awards have been updated.')
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_data_payload(self):
         # No `event_name`

--- a/tests/models_tests/notifications/test_broadcast.py
+++ b/tests/models_tests/notifications/test_broadcast.py
@@ -1,6 +1,5 @@
 import unittest2
 
-from consts.fcm.platform_priority import PlatformPriority
 from consts.notification_type import NotificationType
 
 from models.notifications.broadcast import BroadcastNotification
@@ -18,9 +17,6 @@ class TestBroadcastNotification(unittest2.TestCase):
         self.assertIsNotNone(self.notification.fcm_notification)
         self.assertEqual(self.notification.fcm_notification.title, 'Title Here')
         self.assertEqual(self.notification.fcm_notification.body, 'Some body message ya dig')
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_data_payload(self):
         self.assertEqual(self.notification.data_payload, {'url': None, 'app_version': None})

--- a/tests/models_tests/notifications/test_district_points.py
+++ b/tests/models_tests/notifications/test_district_points.py
@@ -1,6 +1,5 @@
 import unittest2
 
-from consts.fcm.platform_priority import PlatformPriority
 from consts.notification_type import NotificationType
 
 from models.district import District
@@ -20,9 +19,6 @@ class TestDistrictPointsNotification(unittest2.TestCase):
         self.assertIsNotNone(self.notification.fcm_notification)
         self.assertEqual(self.notification.fcm_notification.title, 'FIM District Points Updated')
         self.assertEqual(self.notification.fcm_notification.body, 'FIRST In Michigan district point calculations have been updated.')
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_data_payload(self):
         self.assertEqual(self.notification.data_payload, {'district_key': '2015fim'})

--- a/tests/models_tests/notifications/test_event_level.py
+++ b/tests/models_tests/notifications/test_event_level.py
@@ -8,7 +8,6 @@ from consts.notification_type import NotificationType
 from helpers.event.event_test_creator import EventTestCreator
 from models.team import Team
 
-from consts.fcm.platform_priority import PlatformPriority
 from models.notifications.event_level import EventLevelNotification
 
 
@@ -37,9 +36,6 @@ class TestEventLevelNotification(unittest2.TestCase):
 
     def test_type(self):
         self.assertEqual(EventLevelNotification._type(), NotificationType.LEVEL_STARTING)
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_fcm_notification(self):
         # Remove time for testing

--- a/tests/models_tests/notifications/test_event_schedule.py
+++ b/tests/models_tests/notifications/test_event_schedule.py
@@ -8,7 +8,6 @@ from consts.notification_type import NotificationType
 from helpers.event.event_test_creator import EventTestCreator
 from models.team import Team
 
-from consts.fcm.platform_priority import PlatformPriority
 from models.notifications.event_schedule import EventScheduleNotification
 
 
@@ -55,10 +54,6 @@ class TestEventScheduleNotification(unittest2.TestCase):
 
     def test_type(self):
         self.assertEqual(EventScheduleNotification._type(), NotificationType.SCHEDULE_UPDATED)
-
-    def test_platform_config(self):
-        self._setup_notification()
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_fcm_notification(self):
         self._setup_notification()

--- a/tests/models_tests/notifications/test_match_score.py
+++ b/tests/models_tests/notifications/test_match_score.py
@@ -8,7 +8,6 @@ from consts.notification_type import NotificationType
 from helpers.event.event_test_creator import EventTestCreator
 from models.team import Team
 
-from consts.fcm.platform_priority import PlatformPriority
 from models.notifications.match_score import MatchScoreNotification
 
 
@@ -37,9 +36,6 @@ class TestMatchScoreNotification(unittest2.TestCase):
 
     def test_type(self):
         self.assertEqual(MatchScoreNotification._type(), NotificationType.MATCH_SCORE)
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_fcm_notification(self):
         self.assertIsNotNone(self.notification.fcm_notification)

--- a/tests/models_tests/notifications/test_match_upcoming.py
+++ b/tests/models_tests/notifications/test_match_upcoming.py
@@ -9,7 +9,6 @@ from consts.notification_type import NotificationType
 from helpers.event.event_test_creator import EventTestCreator
 from models.team import Team
 
-from consts.fcm.platform_priority import PlatformPriority
 from models.notifications.match_upcoming import MatchUpcomingNotification
 
 
@@ -38,9 +37,6 @@ class TestMatchUpcomingNotification(unittest2.TestCase):
 
     def test_type(self):
         self.assertEqual(MatchUpcomingNotification._type(), NotificationType.UPCOMING_MATCH)
-
-    def test_platform_config(self):
-        self.assertEqual(self.notification.platform_config.priority, PlatformPriority.HIGH)
 
     def test_fcm_notification(self):
         # Set times for testing


### PR DESCRIPTION
Part of #2670 - I realized that setting the priority higher doesn't get the results I want, so we should just leave notifications to be default priority (we can always add back in higher priority, if necessary)