### PR TITLE
[py3] integrate dev container with cloud builds

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,9 +32,14 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "tba-py3-docker"
   config.vm.provider "docker" do |d|
     d.name = "tba-py3"
-    d.build_dir = "ops/dev"
     d.ports = ports
     d.has_ssh = true
+
+    # By deafult, run with a prebuilt container image
+    d.image = "gcr.io/tbatv-prod-hrd/tba-py3-dev:latest"
+
+    # Or built it from the local checkout
+    # d.build_dir = "ops/dev"
   end
 
   # Configure ssh into container

--- a/ops/dev/build-container-images.sh
+++ b/ops/dev/build-container-images.sh
@@ -1,0 +1,6 @@
+set -e
+
+GCLOUD_PROJECT=${GCLOUD_PROJECT:-tbatv-prod-hrd}
+
+cd ops/dev
+gcloud --project $GCLOUD_PROJECT builds submit . --config=cloudbuild.yaml

--- a/ops/dev/cloudbuild.yaml
+++ b/ops/dev/cloudbuild.yaml
@@ -1,0 +1,15 @@
+# Configuration for Google Cloud Builds for the dev container
+# To build, run: ./ops/dev/build-container-images.sh
+# Local Requirements: gcloud and docker
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--file=Dockerfile'
+      - '--tag=gcr.io/$PROJECT_ID/tba-py3-dev'
+      - '.'
+    id: 'tba-py3-dev'
+
+images:
+- 'gcr.io/$PROJECT_ID/tba-py3-dev:latest'

--- a/ops/dev/print-gae-logs.sh
+++ b/ops/dev/print-gae-logs.sh
@@ -1,0 +1,3 @@
+set -e
+
+vagrant ssh -- -t 'tail -f /var/log/tba.log'

--- a/ops/dev/start-devserver.sh
+++ b/ops/dev/start-devserver.sh
@@ -29,3 +29,6 @@ tmux select-window -t "$session:1"
 
 tmux list-sessions
 tmux list-windows
+
+echo "To view logs, run \`./ops/dev/print-gae-logs.sh\`"
+echo "To make sure files auto-update, run \`vargrant rsync-auto\` in another shell"


### PR DESCRIPTION
By default, pull the container image from our Google project's container registry, which is faster htan building it locally.

Plus some other helpful scripts:
 - to build+push a new container image (we could also integrate this with CI later)
 - view GAE output from within container (by tailing the logfile)