### PR TITLE
Only send upcoming matches for new match schedules when the level changes

### DIFF
--- a/helpers/match/match_test_creator.py
+++ b/helpers/match/match_test_creator.py
@@ -79,3 +79,4 @@ class MatchTestCreator(object):
         complete = False
         matches = [self.buildTestMatch(comp_level, set_number, match_number, complete) for match_number in range(11, 21)]
         MatchManipulator.createOrUpdate(matches)
+        return matches

--- a/helpers/tbans_helper.py
+++ b/helpers/tbans_helper.py
@@ -337,6 +337,15 @@ class TBANSHelper:
 
         from helpers.match_helper import MatchHelper
         next_matches = MatchHelper.upcomingMatches(event.matches, num=2)
+
+        if len(next_matches) == 0:
+            return
+
+        # Only schedule/send upcoming matches for new levels - if a schedule gets updated mid-way through the event, don't
+        # bother sending new notifications (this is to prevent a bug where we send a bunch of duplicate notifications)
+        if not (next_matches[0].set_number == 1 and next_matches[0].match_number == 1):
+            return
+
         for match in next_matches:
             cls.schedule_upcoming_match(match, user_id)
 

--- a/tests/helpers_tests/test_tbans_helper.py
+++ b/tests/helpers_tests/test_tbans_helper.py
@@ -772,12 +772,28 @@ class TestTBANSHelper(unittest2.TestCase):
             mock_send.assert_called_once()
             self.assertFalse(success)
 
+    def test_schedule_upcoming_matches_not_new_schedule(self):
+        # Set some upcoming matches for the Event - not Match 1 though, so no notification gets sent
+        match_creator = MatchTestCreator(self.event)
+        teams = [Team(id="frc%s" % team_number, team_number=team_number) for team_number in range(6)]
+        self.event._teams = teams
+        match_creator.createIncompleteQuals()
+
+        with patch.object(TBANSHelper, 'schedule_upcoming_match') as mock_schedule_upcoming_match:
+            TBANSHelper.schedule_upcoming_matches(self.event)
+            mock_schedule_upcoming_match.assert_not_called()
+
     def test_schedule_upcoming_matches(self):
         # Set some upcoming matches for the Event
         match_creator = MatchTestCreator(self.event)
         teams = [Team(id="frc%s" % team_number, team_number=team_number) for team_number in range(6)]
         self.event._teams = teams
-        match_creator.createIncompleteQuals()
+        matches = match_creator.createIncompleteQuals()
+
+        # Hack our first next upcoming match to be Match 1
+        first_match = matches[0]
+        first_match.match_number = 1
+        first_match.put()
 
         with patch.object(TBANSHelper, 'schedule_upcoming_match') as mock_schedule_upcoming_match:
             TBANSHelper.schedule_upcoming_matches(self.event)
@@ -789,7 +805,12 @@ class TestTBANSHelper(unittest2.TestCase):
         match_creator = MatchTestCreator(self.event)
         teams = [Team(id="frc%s" % team_number, team_number=team_number) for team_number in range(6)]
         self.event._teams = teams
-        match_creator.createIncompleteQuals()
+        matches = match_creator.createIncompleteQuals()
+
+        # Hack our first next upcoming match to be Match 1
+        first_match = matches[0]
+        first_match.match_number = 1
+        first_match.put()
 
         with patch.object(TBANSHelper, 'schedule_upcoming_match') as mock_schedule_upcoming_match:
             TBANSHelper.schedule_upcoming_matches(self.event, 'user_id')


### PR DESCRIPTION
During an event, we get several of these match schedule update events that get posted. I'm not entirely sure *why*, but part of the side effect is that we'll dispatch new upcoming match notifications for a new schedule.

This isn't really what we want. We want to send upcoming match notifications for (ex) semifinal matches when the match schedule gets updated. But if we get a match schedule update notification in the middle of qualifications, we shouldn't send out new upcoming match notifications, since they should be sent after scores get posted.