### PR TITLE
[py3] [nodeploy] Remove main repo update on wiki update

### DIFF
--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -33,10 +33,3 @@ jobs:
           git add .
           git commit --allow-empty -m "Update wiki from master ($GITHUB_SHA)"
           git push "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.wiki.git"
-      - name: Update main repo
-        run: |
-          git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-          git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-          git add .
-          git commit --allow-empty -m "Update wiki from master($GITHUB_SHA)"
-          git push "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.git"


### PR DESCRIPTION
## Description
Removes updating the main repo on wiki submodule update.

## Motivation and Context
This was nice to have/helpful in my test repo setup, but is both failing and unnecessary in our use case.
GitHub Action failure:
https://github.com/the-blue-alliance/the-blue-alliance/runs/737274894?check_suite_focus=true#step:4:13

## How Has This Been Tested?
Tested in my personal fork.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
