### PR TITLE
Lower `push-notifications` queue rate

### DIFF
--- a/queue.yaml
+++ b/queue.yaml
@@ -24,7 +24,7 @@ queue:
   rate: 5/s
 
 - name: push-notifications
-  rate: 100/s
+  rate: 2/s
   retry_parameters:
     task_age_limit: 3m
     min_backoff_seconds: 10


### PR DESCRIPTION
We're seeing timeouts when approving a lot of match videos - my guess is once we hit prime time where a lot of events are going on we're going to get slammed with notifications and they'll start timing out. This lowers the queue rate in an attempt to fix that.

We might slowly start bringing this back up as weeks go on, if we notice the queue isn't draining fast enough (we have a monitoring dashboard for this).