### PR TITLE
Add support for 2020 playoff tiebreakers

### DIFF
--- a/helpers/match_helper.py
+++ b/helpers/match_helper.py
@@ -394,6 +394,34 @@ class MatchHelper(object):
                 tiebreakers.append((red_breakdown['sandStormBonusPoints'], blue_breakdown['sandStormBonusPoints']))
             else:
                 tiebreakers.append(None)
+        elif match.year == 2020 and not (match.comp_level == 'f' and match.match_number <= 3):  # Finals can't be tiebroken. Only overtime
+            # Cumulative FOUL and TECH FOUL points due to opponent rule violations
+            if 'foulPoints' in red_breakdown and 'foulPoints' in blue_breakdown:
+                tiebreakers.append((red_breakdown['foulPoints'], blue_breakdown['foulPoints']))
+            else:
+                tiebreakers.append(None)
+
+            # Cumulative AUTO points
+            if 'autoPoints' in red_breakdown and 'autoPoints' in blue_breakdown:
+                tiebreakers.append((red_breakdown['autoPoints'], blue_breakdown['autoPoints']))
+            else:
+                tiebreakers.append(None)
+
+            # Cumulative ENDGAME points
+            if 'endgamePoints' in red_breakdown and 'endgamePoints' in blue_breakdown:
+                tiebreakers.append((red_breakdown['endgamePoints'], blue_breakdown['endgamePoints']))
+            else:
+                tiebreakers.append(None)
+
+            # Cumulative TELEOP POWER CELL and CONTROL PANEL points
+            if 'teleopCellPoints' in red_breakdown and 'teleopCellPoints' in blue_breakdown and \
+                    'controlPanelPoints' in red_breakdown and 'controlPanelPoints' in blue_breakdown:
+                tiebreakers.append((
+                    red_breakdown['teleopCellPoints'] + red_breakdown['controlPanelPoints'],
+                    blue_breakdown['teleopCellPoints'] + blue_breakdown['controlPanelPoints'],
+                ))
+            else:
+                tiebreakers.append(None)
 
         for tiebreaker in tiebreakers:
             if tiebreaker is None:


### PR DESCRIPTION
## Description
This adds support for 2020 playoff tiebreakers as described in https://firstfrc.blob.core.windows.net/frc2020/Manual/HTML/2020FRCGameSeasonManual.htm#PlayoffMatchesSection

## Motivation and Context
Fixes #2738. 2020isde1_qf2m2 was treated as a tie by TBA, so the playoff schedule and bracket for that event aren't being calculated correctly.

![image](https://user-images.githubusercontent.com/3719547/75305108-25cc7280-5813-11ea-821e-8522db3d6124.png)

![image](https://user-images.githubusercontent.com/3719547/75305119-2e24ad80-5813-11ea-8c6d-d5c291ce3ab0.png)


## How Has This Been Tested?
Local instance. Haven't tested all tiebreakers, but the field names should be right (copied from the breakdown JSON for that match). Breakdown contains `  "winning_alliance": "blue"`

![image](https://user-images.githubusercontent.com/3719547/75305153-4a284f00-5813-11ea-8a82-8e85e1fc3d52.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
