### PR TITLE
Adds "in your timezone" verbiage

### DIFF
--- a/templates_jinja2/event_details.html
+++ b/templates_jinja2/event_details.html
@@ -208,7 +208,7 @@
       </div>
       <div class="row">
         <div class="col-sm-12">
-          {% if has_time_predictions %}<p>Match times listed with a <em>*</em> are unofficial predicted times computed by The Blue Alliance for your convenience.</p>{% endif %}
+          {% if has_time_predictions %}<p>Match times listed with a <em>*</em> are unofficial predicted times in your timezone computed by The Blue Alliance for your convenience.</p>{% endif %}
           <p><a class="btn btn-default" href="/suggest/event/video?event_key={{event.key_name}}"><span class="glyphicon glyphicon-upload"></span> Tell us about YouTube videos</a></p>
           <p><a class="btn btn-default" href="/event/{{ event.key_name }}/feed"><span class="glyphicon glyphicon-barcode"></span> Matches in RSS</a></p>
         </div>


### PR DESCRIPTION
## Description
Adds "in your timezone" to the verbiage about predicted times on the event details page.

## Motivation and Context
Sometimes, it is obvious that they are in local time (e.g. upcoming Israel matches at 4:00 am are obviously in my timezone rather than event) but other times it is somewhat of an unknown (think mid-day matches looking between Eastern and Pacific). Knowing that these times are automatically converted is an easy, and I believe helpful, factoid.

## How Has This Been Tested?
Hasn't.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/75406237-fa628a00-58dd-11ea-9fd4-175a6a942362.png)
![image](https://user-images.githubusercontent.com/22439365/75406253-05b5b580-58de-11ea-9b95-d28b91a53ca9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
