### PR TITLE
Add <abbr> tags to "OPR"

### DIFF
--- a/templates_jinja2/event_partials/event_opr_table.html
+++ b/templates_jinja2/event_partials/event_opr_table.html
@@ -1,10 +1,10 @@
 {% if oprs|length > 0 %}
-  <h3>OPRs - Top 15 (<a href="/opr">?</a>)</h3>
+<h3><abbr title="Offensive Power Rankings">OPRs</abbr> - Top 15 (<a href="/opr">?</a>)</h3>
   <table class="table table-condensed table-striped table-center">
     <thead>
       <tr>
         <th>Team</th>
-        <th>OPR</th>
+        <th><abbr title="Offensive Power Ranking">OPR</abbr></th>
       </tr>
     </thead>
     <tbody>

--- a/templates_jinja2/event_partials/event_opr_table.html
+++ b/templates_jinja2/event_partials/event_opr_table.html
@@ -1,10 +1,10 @@
 {% if oprs|length > 0 %}
-<h3><abbr title="Offensive Power Rankings">OPRs</abbr> - Top 15 (<a href="/opr">?</a>)</h3>
+<h3><abbr title="Offensive Power Ratings">OPRs</abbr> - Top 15 (<a href="/opr">?</a>)</h3>
   <table class="table table-condensed table-striped table-center">
     <thead>
       <tr>
         <th>Team</th>
-        <th><abbr title="Offensive Power Ranking">OPR</abbr></th>
+        <th><abbr title="Offensive Power Rating">OPR</abbr></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Description
On the event insights page, adds `<abbr>` tags to "OPR(s)" spelling out "Offensive Power Ranking(s)."

## Motivation and Context
Sometimes you just want to know what it stands for and don't want to click the `?` and visit the `/opr` explanation page. Also #190 (found while searching for something else), lol.

## How Has This Been Tested?
Hasn't.

## Screenshots (if appropriate):
Cursor isn't in the screenshot but this is what happens when you mouse over the underlined portions.
![image](https://user-images.githubusercontent.com/22439365/74981689-b6b0e180-5400-11ea-8c0c-647ecd8f388b.png)
![image](https://user-images.githubusercontent.com/22439365/74981724-c5979400-5400-11ea-9bf3-2c75bf7f095f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
