### PR TITLE
Rewrite PushHelper.get_users_subscribed_to_event to Subscription.users_subscribed_to_event

### DIFF
--- a/helpers/notification_helper.py
+++ b/helpers/notification_helper.py
@@ -10,6 +10,7 @@ from helpers.push_helper import PushHelper
 
 from models.event import Event
 from models.sitevar import Sitevar
+from models.subscription import Subscription
 
 from notifications.alliance_selections import AllianceSelectionNotification
 from notifications.level_starting import CompLevelStartingNotification
@@ -105,7 +106,7 @@ class NotificationHelper(object):
 
     @classmethod
     def send_schedule_update(cls, event):
-        users = PushHelper.get_users_subscribed_to_event(event, NotificationType.SCHEDULE_UPDATED)
+        users = Subscription.users_subscribed_to_event(event, NotificationType.SCHEDULE_UPDATED)
         keys = PushHelper.get_client_ids_for_users(users)
 
         notification = ScheduleUpdatedNotification(event)
@@ -121,7 +122,7 @@ class NotificationHelper(object):
 
     @classmethod
     def send_award_update(cls, event):
-        users = PushHelper.get_users_subscribed_to_event(event, NotificationType.AWARDS)
+        users = Subscription.users_subscribed_to_event(event, NotificationType.AWARDS)
         keys = PushHelper.get_client_ids_for_users(users)
 
         notification = AwardsUpdatedNotification(event)
@@ -135,7 +136,7 @@ class NotificationHelper(object):
         Otherwise, EventMatchVideoNotification is sent
         """
         match_users = set(PushHelper.get_users_subscribed_to_match(match, NotificationType.MATCH_VIDEO))
-        event_users = set(PushHelper.get_users_subscribed_to_event(match.event.get(), NotificationType.MATCH_VIDEO))
+        event_users = set(Subscription.users_subscribed_to_event(match.event.get(), NotificationType.MATCH_VIDEO))
         users = match_users.union(event_users)
         if match.within_seconds(60*10):
             user_keys = PushHelper.get_client_ids_for_users(users)

--- a/helpers/push_helper.py
+++ b/helpers/push_helper.py
@@ -100,17 +100,6 @@ class PushHelper(object):
         return output
 
     @classmethod
-    def get_users_subscribed_to_event(cls, event, notification):
-        keys = []
-        keys.append(event.key_name)
-        keys.append("{}*".format(event.year))
-        users = Subscription.query(Subscription.model_key.IN(keys), Subscription.notification_types == notification).fetch()
-        output = []
-        for user in users:
-            output.append(user.user_id)
-        return output
-
-    @classmethod
     def get_users_subscribed_for_alliances(cls, event, notification):
         keys = []
         for team in event.alliance_teams:

--- a/models/subscription.py
+++ b/models/subscription.py
@@ -26,3 +26,23 @@ class Subscription(ndb.Model):
     @property
     def notification_names(self):
         return [NotificationType.render_names[index] for index in self.notification_types]
+
+    @classmethod
+    def users_subscribed_to_event(cls, event, notification_type):
+        """
+        Get user IDs subscribed to an Event or the year an Event occurs in and a given notification type.
+        Ex: (model_key = `2020miket` or `2020*`) and (notification_type == NotificationType.UPCOMING_MATCH)
+
+        Args:
+            event (models.event.Event): The Event to query Subscription for.
+            notification_type (consts.notification_type.NotificationType): A NotificationType for the Subscription.
+
+        Returns:
+            list (string): List of user IDs with Subscriptions to the given Event/notification type.
+        """
+        users = Subscription.query(
+            Subscription.model_key.IN([event.key_name, "{}*".format(event.year)]),
+            Subscription.notification_types == notification_type,
+            projection=[Subscription.user_id]
+        ).fetch()
+        return list(set([user.user_id for user in users]))

--- a/tests/models_tests/test_subscription.py
+++ b/tests/models_tests/test_subscription.py
@@ -1,0 +1,110 @@
+import unittest2
+
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+
+from consts.model_type import ModelType
+from consts.notification_type import NotificationType
+
+from models.account import Account
+from models.subscription import Subscription
+
+
+class TestSubscription(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()  # Prevent data from leaking between tests
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_users_subscribed_to_event_year(self):
+        # Make sure we match year*
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_1'),
+            user_id='user_id_1',
+            model_key='2020*',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.UPCOMING_MATCH]
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_2'),
+            user_id='user_id_2',
+            model_key='2020*',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.MATCH_SCORE]
+        ).put()
+
+        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        self.assertEqual(users, ['user_id_1'])
+
+    def test_users_subscribed_to_event_key(self):
+        # Make sure we event key
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_1'),
+            user_id='user_id_1',
+            model_key='2020miket',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.UPCOMING_MATCH]
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_2'),
+            user_id='user_id_2',
+            model_key='2020mike2',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.MATCH_SCORE]
+        ).put()
+
+        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        self.assertEqual(users, ['user_id_1'])
+
+    def test_users_subscribed_to_event_year_key(self):
+        # Make sure we fetch both key and year together
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_1'),
+            user_id='user_id_1',
+            model_key='2020miket',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.UPCOMING_MATCH]
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_2'),
+            user_id='user_id_2',
+            model_key='2020*',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.UPCOMING_MATCH]
+        ).put()
+
+        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        self.assertItemsEqual(users, ['user_id_1', 'user_id_2'])
+
+    def test_users_subscribed_to_event_unique(self):
+        # Make sure we filter for duplicates
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_1'),
+            user_id='user_id_1',
+            model_key='2020miket',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.UPCOMING_MATCH]
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, 'user_id_1'),
+            user_id='user_id_1',
+            model_key='2020*',
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.UPCOMING_MATCH]
+        ).put()
+
+        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        self.assertEqual(users, ['user_id_1'])
+
+
+class MockEvent:
+
+    def __init__(self, key_name, year):
+        self.key_name = key_name
+        self.year = year


### PR DESCRIPTION
I'm looking to pull as much code out of `PushHelper` and `NotificationHelper` when moving to FCM. The old `PushHelper.get_users_subscribed_to_event` is a little weird - it doesn't de-duplicate user IDs, although they get de-duplicated later via a ndb query to mobile clients.

The new method in `Subscription` has one less sharp corner, and tests