### PR TITLE
Set retry params for cache-clearing and datafeed queues, lower rate

### DIFF
--- a/queue.yaml
+++ b/queue.yaml
@@ -5,7 +5,9 @@ queue:
     task_retry_limit: 0
 
 - name: cache-clearing
-  rate: 5/s
+  rate: 1/s
+  retry_parameters:
+    task_age_limit: 3m
 
 - name: api-track-call
   rate: 500/s
@@ -13,9 +15,9 @@ queue:
     task_retry_limit: 0
 
 - name: datafeed
-  rate: 5/s
+  rate: 1/s
   retry_parameters:
-    task_retry_limit: 0
+    task_age_limit: 1h
 
 - name: firebase
   rate: 50/s

--- a/queue.yaml
+++ b/queue.yaml
@@ -5,9 +5,7 @@ queue:
     task_retry_limit: 0
 
 - name: cache-clearing
-  rate: 1/s
-  retry_parameters:
-    task_age_limit: 3m
+  rate: 5/s
 
 - name: api-track-call
   rate: 500/s


### PR DESCRIPTION
A lot of our datafeed and cache-clearing tasks are failing nightly. This setups up a system to give them a little bit more time to execute, along with executing them slower to try to process more of them successfully