### PR TITLE
Take grpcio dependency from built-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 stages:
   - test
   - name: deploy
-    if: (type = push) AND (branch IN (master))
+    if: (type = push) AND (branch IN (master, py3))
 install:
 - travis_retry ./ops/travis/travis-install.sh $JOB
 - export PYTHONPATH=${PYTHONPATH}:${HOME}/google_appengine

--- a/api.yaml
+++ b/api.yaml
@@ -19,6 +19,8 @@ builtins:
 libraries:
 - name: MySQLdb
   version: "latest"
+- name: grpcio
+  version: 1.0.0
 
 handlers:
 - url: /_ah/queue/deferred.*

--- a/app-backend-tasks-b2.yaml
+++ b/app-backend-tasks-b2.yaml
@@ -22,6 +22,8 @@ libraries:
   version: "2016.4"
 - name: MySQLdb
   version: "latest"
+- name: grpcio
+  version: 1.0.0
 
 handlers:
 - url: /backend-tasks-b2/console/.*

--- a/app-backend-tasks.yaml
+++ b/app-backend-tasks.yaml
@@ -25,6 +25,8 @@ libraries:
   version: "2016.4"
 - name: MySQLdb
   version: "latest"
+- name: grpcio
+  version: 1.0.0
 
 handlers:
 - url: /_ah/queue/deferred.*

--- a/app.yaml
+++ b/app.yaml
@@ -28,6 +28,8 @@ libraries:
   version: "2016.4"
 - name: MySQLdb
   version: "latest"
+- name: grpcio
+  version: 1.0.0
 
 handlers:
 - url: /css

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,4 +1,7 @@
 from google.appengine.ext import vendor
 
+import six
+# https://github.com/googleapis/python-ndb/issues/249#issuecomment-560957294
+six.moves.reload_module(six)
 
 vendor.add('lib')

--- a/clientapi.yaml
+++ b/clientapi.yaml
@@ -15,6 +15,8 @@ libraries:
   version: 2.7.11
 - name: MySQLdb
   version: "latest"
+- name: grpcio
+  version: 1.0.0
 
 handlers:
 - url: .*

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -17,5 +17,3 @@ google-endpoints-api-management
 requests-toolbelt
 # See https://github.com/urllib3/urllib3/issues/1456
 urllib3==1.24.2
-grpcio==1.26.0 # Do not bump - App Engine will fail to deploy
-# Could move to using built in library https://cloud.google.com/appengine/docs/standard/python/tools/built-in-libraries-27

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.6.1
 Paver==1.2.4
 pep8==1.7.0
 pyyaml
+grpcio==1.0.0


### PR DESCRIPTION
Restart abstracting out ndb accesses to enable migrating to py3.

Break up the bits in https://github.com/the-blue-alliance/the-blue-alliance/pull/2789 into some smaller pieces so we can be more careful.

Also, I'm testing on my own GAE instance to make sure things aren't totally broken.

This particular diff is needed, because we're going to start depending on precompiled bits of `grpc` (when we later introduce the google cloud libraries to be vendored in). Which means we need to leverage the builtin version, not one we vendor ourselves.