### PR TITLE
Changes tooltip widths

### DIFF
--- a/subtrees/bootstrap/less/tooltip.less
+++ b/subtrees/bootstrap/less/tooltip.less
@@ -25,6 +25,7 @@
 
 // Wrapper for the tooltip content
 .tooltip-inner {
+  width: 100%;
   max-width: @tooltip-max-width;
   padding: 3px 8px;
   color: @tooltip-color;


### PR DESCRIPTION
Autofit tooltips to size of contents

## Description
Max-width isn't what we're concerned with here. It is the (currently undefined) `width` attribute that, when set to 100%, will fit the size of content.

## Motivation and Context
@gregmarra brought up a good point on #2713.

## How Has This Been Tested

## Screenshots (if appropriate):
#### Current behavior:
![image](https://user-images.githubusercontent.com/22439365/74681151-a5fa3480-5190-11ea-8921-50d78173222c.png)
![image](https://user-images.githubusercontent.com/22439365/74681157-adb9d900-5190-11ea-9bda-84a7910d6134.png)

#### New behavior:
![image](https://user-images.githubusercontent.com/22439365/74681184-bf02e580-5190-11ea-984a-d89162933175.png)
![image](https://user-images.githubusercontent.com/22439365/74681205-cc1fd480-5190-11ea-86b9-200955c1e010.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
