### PR TITLE
Assign week numbers using the closest season start weekday (closest Monday/Wednesday) to the first event

### DIFF
--- a/database/event_query.py
+++ b/database/event_query.py
@@ -10,7 +10,7 @@ from models.team import Team
 
 
 class EventQuery(DatabaseQuery):
-    CACHE_VERSION = 2
+    CACHE_VERSION = 3
     CACHE_KEY_FORMAT = 'event_{}'  # (event_key)
     DICT_CONVERTER = EventConverter
 
@@ -22,7 +22,7 @@ class EventQuery(DatabaseQuery):
 
 
 class EventListQuery(DatabaseQuery):
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
     CACHE_KEY_FORMAT = 'event_list_{}'  # (year)
     DICT_CONVERTER = EventConverter
 
@@ -34,7 +34,7 @@ class EventListQuery(DatabaseQuery):
 
 
 class DistrictEventsQuery(DatabaseQuery):
-    CACHE_VERSION = 4
+    CACHE_VERSION = 5
     CACHE_KEY_FORMAT = 'district_events_{}'  # (district_key)
     DICT_CONVERTER = EventConverter
 
@@ -47,7 +47,7 @@ class DistrictEventsQuery(DatabaseQuery):
 
 
 class TeamEventsQuery(DatabaseQuery):
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
     CACHE_KEY_FORMAT = 'team_events_{}'  # (team_key)
     DICT_CONVERTER = EventConverter
 
@@ -61,7 +61,7 @@ class TeamEventsQuery(DatabaseQuery):
 
 
 class TeamYearEventsQuery(DatabaseQuery):
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
     CACHE_KEY_FORMAT = 'team_year_events_{}_{}'  # (team_key, year)
     DICT_CONVERTER = EventConverter
 
@@ -78,7 +78,7 @@ class TeamYearEventsQuery(DatabaseQuery):
 
 
 class TeamYearEventTeamsQuery(DatabaseQuery):
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
     CACHE_KEY_FORMAT = 'team_year_eventteams_{}_{}'  # (team_key, year)
 
     @ndb.tasklet
@@ -92,7 +92,7 @@ class TeamYearEventTeamsQuery(DatabaseQuery):
 
 
 class EventDivisionsQuery(DatabaseQuery):
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
     CACHE_KEY_FORMAT = "event_divisions_{}"  # (event_key)
     DICT_CONVERTER = EventConverter
 

--- a/helpers/season_helper.py
+++ b/helpers/season_helper.py
@@ -76,28 +76,3 @@ class SeasonHelper:
                 earliest_start = event.start_date
                 timezone = event.timezone_id
         return earliest_start
-
-    @staticmethod
-    def stop_build_datetime_est(year=datetime.now().year):
-        """ Computes day teams are done working on robots. The stop build day is kickoff + 6 weeks + 3 days. Set to 23:59:59 """
-        stop_build_date = datetime.combine(SeasonHelper.kickoff_datetime_est(year).date() + timedelta(days=4, weeks=6), datetime.min.time()) - timedelta(seconds=1)
-        return EST.localize(stop_build_date)  # Make our timezone unaware datetime timezone aware
-
-    @staticmethod
-    def stop_build_datetime_utc(year=datetime.now().year):
-        """ Converts stop_build_date to a UTC datetime """
-        return SeasonHelper.stop_build_datetime_est(year).astimezone(UTC)
-
-    @staticmethod
-    def competition_season_start_date(year=datetime.now().year):
-        """
-        Computes the day competition season starts. Competition season starts the Monday after stop build.
-        Since this is a date, and not a datetime, there is no timezone associated with this date.
-        """
-        stop_build_datetime = SeasonHelper.stop_build_datetime_utc(year=year).date()
-        # Find the next Monday after stop_build_datetime via some clever Python datetime nonsense
-        # Pre-2018, TBA considers Week starts to be on Wednesday. 2018 and onward, we consider Monday the Week start
-        if year < 2018:
-            # + 2 moves us from the first-Monday after to the first Wednesday after.
-            return stop_build_datetime + timedelta(days=(7 - stop_build_datetime.weekday() + 2))
-        return stop_build_datetime + timedelta(days=(7 - stop_build_datetime.weekday()))

--- a/models/event.py
+++ b/models/event.py
@@ -224,7 +224,7 @@ class Event(ndb.Model):
     @property
     def week(self):
         """
-        Returns the week of the event relative to the start of the season
+        Returns the week of the event relative to the first official season event as an integer
         Returns None if the event is not of type NON_CMP_EVENT_TYPES or is not official
         """
         if self.event_type_enum not in EventType.NON_CMP_EVENT_TYPES or not self.official:
@@ -233,16 +233,36 @@ class Event(ndb.Model):
         if self._week:
             return self._week
 
-        from helpers.season_helper import SeasonHelper
-        competition_season_start_date = SeasonHelper.competition_season_start_date(year=self.year)
-        # Find the # of weeks this event occurs after the season start
-        day_diff = self.start_date.date() - competition_season_start_date
-        if self.year == 2016:
-            # In 2016, bump all weeks forward one. `2016scmb` sets our `0` (Week 0.5), which occurs before the season officially starts
-            self._week = max((day_diff.days / 7) + 1, 0)
-        else:
-            # Round official events that start before week one (2020isde1) to Week 1
-            self._week = max(day_diff.days / 7, 0)
+        # Cache week_start for the same context
+        cache_key = '{}_season_start:{}'.format(self.year, ndb.get_context().__hash__())
+        season_start = context_cache.get(cache_key)
+        if season_start is None:
+            e = Event.query(
+                Event.year==self.year,
+                Event.event_type_enum.IN(EventType.NON_CMP_EVENT_TYPES),
+                Event.start_date!=None
+            ).order(Event.start_date).fetch(1, projection=[Event.start_date])
+            if e:
+                first_start_date = e[0].start_date
+
+                days_diff = 0
+                # Before 2018, event weeks start on Wednesdays
+                if self.year < 2018:
+                    days_diff = 2  # 2 is Wednesday
+
+                # Find the closest start weekday (Monday or Wednesday) to the first event - this is our season start
+                diff_from_week_start = (first_start_date.weekday() - days_diff) % 7
+                diff_from_week_start = min([diff_from_week_start, diff_from_week_start - 7], key=abs)
+
+                season_start = first_start_date - datetime.timedelta(days=diff_from_week_start)
+            else:
+                season_start = None
+        context_cache.set(cache_key, season_start)
+
+        if self._week is None and season_start is not None:
+            # Round events that occur just before the official start-of-season to the closest week
+            days = max((self.start_date - season_start).days, 0)
+            self._week = days / 7
 
         return self._week
 

--- a/tests/test_season_helper.py
+++ b/tests/test_season_helper.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 from pytz import timezone, UTC
 import unittest2
 
@@ -118,42 +118,3 @@ class TestSeasonHelper(unittest2.TestCase):
         kickoff_2009_utc = kickoff_2009.astimezone(UTC)
         self.assertEqual(SeasonHelper.kickoff_datetime_est(year=2009), kickoff_2009)
         self.assertEqual(SeasonHelper.kickoff_datetime_utc(year=2009), kickoff_2009_utc)
-
-    def test_stop_build_date(self):
-        # 2019 - Feb 19th, 2019
-        stop_build_2019 = datetime(2019, 2, 19, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2019_utc = stop_build_2019.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2019), stop_build_2019)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2019), stop_build_2019_utc)
-        # 2018 - Feb 20th, 2018
-        stop_build_2018 = datetime(2018, 2, 20, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2018_utc = stop_build_2018.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2018), stop_build_2018)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2018), stop_build_2018_utc)
-        # 2017 - Feb 21th, 2017
-        stop_build_2017 = datetime(2017, 2, 21, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2017_utc = stop_build_2017.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2017), stop_build_2017)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2017), stop_build_2017_utc)
-        # 2016 - Feb 23th, 2016
-        stop_build_2016 = datetime(2016, 2, 23, 23, 59, 59, tzinfo=timezone('EST'))
-        stop_build_2016_utc = stop_build_2016.astimezone(UTC)
-        self.assertEqual(SeasonHelper.stop_build_datetime_est(year=2016), stop_build_2016)
-        self.assertEqual(SeasonHelper.stop_build_datetime_utc(year=2016), stop_build_2016_utc)
-
-    def test_competition_season_start_date(self):
-        # 2020 - Feb 24th, 2020
-        comp_season_2020 = date(2020, 2, 24)
-        self.assertEqual(SeasonHelper.competition_season_start_date(year=2020), comp_season_2020)
-        # 2019 - Feb 25th, 2019
-        comp_season_2019 = date(2019, 2, 25)
-        self.assertEqual(SeasonHelper.competition_season_start_date(year=2019), comp_season_2019)
-        # 2018 - Feb 26th, 2018
-        comp_season_2018 = date(2018, 2, 26)
-        self.assertEqual(SeasonHelper.competition_season_start_date(year=2018), comp_season_2018)
-        # 2017 - Mar 1st, 2017
-        comp_season_2017 = date(2017, 3, 1)
-        self.assertEqual(SeasonHelper.competition_season_start_date(year=2017), comp_season_2017)
-        # 2016 - Mar 2nd, 2016
-        comp_season_2016 = date(2016, 3, 2)
-        self.assertEqual(SeasonHelper.competition_season_start_date(year=2016), comp_season_2016)


### PR DESCRIPTION
Thinking in a vacuum about just 2020 - we consider `2020isde1` a Week 1 event because it's *close* to Week 1, even if it doesn't technically start in Week 1. This change introduces code to find the *closest* start weekday to the first event. In the case of a year where Monday is the start of week, we look for the closest Monday to the first event. In 2020, this is Feb 24th, as opposed to Feb 17th. The difference from Feb 23rd being 1 and -6, we take the -1 situation. In other years, this might be the closest Wednesday.

The current "offset from season start" method of assigning week numbers is problematic because old years (1996-2004) the events are several weeks after the "start of season" date we're calculating. This removes that problematic code and reverts to a slightly modified method of the code we've been using for years.

I've manually confirmed this method works for years between 2020 and 2006 (we have a lot of start date discrepancies between FRC Events!) in that we sort as expected based on prod's start dates and FRC Event's way of labeling events (along with our proper labeling for things like Week 0.5 in 2016, etc.)