### PR TITLE
Adds "none" to activation stages

### DIFF
--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -264,11 +264,11 @@
     {% if "stage1Activated" in match.score_breakdown.red %}
     <tr>
       <td class="red" colspan="2">
-        {% if match.score_breakdown.red.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.red.stage2Activated %}2{% elif match.score_breakdown.red.stage1Activated %}1{% else %}None{% endif %}
+        {% if match.score_breakdown.red.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.red.stage2Activated %}2{% elif match.score_breakdown.red.stage1Activated %}1{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
       </td>
       <td>Stage Activations</td>
       <td class="blue" colspan="2">
-        {% if match.score_breakdown.blue.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.blue.stage2Activated %}2{% elif match.score_breakdown.blue.stage1Activated %}1{% else %}None{% endif %}
+        {% if match.score_breakdown.blue.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.blue.stage2Activated %}2{% elif match.score_breakdown.blue.stage1Activated %}1{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
 
       </td>
     </tr>

--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -264,11 +264,11 @@
     {% if "stage1Activated" in match.score_breakdown.red %}
     <tr>
       <td class="red" colspan="2">
-        {% if match.score_breakdown.red.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.red.stage2Activated %}2{% elif match.score_breakdown.red.stage1Activated %}1{% endif %}
+        {% if match.score_breakdown.red.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.red.stage2Activated %}2{% elif match.score_breakdown.red.stage1Activated %}1{% else %}None{% endif %}
       </td>
       <td>Stage Activations</td>
       <td class="blue" colspan="2">
-        {% if match.score_breakdown.blue.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.blue.stage2Activated %}2{% elif match.score_breakdown.blue.stage1Activated %}1{% endif %}
+        {% if match.score_breakdown.blue.stage3Activated %}3 (+1 RP){% elif match.score_breakdown.blue.stage2Activated %}2{% elif match.score_breakdown.blue.stage1Activated %}1{% else %}None{% endif %}
 
       </td>
     </tr>


### PR DESCRIPTION
## Description
On the 2020 Match Breakdown, adds a "none" option if no stages were activated. Currently, the cell is blank unless stages 1, 2, or 3 are activated.

## Motivation and Context
The match breakdown without stage activation data looks kind of empty/missing.

## How Has This Been Tested?
Hasn't. And I probably screwed up by trying to code again.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/74901801-f67cb800-5371-11ea-91f2-955d57fead6e.png)
![image](https://user-images.githubusercontent.com/22439365/74901837-1613e080-5372-11ea-8dbc-faf992f54c5f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
