### PR TITLE
Fix event links on competition season homepage

### DIFF
--- a/templates_jinja2/index/index_competitionseason.html
+++ b/templates_jinja2/index/index_competitionseason.html
@@ -66,7 +66,7 @@
                           </div>
                         </div>
                       </td>
-                      <td><a href="/event/{{event.key.id}}">{{event.name}}</a></td>
+                      <td><a href="/event/{{ event.key_name }}">{{event.name}}</a></td>
                     </tr>
                     {% endfor %}
                   </tbody>


### PR DESCRIPTION
This changes the links from being ndb Keys to event name