### PR TITLE
Check Cloudflare cache is being invalidated properly via Cloudflare worker

### DIFF
--- a/cache-worker/.gitignore
+++ b/cache-worker/.gitignore
@@ -1,0 +1,10 @@
+/target
+/dist
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log
+worker/
+node_modules/
+.cargo-ok

--- a/cache-worker/.prettierrc
+++ b/cache-worker/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 80
+}

--- a/cache-worker/README.md
+++ b/cache-worker/README.md
@@ -1,0 +1,15 @@
+# cache-worker
+
+A Cloudflare Worker for ensuring the TBA cache is being invalidated properly
+
+## History
+
+Sometime in February 2020, Cloudflare stopped respecting `cache-control` headers on some responses. Periodically, instead of responses being revalidated at the specified `max-age`, responses were staying cached for 2 hours (the default Cloudflare Edge Cache TTL).
+
+## Purpose
+
+This very thin Cloudflare Worker will validate that every response's `age` is less than it's `max-age`, as we expect. If a response's `age` is greater than it's `max-age`, the cached response is deleted from the cache, and a new response is fetched from the origin.
+
+If the response is not cached, or if a response's `age` is less than it's `max-age`, we'll fallback to the default Cloudflare caching semantics.
+
+A `X-TBA-Cache-Status` header is set on responses that the worker manually deletes the previously cached content for. For each response with this header, an event is logged in Google Analytics.

--- a/cache-worker/index.js
+++ b/cache-worker/index.js
@@ -1,0 +1,32 @@
+addEventListener('fetch', event => {
+  event.passThroughOnException()
+  event.respondWith(handleRequest(event))
+})
+
+async function handleRequest(event) {
+  let response = await caches.default.match(event.request)
+  if (response) {
+    const age = parseInt(response.headers.get('age'))
+    const cacheControl = response.headers.get('cache-control')
+
+    if (cacheControl) {
+      const matches = cacheControl.match(/max-age=(\d+)/)
+      const maxAge = matches ? parseInt(matches[1]) : null
+
+      // Ensure our Edge Cache TTL is as-expected (age <= max-age)
+      // If our age > maxAge, something has gone wrong
+      if (age && maxAge && age > maxAge) {
+        // Bypass our Cloudflare cache - get a fresh response
+        await caches.default.delete(event.request)
+        response = await fetch(event.request)
+        // Add some debugging information to our response for monitoring
+        response = new Response(response.body, response)
+        response.headers.set('X-TBA-Cache-Status', 'invalidated')
+      }
+    }
+  } else {
+    // Page is not cached - fetch/store from origin accordingly
+    response = await fetch(event.request)
+  }
+  return response
+}

--- a/cache-worker/package.json
+++ b/cache-worker/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "name": "cache-worker",
+  "version": "1.0.0",
+  "description": "A Cloudflare Worker for ensuring the TBA cache is being invalidated properly",
+  "main": "index.js",
+  "scripts": {
+    "format": "prettier --write '**/*.{js,css,json,md}'"
+  },
+  "author": "The Blue Alliance",
+  "license": "MIT",
+  "devDependencies": {
+    "prettier": "^1.18.2"
+  }
+}

--- a/cache-worker/wrangler.toml
+++ b/cache-worker/wrangler.toml
@@ -1,0 +1,3 @@
+name = "cache-worker"
+type = "javascript"
+route = "*thebluealliance.com/*"

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -79,3 +79,6 @@ fi
 
 echo "Updating build info..."
 update_build_info
+
+echo "Deploying Cloudflare Worker..."
+cd cache-worker && CF_API_TOKEN=$CF_API_TOKEN wrangler publish

--- a/ops/travis/travis-install.sh
+++ b/ops/travis/travis-install.sh
@@ -21,4 +21,6 @@ unzip -q google_appengine_$GAE_VERSION.zip -d $HOME
 rm google_appengine_$GAE_VERSION.zip
 npm install
 npm install -g gulp-cli uglify-es uglifycss less request tslib
+# Install Cloudflare Worker CLI
+npm install -g @cloudflare/wrangler
 npm ls || true

--- a/static/javascript/tba_js/tba.js
+++ b/static/javascript/tba_js/tba.js
@@ -173,3 +173,13 @@ var config = {
   messagingSenderId: firebaseMessagingSenderId,
 };
 firebase.initializeApp(config);
+
+function trackCacheHeader() {
+  const req = new XMLHttpRequest();
+  req.open('GET', document.location, false);
+  req.send(null);
+  const cacheStatus = req.getResponseHeader('X-TBA-Cache-Status');
+  if (cacheStatus) {
+    _gaq.push(['_trackEvent', 'cache_status', 'manually_invalidated']);
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -217,6 +217,7 @@
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-1090782-5']);
   _gaq.push(['_trackPageview']);
+  trackCacheHeader();
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/templates_jinja2/base.html
+++ b/templates_jinja2/base.html
@@ -215,6 +215,7 @@
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-1090782-5']);
   _gaq.push(['_trackPageview']);
+  trackCacheHeader();
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
## Description
This very thin Cloudflare Worker will validate that every response's `age` is less than it's `max-age`, as we expect. If a response's `age` is greater than it's `max-age`, the cached response is deleted from the cache, and a new response is fetched from the origin.

If the response is not cached, or if a response's `age` is less than it's `max-age`, we'll fallback to the default Cloudflare caching semantics.

A `X-TBA-Cache-Status` header is set on responses that the worker manually deletes the previously cached content for. For each response with this header, an event is logged in Google Analytics.

## Motivation and Context
Sometime in February 2020, Cloudflare stopped respecting `cache-control` headers on some responses. Periodically, instead of responses being revalidated at the specified `max-age`, responses were staying cached for 2 hours (the default Cloudflare Edge Cache TTL).

## How Has This Been Tested?
A slightly modified demo of this project has been deployed to `cache.zachorr.com`. The subdomain is running a Flask app that sets a `cache-control` header with a `max-age=61`, but code on the modified Cloudflare Worker is looking at the `a-zor-cache-control` `max-age`.
<img width="781" alt="Screen Shot 2020-02-29 at 8 00 57 PM" src="https://user-images.githubusercontent.com/516458/75618461-bf11c680-5b3c-11ea-8cae-72f20ac9c098.png">
<img width="501" alt="Screen Shot 2020-02-29 at 9 46 00 PM" src="https://user-images.githubusercontent.com/516458/75618477-e5cffd00-5b3c-11ea-9708-7776f67f7399.png">

This means that Cloudflare's caching semantics are employed to cache/invalidate the response based on our traditional `cache-control`, but every 10s we'll execute the codepath that verifies the `age` is less than the `a-zor-cache-control` `max-age`, and we'll manually expire the cache/fetch a new response.

Here is a response that properly hits our Cloudflare cache and validates properly, and is then sent on to the client

<img width="351" alt="Screen Shot 2020-02-29 at 7 59 12 PM" src="https://user-images.githubusercontent.com/516458/75618495-1adc4f80-5b3d-11ea-87ad-3dba169abf1c.png">

Here is a response that fails our modified validation and fetches a fresh response from our origin
<img width="327" alt="Screen Shot 2020-02-29 at 7 59 24 PM" src="https://user-images.githubusercontent.com/516458/75618502-3f382c00-5b3d-11ea-9a1a-e2eaccaef955.png">

And finally, here's just showing we have the cute new `X-TBA-Cache-Status` header on only responses that we manually delete the existing cached content
<img width="261" alt="Screen Shot 2020-02-29 at 8 05 16 PM" src="https://user-images.githubusercontent.com/516458/75618510-59720a00-5b3d-11ea-8498-6467ff3b1344.png">

## To Do Before Merge
- [ ] Setup `CF_API_TOKEN`, `CF_ACCOUNT_ID`, and `CF_ZONE_ID` environment variable in Travis
- [ ] Upgrade to Paid Cloudflare Worker plan

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
