### PR TITLE
Redirect /blog to blog.tba.com

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,6 +98,7 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/apiwrite', ApiWriteHandler, 'api-write', strict_slash=True),
       RedirectRoute(r'/avatars/<year:[0-9]+>', AvatarsHandler, 'avatars', strict_slash=True),
       RedirectRoute(r'/bigquery', redirect_to='https://console.cloud.google.com/bigquery?project=tbatv-prod-hrd&p=tbatv-prod-hrd&d=the_blue_alliance&page=dataset'),
+      RedirectRoute(r'/blog', redirect_to='https://blog.thebluealliance.com'),
       RedirectRoute(r'/contact', ContactHandler, 'contact', strict_slash=True),
       RedirectRoute(r'/event/<event_key>', EventDetail, 'event-detail', strict_slash=True),
       RedirectRoute(r'/event/<event_key>/insights', EventInsights, 'event-insights', strict_slash=True),


### PR DESCRIPTION
## Description
Redirects [thebluealliance.com/blog](https://thebluealliance.com/blog) to [blog.thebluealliance.com](https://blog.thebluealliance.com).

## Motivation and Context
I tried to go to `/blog`, assuming it would redirect. It 404'd. I don't have access to data to know if other people do this, but it would be nice at virtually no risk/cost to us.

## How Has This Been Tested?
Hasn't - followed template of other external redirects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
