### PR TITLE
Revert deadline exceeded catch, log error class for uncaught errors

### DIFF
--- a/models/notifications/requests/webhook_request.py
+++ b/models/notifications/requests/webhook_request.py
@@ -1,5 +1,3 @@
-from google.appengine.api.urlfetch_errors import DeadlineExceededError
-
 from models.notifications.requests.request import Request
 
 
@@ -67,8 +65,6 @@ class WebhookRequest(Request):
         except urllib2.URLError, e:
             valid_url = False
             logging.warning('URLError: ' + str(e.reason))
-        except DeadlineExceededError, ex:
-            logging.warning('Deadline exceeded: {}'.format(str(ex)))
         except Exception, ex:
             logging.error("Other Exception: {}".format(str(ex)))
 

--- a/models/notifications/requests/webhook_request.py
+++ b/models/notifications/requests/webhook_request.py
@@ -66,7 +66,7 @@ class WebhookRequest(Request):
             valid_url = False
             logging.warning('URLError: ' + str(e.reason))
         except Exception, ex:
-            logging.error("Other Exception: {}".format(str(ex)))
+            logging.error("Other Exception: ({}) {}".format(ex.__class__.__name__, str(ex)))
 
         return valid_url
 

--- a/tests/models_tests/notifications/requests/test_webhook_request.py
+++ b/tests/models_tests/notifications/requests/test_webhook_request.py
@@ -3,7 +3,6 @@ from mock import Mock, patch
 import urllib2
 
 from google.appengine.api import taskqueue
-from google.appengine.api.urlfetch_errors import DeadlineExceededError
 from google.appengine.ext import testbed
 
 from models.notifications.requests.request import Request
@@ -130,18 +129,6 @@ class TestWebhookRequest(unittest2.TestCase):
         mock_urlopen.assert_called_once()
         mock_track.assert_not_called()
         self.assertFalse(success)
-
-    def test_send_fail_deadline_error(self):
-        message = WebhookRequest(MockNotification(webhook_message_data={'data': 'value'}), 'https://www.thebluealliance.com', 'secret')
-
-        error_mock = Mock()
-        error_mock.side_effect = DeadlineExceededError('testing')
-
-        with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
-            success = message.send()
-        mock_urlopen.assert_called_once()
-        mock_track.assert_not_called()
-        self.assertTrue(success)
 
     def test_send_error_other(self):
         message = WebhookRequest(MockNotification(webhook_message_data={'data': 'value'}), 'https://www.thebluealliance.com', 'secret')


### PR DESCRIPTION
It looks like https://github.com/the-blue-alliance/the-blue-alliance/pull/2722 didn't work - going to revert that commit and add some logging so we can try to track down exactly what exception is getting thrown that we're not catching