### PR TITLE
Update instagram partial to render thumbs correctly in Firefox.

### DIFF
--- a/templates_jinja2/media_partials/instagram_partial.html
+++ b/templates_jinja2/media_partials/instagram_partial.html
@@ -1,6 +1,6 @@
 <div class="thumbnail cdphotothread-thumbnail">
   <a href="{{media.image_direct_url}}" class="gallery">
-    <span style="background-image:url('{{media.image_direct_url_med}}')"></span>
+    <span style="background:url('{{media.image_direct_url_med}}')"></span>
   </a>
   <div class="caption">
     <a href="{{media.view_image_url}}" target="_blank">Instagram Page</a>


### PR DESCRIPTION
Firefox seems to have a bug rendering span background-image media objects when they also follow a 302 redirect.  Switching to a `background` media type and allowing FF to infer the source being an image seems to work though.

## Motivation and Context
This would allow Firefox to display Instagram thumbnails on the carousel and homepage.

## How Has This Been Tested?
Inspect Element seems to both trigger the loading of it in Network monitor and rendering on the page when edited.  Doing the same in Chromium (80.0.3987.87) doesn't break either.
## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/6531081/76577463-deddae80-649b-11ea-9589-73d940d26313.png)
After:
![image](https://user-images.githubusercontent.com/6531081/76577484-f0bf5180-649b-11ea-9ae2-6b4445a21100.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
