### PR TITLE
Set /events/all and /teams/all cache time to be an hour

### DIFF
--- a/api/apiv3/api_event_controller.py
+++ b/api/apiv3/api_event_controller.py
@@ -20,7 +20,8 @@ from models.match import Match
 
 class ApiEventListAllController(ApiBaseController):
     CACHE_VERSION = 0
-    CACHE_HEADER_LENGTH = 61
+    # `all` endpoints have a longer-than-usual edge cache of one hour
+    CACHE_HEADER_LENGTH = 60 * 60
 
     def _track_call(self, model_type=None):
         action = 'event/list'

--- a/api/apiv3/api_team_controller.py
+++ b/api/apiv3/api_team_controller.py
@@ -20,7 +20,8 @@ from models.team import Team
 
 class ApiTeamListAllController(ApiBaseController):
     CACHE_VERSION = 0
-    CACHE_HEADER_LENGTH = 61
+    # `all` endpoints have a longer-than-usual edge cache of one hour
+    CACHE_HEADER_LENGTH = 60 * 60
 
     def _track_call(self, model_type=None):
         action = 'team/list'


### PR DESCRIPTION
From Slack - since the `/events/all` and `/teams/all` endpoints are fairly large and don't get updated that often, we're going to bump the cache up to an hour for each