### PR TITLE
Make SVGs transparent

### DIFF
--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -1,18 +1,18 @@
 {% macro drawBottomGoalSVG() %}
 <svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Bottom Goal">
-  <rect x="1" y="5" width="14" height="6" fill="white" stroke="black" stroke-width="2" />
+  <rect x="1" y="5" width="14" height="6" fill="none" stroke="black" stroke-width="2" />
 </svg>
 {% endmacro %}
 
 {% macro drawOuterGoalSVG() %}
 <svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Outer Goal">
-  <path d="M 4.536 2 L 11.464 2 L 14.928 8 L 11.464 14 L 4.536 14 L 1.072 8 Z" fill="white" stroke="black" stroke-width="2"></path>
+  <path d="M 4.536 2 L 11.464 2 L 14.928 8 L 11.464 14 L 4.536 14 L 1.072 8 Z" fill="none" stroke="black" stroke-width="2"></path>
 </svg>
 {% endmacro %}
 
 {% macro drawInnerGoalSVG() %}
 <svg width="16px" height="16px" style="display: inline-block; vertical-align: middle;" rel="tooltip" title="Inner Goal">
-  <circle cx="8" cy="8" r="6" fill="white" stroke="black" stroke-width="2"/>
+  <circle cx="8" cy="8" r="6" fill="none" stroke="black" stroke-width="2"/>
 </svg>
 {% endmacro %}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
2020 match breakdown SVG appearance change

## Description
Changes the fill color of the SVGs from white to none, creating transparency. 


## Motivation and Context
Doesn't match anything by having a white background. Looks a bit weird on the page.

## How Has This Been Tested?
Hasn't.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/74686094-6e928480-519e-11ea-9a81-eb27471707ce.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
