### PR TITLE
Add well-known directory in prep for Apple-things

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -64,6 +64,8 @@ handlers:
   static_files: static/manifest.json
   upload: static/manifest.json
   expiration: "1d"
+- url: /.well-known
+  static_dir: static/well-known
 
 - url: /tasks/.* # Here to take care of requests until new dispatch.yaml kicks in
   script: cron_main.app

--- a/static/well-known/apple-app-site-association
+++ b/static/well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "activitycontinuation": {
+    "apps": ["LKZ8X6P249.com.the-blue-alliance.tba"]
+  }
+}


### PR DESCRIPTION
Adds a `well-known` directory and `/.well-known` endpoint in prep for universal links, handoff, sign in with Apple, etc.