### PR TITLE
Team attribution tooltips

### DIFF
--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -23,38 +23,38 @@
     <tr>
       <td class="red" colspan="2">
         {% if match.score_breakdown.red.initLineRobot1 == 'Exited' %}
-        <span class="glyphicon glyphicon-ok"></span>
+        <span class="glyphicon glyphicon-ok" rel="tooltip" title="{{match.alliances.red.teams.0}}"></span>
         {% else %}
-        <span class="glyphicon glyphicon-remove"></span>
+        <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{match.alliances.red.teams.0}}"></span>
         {% endif %}
         {% if match.score_breakdown.red.initLineRobot2 == 'Exited' %}
-        <span class="glyphicon glyphicon-ok"></span>
+        <span class="glyphicon glyphicon-ok" rel="tooltip" title="{{match.alliances.red.teams.1}}"></span>
         {% else %}
-        <span class="glyphicon glyphicon-remove"></span>
+        <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{match.alliances.red.teams.1}}"></span>
         {% endif %}
         {% if match.score_breakdown.red.initLineRobot3 == 'Exited' %}
-        <span class="glyphicon glyphicon-ok"></span>
+        <span class="glyphicon glyphicon-ok" rel="tooltip" title="{{match.alliances.red.teams.2}}"></span>
         {% else %}
-        <span class="glyphicon glyphicon-remove"></span>
+        <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{match.alliances.red.teams.2}}"></span>
         {% endif %}
         (+{{match.score_breakdown.red.autoInitLinePoints}})
       </td>
       <td>Initiation Line Exited</td>
       <td class="blue" colspan="2">
         {% if match.score_breakdown.blue.initLineRobot1 == 'Exited' %}
-        <span class="glyphicon glyphicon-ok"></span>
+        <span class="glyphicon glyphicon-ok" rel="tooltip" title="{{match.alliances.blue.teams.0}}"></span>
         {% else %}
-        <span class="glyphicon glyphicon-remove"></span>
+        <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{match.alliances.blue.teams.0}}"></span>
         {% endif %}
         {% if match.score_breakdown.blue.initLineRobot2 == 'Exited' %}
-        <span class="glyphicon glyphicon-ok"></span>
+        <span class="glyphicon glyphicon-ok" rel="tooltip" title="{{match.alliances.blue.teams.1}}"></span>
         {% else %}
-        <span class="glyphicon glyphicon-remove"></span>
+        <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{match.alliances.blue.teams.1}}"></span>
         {% endif %}
         {% if match.score_breakdown.blue.initLineRobot3 == 'Exited' %}
-        <span class="glyphicon glyphicon-ok"></span>
+        <span class="glyphicon glyphicon-ok" rel="tooltip" title="{{match.alliances.blue.teams.2}}"></span>
         {% else %}
-        <span class="glyphicon glyphicon-remove"></span>
+        <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{match.alliances.blue.teams.2}}"></span>
         {% endif %}
         (+{{match.score_breakdown.blue.autoInitLinePoints}})
       </td>
@@ -152,7 +152,7 @@
     <!-- Robot 1 Endgame -->
     {% if "endgameRobot1" in match.score_breakdown.red %}
     <tr>
-      <td class="red" colspan="2">
+      <td class="red" colspan="2" rel="tooltip" title="{{match.alliances.red.teams.0}}">
         {% if match.score_breakdown.red.endgameRobot1 == 'Hang' %}
           Hang (+25)
         {% elif match.score_breakdown.red.endgameRobot1 == 'Park' %}
@@ -161,7 +161,7 @@
           <span class="glyphicon glyphicon-remove"></span>
         {% endif %}
       <td>Robot 1 Endgame</td>
-      <td class="blue" colspan="2">
+      <td class="blue" colspan="2" rel="tooltip" title="{{match.alliances.blue.teams.0}}">
         {% if match.score_breakdown.blue.endgameRobot1 == 'Hang' %}
           Hang (+25)
         {% elif match.score_breakdown.blue.endgameRobot1 == 'Park' %}
@@ -175,7 +175,7 @@
     <!-- Robot 2 Endgame -->
     {% if "endgameRobot2" in match.score_breakdown.red %}
     <tr>
-      <td class="red" colspan="2">
+      <td class="red" colspan="2" rel="tooltip" title="{{match.alliances.red.teams.1}}">
         {% if match.score_breakdown.red.endgameRobot2 == 'Hang' %}
           Hang (+25)
         {% elif match.score_breakdown.red.endgameRobot2 == 'Park' %}
@@ -184,7 +184,7 @@
           <span class="glyphicon glyphicon-remove"></span>
         {% endif %}
       <td>Robot 2 Endgame</td>
-      <td class="blue" colspan="2">
+      <td class="blue" colspan="2" rel="tooltip" title="{{match.alliances.blue.teams.1}}">
         {% if match.score_breakdown.blue.endgameRobot2 == 'Hang' %}
           Hang (+25)
         {% elif match.score_breakdown.blue.endgameRobot2 == 'Park' %}
@@ -198,7 +198,7 @@
     <!-- Robot 3 Endgame -->
     {% if "endgameRobot3" in match.score_breakdown.red %}
     <tr>
-      <td class="red" colspan="2">
+      <td class="red" colspan="2" rel="tooltip" title="{{match.alliances.red.teams.2}}">
         {% if match.score_breakdown.red.endgameRobot3 == 'Hang' %}
           Hang (+25)
         {% elif match.score_breakdown.red.endgameRobot3 == 'Park' %}
@@ -207,7 +207,7 @@
           <span class="glyphicon glyphicon-remove"></span>
         {% endif %}
       <td>Robot 3 Endgame</td>
-      <td class="blue" colspan="2">
+      <td class="blue" colspan="2" rel="tooltip" title="{{match.alliances.blue.teams.2}}">
         {% if match.score_breakdown.blue.endgameRobot3 == 'Hang' %}
           Hang (+25)
         {% elif match.score_breakdown.blue.endgameRobot3 == 'Park' %}


### PR DESCRIPTION
Adds tooltips to the 2020 match breakdown.

## Description
On the 2020 match breakdown page, this PR will add tooltips over initiation line and end game actions, attributing it to the teams.


## Motivation and Context
On [Chief](https://www.chiefdelphi.com/t/the-blue-alliance-endgame-data/377891), someone was asking if endgame data was in the order of the schedule (e.g. is "Red Robot 1" the same as "Red 1" on the schedule). I thought it was fairly obvious but also it definitely makes sense to add these tooltips because if someone is scrolled down to the match breakdown, they shouldn't have to scroll back up to the schedule (so much work!).

## How Has This Been Tested?
Inspect element 🤣 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/74679842-ece62b00-518c-11ea-9c35-36f458f08636.png)
![image](https://user-images.githubusercontent.com/22439365/74679902-1606bb80-518d-11ea-9dcd-468402fa5bfe.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
