### PR TITLE
Upgrade from ga.js to analytics.js

### DIFF
--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -135,19 +135,5 @@
 
     </div>
 
-    <script type="text/javascript">
-
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-1090782-5']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
-    </script>
-
   </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -214,15 +214,13 @@
 }(document, 'script', 'facebook-jssdk'));</script>
 
 <script>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-1090782-5']);
-  _gaq.push(['_trackPageview']);
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+ga('create', 'UA-1090782-5', 'auto');
+ga('send', 'pageview');
 </script>
 
 <script>

--- a/templates/datafeeds/base.html
+++ b/templates/datafeeds/base.html
@@ -68,19 +68,5 @@
 
     </div>
 
-    <script type="text/javascript">
-
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-1090782-5']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
-    </script>
-
   </body>
 </html>

--- a/templates/gameday.html
+++ b/templates/gameday.html
@@ -280,7 +280,7 @@
       return ((parseInt(t[1]) || 0) + 1) + ':00';
     })(tos.split(':').reverse());
     // Collect and send the time to Google Analytics
-    window.pageTracker ? pageTracker._trackEvent('gameday_time', 'Log', tos) : _gaq.push(['_trackEvent', 'gameday_time', 'Log', tos]);
+    ga('send', 'event', 'gameday_time', 'gameday_time', 'Log', tos);
     }, 60000);
   })('00');
 </script>

--- a/templates/gameday2.html
+++ b/templates/gameday2.html
@@ -50,7 +50,7 @@
       return ((parseInt(t[1]) || 0) + 1) + ':00';
     })(tos.split(':').reverse());
     // Collect and send the time to Google Analytics
-    window.pageTracker ? pageTracker._trackEvent('gameday_time', 'Log', tos) : _gaq.push(['_trackEvent', 'gameday_time', 'Log', tos]);
+    ga('send', 'event', 'gameday_time', 'gameday_time', 'Log', tos);
     }, 60000);
   })('00');
 </script>

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -212,15 +212,13 @@
 }(document, 'script', 'facebook-jssdk'));</script>
 
 <script>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-1090782-5']);
-  _gaq.push(['_trackPageview']);
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+ga('create', 'UA-1090782-5', 'auto');
+ga('send', 'pageview');
 </script>
 
 <script>


### PR DESCRIPTION
TIL our Google Analytics tracking script is legacy. This upgrades all the old `ga.js` to `analytics.js`

Migration information here https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs

I removed all the Google Analytics tracking from the datafeed and admin pages - it doesn't feel particularly useful to include those in our Google Analytics data.