### PR TITLE
Dispatch Awards notifications to iOS, web, and webhooks via TBANS

### DIFF
--- a/admin_main.py
+++ b/admin_main.py
@@ -29,6 +29,7 @@ from controllers.admin.admin_offseason_scraper_controller import AdminOffseasonS
 from controllers.admin.admin_offseason_spreadsheet_controller import AdminOffseasonSpreadsheetController
 from controllers.admin.admin_sitevar_controller import AdminSitevarCreate, AdminSitevarEdit, AdminSitevarList
 from controllers.admin.admin_suggestion_controller import AdminCreateTestSuggestions
+from controllers.admin.admin_tbans_controller import AdminTBANS
 from controllers.admin.admin_team_controller import AdminTeamCreateTest, AdminTeamDetail, AdminTeamList, \
     AdminTeamRobotNameUpdate
 from controllers.admin.admin_team_media_mod import AdminTeamMediaModCodeList, AdminTeamMediaModCodeAdd, AdminTeamMediaModCodeEdit
@@ -122,6 +123,7 @@ app = webapp2.WSGIApplication([('/admin/', AdminMain),
                                ('/admin/user/create/test', AdminUserTestSetup),
                                ('/admin/user/(.*)', AdminUserDetail),
                                ('/admin/videos/add', AdminVideosAdd),
+                               ('/admin/tbans', AdminTBANS),
                                ('/admin/mobile', AdminMobile),
                                ('/admin/mobile/broadcast', AdminBroadcast),
                                ('/admin/mobile/webhooks', AdminMobileWebhooks),

--- a/controllers/admin/admin_tbans_controller.py
+++ b/controllers/admin/admin_tbans_controller.py
@@ -1,0 +1,42 @@
+import logging
+import os
+
+from controllers.base_controller import LoggedInHandler
+from google.appengine.ext.webapp import template
+from models.event import Event
+from models.mobile_client import MobileClient
+from helpers.tbans_helper import TBANSHelper
+
+
+class AdminTBANS(LoggedInHandler):
+    """
+    TBANS debug panel
+    """
+    def get(self):
+        self._require_admin()
+
+        path = os.path.join(os.path.dirname(__file__), '../../templates/admin/tbans_debug.html')
+        self.response.out.write(template.render(path, self.template_values))
+
+    def post(self):
+        self._require_admin()
+
+        user_id = self.user_bundle.account.key.id()
+
+        notification_type = self.request.get('type')
+        if notification_type == "awards":
+            event_key = self.request.get('event_key')
+            event = Event.get_by_id(event_key)
+            if not event:
+                self.template_values.update({
+                    'error': 'No event for key {}'.format(event_key)
+                })
+                return self.redirect('/admin/tbans')
+
+            TBANSHelper.awards(event, user_id)
+        elif notification_type == "ping":
+            clients = MobileClient.clients([user_id])
+            for client in clients:
+                TBANSHelper.ping(client)
+
+        return self.redirect('/admin/tbans')

--- a/helpers/award_manipulator.py
+++ b/helpers/award_manipulator.py
@@ -6,6 +6,7 @@ from google.appengine.api import taskqueue
 from helpers.cache_clearer import CacheClearer
 from helpers.manipulator_base import ManipulatorBase
 from helpers.notification_helper import NotificationHelper
+from helpers.tbans_helper import TBANSHelper
 
 
 class AwardManipulator(ManipulatorBase):
@@ -31,6 +32,10 @@ class AwardManipulator(ManipulatorBase):
             if event.get().within_a_day:
                 try:
                     NotificationHelper.send_award_update(event.get())
+                except Exception:
+                    logging.error("Error sending award update for {}".format(event.id()))
+                try:
+                    TBANSHelper.awards(event.get())
                 except Exception:
                     logging.error("Error sending award update for {}".format(event.id()))
 

--- a/helpers/notification_helper.py
+++ b/helpers/notification_helper.py
@@ -123,7 +123,7 @@ class NotificationHelper(object):
     @classmethod
     def send_award_update(cls, event):
         users = Subscription.users_subscribed_to_event(event, NotificationType.AWARDS)
-        keys = PushHelper.get_client_ids_for_users(users)
+        keys = PushHelper.get_client_ids_for_users(users, os_types=[ClientType.OS_ANDROID])
 
         notification = AwardsUpdatedNotification(event)
         notification.send(keys)

--- a/helpers/push_helper.py
+++ b/helpers/push_helper.py
@@ -113,26 +113,20 @@ class PushHelper(object):
 
     @classmethod
     def get_client_ids_for_users(cls, user_list, os_types=None):
-        output = defaultdict(list)
         if not user_list:
-            return output
+            return defaultdict(list)
 
         if os_types is None:
             os_types = ClientType.names.keys()
         clients = MobileClient.query(MobileClient.user_id.IN(user_list), MobileClient.client_type.IN(os_types), MobileClient.verified == True).fetch()
+        return cls.get_client_ids_for_clients(clients)
+
+    @classmethod
+    def get_client_ids_for_clients(cls, clients):
+        output = defaultdict(list)
         for client in clients:
             if client.client_type == ClientType.WEBHOOK:
                 output[client.client_type].append((client.messaging_id, client.secret))
             else:
                 output[client.client_type].append(client.messaging_id)
-        return output
-
-    @classmethod
-    def get_all_mobile_clients(cls, client_types=[]):
-        output = []
-        if client_types == []:
-            return output
-        clients = MobileClient.query(MobileClient.client_type.IN(client_types))
-        for user in clients:
-            output.append(user.user_id)
         return output

--- a/models/mobile_client.py
+++ b/models/mobile_client.py
@@ -44,40 +44,25 @@ class MobileClient(ndb.Model):
         return self.messaging_id if len(self.messaging_id)<=50 else self.messaging_id[0:50]+'...'
 
     @staticmethod
-    def clients(user_id, client_types=ClientType.names.keys()):
+    def clients(users, client_types=ClientType.names.keys()):
         """
-        Get Mobile Clients for a given user.
+        Get all clients for a list of users.
 
         Args:
-            user_id (string): The User ID to fetch clients for.
+            users (list, string): A list of User ID to fetch clients for.
             client_types (list, ClientType): The client types to filter for.
 
         Returns:
             list (MobileClient): List of Mobile Clients for the user.
         """
+        if not users or not client_types:
+            return []
         from models.account import Account
         return MobileClient.query(
+            MobileClient.user_id.IN(users),
             MobileClient.client_type.IN(client_types),
-            ancestor=ndb.Key(Account, user_id)
+            MobileClient.verified == True
         ).fetch()
-
-    @staticmethod
-    def fcm_messaging_ids(user_id):
-        """
-        Get messaging IDs for FCM clients for a given user.
-
-        Args:
-            user_id (string): The User ID to fetch device tokens for.
-
-        Returns:
-            list (string): List of device tokens for the user.
-        """
-        from models.account import Account
-        clients = MobileClient.query(
-            MobileClient.client_type.IN(ClientType.FCM_CLIENTS),
-            ancestor=ndb.Key(Account, user_id)
-        ).fetch(projection=[MobileClient.messaging_id])
-        return [c.messaging_id for c in clients]
 
     @staticmethod
     def delete_for_messaging_id(messaging_id):

--- a/models/notifications/awards.py
+++ b/models/notifications/awards.py
@@ -15,21 +15,21 @@ class AwardsNotification(Notification):
     def fcm_notification(self):
         from firebase_admin import messaging
         return messaging.Notification(
-            title='{} Awards Updated'.format(self.event.event_short.upper()),
-            body='{} awards have been updated.'.format(self.event.normalized_name)
+            title='Awards Updated'.format(self.event.event_short.upper()),
+            body='{} {} awards have been updated.'.format(self.event.year, self.event.normalized_name)
         )
 
     @property
     def data_payload(self):
-        from helpers.award_helper import AwardHelper
-        from helpers.model_to_dict import ModelToDict
         return {
-            'awards': [ModelToDict.awardConverter(award) for award in AwardHelper.organizeAwards(self.event.awards)],
             'event_key': self.event.key_name
         }
 
     @property
     def webhook_message_data(self):
+        from helpers.award_helper import AwardHelper
+        from helpers.model_to_dict import ModelToDict
         payload = self.data_payload
         payload['event_name'] = self.event.name
+        payload['awards'] = [ModelToDict.awardConverter(award) for award in AwardHelper.organizeAwards(self.event.awards)],
         return payload

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -118,6 +118,7 @@
               <li><a href="/admin/mobile">Mobile Clients</a></li>
               <li><a href="/admin/apistatus">API Status</a></li>
               <li><a href="/admin/authkeys">Third Party API Keys</a></li>
+              <li><a href="/admin/tbans">TBANS Debug</a></li>
             </ul>
           </div>
         </div>

--- a/templates/admin/tbans_debug.html
+++ b/templates/admin/tbans_debug.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}TBANS Debug{% endblock %}
+
+{% block content %}
+Used to send notifications via TBANS to the logged-in user.
+
+{% if error %}
+<div class="row">
+  <div class="col-sm-8 col-sm-offset-2 col-md-offset-2 col-lg-offset-2">
+    <div class="alert alert-danger">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <h4>Error</h4>
+      <p>{{error}}</p>
+    </div>
+  </div>
+</div>
+{% endif %}
+<div class="row">
+  <div class="col-sm-12">
+    <form action="/admin/tbans" method="post">
+      <h3>Award Notification</h3>
+      <table class="table table-striped table-hover table-condensed">
+        <tr>
+          <td>Event Key</td>
+           <td>
+             <input class="form-control" type="text" name="event_key" placeholder="2020miket" />
+           </td>
+         </tr>
+         <input name="type" type="hidden" value="awards" />
+       </table>
+      <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Send</button>
+    </form>
+  </div>
+  <div class="col-sm-12">
+    <form action="/admin/tbans" method="post">
+      <h3>Ping Notification</h3>
+      <table class="table table-striped table-hover table-condensed">
+         <input name="type" type="hidden" value="ping" />
+       </table>
+      <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Send</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/tests/mocks/models/mock_event.py
+++ b/tests/mocks/models/mock_event.py
@@ -1,0 +1,21 @@
+from models.event import Event
+
+
+class MockEvent(Event):
+
+    def __init__(self, key_name=None, week=None, year=None):
+        self._key_name = key_name
+        self._week = week
+        self._year = year
+
+    @property
+    def key_name(self):
+        return self._key_name
+
+    @property
+    def week(self):
+        return self._week
+
+    @property
+    def year(self):
+        return self._year

--- a/tests/models_tests/notifications/test_awards.py
+++ b/tests/models_tests/notifications/test_awards.py
@@ -36,25 +36,24 @@ class TestAwardsNotification(unittest2.TestCase):
 
     def test_fcm_notification(self):
         self.assertIsNotNone(self.notification.fcm_notification)
-        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Awards Updated')
-        self.assertEqual(self.notification.fcm_notification.body, 'Present Test Event awards have been updated.')
+        self.assertEqual(self.notification.fcm_notification.title, 'Awards Updated')
+        self.assertEqual(self.notification.fcm_notification.body, '{} Present Test Event awards have been updated.'.format(self.event.year))
 
     def test_fcm_notification_short_name(self):
         self.notification.event.short_name = 'Arizona North'
 
         self.assertIsNotNone(self.notification.fcm_notification)
-        self.assertEqual(self.notification.fcm_notification.title, 'TESTPRESENT Awards Updated')
-        self.assertEqual(self.notification.fcm_notification.body, 'Arizona North Regional awards have been updated.')
+        self.assertEqual(self.notification.fcm_notification.title, 'Awards Updated')
+        self.assertEqual(self.notification.fcm_notification.body, '{} Arizona North Regional awards have been updated.'.format(self.event.year))
 
     def test_data_payload(self):
         # No `event_name`
         payload = self.notification.data_payload
-        self.assertEqual(len(payload), 2)
+        self.assertEqual(len(payload), 1)
         self.assertEqual(payload['event_key'], '{}testpresent'.format(self.event.year))
-        self.assertIsNotNone(payload['awards'])
 
     def test_webhook_message_data(self):
-        # Has `event_name`
+        # Has `event_name` and `awards`
         payload = self.notification.webhook_message_data
         self.assertEqual(len(payload), 3)
         self.assertEqual(payload['event_key'], '{}testpresent'.format(self.event.year))

--- a/tests/models_tests/test_subscription.py
+++ b/tests/models_tests/test_subscription.py
@@ -9,6 +9,8 @@ from consts.notification_type import NotificationType
 from models.account import Account
 from models.subscription import Subscription
 
+from mocks.models.mock_event import MockEvent
+
 
 class TestSubscription(unittest2.TestCase):
 
@@ -39,7 +41,7 @@ class TestSubscription(unittest2.TestCase):
             notification_types=[NotificationType.MATCH_SCORE]
         ).put()
 
-        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        users = Subscription.users_subscribed_to_event(MockEvent(key_name="2020miket", year=2020), NotificationType.UPCOMING_MATCH)
         self.assertEqual(users, ['user_id_1'])
 
     def test_users_subscribed_to_event_key(self):
@@ -59,7 +61,7 @@ class TestSubscription(unittest2.TestCase):
             notification_types=[NotificationType.MATCH_SCORE]
         ).put()
 
-        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        users = Subscription.users_subscribed_to_event(MockEvent(key_name="2020miket", year=2020), NotificationType.UPCOMING_MATCH)
         self.assertEqual(users, ['user_id_1'])
 
     def test_users_subscribed_to_event_year_key(self):
@@ -79,7 +81,7 @@ class TestSubscription(unittest2.TestCase):
             notification_types=[NotificationType.UPCOMING_MATCH]
         ).put()
 
-        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        users = Subscription.users_subscribed_to_event(MockEvent(key_name="2020miket", year=2020), NotificationType.UPCOMING_MATCH)
         self.assertItemsEqual(users, ['user_id_1', 'user_id_2'])
 
     def test_users_subscribed_to_event_unique(self):
@@ -99,12 +101,5 @@ class TestSubscription(unittest2.TestCase):
             notification_types=[NotificationType.UPCOMING_MATCH]
         ).put()
 
-        users = Subscription.users_subscribed_to_event(MockEvent("2020miket", 2020), NotificationType.UPCOMING_MATCH)
+        users = Subscription.users_subscribed_to_event(MockEvent(key_name="2020miket", year=2020), NotificationType.UPCOMING_MATCH)
         self.assertEqual(users, ['user_id_1'])
-
-
-class MockEvent:
-
-    def __init__(self, key_name, year):
-        self.key_name = key_name
-        self.year = year

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -8,6 +8,8 @@ from consts.event_type import EventType
 from helpers.event.event_test_creator import EventTestCreator
 from models.event import Event
 
+from mocks.models.mock_event import MockEvent
+
 
 class TestEvent(unittest2.TestCase):
 
@@ -147,18 +149,3 @@ class TestEvent(unittest2.TestCase):
                 self.assertFalse(event.is_offseason)
             else:
                 self.assertTrue(event.is_offseason)
-
-
-class MockEvent(Event):
-
-    def __init__(self, week, year):
-        self._week = week
-        self._year = year
-
-    @property
-    def week(self):
-        return self._week
-
-    @property
-    def year(self):
-        return self._year


### PR DESCRIPTION
Kind of a big PR - will break down each piece one by one

## New
- Dispatch Awards notifications via TBANS to FCM clients (web and iOS) and webhooks
- Adds `/admin/tbans` endpoint to test sending notifications to currently-signed-in user's clients

## Modified
- `NotificationHelper.send_award_update` will now ONLY send to Android clients - this is so we don't double send to webhooks. This code will say here for now, since the new Awards notifications will be a breaking change for Android (unlike ping and broadcast - which should not be)
- `MobileClient.clients` now takes an array of `user_id` as opposed to a single `user_id` - this should enable us to send notifications to a larger set of users. This wasn't used before, so this change should be whatever.

## QOL
- Modified `PushHelper.get_client_ids_for_users` to call in to a sub-method `PushHelper.get_client_ids_for_clients` - TBANS needs to generate the old GCM-format keys for sending broadcast notifications (for now)
- Removed `PushHelper.get_all_mobile_clients` - only TBANS was using it after migrating broadcast notifications, removed for a clearer pattern
- Added TBANS helper methods to send to both FCM and webhooks (should help DRY out code) as well as methods to defer FCM and webhook sends