### PR TITLE
Add IN to FIN district mapping

### DIFF
--- a/database/district_query.py
+++ b/database/district_query.py
@@ -11,9 +11,11 @@ CODE_MAP = {
     # Old to new
     'mar': 'fma',
     'nc': 'fnc',
+    'in': 'fin',
     # New to old
     'fma': 'mar',
     'fnc': 'nc',
+    'fin': 'in',
 }
 
 

--- a/helpers/event_helper.py
+++ b/helpers/event_helper.py
@@ -232,6 +232,8 @@ class EventHelper(object):
                 codes.add('FMA')
             if 'TX' in codes:  # TX and FIT used interchangeably
                 codes.add('FIT')
+            if 'IN' in codes:  # IN and FIN used interchangeably
+                codes.add('FIN')
             district_keys = '|'.join(codes)
         memcache.set('EventHelper.getShortName():district_keys', district_keys, 60*60)
 


### PR DESCRIPTION
## Description
The Indiana robotics organization, as well as as the Indiana district name, has changed.

https://frc-api.firstinspires.org/v2.0/2019/districts:
```
{
  "code": "IN",
  "name": "Indiana FIRST"
}
```

https://frc-api.firstinspires.org/v2.0/2020/districts:
```
{
  "code": "FIN",
  "name": "FIRST Indiana Robotics"
}
```

## Motivation and Context
https://www.thebluealliance.com/events/in is returning a 500 error.

https://www.thebluealliance.com/events/fin is the new "correct" url

## How Has This Been Tested?
I lost my local setup with a recent format, so this is totally just YOLO'ed.  😅
Travis?  🙏 

## Screenshots (if appropriate):
👀 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
