### PR TITLE
Calculate Event weeks starting from beginning of competition season

### DIFF
--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -188,13 +188,8 @@ class EventHelper(object):
 
         events = []
 
-        days_diff = 0
-        # Before 2020, event weeks start on Wednesdays
-        if today.year < 2020:
-            days_diff = 2  # 2 is Wednesday. diff_from_week_start ranges from 3 to -3 (Monday thru Sunday)
-        diff_from_week_start = days_diff - today.weekday()
-        # Pre-2020 this is going to be a Wednesday. Post-2020 this is going to be a Monday
-        closest_start_weekday = today + datetime.timedelta(days=diff_from_week_start)
+        diff_from_week_start = 0 - today.weekday()
+        closest_start_monday = today + datetime.timedelta(days=diff_from_week_start)
 
         two_weeks_of_event_futures = ndb.get_multi_async(two_weeks_of_events_keys_future.get_result())
         for event_future in two_weeks_of_event_futures:
@@ -202,7 +197,7 @@ class EventHelper(object):
             if event.within_a_day:
                 events.append(event)
             else:
-                offset = event.start_date.date() - closest_start_weekday.date()
+                offset = event.start_date.date() - closest_start_monday.date()
                 if (offset == datetime.timedelta(0)) or (offset > datetime.timedelta(0) and offset < datetime.timedelta(weeks=1)):
                     events.append(event)
 

--- a/helpers/season_helper.py
+++ b/helpers/season_helper.py
@@ -4,7 +4,6 @@ from google.appengine.ext import ndb
 from pytz import timezone, UTC
 
 from consts.event_type import EventType
-from database import event_query
 from models.event import Event
 
 
@@ -68,6 +67,7 @@ class SeasonHelper:
     @staticmethod
     def first_event_datetime_utc(year=datetime.now().year):
         """ Computes day the first in-season event begins """
+        from database import event_query
         events = event_query.EventListQuery(year).fetch()
         earliest_start = None
         timezone = None
@@ -76,3 +76,28 @@ class SeasonHelper:
                 earliest_start = event.start_date
                 timezone = event.timezone_id
         return earliest_start
+
+    @staticmethod
+    def stop_build_datetime_est(year=datetime.now().year):
+        """ Computes day teams are done working on robots. The stop build day is kickoff + 6 weeks + 3 days. Set to 23:59:59 """
+        stop_build_date = datetime.combine(SeasonHelper.kickoff_datetime_est(year).date() + timedelta(days=4, weeks=6), datetime.min.time()) - timedelta(seconds=1)
+        return EST.localize(stop_build_date)  # Make our timezone unaware datetime timezone aware
+
+    @staticmethod
+    def stop_build_datetime_utc(year=datetime.now().year):
+        """ Converts stop_build_date to a UTC datetime """
+        return SeasonHelper.stop_build_datetime_est(year).astimezone(UTC)
+
+    @staticmethod
+    def competition_season_start_date(year=datetime.now().year):
+        """
+        Computes the day competition season starts. Competition season starts the Monday after stop build.
+        Since this is a date, and not a datetime, there is no timezone associated with this date.
+        """
+        stop_build_datetime = SeasonHelper.stop_build_datetime_utc(year=year).date()
+        # Find the next Monday after stop_build_datetime via some clever Python datetime nonsense
+        # Pre-2018, TBA considers Week starts to be on Wednesday. 2018 and onward, we consider Monday the Week start
+        if year < 2018:
+            # + 2 moves us from the first-Monday after to the first Wednesday after.
+            return stop_build_datetime + timedelta(days=(7 - stop_build_datetime.weekday() + 2))
+        return stop_build_datetime + timedelta(days=(7 - stop_build_datetime.weekday()))

--- a/tests/test_season_helper.py
+++ b/tests/test_season_helper.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from pytz import timezone, UTC
 import unittest2
 
@@ -118,3 +118,42 @@ class TestSeasonHelper(unittest2.TestCase):
         kickoff_2009_utc = kickoff_2009.astimezone(UTC)
         self.assertEqual(SeasonHelper.kickoff_datetime_est(year=2009), kickoff_2009)
         self.assertEqual(SeasonHelper.kickoff_datetime_utc(year=2009), kickoff_2009_utc)
+
+    def test_stop_build_date(self):
+        # 2019 - Feb 19th, 2019
+        stop_build_2019 = datetime(2019, 2, 19, 23, 59, 59, tzinfo=timezone('EST'))
+        stop_build_2019_utc = stop_build_2019.astimezone(UTC)
+        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2019), stop_build_2019)
+        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2019), stop_build_2019_utc)
+        # 2018 - Feb 20th, 2018
+        stop_build_2018 = datetime(2018, 2, 20, 23, 59, 59, tzinfo=timezone('EST'))
+        stop_build_2018_utc = stop_build_2018.astimezone(UTC)
+        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2018), stop_build_2018)
+        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2018), stop_build_2018_utc)
+        # 2017 - Feb 21th, 2017
+        stop_build_2017 = datetime(2017, 2, 21, 23, 59, 59, tzinfo=timezone('EST'))
+        stop_build_2017_utc = stop_build_2017.astimezone(UTC)
+        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2017), stop_build_2017)
+        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2017), stop_build_2017_utc)
+        # 2016 - Feb 23th, 2016
+        stop_build_2016 = datetime(2016, 2, 23, 23, 59, 59, tzinfo=timezone('EST'))
+        stop_build_2016_utc = stop_build_2016.astimezone(UTC)
+        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2016), stop_build_2016)
+        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2016), stop_build_2016_utc)
+
+    def test_competition_season_start_date(self):
+        # 2020 - Feb 24th, 2020
+        comp_season_2020 = date(2020, 2, 24)
+        self.assertEqual(SeasonHelper.competition_season_start_date(year=2020), comp_season_2020)
+        # 2019 - Feb 25th, 2019
+        comp_season_2019 = date(2019, 2, 25)
+        self.assertEqual(SeasonHelper.competition_season_start_date(year=2019), comp_season_2019)
+        # 2018 - Feb 26th, 2018
+        comp_season_2018 = date(2018, 2, 26)
+        self.assertEqual(SeasonHelper.competition_season_start_date(year=2018), comp_season_2018)
+        # 2017 - Mar 1st, 2017
+        comp_season_2017 = date(2017, 3, 1)
+        self.assertEqual(SeasonHelper.competition_season_start_date(year=2017), comp_season_2017)
+        # 2016 - Mar 2nd, 2016
+        comp_season_2016 = date(2016, 3, 2)
+        self.assertEqual(SeasonHelper.competition_season_start_date(year=2016), comp_season_2016)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change calculates weeks for events starting on the first day of the competition season, moving forward. We consider the first day of competition season to be the first Monday after stop build day for 2018+. Pre-2018, we consider the first *Wednesday* after stop build day to be the first day of competition season.

2016 is special-cased in order to support `2016scmb` being Week 0.5. Official events that start before the first day of competition season are rounded up to start during the first week of competition season. This should also fix some event weeks being wrong in 2019/2018 (closes #2454).

tl;dr - `SeasonHelper` has a new `competition_season_start_date` which calculates the start date for a given season. Event weeks are determined based on their offset from this day.

## Motivation and Context
Our week sorting is broken for 2020, since we have one event (`2020isde1`) that starts on its own week just before the official competition season start (season start is Feb 24th, this even starts on Feb 23rd). Since we calculate event weeks based on the first event, all event weeks are off-by-one.

<img width="1267" alt="Screen Shot 2020-02-26 at 1 32 42 PM" src="https://user-images.githubusercontent.com/516458/75375835-ec404980-589c-11ea-9f83-4e473494e2fa.png">

With this change, this event week gets rounded to Week 1, since it's an official event that happens before the season starts.

## How Has This Been Tested?
This has been tested for all events in 2020, 2019, 2018, 2017, and 2016. For all events in 2020-2017, week numbers match up with what's on prod and what FRC Events shows.

<img width="1191" alt="Screen Shot 2020-02-26 at 12 43 09 PM" src="https://user-images.githubusercontent.com/516458/75375910-15f97080-589d-11ea-9f7d-fc7de9ed0404.png">

For 2016, we still consider `2016scmb` a Week 0.5 event and offset other events accordingly, which matches prod. Other than that one difference, all weeks are labeled in a way that matches FRC Events.

<img width="1252" alt="Screen Shot 2020-02-26 at 1 37 43 PM" src="https://user-images.githubusercontent.com/516458/75375994-3f1a0100-589d-11ea-86bc-7835c68499f2.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)