### PR TITLE
Another tooltip fix

### DIFF
--- a/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
+++ b/templates_jinja2/match_partials/match_breakdown/match_breakdown_2020.html
@@ -152,22 +152,22 @@
     <!-- Robot 1 Endgame -->
     {% if "endgameRobot1" in match.score_breakdown.red %}
     <tr>
-      <td class="red" colspan="2" rel="tooltip" title="{{match.alliances.red.teams.0|digits}}">
+      <td class="red" colspan="2">
         {% if match.score_breakdown.red.endgameRobot1 == 'Hang' %}
-          Hang (+25)
+          <span rel="tooltip" title="{{match.alliances.red.teams.0|digits}}">Hang (+25)</span>
         {% elif match.score_breakdown.red.endgameRobot1 == 'Park' %}
-          Park (+5)
+          <span rel="tooltip" title="{{match.alliances.red.teams.0|digits}}">Park (+5)</span>
         {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
+          <span rel="tooltip" title="{{match.alliances.red.teams.0|digits}}" class="glyphicon glyphicon-remove"></span>
         {% endif %}
       <td>Robot 1 Endgame</td>
-      <td class="blue" colspan="2" rel="tooltip" title="{{match.alliances.blue.teams.0|digits}}">
+      <td class="blue" colspan="2">
         {% if match.score_breakdown.blue.endgameRobot1 == 'Hang' %}
-          Hang (+25)
+          <span rel="tooltip" title="{{match.alliances.blue.teams.0|digits}}">Hang (+25)</span>
         {% elif match.score_breakdown.blue.endgameRobot1 == 'Park' %}
-          Park (+5)
+          <span rel="tooltip" title="{{match.alliances.blue.teams.0|digits}}">Park (+5)</span>
         {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
+          <span rel="tooltip" title="{{match.alliances.blue.teams.0|digits}}" class="glyphicon glyphicon-remove"></span>
         {% endif %}
       </td>
     </tr>
@@ -175,22 +175,22 @@
     <!-- Robot 2 Endgame -->
     {% if "endgameRobot2" in match.score_breakdown.red %}
     <tr>
-      <td class="red" colspan="2" rel="tooltip" title="{{match.alliances.red.teams.1|digits}}">
+      <td class="red" colspan="2">
         {% if match.score_breakdown.red.endgameRobot2 == 'Hang' %}
-          Hang (+25)
+          <span rel="tooltip" title="{{match.alliances.red.teams.1|digits}}">Hang (+25)</span>
         {% elif match.score_breakdown.red.endgameRobot2 == 'Park' %}
-          Park (+5)
+          <span rel="tooltip" title="{{match.alliances.red.teams.1|digits}}">Park (+5)</span>
         {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
+          <span rel="tooltip" title="{{match.alliances.red.teams.1|digits}}" class="glyphicon glyphicon-remove"></span>
         {% endif %}
       <td>Robot 2 Endgame</td>
-      <td class="blue" colspan="2" rel="tooltip" title="{{match.alliances.blue.teams.1|digits}}">
+      <td class="blue" colspan="2">
         {% if match.score_breakdown.blue.endgameRobot2 == 'Hang' %}
-          Hang (+25)
+          <span rel="tooltip" title="{{match.alliances.blue.teams.1|digits}}">Hang (+25)</span>
         {% elif match.score_breakdown.blue.endgameRobot2 == 'Park' %}
-          Park (+5)
+          <span rel="tooltip" title="{{match.alliances.blue.teams.1|digits}}">Park (+5)</span>
         {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
+          <span rel="tooltip" title="{{match.alliances.blue.teams.1|digits}}" class="glyphicon glyphicon-remove"></span>
         {% endif %}
       </td>
     </tr>
@@ -198,22 +198,22 @@
     <!-- Robot 3 Endgame -->
     {% if "endgameRobot3" in match.score_breakdown.red %}
     <tr>
-      <td class="red" colspan="2" rel="tooltip" title="{{match.alliances.red.teams.2|digits}}">
+      <td class="red" colspan="2">
         {% if match.score_breakdown.red.endgameRobot3 == 'Hang' %}
-          Hang (+25)
+          <span rel="tooltip" title="{{match.alliances.red.teams.2|digits}}">Hang (+25)</span>
         {% elif match.score_breakdown.red.endgameRobot3 == 'Park' %}
-          Park (+5)
+          <span rel="tooltip" title="{{match.alliances.red.teams.2|digits}}">Park (+5)</span>
         {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
+          <span rel="tooltip" title="{{match.alliances.red.teams.2|digits}}" class="glyphicon glyphicon-remove"></span>
         {% endif %}
       <td>Robot 3 Endgame</td>
-      <td class="blue" colspan="2" rel="tooltip" title="{{match.alliances.blue.teams.2|digits}}">
+      <td class="blue" colspan="2">
         {% if match.score_breakdown.blue.endgameRobot3 == 'Hang' %}
-          Hang (+25)
+          <span rel="tooltip" title="{{match.alliances.blue.teams.2|digits}}">Hang (+25)</span>
         {% elif match.score_breakdown.blue.endgameRobot3 == 'Park' %}
-          Park (+5)
+          <span rel="tooltip" title="{{match.alliances.blue.teams.2|digits}}">Park (+5)</span>
         {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
+          <span rel="tooltip" title="{{match.alliances.blue.teams.2|digits}}" class="glyphicon glyphicon-remove"></span>
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Description
On the 2020 match breakdown, there is currently a bug caused by the new tooltips. When hovering over red end game, the content shifts over one `<td>`. When I originally created these tooltips in #2713, I added `rel="tooltip" title=team_number` to the entire `<td>` out of laziness and to make the code shorter. That is what causes the glitch.

This PR instead wraps each of the possible contents of the cell in their own `<span>` tags and adds `rel="tooltip" title=team_number` to each of them. Also, the glyphicon representing no action is already in a `<span>` so this just adds the tooltip attributes to it.

## Motivation and Context
Closes #2732

## How Has This Been Tested?
Inspect. Element. As. Always.

## Screenshots (if appropriate):
See #2732 for current behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
