### PR TITLE
Catch DeadlineExceededError in webhook request in TBANS, warning log

### DIFF
--- a/models/notifications/requests/webhook_request.py
+++ b/models/notifications/requests/webhook_request.py
@@ -1,3 +1,5 @@
+from google.appengine.api.urlfetch_errors import DeadlineExceededError
+
 from models.notifications.requests.request import Request
 
 
@@ -65,6 +67,8 @@ class WebhookRequest(Request):
         except urllib2.URLError, e:
             valid_url = False
             logging.warning('URLError: ' + str(e.reason))
+        except DeadlineExceededError, ex:
+            logging.warning('Deadline exceeded: {}'.format(str(ex)))
         except Exception, ex:
             logging.error("Other Exception: {}".format(str(ex)))
 

--- a/tests/models_tests/notifications/requests/test_webhook_request.py
+++ b/tests/models_tests/notifications/requests/test_webhook_request.py
@@ -3,6 +3,7 @@ from mock import Mock, patch
 import urllib2
 
 from google.appengine.api import taskqueue
+from google.appengine.api.urlfetch_errors import DeadlineExceededError
 from google.appengine.ext import testbed
 
 from models.notifications.requests.request import Request
@@ -129,6 +130,18 @@ class TestWebhookRequest(unittest2.TestCase):
         mock_urlopen.assert_called_once()
         mock_track.assert_not_called()
         self.assertFalse(success)
+
+    def test_send_fail_deadline_error(self):
+        message = WebhookRequest(MockNotification(webhook_message_data={'data': 'value'}), 'https://www.thebluealliance.com', 'secret')
+
+        error_mock = Mock()
+        error_mock.side_effect = DeadlineExceededError('testing')
+
+        with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
+            success = message.send()
+        mock_urlopen.assert_called_once()
+        mock_track.assert_not_called()
+        self.assertTrue(success)
 
     def test_send_error_other(self):
         message = WebhookRequest(MockNotification(webhook_message_data={'data': 'value'}), 'https://www.thebluealliance.com', 'secret')


### PR DESCRIPTION
Explicitly catch `DeadlineExceededError` so we can emit a warning log instead of an error log to prevent alerting on non-actionable issues for webhooks. GAE has several `DeadlineExceededError`, but I think this is the right one to catch. We'll know if we get alerted again, and we can fix accordingly.