### PR TITLE
Run `backend-tasks` on `tasks`

### DIFF
--- a/backend_main.py
+++ b/backend_main.py
@@ -8,26 +8,18 @@ from controllers.admin.admin_cron_controller import AdminPostEventTasksDo, Admin
     AdminBackfillPlayoffTypeEnqueue
 from controllers.backup_controller import DatastoreBackupFull, BigQueryImportEnqueue, \
     BigQueryImportEntity, MainBackupsEnqueue, DatastoreBackupArchive, DatastoreBackupArchiveFile
-from controllers.datafeed_controller import EventListEnqueue, EventDetailsEnqueue, EventAwardsEnqueue, EventAlliancesEnqueue, EventRankingsEnqueue, EventMatchesEnqueue
-from controllers.datafeed_controller import EventListGet, EventDetailsGet, EventAwardsGet, EventAlliancesGet, EventRankingsGet, EventMatchesGet, TeamDetailsGet, TeamAvatarGet, DistrictListGet, DistrictRankingsGet, TeamBlacklistWebsiteDo, EventListCurrentEnqueue
+from controllers.datafeed_controller import EventListEnqueue, EventDetailsEnqueue
+from controllers.datafeed_controller import EventListGet, EventDetailsGet, TeamDetailsGet, TeamAvatarGet, DistrictListGet, DistrictRankingsGet, TeamBlacklistWebsiteDo, EventListCurrentEnqueue
 
 
 app = webapp2.WSGIApplication([('/backend-tasks/enqueue/event_list/([0-9]*)', EventListEnqueue),
                                ('/backend-tasks/enqueue/event_list/current', EventListCurrentEnqueue),
                                ('/backend-tasks/enqueue/event_details/(.*)', EventDetailsEnqueue),
-                               ('/backend-tasks/enqueue/event_awards/(.*)', EventAwardsEnqueue),
-                               ('/backend-tasks/enqueue/event_event_alliances/(.*)', EventAlliancesEnqueue),
-                               ('/backend-tasks/enqueue/event_event_rankings/(.*)', EventRankingsEnqueue),
-                               ('/backend-tasks/enqueue/event_matches/(.*)', EventMatchesEnqueue),
                                ('/backend-tasks/get/event_list/([0-9]*)', EventListGet),
                                ('/backend-tasks/get/district_list/([0-9]*)', DistrictListGet),
                                ('/backend-tasks/get/event_details/(.*)', EventDetailsGet),
                                ('/backend-tasks/get/team_details/(.*)', TeamDetailsGet),
                                ('/backend-tasks/get/team_avatar/(.*)', TeamAvatarGet),
-                               ('/backend-tasks/get/event_awards/(.*)', EventAwardsGet),
-                               ('/backend-tasks/get/event_event_alliances/(.*)', EventAlliancesGet),
-                               ('/backend-tasks/get/event_event_rankings/(.*)', EventRankingsGet),
-                               ('/backend-tasks/get/event_matches/(.*)', EventMatchesGet),
                                ('/backend-tasks/do/team_blacklist_website/(.*)', TeamBlacklistWebsiteDo),
                                ('/backend-tasks/get/district_rankings/(.*)', DistrictRankingsGet),
                                ('/backend-tasks/do/post_event_tasks/(.*)', AdminPostEventTasksDo),

--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -45,7 +45,7 @@ from models.team import Team
 from sitevars.website_blacklist import WebsiteBlacklist
 
 
-class EventAwardsEnqueue(webapp.RequestHandler):
+class FMSAPIAwardsEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting awards
     """
@@ -60,8 +60,7 @@ class EventAwardsEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                target='backend-tasks',
-                url='/backend-tasks/get/event_awards/%s' % (event.key_name),
+                url='/tasks/get/fmsapi_awards/%s' % (event.key_name),
                 method='GET')
         template_values = {
             'events': events,
@@ -72,7 +71,7 @@ class EventAwardsEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventAwardsGet(webapp.RequestHandler):
+class FMSAPIAwardsGet(webapp.RequestHandler):
     """
     Handles updating awards
     """
@@ -120,7 +119,7 @@ class EventAwardsGet(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventAlliancesEnqueue(webapp.RequestHandler):
+class FMSAPIEventAlliancesEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting alliances
     """
@@ -138,8 +137,7 @@ class EventAlliancesEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                target='backend-tasks',
-                url='/backend-tasks/get/event_event_alliances/' + event.key_name,
+                url='/tasks/get/fmsapi_event_alliances/' + event.key_name,
                 method='GET')
 
         template_values = {
@@ -151,7 +149,7 @@ class EventAlliancesEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventAlliancesGet(webapp.RequestHandler):
+class FMSAPIEventAlliancesGet(webapp.RequestHandler):
     """
     Handles updating an event's alliances
     """
@@ -179,7 +177,7 @@ class EventAlliancesGet(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventRankingsEnqueue(webapp.RequestHandler):
+class FMSAPIEventRankingsEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting rankings
     """
@@ -194,8 +192,7 @@ class EventRankingsEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                target='backend-tasks',
-                url='/backend-tasks/get/event_event_rankings/' + event.key_name,
+                url='/tasks/get/fmsapi_event_rankings/' + event.key_name,
                 method='GET')
 
         template_values = {
@@ -207,7 +204,7 @@ class EventRankingsEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventRankingsGet(webapp.RequestHandler):
+class FMSAPIEventRankingsGet(webapp.RequestHandler):
     """
     Handles updating an event's rankings
     """
@@ -237,7 +234,7 @@ class EventRankingsGet(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventMatchesEnqueue(webapp.RequestHandler):
+class FMSAPIMatchesEnqueue(webapp.RequestHandler):
     """
     Handles enqueing getting match results
     """
@@ -252,8 +249,7 @@ class EventMatchesEnqueue(webapp.RequestHandler):
         for event in events:
             taskqueue.add(
                 queue_name='datafeed',
-                target='backend-tasks',
-                url='/backend-tasks/get/event_matches/' + event.key_name,
+                url='/tasks/get/fmsapi_matches/' + event.key_name,
                 method='GET')
 
         template_values = {
@@ -265,7 +261,7 @@ class EventMatchesEnqueue(webapp.RequestHandler):
             self.response.out.write(template.render(path, template_values))
 
 
-class EventMatchesGet(webapp.RequestHandler):
+class FMSAPIMatchesGet(webapp.RequestHandler):
     """
     Handles updating matches
     """

--- a/cron.yaml
+++ b/cron.yaml
@@ -15,23 +15,23 @@ cron:
 #   timezone: America/Los_Angeles
 
 - description: FIRST match scraping for current events
-  url: /backend-tasks/enqueue/event_matches/now
+  url: /tasks/enqueue/fmsapi_matches/now
   schedule: every 1 minutes
 
 - description: FIRST event ranking scraping for current events
-  url: /backend-tasks/enqueue/event_event_rankings/now
+  url: /tasks/enqueue/fmsapi_event_rankings/now
   schedule: every 1 minutes
 
 - description: FIRST event alliance scraping for current events
-  url: /backend-tasks/enqueue/event_event_alliances/now
+  url: /tasks/enqueue/fmsapi_event_alliances/now
   schedule: every 30 minutes
 
 - description: FIRST event alliance scraping for current events on their last day
-  url: /backend-tasks/enqueue/event_event_alliances/last_day_only
+  url: /tasks/enqueue/fmsapi_event_alliances/last_day_only
   schedule: every 5 minutes
 
 - description: FIRST award scraping for current events
-  url: /backend-tasks/enqueue/event_awards/now
+  url: /tasks/enqueue/fmsapi_awards/now
   schedule: every 1 hours
 
 - description: Hall of Fame team list scraping

--- a/cron_main.py
+++ b/cron_main.py
@@ -7,6 +7,8 @@ from controllers.backup_controller import TbaCSVBackupEventsEnqueue, TbaCSVBacku
 from controllers.backup_controller import TbaCSVBackupTeamsEnqueue
 
 from controllers.datafeed_controller import TbaVideosGet, TbaVideosEnqueue
+from controllers.datafeed_controller import FMSAPIAwardsEnqueue, FMSAPIEventAlliancesEnqueue, FMSAPIEventRankingsEnqueue, FMSAPIMatchesEnqueue
+from controllers.datafeed_controller import FMSAPIAwardsGet, FMSAPIEventAlliancesGet, FMSAPIEventRankingsGet, FMSAPIMatchesGet
 from controllers.datafeed_controller import HallOfFameTeamsGet
 
 from controllers.cron_controller import DistrictPointsCalcEnqueue, DistrictPointsCalcDo, \
@@ -37,7 +39,15 @@ app = webapp2.WSGIApplication([('/tasks/enqueue/csv_backup_events', TbaCSVBackup
                                ('/tasks/do/csv_restore_event/(.*)', TbaCSVRestoreEventDo),
                                ('/tasks/enqueue/csv_backup_teams', TbaCSVBackupTeamsEnqueue),
                                ('/tasks/enqueue/tba_videos', TbaVideosEnqueue),
+                               ('/tasks/enqueue/fmsapi_awards/(.*)', FMSAPIAwardsEnqueue),
+                               ('/tasks/enqueue/fmsapi_event_alliances/(.*)', FMSAPIEventAlliancesEnqueue),
+                               ('/tasks/enqueue/fmsapi_event_rankings/(.*)', FMSAPIEventRankingsEnqueue),
+                               ('/tasks/enqueue/fmsapi_matches/(.*)', FMSAPIMatchesEnqueue),
                                ('/tasks/get/tba_videos/(.*)', TbaVideosGet),
+                               ('/tasks/get/fmsapi_awards/(.*)', FMSAPIAwardsGet),
+                               ('/tasks/get/fmsapi_event_alliances/(.*)', FMSAPIEventAlliancesGet),
+                               ('/tasks/get/fmsapi_event_rankings/(.*)', FMSAPIEventRankingsGet),
+                               ('/tasks/get/fmsapi_matches/(.*)', FMSAPIMatchesGet),
                                ('/tasks/get/hof_teams', HallOfFameTeamsGet),
                                ('/tasks/math/enqueue/district_points_calc/([0-9]*)', DistrictPointsCalcEnqueue),
                                ('/tasks/math/do/district_points_calc/(.*)', DistrictPointsCalcDo),

--- a/datafeeds/datafeed_fms_api.py
+++ b/datafeeds/datafeed_fms_api.py
@@ -194,7 +194,7 @@ class DatafeedFMSAPI(object):
                 'Pragma': 'no-cache',
             }
             try:
-                result = yield context.urlfetch(url, headers=headers, deadline=5)
+                result = yield context.urlfetch(url, headers=headers)
             except Exception, e:
                 logging.error("URLFetch failed for: {}".format(url))
                 logging.info(e)

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -20,9 +20,9 @@ dispatch:
 - url: "*/clientapi/*"
   service: clientapi
 
-# Handles latency-insensive tasks
-# - url: "*/tasks/*"
-#   service: tasks
+Handles latency-insensive tasks
+- url: "*/tasks/*"
+  service: tasks
 
 # Send everything else to default module
 - url: "*/"

--- a/helpers/award_manipulator.py
+++ b/helpers/award_manipulator.py
@@ -43,7 +43,6 @@ class AwardManipulator(ManipulatorBase):
         # Enqueue task to calculate district points
         for event in events:
             taskqueue.add(
-                target='default',
                 url='/tasks/math/do/district_points_calc/{}'.format(event.id()),
                 method='GET')
 

--- a/helpers/district_team_manipulator.py
+++ b/helpers/district_team_manipulator.py
@@ -20,7 +20,6 @@ class DistrictTeamManipulator(ManipulatorBase):
             # Enqueue task to calculate district rankings
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/district_rankings_calc/{}'.format(district_team.district_key.id()),
                     method='GET')
             except Exception:

--- a/helpers/event_details_manipulator.py
+++ b/helpers/event_details_manipulator.py
@@ -43,7 +43,6 @@ class EventDetailsManipulator(ManipulatorBase):
             # Enqueue task to calculate district points
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/district_points_calc/{}'.format(event.key.id()),
                     method='GET')
             except Exception:
@@ -53,7 +52,6 @@ class EventDetailsManipulator(ManipulatorBase):
             # Enqueue task to calculate event team status
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/event_team_status/{}'.format(event.key.id()),
                     method='GET')
             except Exception:

--- a/helpers/match_manipulator.py
+++ b/helpers/match_manipulator.py
@@ -117,7 +117,6 @@ class MatchManipulator(ManipulatorBase):
             # Enqueue task to calculate matchstats
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/event_matchstats/' + event_key,
                     method='GET')
             except Exception:
@@ -127,7 +126,6 @@ class MatchManipulator(ManipulatorBase):
             # Enqueue task to calculate district points
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/district_points_calc/{}'.format(event_key),
                     method='GET')
             except Exception:
@@ -137,7 +135,6 @@ class MatchManipulator(ManipulatorBase):
             # Enqueue task to calculate event team status
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/event_team_status/{}'.format(event_key),
                     method='GET')
             except Exception:
@@ -147,7 +144,6 @@ class MatchManipulator(ManipulatorBase):
             # Enqueue updating playoff advancement
             try:
                 taskqueue.add(
-                    target='default',
                     url='/tasks/math/do/playoff_advancement_update/{}'.format(event_key),
                     method='GET')
             except Exception:

--- a/templates/admin/event_details.html
+++ b/templates/admin/event_details.html
@@ -172,10 +172,10 @@
   <h2>FMS API Tasks</h2>
   <div class="btn-group">
     <a href="/backend-tasks/get/event_details/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Details</a>
-    <a href="/backend-tasks/get/event_matches/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Matches</a>
-    <a href="/backend-tasks/get/event_event_alliances/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Alliances</a>
-    <a href="/backend-tasks/get/event_event_rankings/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Rankings</a>
-    <a href="/backend-tasks/get/event_awards/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Awards</a>
+    <a href="/tasks/get/fmsapi_matches/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Matches</a>
+    <a href="/tasks/get/fmsapi_event_alliances/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Alliances</a>
+    <a href="/tasks/get/fmsapi_event_rankings/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Rankings</a>
+    <a href="/tasks/get/fmsapi_awards/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Awards</a>
     <a href="/admin/event/update_loaction/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-map-marker"></span> Geocode Location</a>
   </div>
   <h2>Math Tasks</h2>

--- a/templates/admin/tasks.html
+++ b/templates/admin/tasks.html
@@ -46,7 +46,7 @@
         </form>
         <script>
         $("#enqueue_matches_year_submit").click(function() {
-            window.location = "/backend-tasks/enqueue/event_matches/" + $("#enqueue_matches_year").val();
+            window.location = "/tasks/enqueue/fmsapi_matches/" + $("#enqueue_matches_year").val();
         });
         </script>
     </div>
@@ -63,7 +63,7 @@
         </form>
         <script>
         $("#enqueue_rankings_year_submit").click(function() {
-            window.location = "/backend-tasks/enqueue/event_event_rankings/" + $("#enqueue_rankings_year").val();
+            window.location = "/tasks/enqueue/fmsapi_event_rankings/" + $("#enqueue_rankings_year").val();
         });
         </script>
     </div>
@@ -80,7 +80,7 @@
         </form>
         <script>
         $("#enqueue_alliances_year_submit").click(function() {
-            window.location = "/backend-tasks/enqueue/event_event_alliances/" + $("#enqueue_alliances_year").val();
+            window.location = "/tasks/enqueue/fmsapi_event_alliances/" + $("#enqueue_alliances_year").val();
         });
         </script>
     </div>
@@ -97,7 +97,7 @@
         </form>
         <script>
         $("#enqueue_awards_year_submit").click(function() {
-            window.location = "/backend-tasks/enqueue/event_awards/" + $("#enqueue_awards_year").val();
+            window.location = "/tasks/enqueue/fmsapi_awards/" + $("#enqueue_awards_year").val();
         });
         </script>
     </div>
@@ -137,7 +137,7 @@
         </form>
         <script>
         $("#enqueue_matches_event_submit").click(function() {
-            window.location = "/backend-tasks/get/event_matches/" + $("#enqueue_matches_event").val();
+            window.location = "/tasks/get/fmsapi_matches/" + $("#enqueue_matches_event").val();
         });
         </script>
     </div>
@@ -154,7 +154,7 @@
         </form>
         <script>
         $("#enqueue_rankings_event_submit").click(function() {
-            window.location = "/backend-tasks/get/event_event_rankings/" + $("#enqueue_rankings_event").val();
+            window.location = "/tasks/get/fmsapi_event_rankings/" + $("#enqueue_rankings_event").val();
         });
         </script>
     </div>
@@ -171,7 +171,7 @@
         </form>
         <script>
         $("#enqueue_alliances_event_submit").click(function() {
-            window.location = "/backend-tasks/get/event_event_alliances/" + $("#enqueue_alliances_event").val();
+            window.location = "/tasks/get/fmsapi_event_alliances/" + $("#enqueue_alliances_event").val();
         });
         </script>
     </div>
@@ -188,7 +188,7 @@
         </form>
         <script>
         $("#enqueue_awards_event_submit").click(function() {
-            window.location = "/backend-tasks/get/event_awards/" + $("#enqueue_awards_event").val();
+            window.location = "/tasks/get/fmsapi_awards/" + $("#enqueue_awards_event").val();
         });
         </script>
     </div>


### PR DESCRIPTION
Several reverts to run the tasks we moved from `backend-tasks` back to `tasks`