### PR TITLE
Init Line --> Initiation Line (2020 insights) 

### DIFF
--- a/templates_jinja2/event_partials/event_insights_2020.html
+++ b/templates_jinja2/event_partials/event_insights_2020.html
@@ -12,7 +12,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Exit Init Line</td>
+        <td>Exit Initiation Line</td>
         <td>{{event_insights.exit_init_line_count[0]}}</td>
         <td>{{event_insights.exit_init_line_count[1]}}</td>
         <td>{{'%0.2f' | format(event_insights.exit_init_line_count[2])}}%</td>
@@ -108,7 +108,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Average Init Line Points</td>
+          <td>Average Initiation Line Points</td>
           <td>{{'%0.2f' | format(event_insights.average_init_line_points_auto|float)}}</td>
           <td>--</td>
           <td>--</td>


### PR DESCRIPTION
Changes `Init Line` to `Initiation Line`

## Description
On the 2020 insights page, changes the words "Init Line" to "Initiation Line."

## Motivation and Context
There is enough room for it (some lines are much longer) and it seems clearer to me not to abbreviate it. I know it's trivial, but I checked the discussion on Slack slightly too late to give feedback.

## How Has This Been Tested?
It hasn't. It's just changing some text.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/74600196-e1dfad80-505b-11ea-80ce-d503a1ee67d0.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
