### PR TITLE
Support single-instance deploy type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,7 @@ env:
 stages:
   - test
   - name: deploy
-    if: (type = push) AND (branch IN (master, deploy-test))
-before_install:
-- nvm install 8.16.0
+    if: (type = push) AND (branch IN (master))
 install:
 - travis_retry ./ops/travis/travis-install.sh $JOB
 - export PYTHONPATH=${PYTHONPATH}:${HOME}/google_appengine

--- a/app.yaml
+++ b/app.yaml
@@ -88,6 +88,20 @@ handlers:
   login: admin
 - url: /clientapi/.*
   script: clientapi.clientapi_service.app
+
+# These are duplicates of other modules, but are handy to run the
+# entire site on fewer GAE instances; dispatch.yaml will override this
+# if it is deployed
+- url: /backend-tasks/.*
+  script: backend_main.app
+  login: admin
+- url: /backend-tasks-b2/.*
+  script: backend_main_b2.app
+  login: admin
+- url: /tasks/.*
+  script: cron_main.app
+  login: admin
+
 - url: .*
   script: main.app
 

--- a/ops/standalone/cron-empty.yaml
+++ b/ops/standalone/cron-empty.yaml
@@ -1,0 +1,2 @@
+# A file with no cronjobs, for standalone mode
+cron: []

--- a/ops/standalone/dispatch-empty.yaml
+++ b/ops/standalone/dispatch-empty.yaml
@@ -1,0 +1,4 @@
+dispatch:
+  # Send everything to default module
+  - url: "*/"
+    service: default

--- a/ops/travis/travis-deploy.sh
+++ b/ops/travis/travis-deploy.sh
@@ -24,6 +24,37 @@ with_python27() {
     bash -c "source $HOME/virtualenv/python2.7/bin/activate; $1"
 }
 
+deploy_module() {
+    with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $1 --version $VERSION"
+}
+
+deploy_full() {
+  for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml api.yaml clientapi.yaml tasks.yaml cron.yaml dispatch.yaml index.yaml queue.yaml; do
+    deploy_module $config
+  done
+
+  # Check if we need to deploy our Endpoints config - cleanup afterwards so it's not in our web deploy
+  paver make_endpoints_config
+  if check_deploy_endpoints_config; then
+    with_python27 "$GCLOUD endpoints services deploy tbaMobilev9openapi.json"
+  fi
+  if check_deploy_tbaClient_endpoints_config; then
+    with_python27 "$GCLOUD endpoints services deploy tbaClientv9openapi.json"
+  fi
+}
+
+deploy_single() {
+  deploy_module app.yaml
+  deploy_module index.yaml
+  deploy_module queue.yaml
+
+  # Overwrite files with magic names
+  mv -f ops/standalone/cron-empty.yaml ./cron.yaml
+  mv -f ops/standalone/dispatch-empty.yaml ./dispatch.yaml
+  deploy_module cron.yaml
+  deploy_module dispatch.yaml
+}
+
 # Install the lock release function as a trap so it always runs
 # http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_12_02.html
 release_lock() {
@@ -63,19 +94,19 @@ lock $DEPLOY_LOCK
 echo "Installing trap handler to release deploy lock on exit..."
 trap release_lock EXIT INT TERM
 
-echo "Obtained Lock. Deploying $PROJECT:$VERSION"
-for config in app.yaml app-backend-tasks.yaml app-backend-tasks-b2.yaml api.yaml clientapi.yaml tasks.yaml cron.yaml dispatch.yaml index.yaml queue.yaml; do
-    with_python27 "$GCLOUD --quiet --verbosity warning --project $PROJECT app deploy $config --version $VERSION"
-done
-
-# Check if we need to deploy our Endpoints config - cleanup afterwards so it's not in our web deploy
-paver make_endpoints_config
-if check_deploy_endpoints_config; then
-  with_python27 "$GCLOUD endpoints services deploy tbaMobilev9openapi.json"
-fi
-if check_deploy_tbaClient_endpoints_config; then
-  with_python27 "$GCLOUD endpoints services deploy tbaClientv9openapi.json"
-fi
+echo "Obtained Lock. Deploying $PROJECT:$VERSION in mode $TBA_DEPLOY_TYPE"
+case "$TBA_DEPLOY_TYPE" in
+  "prod")
+    deploy_full
+    ;;
+  "single-instance")
+    deploy_single
+    ;;
+  *)
+    echo "Unknown deploy type $TBA_DEPLOY_TYPE!"
+    exit -1
+    ;;
+esac
 
 echo "Updating build info..."
 update_build_info

--- a/ops/travis/travis-install.sh
+++ b/ops/travis/travis-install.sh
@@ -13,6 +13,7 @@ else
     check_clowntown_tag
 fi
 
+bash -c "source ~/.nvm/nvm.sh; nvm install $NODE_JS_VERSION; nvm install 8.16.0"
 pip install -r travis_requirements.txt
 paver install_libs
 GAE_VERSION="1.9.66"


### PR DESCRIPTION
This will let you deploy a staging instance without cronjobs, and with only a single GAE instance, so that random people's staging instances can stay within the free tier usage