### PR TITLE
Generalize Continuous Deployment Tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,7 @@ coverage
 ########
 static/javascript/tba_js/tba_keys.js
 ops/deploy_keys.tar
-ops/tbatv-prod-hrd-deploy.json
+ops/*deploy.json
 ops/dev/conf.json
 ops/dev/*-auth.json
 test_keys.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 stages:
   - test
   - name: deploy
-    if: (type = push) AND (branch = master)
+    if: (type = push) AND (branch IN (master, deploy-test))
 before_install:
 - nvm install 8.16.0
 install:
@@ -33,7 +33,7 @@ script:
 after_failure:
 - cat test_failures.temp
 before_deploy:
-- openssl aes-256-cbc -K $encrypted_7463bcfc1880_key -iv $encrypted_7463bcfc1880_iv -in ops/deploy_keys.tar.enc -out ops/deploy_keys.tar -d
+- ./ops/manage_deploy_keys.sh -d
 - ./ops/manage_deploy_keys.sh -x
 jobs:
   include:
@@ -45,5 +45,4 @@ jobs:
       provider: script
       script: ./ops/travis/travis-deploy.sh
       on:
-        repo: the-blue-alliance/the-blue-alliance
-        branch: master
+        branch: $CONTINUOUS_PUSH_BRANCH

--- a/ops/manage_deploy_keys.sh
+++ b/ops/manage_deploy_keys.sh
@@ -4,15 +4,24 @@
 # Any file in here should MOST DEFINITELY be in .gitignore
 # Run this script from the root of the repo. Use -c to build the archive, -x to extract
 
-while getopts "cx" o; do
+while getopts "cxd" o; do
     case "${o}" in
         c)
             echo "Creating key archive..."
-            tar cvf ops/deploy_keys.tar static/javascript/tba_js/tba_keys.js ops/tbatv-prod-hrd-deploy.json
+            tar cvf ops/deploy_keys.tar static/javascript/tba_js/tba_keys.js ops/*deploy.json
             ;;
         x)
             echo "Extracting key archive..."
             tar xvf ops/deploy_keys.tar
+            ;;
+        d)
+            echo "Fetching key bundle..."
+            curl -o ops/deploy_keys.tar.enc $DEPLOY_KEY_FILE
+
+            echo "Decrypting key bundle..."
+            key="encrypted_${KEY_FILE_ENC_ID}_key"
+            iv="encrypted_${KEY_FILE_ENC_ID}_iv"
+            openssl aes-256-cbc -K ${!key} -iv ${!iv} -in ops/deploy_keys.tar.enc -out ops/deploy_keys.tar -d
             ;;
         *)
             exit -1

--- a/ops/travis/should-deploy.sh
+++ b/ops/travis/should-deploy.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env sh
 
-API_STATUS=https://www.thebluealliance.com/api/v3/status
-SET_BUILD_STATUS=https://www.thebluealliance.com/api/v3/_/build
+API_STATUS=$TBA_DOMAIN/api/v3/status
+SET_BUILD_STATUS=$TBA_DOMAIN/api/v3/_/build
 fetch_apiv3_status() {
     curl -s --header "X-TBA-Auth-Key: $APIv3_KEY" $API_STATUS
 }

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -8,10 +8,10 @@ export BOTO_CONFIG=/dev/null # Hack to fix https://github.com/travis-ci/travis-c
 # Basically an implementation of:
 # https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/gae.rb
 
-KEYFILE=ops/tbatv-prod-hrd-deploy.json
-PROJECT=tbatv-prod-hrd
+KEYFILE=ops/$GAE_PROJECT_ID-deploy.json
+PROJECT=$GAE_PROJECT_ID
 VERSION=prod-2
-DEPLOY_LOCK=tbatv-prod-hrd-deploy-lock
+DEPLOY_LOCK=$PROJECT-deploy-lock
 
 BASE='https://dl.google.com/dl/cloudsdk/channels/rapid/'
 NAME='google-cloud-sdk'
@@ -48,7 +48,7 @@ PATH=$PATH:$INSTALL/$NAME/bin/
 echo "Building TBA..."
 paver make
 
-if [ "$TBA_DEPLOY_VERBOSE" = "1"]; then
+if [ "$TBA_DEPLOY_VERBOSE" = "1" ]; then
   echo "Deploying TBA with the following JS modules"
   npm ls || true
 fi


### PR DESCRIPTION
We should be able to leverage the same tooling to deploy to staging GAE instances of TBA. This should eliminate all the dependencies on the prod instance