### PR TITLE
2020 Match Breakdowns

### DIFF
--- a/controllers/admin/admin_match_controller.py
+++ b/controllers/admin/admin_match_controller.py
@@ -152,6 +152,7 @@ class AdminMatchEdit(LoggedInHandler):
     def post(self, match_key):
         self._require_admin()
         alliances_json = self.request.get("alliances_json")
+        score_breakdown_json = self.request.get("score_breakdown_json")
         alliances = json.loads(alliances_json)
         tba_videos = json.loads(self.request.get("tba_videos")) if self.request.get("tba_videos") else []
         youtube_videos = json.loads(self.request.get("youtube_videos")) if self.request.get("youtube_videos") else []
@@ -168,6 +169,7 @@ class AdminMatchEdit(LoggedInHandler):
             comp_level=self.request.get("comp_level"),
             team_key_names=team_key_names,
             alliances_json=alliances_json,
+            score_breakdown_json=score_breakdown_json,
             tba_videos=tba_videos,
             youtube_videos=youtube_videos
             # no_auto_update = str(self.request.get("no_auto_update")).lower() == "true", #TODO

--- a/controllers/match_controller.py
+++ b/controllers/match_controller.py
@@ -17,7 +17,7 @@ class MatchDetail(CacheableHandler):
     SHORT_CACHE_EXPIRATION = 61
     CACHE_VERSION = 4
     CACHE_KEY_FORMAT = "match_detail_{}"  # (match_key)
-    VALID_BREAKDOWN_YEARS = set([2015, 2016, 2017, 2018, 2019])
+    VALID_BREAKDOWN_YEARS = set([2015, 2016, 2017, 2018, 2019, 2020])
 
     def __init__(self, *args, **kw):
         super(MatchDetail, self).__init__(*args, **kw)

--- a/models/match.py
+++ b/models/match.py
@@ -149,8 +149,8 @@ class Match(ndb.Model):
         if self._score_breakdown is None and self.score_breakdown_json is not None:
             self._score_breakdown = json.loads(self.score_breakdown_json)
 
-            # Add in RP calculations
             if self.has_been_played:
+                # Add in RP calculations
                 if self.year in {2016, 2017}:
                     for color in ['red', 'blue']:
                         if self.comp_level == 'qm':
@@ -173,6 +173,10 @@ class Match(ndb.Model):
                             self._score_breakdown[color]['tba_rpEarned'] = rp_earned
                         else:
                             self._score_breakdown[color]['tba_rpEarned'] = None
+                # Derive if bonus RP came from fouls
+                if self.year == 2020:
+                    for color in ['red', 'blue']:
+                        self._score_breakdown[color]['tba_shieldEnergizedRankingPointFromFoul'] = self._score_breakdown[color]['shieldEnergizedRankingPoint'] and not self._score_breakdown[color]['stage3Activated']
 
         return self._score_breakdown
 

--- a/static/swagger/api_v3.json
+++ b/static/swagger/api_v3.json
@@ -6564,6 +6564,10 @@
           "shieldEnergizedRankingPoint": {
             "type": "boolean"
           },
+          "tba_shieldEnergizedRankingPointFromFoul": {
+            "type": "boolean",
+            "description": "Unofficial TBA-computed value that indicates whether the shieldEnergizedRankingPoint was earned normally or awarded due to a foul."
+          },
           "foulCount": {
             "type": "integer"
           },

--- a/templates/admin/match_edit.html
+++ b/templates/admin/match_edit.html
@@ -49,6 +49,10 @@
             <td><textarea class="form-control" type="text" name="alliances_json" rows="6" cols="60">{{match.alliances_json}}</textarea></td>
         </tr>
         <tr>
+            <td>Score Breakdown JSON</td>
+            <td><textarea class="form-control" type="text" name="score_breakdown_json" rows="6" cols="60">{{match.score_breakdown_json}}</textarea></td>
+        </tr>
+        <tr>
             <td>TBA Videos</td>
             <td><textarea class="form-control" type="text" name="tba_videos" rows="6" cols="60">[{% for video in match.tba_videos %}"{{video}}"{% if not forloop.last %},{% endif %}{% endfor %}]</textarea></td>
         </tr>        <tr>

--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -1,0 +1,360 @@
+{% macro drawNullPanelSVG() %}
+<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Null Hatch Panel">
+  <circle cx="8" cy="8" r="6" fill="none" stroke="#555" stroke-width="4"/>
+</svg>
+{% endmacro %}
+
+{% macro drawPanelSVG() %}
+<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Hatch Panel">
+  <circle cx="8" cy="8" r="6" fill="none" stroke="#f4d941" stroke-width="4"/>
+</svg>
+{% endmacro %}
+
+{% macro drawCargoSVG() %}
+<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Cargo">
+  <circle cx="8" cy="8" r="8" fill="#ffa500" />
+</svg>
+{% endmacro %}
+
+{% macro drawBottomGoalSVG() %}
+<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Bottom Goal">
+  <rect x="1" y="5" width="14" height="6" fill="white" stroke="black" stroke-width="2" />
+</svg>
+{% endmacro %}
+
+{% macro drawOuterGoalSVG() %}
+<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Outer Goal">
+  <path d="M 4.536 2 L 11.464 2 L 14.928 8 L 11.464 14 L 4.536 14 L 1.072 8 Z" fill="white" stroke="black" stroke-width="2"></path>
+</svg>
+{% endmacro %}
+
+{% macro drawInnerGoalSVG() %}
+<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Inner Goal">
+  <circle cx="8" cy="8" r="6" fill="white" stroke="black" stroke-width="2"/>
+</svg>
+{% endmacro %}
+
+<table class="match-table">
+  <tbody>
+    <!-- Autonomous -->
+    {% if "initLineRobot1" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.initLineRobot1 == 'Exited' %}
+        <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+        <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        {% if match.score_breakdown.red.initLineRobot2 == 'Exited' %}
+        <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+        <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        {% if match.score_breakdown.red.initLineRobot3 == 'Exited' %}
+        <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+        <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        (+{{match.score_breakdown.red.autoInitLinePoints}})
+      </td>
+      <td>Initiation Line Extended</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.initLineRobot1 == 'Exited' %}
+        <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+        <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        {% if match.score_breakdown.blue.initLineRobot2 == 'Exited' %}
+        <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+        <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        {% if match.score_breakdown.blue.initLineRobot3 == 'Exited' %}
+        <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+        <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        (+{{match.score_breakdown.blue.autoInitLinePoints}})
+      </td>
+    </tr>
+    {% endif %}
+    {% if "autoCellsBottom" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {{drawBottomGoalSVG()}}
+        {{match.score_breakdown.red.autoCellsBottom}}
+        {{drawOuterGoalSVG()}}
+        {{match.score_breakdown.red.autoCellsOuter}}
+        {{drawInnerGoalSVG()}}
+        {{match.score_breakdown.red.autoCellsInner}}
+      </td>
+      <td>Auto Power Cells</td>
+      <td class="blue" colspan="2">
+        {{drawBottomGoalSVG()}}
+        {{match.score_breakdown.blue.autoCellsBottom}}
+        {{drawOuterGoalSVG()}}
+        {{match.score_breakdown.blue.autoCellsOuter}}
+        {{drawInnerGoalSVG()}}
+        {{match.score_breakdown.blue.autoCellsInner}}
+      </td>
+    </tr>
+    {% endif %}
+    {% if "autoCellPoints" in match.score_breakdown.red %}
+    <tr class="key">
+      <td class="redScore" colspan="2">
+        {{match.score_breakdown.red.autoCellPoints}}
+      </td>
+      <td>Auto Power Cell Points</td>
+      <td class="blueScore" colspan="2">
+        {{match.score_breakdown.blue.autoCellPoints}}
+      </td>
+    </tr>
+    {% endif %}
+    {% if "autoPoints" in match.score_breakdown.red %}
+    <tr class="key">
+      <td class="redScore" colspan="2">
+        <b>{% if match.score_breakdown.red.autoPoints %}{{match.score_breakdown.red.autoPoints}}{%else%}0{%endif%}</b>
+      </td>
+      <th>Total Auto</th>
+      <td class="blueScore" colspan="2">
+        <b>{% if match.score_breakdown.blue.autoPoints %}{{match.score_breakdown.blue.autoPoints}}{%else%}0{%endif%}</b>
+      </td>
+    </tr>
+    {% endif %}
+
+    <!-- Teleop -->
+    {% if "teleopCellsBottom" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {{drawBottomGoalSVG()}}
+        {{match.score_breakdown.red.teleopCellsBottom}}
+        {{drawOuterGoalSVG()}}
+        {{match.score_breakdown.red.teleopCellsOuter}}
+        {{drawInnerGoalSVG()}}
+        {{match.score_breakdown.red.teleopCellsInner}}
+      </td>
+      <td>Teleop Power Cells</td>
+      <td class="blue" colspan="2">
+        {{drawBottomGoalSVG()}}
+        {{match.score_breakdown.blue.teleopCellsBottom}}
+        {{drawOuterGoalSVG()}}
+        {{match.score_breakdown.blue.teleopCellsOuter}}
+        {{drawInnerGoalSVG()}}
+        {{match.score_breakdown.blue.teleopCellsInner}}
+      </td>
+    </tr>
+    {% endif %}
+    {% if "teleopCellPoints" in match.score_breakdown.red %}
+    <tr class="key">
+      <td class="redScore" colspan="2">
+        {{match.score_breakdown.red.teleopCellPoints}}
+      </td>
+      <td>Teleop Power Cell Points</td>
+      <td class="blueScore" colspan="2">
+        {{match.score_breakdown.blue.teleopCellPoints}}
+      </td>
+    </tr>
+    {% endif %}
+    {% if "controlPanelPoints" in match.score_breakdown.red %}
+    <tr class="key">
+      <td class="redScore" colspan="2">
+        {{match.score_breakdown.red.controlPanelPoints}}
+      </td>
+      <td>Control Panel Points</td>
+      <td class="blueScore" colspan="2">
+        {{match.score_breakdown.blue.controlPanelPoints}}
+      </td>
+    </tr>
+    {% endif %}
+
+    <!-- Robot 1 Endgame -->
+    {% if "endgameRobot1" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.endgameRobot1 == 'Hang' %}
+          Hang (+25)
+        {% elif match.score_breakdown.red.endgameRobot1 == 'Park' %}
+          Park (+5)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      <td>Robot 1 Endgame</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.endgameRobot1 == 'Hang' %}
+          Hang (+25)
+        {% elif match.score_breakdown.blue.endgameRobot1 == 'Park' %}
+          Park (+5)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endif %}
+    <!-- Robot 2 Endgame -->
+    {% if "endgameRobot2" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.endgameRobot2 == 'Hang' %}
+          Hang (+25)
+        {% elif match.score_breakdown.red.endgameRobot2 == 'Park' %}
+          Park (+5)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      <td>Robot 2 Endgame</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.endgameRobot2 == 'Hang' %}
+          Hang (+25)
+        {% elif match.score_breakdown.blue.endgameRobot2 == 'Park' %}
+          Park (+5)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endif %}
+    <!-- Robot 3 Endgame -->
+    {% if "endgameRobot3" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.endgameRobot3 == 'Hang' %}
+          Hang (+25)
+        {% elif match.score_breakdown.red.endgameRobot3 == 'Park' %}
+          Park (+5)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      <td>Robot 3 Endgame</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.endgameRobot3 == 'Hang' %}
+          Hang (+25)
+        {% elif match.score_breakdown.blue.endgameRobot3 == 'Park' %}
+          Park (+5)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endif %}
+
+    {% if "endgameRungIsLevel" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.endgameRungIsLevel == 'IsLevel' %}
+          <span class="glyphicon glyphicon-ok"></span> (+15)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      <td>Shield Generator Switch Level</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.endgameRungIsLevel == 'IsLevel' %}
+          <span class="glyphicon glyphicon-ok"></span> (+15)
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endif %}
+    {% if "endgamePoints" in match.score_breakdown.red %}
+    <tr class="key">
+      <td class="redScore" colspan="2">
+        {{match.score_breakdown.red.endgamePoints}}
+      </td>
+      <td>Endgame Points</td>
+      <td class="blueScore" colspan="2">
+        {{match.score_breakdown.blue.endgamePoints}}
+      </td>
+    </tr>
+    {% endif %}
+    {% if "teleopPoints" in match.score_breakdown.red %}
+    <tr class="key">
+      <td class="redScore" colspan="2">
+        <b>{% if match.score_breakdown.red.teleopPoints %}{{match.score_breakdown.red.teleopPoints}}{%else%}0{%endif%}</b>
+      </td>
+      <th>Total Teleop</th>
+      <td class="blueScore" colspan="2">
+        <b>{% if match.score_breakdown.blue.teleopPoints %}{{match.score_breakdown.blue.teleopPoints}}{%else%}0{%endif%}</b>
+      </td>
+    </tr>
+    {% endif %}
+
+    <!-- Bonus RP -->
+    {% if "stage1Activated" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.red.stage2Activated %}2{% elif match.score_breakdown.red.stage1Activated %}1{% endif %}
+      </td>
+      <td>Stage Activations</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.blue.stage2Activated %}2{% elif match.score_breakdown.blue.stage1Activated %}1{% endif %}
+
+      </td>
+    </tr>
+    {% endif %}
+    {% if "shieldOperationalRankingPoint" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.shieldOperationalRankingPoint %}<span class="glyphicon glyphicon-ok"></span> (+1 RP){% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
+      </td>
+      <td>Shield Generator Operational</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.shieldOperationalRankingPoint %}<span class="glyphicon glyphicon-ok"></span> (+1 RP){% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
+      </td>
+    </tr>
+    {% endif %}
+
+    <!-- Fouls & Adjustments -->
+    {% if "foulCount" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">+{%if match.score_breakdown.red.foulCount%}{{match.score_breakdown.red.foulCount * 3}}{%else%}0{%endif%} / +{%if match.score_breakdown.red.techFoulCount%}{{match.score_breakdown.red.techFoulCount * 15}}{%else%}0{%endif%}{% if match.score_breakdown.red.tba_shieldEnergizedRankingPointFromFoul %} / +1 RP{% endif %}</td>
+      <td>Fouls / Tech Fouls</td>
+      <td class="blue" colspan="2">+{%if match.score_breakdown.blue.foulCount%}{{match.score_breakdown.blue.foulCount * 3}}{%else%}0{%endif%} / +{%if match.score_breakdown.blue.techFoulCount%}{{match.score_breakdown.blue.techFoulCount * 15}}{%else%}0{%endif%}{% if match.score_breakdown.blue.tba_shieldEnergizedRankingPointFromFoul %} / +1 RP{% endif %}</td>
+    </tr>
+    {% endif %}
+    {% if "adjustPoints" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">{% if match.score_breakdown.red.adjustPoints%}{{match.score_breakdown.red.adjustPoints}}{%else%}0{%endif%}</td>
+      <td>Adjustments</td>
+      <td class="blue" colspan="2">{%if match.score_breakdown.blue.adjustPoints%}{{match.score_breakdown.blue.adjustPoints}}{%else%}0{%endif%}</td>
+    </tr>
+    {% endif %}
+
+    <tr class="key">
+      <td class="redScore" colspan="2"><b>{%if match.score_breakdown.red.totalPoints%}{{match.score_breakdown.red.totalPoints}}{%else%}0{%endif%}</b></td>
+      <th>Total Score</th>
+      <td class="blueScore" colspan="2"><b>{%if match.score_breakdown.blue.totalPoints%}{{match.score_breakdown.blue.totalPoints}}{%else%}0{%endif%}</b></td>
+    </tr>
+
+    {% if 'rp' in match.score_breakdown.red and match.comp_level == 'qm' %}
+    <tr>
+      <td class="red" colspan="2">
+        {% if match.score_breakdown.red.shieldEnergizedRankingPoint %}
+        <svg class="top-left-dot" rel="tooltip" title="Shield Energized">
+          <circle cx="2" cy="2" r="2"/>
+        </svg>
+        {% endif %}
+        {% if match.score_breakdown.red.shieldOperationalRankingPoint %}
+        <svg class="top-left-dot-2" rel="tooltip" title="Shield Operational">
+          <circle cx="2" cy="2" r="2"/>
+        </svg>
+        {% endif %}
+        +{{match.score_breakdown.red.rp}} RP
+      </td>
+      <td>Ranking Points</td>
+      <td class="blue" colspan="2">
+        {% if match.score_breakdown.blue.shieldEnergizedRankingPoint %}
+        <svg class="top-left-dot" rel="tooltip" title="Shield Energized">
+          <circle cx="2" cy="2" r="2"/>
+        </svg>
+        {% endif %}
+        {% if match.score_breakdown.blue.shieldOperationalRankingPoint %}
+        <svg class="top-left-dot-2" rel="tooltip" title="Shield Operational">
+          <circle cx="2" cy="2" r="2"/>
+        </svg>
+        {% endif %}
+        +{{match.score_breakdown.blue.rp}} RP
+      </td>
+    </tr>
+    {% endif %}
+  </tbody>
+</table>

--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -1,21 +1,3 @@
-{% macro drawNullPanelSVG() %}
-<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Null Hatch Panel">
-  <circle cx="8" cy="8" r="6" fill="none" stroke="#555" stroke-width="4"/>
-</svg>
-{% endmacro %}
-
-{% macro drawPanelSVG() %}
-<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Hatch Panel">
-  <circle cx="8" cy="8" r="6" fill="none" stroke="#f4d941" stroke-width="4"/>
-</svg>
-{% endmacro %}
-
-{% macro drawCargoSVG() %}
-<svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Cargo">
-  <circle cx="8" cy="8" r="8" fill="#ffa500" />
-</svg>
-{% endmacro %}
-
 {% macro drawBottomGoalSVG() %}
 <svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Bottom Goal">
   <rect x="1" y="5" width="14" height="6" fill="white" stroke="black" stroke-width="2" />

--- a/templates_jinja2/match_partials/match_table_cell_macros.html
+++ b/templates_jinja2/match_partials/match_table_cell_macros.html
@@ -75,8 +75,9 @@
       or match.score_breakdown.get(alliance_color).kPaRankingPointAchieved
       or match.score_breakdown.get(alliance_color).kPaBonusPoints
       or match.score_breakdown.get(alliance_color).autoQuestRankingPoint
-      or match.score_breakdown.get(alliance_color).completeRocketRankingPoint %}
-    <svg class="top-left-dot" rel="tooltip" title="{% if match.year == 2016 %}Defenses Breached{% elif match.year == 2017 %}Pressure Reached{% elif match.year == 2018 %}Auto Quest{% elif match.year == 2019 %}Complete Rocket{% endif %}">
+      or match.score_breakdown.get(alliance_color).completeRocketRankingPoint
+      or match.score_breakdown.get(alliance_color).shieldEnergizedRankingPoint %}
+    <svg class="top-left-dot" rel="tooltip" title="{% if match.year == 2016 %}Defenses Breached{% elif match.year == 2017 %}Pressure Reached{% elif match.year == 2018 %}Auto Quest{% elif match.year == 2019 %}Complete Rocket{% elif match.year == 2020 %}Shield Energized{% endif %}">
       <circle cx="2" cy="2" r="2"/>
     </svg>
     {% endif %}
@@ -84,8 +85,9 @@
       or match.score_breakdown.get(alliance_color).rotorRankingPointAchieved
       or match.score_breakdown.get(alliance_color).rotorBonusPoints
       or match.score_breakdown.get(alliance_color).faceTheBossRankingPoint
-      or match.score_breakdown.get(alliance_color).habDockingRankingPoint %}
-    <svg class="top-left-dot-2" rel="tooltip" title="{% if match.year == 2016 %}Tower Captured{% elif match.year == 2017 %}All Rotors Engaged{% elif match.year == 2018 %}Face The Boss{% elif match.year == 2019 %}HAB Docking{% endif %}">
+      or match.score_breakdown.get(alliance_color).habDockingRankingPoint
+      or match.score_breakdown.get(alliance_color).shieldOperationalRankingPoint %}
+    <svg class="top-left-dot-2" rel="tooltip" title="{% if match.year == 2016 %}Tower Captured{% elif match.year == 2017 %}All Rotors Engaged{% elif match.year == 2018 %}Face The Boss{% elif match.year == 2019 %}HAB Docking{% elif match.year == 2020 %}Shield Operational{% endif %}">
       <circle cx="2" cy="2" r="2"/>
     </svg>
     {% endif %}


### PR DESCRIPTION
## Description

- Added derived `tba_shieldEnergizedRankingPointFromFoul` field to indicate whether the shieldEnergizedRankingPoint was earned normally or awarded due to a foul.
- Added 2020 breakdown table

## How Has This Been Tested?
Local dev

## Screenshots (if appropriate):
(scores are fake and may not add up)
![image](https://user-images.githubusercontent.com/1421884/73680083-a1f6ee80-4689-11ea-9123-c4aa3baad426.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
