### PR TITLE
[py3] Add flask middleware for ndb context

### DIFF
--- a/src/.gcloudignore
+++ b/src/.gcloudignore
@@ -22,3 +22,4 @@ __pycache__/
 
 # Tests
 tests/
+conftest.py

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,6 +1,9 @@
 from flask import Flask
 from api.handlers import RootHandler
+from common.middleware import install_middleware
 
 
 app = Flask(__name__)
+install_middleware(app)
+
 app.add_url_rule("/api/<path:path>", view_func=RootHandler)

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from werkzeug.test import Client
+
+
+@pytest.fixture
+def api_client() -> Client:
+    from api.main import app
+
+    return app.test_client()

--- a/src/api/tests/main_test.py
+++ b/src/api/tests/main_test.py
@@ -1,7 +1,7 @@
-from api.main import app
+import pytest
+from werkzeug.test import Client
 
 
-def test_root() -> None:
-    client = app.test_client()
-    resp = client.get("/api/v3")
+def test_root(api_client: Client) -> None:
+    resp = api_client.get("/api/v3")
     assert resp.status_code == 200

--- a/src/common/middleware.py
+++ b/src/common/middleware.py
@@ -1,0 +1,21 @@
+from flask import Flask
+from typing import Any, Callable
+
+
+class NdbMiddleware(object):
+
+    """
+    A middleware that gives each request access to an ndb context
+    """
+
+    app: Callable[[Any, Any], Any]
+
+    def __init__(self, app: Callable[[Any, Any], Any]):
+        self.app = app
+
+    def __call__(self, environ: Any, start_response: Any):
+        return self.app(environ, start_response)
+
+
+def install_middleware(app: Flask) -> None:
+    app.wsgi_app = NdbMiddleware(app.wsgi_app)  # type: ignore[override]

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+
+from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.fixture(autouse=True)
+def init_ndb_env_vars(monkeypatch: MonkeyPatch) -> None:
+    """
+    Initializing an ndb Client in a test env requires some environment variables to be set
+    For now, these are just garbage values intended to give the library _something_
+    (we don't expect them to actually work yet)
+    """
+
+    monkeypatch.setenv("DATASTORE_EMULATOR_HOST", "localhost:8432")
+    monkeypatch.setenv("DATASTORE_DATASET", "tba-unit-test")

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:google.cloud

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1,8 +1,11 @@
 from flask import Flask
+from common.middleware import install_middleware
 from web.handlers import HomeHandler
 from web.jinja2_filters import register_template_filters
 
 
 app = Flask(__name__)
+install_middleware(app)
+
 app.add_url_rule("/", view_func=HomeHandler)
 register_template_filters(app)

--- a/src/web/tests/conftest.py
+++ b/src/web/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from werkzeug.test import Client
+
+
+@pytest.fixture
+def web_client() -> Client:
+    from web.main import app
+
+    return app.test_client()

--- a/src/web/tests/main_test.py
+++ b/src/web/tests/main_test.py
@@ -1,7 +1,7 @@
-from web.main import app
+import pytest
+from werkzeug.test import Client
 
 
-def test_root() -> None:
-    client = app.test_client()
-    resp = client.get("/")
+def test_root(web_client: Client) -> None:
+    resp = web_client.get("/")
     assert resp.status_code == 200


### PR DESCRIPTION
We'll want to wrap each request in an ndb context, which we can do using a middleware.

There are a few fun things/dependencies:
 - This needs some library stubs for `pyre` to be happy. These have been added already in 548b4d490571490b82d1c1a6c84c753f59e6c7a8 and 2e3d6931a4694835fd79a360521b0788ea8eeae2
 - Added a base `pytest` fixture that'll monkeypath some env variables for cloud datastore to garbage values for now, just enough so the tests pass currently
 - Moved API test client generation to `pytest` fixtures, because of the necessary monkeypatching of environment variables we'll need to do

Stubs generated using
```
$ stubgen -p google.cloud.ndb -o stubs/
$ stubgen -p pytest -o stubs/
$ stubgen -p _pytest -o stubs/
```