### PR TITLE
Run all datafeed tasks on backend-tasks

### DIFF
--- a/backend_main.py
+++ b/backend_main.py
@@ -8,18 +8,26 @@ from controllers.admin.admin_cron_controller import AdminPostEventTasksDo, Admin
     AdminBackfillPlayoffTypeEnqueue
 from controllers.backup_controller import DatastoreBackupFull, BigQueryImportEnqueue, \
     BigQueryImportEntity, MainBackupsEnqueue, DatastoreBackupArchive, DatastoreBackupArchiveFile
-from controllers.datafeed_controller import EventListEnqueue, EventDetailsEnqueue
-from controllers.datafeed_controller import EventListGet, EventDetailsGet, TeamDetailsGet, TeamAvatarGet, DistrictListGet, DistrictRankingsGet, TeamBlacklistWebsiteDo, EventListCurrentEnqueue
+from controllers.datafeed_controller import EventListEnqueue, EventDetailsEnqueue, EventAwardsEnqueue, EventAlliancesEnqueue, EventRankingsEnqueue, EventMatchesEnqueue
+from controllers.datafeed_controller import EventListGet, EventDetailsGet, EventAwardsGet, EventAlliancesGet, EventRankingsGet, EventMatchesGet, TeamDetailsGet, TeamAvatarGet, DistrictListGet, DistrictRankingsGet, TeamBlacklistWebsiteDo, EventListCurrentEnqueue
 
 
 app = webapp2.WSGIApplication([('/backend-tasks/enqueue/event_list/([0-9]*)', EventListEnqueue),
                                ('/backend-tasks/enqueue/event_list/current', EventListCurrentEnqueue),
                                ('/backend-tasks/enqueue/event_details/(.*)', EventDetailsEnqueue),
+                               ('/backend-tasks/enqueue/event_awards/(.*)', EventAwardsEnqueue),
+                               ('/backend-tasks/enqueue/event_event_alliances/(.*)', EventAlliancesEnqueue),
+                               ('/backend-tasks/enqueue/event_event_rankings/(.*)', EventRankingsEnqueue),
+                               ('/backend-tasks/enqueue/event_matches/(.*)', EventMatchesEnqueue),
                                ('/backend-tasks/get/event_list/([0-9]*)', EventListGet),
                                ('/backend-tasks/get/district_list/([0-9]*)', DistrictListGet),
                                ('/backend-tasks/get/event_details/(.*)', EventDetailsGet),
                                ('/backend-tasks/get/team_details/(.*)', TeamDetailsGet),
                                ('/backend-tasks/get/team_avatar/(.*)', TeamAvatarGet),
+                               ('/backend-tasks/get/event_awards/(.*)', EventAwardsGet),
+                               ('/backend-tasks/get/event_event_alliances/(.*)', EventAlliancesGet),
+                               ('/backend-tasks/get/event_event_rankings/(.*)', EventRankingsGet),
+                               ('/backend-tasks/get/event_matches/(.*)', EventMatchesGet),
                                ('/backend-tasks/do/team_blacklist_website/(.*)', TeamBlacklistWebsiteDo),
                                ('/backend-tasks/get/district_rankings/(.*)', DistrictRankingsGet),
                                ('/backend-tasks/do/post_event_tasks/(.*)', AdminPostEventTasksDo),

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -45,7 +45,7 @@ from models.team import Team
 from sitevars.website_blacklist import WebsiteBlacklist
 
 
-class FMSAPIAwardsEnqueue(webapp.RequestHandler):
+class EventAwardsEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting awards
     """
@@ -60,7 +60,8 @@ class FMSAPIAwardsEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                url='/tasks/get/fmsapi_awards/%s' % (event.key_name),
+                target='backend-tasks',
+                url='/backend-tasks/get/event_awards/%s' % (event.key_name),
                 method='GET')
         template_values = {
             'events': events,
@@ -71,7 +72,7 @@ class FMSAPIAwardsEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIAwardsGet(webapp.RequestHandler):
+class EventAwardsGet(webapp.RequestHandler):
     """
     Handles updating awards
     """
@@ -119,7 +120,7 @@ class FMSAPIAwardsGet(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIEventAlliancesEnqueue(webapp.RequestHandler):
+class EventAlliancesEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting alliances
     """
@@ -137,7 +138,8 @@ class FMSAPIEventAlliancesEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                url='/tasks/get/fmsapi_event_alliances/' + event.key_name,
+                target='backend-tasks',
+                url='/backend-tasks/get/event_event_alliances/' + event.key_name,
                 method='GET')
 
         template_values = {
@@ -149,7 +151,7 @@ class FMSAPIEventAlliancesEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIEventAlliancesGet(webapp.RequestHandler):
+class EventAlliancesGet(webapp.RequestHandler):
     """
     Handles updating an event's alliances
     """
@@ -177,7 +179,7 @@ class FMSAPIEventAlliancesGet(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIEventRankingsEnqueue(webapp.RequestHandler):
+class EventRankingsEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting rankings
     """
@@ -192,7 +194,8 @@ class FMSAPIEventRankingsEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                url='/tasks/get/fmsapi_event_rankings/' + event.key_name,
+                target='backend-tasks',
+                url='/backend-tasks/get/event_event_rankings/' + event.key_name,
                 method='GET')
 
         template_values = {
@@ -204,7 +207,7 @@ class FMSAPIEventRankingsEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIEventRankingsGet(webapp.RequestHandler):
+class EventRankingsGet(webapp.RequestHandler):
     """
     Handles updating an event's rankings
     """
@@ -234,7 +237,7 @@ class FMSAPIEventRankingsGet(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIMatchesEnqueue(webapp.RequestHandler):
+class EventMatchesEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting match results
     """
@@ -249,7 +252,8 @@ class FMSAPIMatchesEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                url='/tasks/get/fmsapi_matches/' + event.key_name,
+                target='backend-tasks',
+                url='/backend-tasks/get/event_matches/' + event.key_name,
                 method='GET')
 
         template_values = {
@@ -261,7 +265,7 @@ class FMSAPIMatchesEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class FMSAPIMatchesGet(webapp.RequestHandler):
+class EventMatchesGet(webapp.RequestHandler):
     """
     Handles updating matches
     """
@@ -333,6 +337,7 @@ class FMSAPIMatchesGet(webapp.RequestHandler):
 #         for team in teams:
 #             taskqueue.add(
 #                 queue_name='datafeed',
+#                 target='backend-tasks',
 #                 url='/tasks/get/fmsapi_team_details/' + team.key_name,
 #                 method='GET')
 

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -291,60 +291,6 @@ class EventMatchesGet(webapp.RequestHandler):
             path = os.path.join(os.path.dirname(__file__), '../templates/datafeeds/usfirst_matches_get.html')
             self.response.out.write(template.render(path, template_values))
 
-# TODO: Currently unused
-
-# class TeamDetailsEnqueue(webapp.RequestHandler):
-#     """
-#     Handles enqueing updates to individual teams
-#     """
-#     def get(self):
-#         offset = int(self.request.get("offset", 0))
-
-#         team_keys = Team.query().fetch(1000, offset=int(offset), keys_only=True)
-#         teams = ndb.get_multi(team_keys)
-#         for team in teams:
-#             taskqueue.add(
-#                 queue_name='frc-api',
-#                 url='/tasks/get/fmsapi_team_details/' + team.key_name,
-#                 method='GET')
-
-#         # FIXME omg we're just writing out? -gregmarra 2012 Aug 26
-#         self.response.out.write("%s team gets have been enqueued offset from %s.<br />" % (len(teams), offset))
-#         self.response.out.write("Reload with ?offset=%s to enqueue more." % (offset + len(teams)))
-
-
-# class TeamDetailsRollingEnqueue(webapp.RequestHandler):
-#     """
-#     Handles enqueing updates to individual teams
-#     Enqueues a certain fraction of teams so that all teams will get updated
-#     every PERIOD days.
-#     """
-#     PERIOD = 14  # a particular team will be updated every PERIOD days
-
-#     def get(self):
-#         now_epoch = time.mktime(datetime.datetime.now().timetuple())
-#         bucket_num = int((now_epoch / (60 * 60 * 24)) % self.PERIOD)
-
-#         highest_team_key = Team.query().order(-Team.team_number).fetch(1, keys_only=True)[0]
-#         highest_team_num = int(highest_team_key.id()[3:])
-#         bucket_size = int(highest_team_num / (self.PERIOD)) + 1
-
-#         min_team = bucket_num * bucket_size
-#         max_team = min_team + bucket_size
-#         team_keys = Team.query(Team.team_number >= min_team, Team.team_number < max_team).fetch(1000, keys_only=True)
-
-#         teams = ndb.get_multi(team_keys)
-#         for team in teams:
-#             taskqueue.add(
-#                 queue_name='datafeed',
-#                 target='backend-tasks',
-#                 url='/tasks/get/fmsapi_team_details/' + team.key_name,
-#                 method='GET')
-
-#         # FIXME omg we're just writing out? -fangeugene 2013 Nov 6
-#         self.response.out.write("Bucket number {} out of {}<br>".format(bucket_num, self.PERIOD))
-#         self.response.out.write("{} team gets have been enqueued in the interval [{}, {}).".format(len(teams), min_team, max_team))
-
 
 class TeamDetailsGet(webapp.RequestHandler):
     """

--- a/cron.yaml
+++ b/cron.yaml
@@ -15,23 +15,23 @@ cron:
 #   timezone: America/Los_Angeles
 
 - description: FIRST match scraping for current events
-  url: /tasks/enqueue/fmsapi_matches/now
+  url: /backend-tasks/enqueue/event_matches/now
   schedule: every 1 minutes
 
 - description: FIRST event ranking scraping for current events
-  url: /tasks/enqueue/fmsapi_event_rankings/now
+  url: /backend-tasks/enqueue/event_event_rankings/now
   schedule: every 1 minutes
 
 - description: FIRST event alliance scraping for current events
-  url: /tasks/enqueue/fmsapi_event_alliances/now
+  url: /backend-tasks/enqueue/event_event_alliances/now
   schedule: every 30 minutes
 
 - description: FIRST event alliance scraping for current events on their last day
-  url: /tasks/enqueue/fmsapi_event_alliances/last_day_only
+  url: /backend-tasks/enqueue/event_event_alliances/last_day_only
   schedule: every 5 minutes
 
 - description: FIRST award scraping for current events
-  url: /tasks/enqueue/fmsapi_awards/now
+  url: /backend-tasks/enqueue/event_awards/now
   schedule: every 1 hours
 
 - description: Hall of Fame team list scraping

--- a/cron_main.py
+++ b/cron_main.py
@@ -7,8 +7,6 @@ from controllers.backup_controller import TbaCSVBackupEventsEnqueue, TbaCSVBacku
 from controllers.backup_controller import TbaCSVBackupTeamsEnqueue
 
 from controllers.datafeed_controller import TbaVideosGet, TbaVideosEnqueue
-from controllers.datafeed_controller import FMSAPIAwardsEnqueue, FMSAPIEventAlliancesEnqueue, FMSAPIEventRankingsEnqueue, FMSAPIMatchesEnqueue
-from controllers.datafeed_controller import FMSAPIAwardsGet, FMSAPIEventAlliancesGet, FMSAPIEventRankingsGet, FMSAPIMatchesGet
 from controllers.datafeed_controller import HallOfFameTeamsGet
 
 from controllers.cron_controller import DistrictPointsCalcEnqueue, DistrictPointsCalcDo, \
@@ -39,15 +37,7 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/do/csv_restore_event/(.*)', TbaCSVRestoreEventDo),
                                ('/tasks/enqueue/csv_backup_teams', TbaCSVBackupTeamsEnqueue),
                                ('/tasks/enqueue/tba_videos', TbaVideosEnqueue),
-                               ('/tasks/enqueue/fmsapi_awards/(.*)', FMSAPIAwardsEnqueue),
-                               ('/tasks/enqueue/fmsapi_event_alliances/(.*)', FMSAPIEventAlliancesEnqueue),
-                               ('/tasks/enqueue/fmsapi_event_rankings/(.*)', FMSAPIEventRankingsEnqueue),
-                               ('/tasks/enqueue/fmsapi_matches/(.*)', FMSAPIMatchesEnqueue),
                                ('/tasks/get/tba_videos/(.*)', TbaVideosGet),
-                               ('/tasks/get/fmsapi_awards/(.*)', FMSAPIAwardsGet),
-                               ('/tasks/get/fmsapi_event_alliances/(.*)', FMSAPIEventAlliancesGet),
-                               ('/tasks/get/fmsapi_event_rankings/(.*)', FMSAPIEventRankingsGet),
-                               ('/tasks/get/fmsapi_matches/(.*)', FMSAPIMatchesGet),
                                ('/tasks/get/hof_teams', HallOfFameTeamsGet),
                                ('/tasks/math/enqueue/district_points_calc/([0-9]*)', DistrictPointsCalcEnqueue),
                                ('/tasks/math/do/district_points_calc/(.*)', DistrictPointsCalcDo),

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -172,10 +172,10 @@
   <h2>FMS API Tasks</h2>
   <div class="btn-group">
     <a href="/backend-tasks/get/event_details/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Details</a>
-    <a href="/tasks/get/fmsapi_matches/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Matches</a>
-    <a href="/tasks/get/fmsapi_event_alliances/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Alliances</a>
-    <a href="/tasks/get/fmsapi_event_rankings/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Rankings</a>
-    <a href="/tasks/get/fmsapi_awards/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Awards</a>
+    <a href="/backend-tasks/get/event_matches/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Matches</a>
+    <a href="/backend-tasks/get/event_event_alliances/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Alliances</a>
+    <a href="/backend-tasks/get/event_event_rankings/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Rankings</a>
+    <a href="/backend-tasks/get/event_awards/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Awards</a>
     <a href="/admin/event/update_loaction/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-map-marker"></span> Geocode Location</a>
   </div>
   <h2>Math Tasks</h2>

--- a/templates/admin/tasks.html
+++ b/templates/admin/tasks.html
@@ -46,7 +46,7 @@
         </form>
         <script>
         $("#enqueue_matches_year_submit").click(function() {
-            window.location = "/tasks/enqueue/fmsapi_matches/" + $("#enqueue_matches_year").val();
+            window.location = "/backend-tasks/enqueue/event_matches/" + $("#enqueue_matches_year").val();
         });
         </script>
     </div>
@@ -63,7 +63,7 @@
         </form>
         <script>
         $("#enqueue_rankings_year_submit").click(function() {
-            window.location = "/tasks/enqueue/fmsapi_event_rankings/" + $("#enqueue_rankings_year").val();
+            window.location = "/backend-tasks/enqueue/event_event_rankings/" + $("#enqueue_rankings_year").val();
         });
         </script>
     </div>
@@ -80,7 +80,7 @@
         </form>
         <script>
         $("#enqueue_alliances_year_submit").click(function() {
-            window.location = "/tasks/enqueue/fmsapi_event_alliances/" + $("#enqueue_alliances_year").val();
+            window.location = "/backend-tasks/enqueue/event_event_alliances/" + $("#enqueue_alliances_year").val();
         });
         </script>
     </div>
@@ -97,7 +97,7 @@
         </form>
         <script>
         $("#enqueue_awards_year_submit").click(function() {
-            window.location = "/tasks/enqueue/fmsapi_awards/" + $("#enqueue_awards_year").val();
+            window.location = "/backend-tasks/enqueue/event_awards/" + $("#enqueue_awards_year").val();
         });
         </script>
     </div>
@@ -137,7 +137,7 @@
         </form>
         <script>
         $("#enqueue_matches_event_submit").click(function() {
-            window.location = "/tasks/get/fmsapi_matches/" + $("#enqueue_matches_event").val();
+            window.location = "/backend-tasks/get/event_matches/" + $("#enqueue_matches_event").val();
         });
         </script>
     </div>
@@ -154,7 +154,7 @@
         </form>
         <script>
         $("#enqueue_rankings_event_submit").click(function() {
-            window.location = "/tasks/get/fmsapi_event_rankings/" + $("#enqueue_rankings_event").val();
+            window.location = "/backend-tasks/get/event_event_rankings/" + $("#enqueue_rankings_event").val();
         });
         </script>
     </div>
@@ -171,7 +171,7 @@
         </form>
         <script>
         $("#enqueue_alliances_event_submit").click(function() {
-            window.location = "/tasks/get/fmsapi_event_alliances/" + $("#enqueue_alliances_event").val();
+            window.location = "/backend-tasks/get/event_event_alliances/" + $("#enqueue_alliances_event").val();
         });
         </script>
     </div>
@@ -188,7 +188,7 @@
         </form>
         <script>
         $("#enqueue_awards_event_submit").click(function() {
-            window.location = "/tasks/get/fmsapi_awards/" + $("#enqueue_awards_event").val();
+            window.location = "/backend-tasks/get/event_awards/" + $("#enqueue_awards_event").val();
         });
         </script>
     </div>


### PR DESCRIPTION
In an effort to move all non-HTML rendering tasks to other services, this moves some `datafeed` tasks to execute on `backend-tasks`