### PR TITLE
Migrated non-indexed string model fields to TextProperty

### DIFF
--- a/models/api_auth_access.py
+++ b/models/api_auth_access.py
@@ -14,7 +14,7 @@ class ApiAuthAccess(ndb.Model):
     - Access may be granted for more than one event.
     """
     # For both read and write:
-    description = ndb.StringProperty(indexed=False)  # human-readable description
+    description = ndb.TextProperty(indexed=False)  # human-readable description
     auth_types_enum = ndb.IntegerProperty(repeated=True)  # read and write types should never be mixed
     owner = ndb.KeyProperty(kind=Account)
     allow_admin = ndb.BooleanProperty(default=False)  # Allow access to admin APIv3
@@ -23,7 +23,7 @@ class ApiAuthAccess(ndb.Model):
     updated = ndb.DateTimeProperty(auto_now=True)
 
     # Write only:
-    secret = ndb.StringProperty(indexed=False)
+    secret = ndb.TextProperty(indexed=False)
     event_list = ndb.KeyProperty(kind=Event, repeated=True)  # events for which auth is granted
     expiration = ndb.DateTimeProperty()
 

--- a/models/award.py
+++ b/models/award.py
@@ -16,7 +16,7 @@ class Award(ndb.Model):
     Winner or Dean's List), they show up under the repeated properties.
     """
 
-    name_str = ndb.StringProperty(required=True, indexed=False)  # award name that shows up on USFIRST Pages. May vary for the same award type.
+    name_str = ndb.TextProperty(required=True, indexed=False)  # award name that shows up on USFIRST Pages. May vary for the same award type.
     award_type_enum = ndb.IntegerProperty(required=True)
     year = ndb.IntegerProperty(required=True)  # year the award was awarded
     event = ndb.KeyProperty(kind=Event, required=True)  # event at which the award was awarded

--- a/models/event.py
+++ b/models/event.py
@@ -19,8 +19,8 @@ class Event(ndb.Model):
     """
     name = ndb.StringProperty()
     event_type_enum = ndb.IntegerProperty(required=True)
-    short_name = ndb.StringProperty(indexed=False)  # Should not contain "Regional" or "Division", like "Hartford"
-    event_short = ndb.StringProperty(required=True, indexed=False)  # Smaller abbreviation like "CT"
+    short_name = ndb.TextProperty(indexed=False)  # Should not contain "Regional" or "Division", like "Hartford"
+    event_short = ndb.TextProperty(required=True, indexed=False)  # Smaller abbreviation like "CT"
     first_code = ndb.StringProperty()  # Event code used in FIRST's API, if different from event_short
     year = ndb.IntegerProperty(required=True)
     event_district_enum = ndb.IntegerProperty(default=DistrictType.NO_DISTRICT)  # Deprecated, use district_key instead
@@ -30,8 +30,8 @@ class Event(ndb.Model):
     playoff_type = ndb.IntegerProperty()
 
     # venue, venue_addresss, city, state_prov, country, and postalcode are from FIRST
-    venue = ndb.StringProperty(indexed=False)  # Name of the event venue
-    venue_address = ndb.StringProperty(indexed=False)  # Most detailed venue address (includes venue, street, and location separated by \n)
+    venue = ndb.TextProperty(indexed=False)  # Name of the event venue
+    venue_address = ndb.TextProperty(indexed=False)  # Most detailed venue address (includes venue, street, and location separated by \n)
     city = ndb.StringProperty()  # Equivalent to locality. From FRCAPI
     state_prov = ndb.StringProperty()  # Equivalent to region. From FRCAPI
     country = ndb.StringProperty()  # From FRCAPI
@@ -44,9 +44,9 @@ class Event(ndb.Model):
     first_eid = ndb.StringProperty()  # from USFIRST
     parent_event = ndb.KeyProperty()  # This is the division -> event champs relationship
     divisions = ndb.KeyProperty(repeated=True)  # event champs -> all divisions
-    facebook_eid = ndb.StringProperty(indexed=False)  # from Facebook
-    custom_hashtag = ndb.StringProperty(indexed=False)  # Custom HashTag
-    website = ndb.StringProperty(indexed=False)
+    facebook_eid = ndb.TextProperty(indexed=False)  # from Facebook
+    custom_hashtag = ndb.TextProperty(indexed=False)  # Custom HashTag
+    website = ndb.TextProperty(indexed=False)
     webcast_json = ndb.TextProperty(indexed=False)  # list of dicts, valid keys include 'type' and 'channel'
     enable_predictions = ndb.BooleanProperty(default=False)
     remap_teams = ndb.JsonProperty()  # Map of temporary team numbers to pre-rookie and B teams
@@ -482,7 +482,7 @@ class Event(ndb.Model):
             return "frc" + self.event_short
 
     # Depreciated, still here to keep GAE clean.
-    webcast_url = ndb.StringProperty(indexed=False)
+    webcast_url = ndb.TextProperty(indexed=False)
 
     @classmethod
     def validate_key_name(self, event_key):

--- a/models/insight.py
+++ b/models/insight.py
@@ -61,7 +61,7 @@ class Insight(ndb.Model):
 
     name = ndb.StringProperty(required=True)  # general name used for sorting
     year = ndb.IntegerProperty(required=True)  # year this insight pertains to. year = 0 for overall insights
-    data_json = ndb.StringProperty(required=True, indexed=False)  # JSON dictionary of the data of the insight
+    data_json = ndb.TextProperty(required=True, indexed=False)  # JSON dictionary of the data of the insight
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/models/match.py
+++ b/models/match.py
@@ -45,7 +45,7 @@ class Match(ndb.Model):
         'f': 5,
     }
 
-    alliances_json = ndb.StringProperty(required=True, indexed=False)  # JSON dictionary with alliances and scores.
+    alliances_json = ndb.TextProperty(required=True, indexed=False)  # JSON dictionary with alliances and scores.
 
     # {
     #   "red": {
@@ -62,7 +62,7 @@ class Match(ndb.Model):
     #   }
     # }
 
-    score_breakdown_json = ndb.StringProperty(indexed=False)  # JSON dictionary with score breakdowns. Fields are those used for seeding. Varies by year.
+    score_breakdown_json = ndb.TextProperty(indexed=False)  # JSON dictionary with score breakdowns. Fields are those used for seeding. Varies by year.
     # Example for 2014. Seeding outlined in Section 5.3.4 in the 2014 manual.
     # {"red": {
     #     "auto": 20,
@@ -85,7 +85,7 @@ class Match(ndb.Model):
     set_number = ndb.IntegerProperty(required=True, indexed=False)
     team_key_names = ndb.StringProperty(repeated=True)  # list of teams in Match, for indexing.
     time = ndb.DateTimeProperty()  # UTC time of scheduled start
-    time_string = ndb.StringProperty(indexed=False)  # the time as displayed on FIRST's site (event's local time)
+    time_string = ndb.TextProperty(indexed=False)  # the time as displayed on FIRST's site (event's local time)
     actual_time = ndb.DateTimeProperty()  # UTC time of match actual start
     predicted_time = ndb.DateTimeProperty()  # UTC time of when we predict the match will start
     post_result_time = ndb.DateTimeProperty()  # UTC time scores were shown to the audience

--- a/models/sitevar.py
+++ b/models/sitevar.py
@@ -14,8 +14,8 @@ class Sitevar(ndb.Model):
     contain a json blob that contain one or more keys with values. They are
     manually edited by site administrators in the admin console.
     """
-    description = ndb.StringProperty(indexed=False)
-    values_json = ndb.StringProperty(indexed=False, default="{}")  # a json blob
+    description = ndb.TextProperty(indexed=False)
+    values_json = ndb.TextProperty(indexed=False, default="{}")  # a json blob
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/models/suggestion.py
+++ b/models/suggestion.py
@@ -37,7 +37,7 @@ class Suggestion(ndb.Model):
     reviewed_at = ndb.DateTimeProperty()
     reviewer = ndb.KeyProperty(kind=Account)
     author = ndb.KeyProperty(kind=Account, required=True)
-    contents_json = ndb.StringProperty(indexed=False)  # a json blob
+    contents_json = ndb.TextProperty(indexed=False)  # a json blob
     target_key = ndb.StringProperty()  # "2012cmp"
     target_model = ndb.StringProperty(choices=MODELS, required=True)  # "event"
 

--- a/models/team.py
+++ b/models/team.py
@@ -12,7 +12,7 @@ class Team(ndb.Model):
     """
     team_number = ndb.IntegerProperty(required=True)
     name = ndb.TextProperty(indexed=False)
-    nickname = ndb.StringProperty(indexed=False)
+    nickname = ndb.TextProperty(indexed=False)
     school_name = ndb.TextProperty(indexed=False)
     home_cmp = ndb.StringProperty()
 
@@ -24,11 +24,11 @@ class Team(ndb.Model):
     # Normalized address from the Google Maps API, constructed using the above
     normalized_location = ndb.StructuredProperty(Location)
 
-    website = ndb.StringProperty(indexed=False)
+    website = ndb.TextProperty(indexed=False)
     first_tpid = ndb.IntegerProperty()  # from USFIRST. FIRST team ID number. -greg 5/20/2010
     first_tpid_year = ndb.IntegerProperty()  # from USFIRST. Year tpid is applicable for. -greg 9 Jan 2011
     rookie_year = ndb.IntegerProperty()
-    motto = ndb.StringProperty(indexed=False)
+    motto = ndb.TextProperty(indexed=False)
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)

--- a/models/typeahead_entry.py
+++ b/models/typeahead_entry.py
@@ -12,7 +12,7 @@ class TypeaheadEntry(ndb.Model):
     ALL_DISTRICTS_KEY = 'districts-all'
     YEAR_EVENTS_KEY = 'events-{}'
 
-    data_json = ndb.StringProperty(required=True, indexed=False)
+    data_json = ndb.TextProperty(required=True, indexed=False)
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)


### PR DESCRIPTION
`cloud-ndb` enforces that:
 - [`StringProperty` is always indexed](https://googleapis.dev/python/python-ndb/latest/model.html#google.cloud.ndb.model.StringProperty)
 - [`TextProperty` is never indexed](https://googleapis.dev/python/python-ndb/latest/model.html#google.cloud.ndb.model.TextProperty)

So codemod our models to make that so

```
$ find models/ -type f -name "*.py" -print0 | xargs -0 sed -i '' -e 's/StringProperty(indexed=False/TextProperty(indexed=False/g'
# ... fix some stuff this missed
# and check there's nothing left
$ ack StringProperty . | grep "indexed=False"  | wc -l
0
```

## Description
Towards https://github.com/the-blue-alliance/the-blue-alliance/issues/2791
