### PR TITLE
Add Coronavirus warning to CompSeason template

### DIFF
--- a/templates_jinja2/index/index_competitionseason.html
+++ b/templates_jinja2/index/index_competitionseason.html
@@ -12,7 +12,7 @@
     </div>
     <div class="col-sm-8">
 <div class="alert alert-dismissible alert-danger ">
-<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>As a result of the spread of the Coronavirus, <i>FIRST</i> has published their current status on the Coronavirus impacting their events on their website.  Please refer to <a href="https://www.firstinspires.org/covid-19" title="this">this page</a> to see overall status.</div>
+<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>As a result of the spread of COVID-19 (Coronavirus), <i>FIRST</i> has published current status on their website.  Please refer to <a href="https://www.firstinspires.org/covid-19" title="this">this page</a> for more information.</div>
       {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
         {% with first_event = events|first %}

--- a/templates_jinja2/index/index_competitionseason.html
+++ b/templates_jinja2/index/index_competitionseason.html
@@ -12,7 +12,7 @@
     </div>
     <div class="col-sm-8">
 <div class="alert alert-dismissible alert-danger ">
-<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>As a result of the spread of COVID-19 (Coronavirus), <i>FIRST</i> has published current status on their website.  Please refer to <a href="https://www.firstinspires.org/covid-19" title="this">this page</a> for more information.</div>
+<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>As a result of the spread of COVID-19 (Coronavirus), <i>FIRST</i> is sharing guidance on their website.  Please refer to <a href="https://www.firstinspires.org/covid-19" title="this">this page</a> for more information.</div>
       {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
         {% with first_event = events|first %}

--- a/templates_jinja2/index/index_competitionseason.html
+++ b/templates_jinja2/index/index_competitionseason.html
@@ -11,6 +11,8 @@
       {% include "index_partials/index_lhc.html" %}
     </div>
     <div class="col-sm-8">
+<div class="alert alert-dismissible alert-danger ">
+<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>As a result of the spread of the Coronavirus, <i>FIRST</i> has published their current status on the Coronavirus impacting their events on their website.  Please refer to <a href="https://www.firstinspires.org/covid-19" title="this">this page</a> to see overall status.</div>
       {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
         {% with first_event = events|first %}


### PR DESCRIPTION
Add Coronavirus warning to CompSeason template until we can get a sitevar for alerts placed in.

## Motivation and Context
To avoid confusion and increase awareness, place a link to the Coronavirus status page on the FIRST website.

## How Has This Been Tested?
The overall styling has been tested using Inspect Element.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6531081/76268477-9f695500-6244-11ea-8e39-8ea6e63a682b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
