### PR TITLE
Update Broadcast notification

### DIFF
--- a/models/notifications/broadcast.py
+++ b/models/notifications/broadcast.py
@@ -22,21 +22,23 @@ class BroadcastNotification(Notification):
     @property
     def data_payload(self):
         payload = {}
+
         if self.url:
             payload['url'] = self.url
-        else:
-            payload['url'] = None
 
         if self.app_version:
             payload['app_version'] = self.app_version
-        else:
-            payload['app_version'] = None
 
         return payload
 
     @property
     def webhook_message_data(self):
-        payload = self.data_payload
-        payload['title'] = self.title
-        payload['desc'] = self.message
+        payload = {
+            'title': self.title,
+            'desc': self.message
+        }
+
+        if self.url:
+            payload['url'] = self.url
+
         return payload

--- a/templates/webhookdocs.html
+++ b/templates/webhookdocs.html
@@ -446,12 +446,11 @@
               <li>fields in message_data object<ul>
                 <li>"title": Title of the notification to be shown</li>
                 <li>"desc": Contents of the notification</li>
-                <li>"url": URL to open when the notification is tapped</li>
-                <li>"app_version": App version number this broadcast is targeting</ul></li>
+                <li>"url": A URL with additional information - may be omitted.</li>
             </ul>
           <h4>Example JSON</h4>
             <pre class="example-json">
-            {"message_data": {"title": "Test", "desc": "Test Broadcast", "url": "http://foo.bar", "app_version": "2.0.0"}, "message_type": "broadcast"}
+            {"message_data": {"title": "Test", "desc": "Test Broadcast", "url": "http://foo.bar"}, "message_type": "broadcast"}
             </pre>
         <h3 id="notification_verification">Webhook Verification Notifications</h3>
           <p>This notification is sent when a new webhook is created. It contains a verification code that needs to be entered in the <a href="/account">Account Overview</a> page for the webhook before it recieves live updates.</p>

--- a/tests/models_tests/notifications/test_broadcast.py
+++ b/tests/models_tests/notifications/test_broadcast.py
@@ -19,11 +19,11 @@ class TestBroadcastNotification(unittest2.TestCase):
         self.assertEqual(self.notification.fcm_notification.body, 'Some body message ya dig')
 
     def test_data_payload(self):
-        self.assertEqual(self.notification.data_payload, {'url': None, 'app_version': None})
+        self.assertEqual(self.notification.data_payload, {})
 
     def test_data_payload_url(self):
         notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/')
-        self.assertEqual(notification.data_payload, {'url': 'https://thebluealliance.com/', 'app_version': None})
+        self.assertEqual(notification.data_payload, {'url': 'https://thebluealliance.com/'})
 
     def test_data_payload_app_version(self):
         notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', '1.0.0')
@@ -31,23 +31,23 @@ class TestBroadcastNotification(unittest2.TestCase):
 
     def test_data_payload_url_app_version(self):
         notification = BroadcastNotification('T', 'B', None, '1.0.0')
-        self.assertEqual(notification.data_payload, {'url': None, 'app_version': '1.0.0'})
+        self.assertEqual(notification.data_payload, {'app_version': '1.0.0'})
 
     def test_webhook_message_data(self):
-        payload = {'title': 'Title Here', 'desc': 'Some body message ya dig', 'url': None, 'app_version': None}
+        payload = {'title': 'Title Here', 'desc': 'Some body message ya dig'}
         self.assertEqual(self.notification.webhook_message_data, payload)
 
     def test_webhook_message_data_url(self):
         notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', None)
-        payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/', 'app_version': None}
+        payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/'}
         self.assertEqual(notification.webhook_message_data, payload)
 
     def test_webhook_message_data_app_version(self):
         notification = BroadcastNotification('T', 'B', None, '1.0.0')
-        payload = {'title': 'T', 'desc': 'B', 'url': None, 'app_version': '1.0.0'}
+        payload = {'title': 'T', 'desc': 'B'}
         self.assertEqual(notification.webhook_message_data, payload)
 
     def test_webhook_message_data_url_app_version(self):
         notification = BroadcastNotification('T', 'B', 'https://thebluealliance.com/', '1.0.0')
-        payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/', 'app_version': '1.0.0'}
+        payload = {'title': 'T', 'desc': 'B', 'url': 'https://thebluealliance.com/'}
         self.assertEqual(notification.webhook_message_data, payload)


### PR DESCRIPTION
This does a handful of things to the Broadcast notification

- Drops `None` values in the notification payloads - FCM wants only string values in the data payloads
- Removes `app_version` from webhook payload - not something the webhooks particularly need (unless we bump webhook versions/start targeting webhooks, which is two pretty big ifs)


The webhook docs are updated accordingly