### PR TITLE
[py3] [nodeploy] Update wiki auto-updating

### DIFF
--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - py3
-    paths:
-      - "docs/**"
+    # paths:
+    #   - "docs/**"
 
 jobs:
   update-wiki:
@@ -13,21 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       wiki-dir: docs
-      submodule-dir: ./the-blue-alliance.wiki
 
     steps:
-      - name: Checkout with submodules
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Update wiki submodule
-        working-directory: ${{env.submodule-dir}}
+      - uses: actions/checkout@v2
+      - name: Update wiki repo
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git checkout master
+          git clone "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.wiki.git"
+          cd ${GITHUB_REPOSITORY}.wiki
           rm -rf *
           cp -r ../${{env.wiki-dir}} .
           git add .

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - py3
-    # paths:
-    #   - "docs/**"
+    paths:
+      - "docs/**"
 
 jobs:
   update-wiki:

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -21,7 +21,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git clone "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.wiki.git"
-          cd ${GITHUB_REPOSITORY}.wiki
+          cd ${GITHUB_REPOSITORY##*/}.wiki
           rm -rf *
           cp -r ../${{env.wiki-dir}} .
           git add .

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -33,10 +33,3 @@ jobs:
           git add .
           git commit --allow-empty -m "Update wiki from master ($GITHUB_SHA)"
           git push "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.wiki.git"
-      - name: Update main repo
-        run: |
-          git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-          git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-          git add .
-          git commit --allow-empty -m "Update wiki from master($GITHUB_SHA)"
-          git push "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update wiki repo
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
           git clone "https://$GITHUB_ACTOR:${{secrets.GITHUB_TOKEN}}@github.com/$GITHUB_REPOSITORY.wiki.git"
           cd ${GITHUB_REPOSITORY##*/}.wiki
           rm -rf *

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "the-blue-alliance.wiki"]
-	path = the-blue-alliance.wiki
-	url = https://github.com/the-blue-alliance/the-blue-alliance.wiki.git


### PR DESCRIPTION
## Description
Update the self-updating wiki to not use a `git` submodule.

## Motivation and Context
After I thought about my current implementation a bit more, I realized that we 100% don't actually need the wiki submodule at all.  Instead of having it in the repo, which has to then be cloned down, and changed for forks (if testing), we could just clone the wiki repo at the time the GitHub Action is run.  This cleans up the repo, and doesn't add any more time/complexity to the Action.

## How Has This Been Tested?
Passing build with this code:
https://github.com/dracco1993/the-blue-alliance/runs/738962512?check_suite_focus=true

Currently running at:
https://github.com/dracco1993/the-blue-alliance/tree/py3
https://github.com/dracco1993/the-blue-alliance/wiki

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
