### PR TITLE
Third attempt at catching deadline exceeded errors from webhooks

### DIFF
--- a/models/notifications/requests/webhook_request.py
+++ b/models/notifications/requests/webhook_request.py
@@ -1,5 +1,3 @@
-from google.appengine.runtime import DeadlineExceededError
-
 from models.notifications.requests.request import Request
 
 
@@ -67,10 +65,11 @@ class WebhookRequest(Request):
         except urllib2.URLError, e:
             valid_url = False
             logging.warning('URLError: ' + str(e.reason))
-        except DeadlineExceededError, ex:
-            logging.warning('Deadline exceeded: {}'.format(str(ex)))
         except Exception, ex:
-            logging.error("Other Exception: {}".format(str(ex)))
+            if 'Deadline exceeded' in str(ex):
+                logging.warning('Deadline exceeded: {}'.format(str(ex)))
+            else:
+                logging.error("Other Exception ({}): {}".format(ex.__class__.__name__, str(ex)))
 
         return valid_url
 

--- a/tests/models_tests/notifications/requests/test_webhook_request.py
+++ b/tests/models_tests/notifications/requests/test_webhook_request.py
@@ -4,7 +4,6 @@ import urllib2
 
 from google.appengine.api import taskqueue
 from google.appengine.ext import testbed
-from google.appengine.runtime import DeadlineExceededError
 
 from models.notifications.requests.request import Request
 from models.notifications.requests.webhook_request import WebhookRequest
@@ -135,7 +134,7 @@ class TestWebhookRequest(unittest2.TestCase):
         message = WebhookRequest(MockNotification(webhook_message_data={'data': 'value'}), 'https://www.thebluealliance.com', 'secret')
 
         error_mock = Mock()
-        error_mock.side_effect = DeadlineExceededError('testing')
+        error_mock.side_effect = Exception('Deadline exceeded while waiting for HTTP response from URL: https://thebluealliance.com')
 
         with patch.object(urllib2, 'urlopen', error_mock) as mock_urlopen, patch.object(message, 'defer_track_notification') as mock_track:
             success = message.send()


### PR DESCRIPTION
Okay - re: [this question](https://stackoverflow.com/questions/26106358/httpexception-deadline-exceeded-while-waiting-for-http-response-from-url) - it looks like the stack trace for this exception (in `gae_override/httplib.py`) is catching our timeout from `urllib2` and throwing a pretty generic `HTTPException`, which is why catching those deadline exceeded exceptions isn't working.

The original answer seems promising, where setting an explicit deadline will work. We need to make sure GAE doesn't timeout our request though (10s?). Catching this in a kinda dumb way will fix our error logs while I work on a proper fix.