### PR TITLE
Fix "energzied" typo

### DIFF
--- a/templates_jinja2/event_partials/event_insights_2020.html
+++ b/templates_jinja2/event_partials/event_insights_2020.html
@@ -60,7 +60,7 @@
         <td>{{'%0.2f' | format(event_insights.generator_operational_rp_achieved[2])}}%</td>
       </tr>
       <tr>
-        <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Shield Generator Energzied RP Achieved *</span></td>
+        <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Shield Generator Energized RP Achieved *</span></td>
         <td>{{event_insights.generator_energized_rp_achieved[0]}}</td>
         <td>{{event_insights.generator_energized_rp_achieved[1]}}</td>
         <td>{{'%0.2f' | format(event_insights.generator_energized_rp_achieved[2])}}%</td>


### PR DESCRIPTION
## Description
`Energzied` -> `Energized`

😅 