### PR TITLE
Add conditional for 2015+ Team information from FRC API

### DIFF
--- a/templates_jinja2/team_partials/team_info.html
+++ b/templates_jinja2/team_partials/team_info.html
@@ -30,7 +30,9 @@
       {% if team.website %}<span class="glyphicon glyphicon-globe"></span> <a href="{{team.website}}" target="_blank">{{ team.website }}</a><br>{% endif %}
       {% if team.championship_location and team.championship_location[year] %}<span class="glyphicon glyphicon-flag"></span> Home Championship: {{team.championship_location[year]}}<br>{% endif %}
       {% if hof.is_hof %}<span class="hall-of-fame"><span class="glyphicon glyphicon-certificate"></span> Hall of Fame ({% for year in hof.years %}{{ year }}{{ ", " if not loop.last }}{% endfor %}){% if hof.media.video or hof.media.presentation or hof.media.essay %}:{% endif %}{% if hof.media.video %} <a href="{{hof.media.video}}">Video</a>{% endif %}{% if hof.media.presentation %}, <a href="{{hof.media.presentation}}">Presentation</a>{% endif %}{% if hof.media.essay %}, <a href="{{hof.media.essay}}">Essay</a>{% endif %}</span><br>{% endif %}
-      <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank">FIRST Events API</a><br>
+      {% if year %}
+        {% if year >= 2015 %}<span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank">FIRST Events API</a><br>{% endif %}
+      {% endif %}
 
       <hr>
       <a class="btn btn-xs btn-default{% if social_medias %} pull-right{% endif %}" href="/suggest/team/social_media?team_key={{team.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add Social Media!</a>


### PR DESCRIPTION
A small change - it's a little bit weird to click an old team and see the "Data from FRC Events" when we for sure did not get that data for that team from FRC Events (like ~2002 teams or something). This is kinda a middle-ground best effort to only show the link when it's appropriate on a Team page (we do something similar for Events)