### PR TITLE
Update COVID-19 information on landing page, hide event list

### DIFF
--- a/templates_jinja2/index/index_competitionseason.html
+++ b/templates_jinja2/index/index_competitionseason.html
@@ -12,8 +12,8 @@
     </div>
     <div class="col-sm-8">
 <div class="alert alert-dismissible alert-danger ">
-<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>As a result of the spread of COVID-19 (Coronavirus), <i>FIRST</i> is sharing guidance on their website.  Please refer to <a href="https://www.firstinspires.org/covid-19" title="this">this page</a> for more information.</div>
-      {% include "media_partials/live_special_webcast_partial.html" %}
+<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>Due to COVID-19 (Coronavirus), FIRST has decided to suspend all season play across all Programs worldwide, effective immediately, including the cancellation of both FIRST Championship events. Refer to <a href="https://www.firstinspires.org/covid-19" title="firstinspires.org/covid-19">firstinspires.org/covid-19</a> for more information.</div>
+      <!-- {% include "media_partials/live_special_webcast_partial.html" %}
       {% if events %}
         {% with first_event = events|first %}
         {% with last_event = events|last %}
@@ -108,7 +108,7 @@
           <iframe width="420" height="315" src="https://www.youtube.com/embed/{{game_animation_youtube_id}}" frameborder="0" allowfullscreen></iframe>
         </div>
       {% endif %}
-    </div>
+    </div> -->
   </div>
 </div>
 


### PR DESCRIPTION
We can try to iterate on the landing page to surface something besides an empty list - showing a list of events feels like counter to the information available right now.

<img width="1237" alt="Screen Shot 2020-03-12 at 2 15 52 PM" src="https://user-images.githubusercontent.com/516458/76554446-4da31380-646c-11ea-9dc5-06e82bd18ab8.png">
