### PR TITLE
[py3] Introduce Typed DatabaseQuery abstraction

### DIFF
--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -1,0 +1,29 @@
+import abc
+from backend.common.typed_future import TypedFuture
+from google.cloud import ndb
+from typing import TypeVar, Generic
+
+
+QueryReturn = TypeVar("QueryReturn")
+
+
+class DatabaseQuery(abc.ABC, Generic[QueryReturn]):
+
+    _query_args: int
+
+    def __init__(self, *args, **kwargs):
+        self._query_args = kwargs
+
+    @abc.abstractmethod
+    def _query_async(self) -> TypedFuture[QueryReturn]:
+        ...
+
+    def fetch(self) -> QueryReturn:
+        return self.fetch_async().get_result()
+
+    @ndb.tasklet
+    def fetch_async(self) -> TypedFuture[QueryReturn]:
+        query_result = yield self._query_async(**self._query_args)
+        # Type-hinting the tasklet decorator is hard, but it consumes
+        # the generator and returns the overall future
+        return query_result  # pyre-ignore

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -1,0 +1,98 @@
+import pytest
+from backend.common.typed_future import TypedFuture
+from backend.common.queries.database_query import DatabaseQuery
+from google.cloud import ndb
+from typing import List
+
+
+@pytest.fixture(autouse=True)
+def auto_add_ndb_context(ndb_context):
+    pass
+
+
+class DummyModel(ndb.Model):
+    int_prop = ndb.IntegerProperty()
+
+
+class DummyModelPointQuery(DatabaseQuery[DummyModel]):
+    @ndb.tasklet
+    def _query_async(self, model_key: str) -> TypedFuture[DummyModel]:
+        model = yield DummyModel.get_by_id_async(model_key)
+        return model
+
+
+class DummyModelRangeQuery(DatabaseQuery[List[DummyModel]]):
+    @ndb.tasklet
+    def _query_async(self, min: int, max: int) -> TypedFuture[List[DummyModel]]:
+        models = yield DummyModel.query(
+            DummyModel.int_prop >= min, DummyModel.int_prop <= max
+        ).fetch_async()
+        return models
+
+
+def test_point_query_exists_sync() -> None:
+    m = DummyModel(id="test")
+    m.put()
+
+    query = DummyModelPointQuery(model_key="test")
+    result = query.fetch()
+    assert result == m
+
+
+def test_point_query_not_exists_sync() -> None:
+    query = DummyModelPointQuery(model_key="test")
+    result = query.fetch()
+    assert result is None
+
+
+def test_point_query_exists_async() -> None:
+    m = DummyModel(id="test")
+    m.put()
+
+    query = DummyModelPointQuery(model_key="test")
+    result_future = query.fetch_async()
+
+    result = result_future.result()
+    assert result == m
+
+
+def test_point_query_not_exists_async() -> None:
+    query = DummyModelPointQuery(model_key="test")
+    result_future = query.fetch_async()
+
+    result = result_future.result()
+    assert result is None
+
+
+def test_range_query_empty_sync() -> None:
+    query = DummyModelRangeQuery(min=0, max=10)
+    result = query.fetch()
+
+    assert result == []
+
+
+def test_range_query_empty_async() -> None:
+    query = DummyModelRangeQuery(min=0, max=10)
+    result_future = query.fetch_async()
+    result = result_future.result()
+
+    assert result == []
+
+
+def test_range_query_with_data_sync() -> None:
+    keys = ndb.put_multi([DummyModel(id=f"{i}", int_prop=i) for i in range(0, 5)])
+    assert len(keys) == 5
+
+    query = DummyModelRangeQuery(min=0, max=2)
+    result = query.fetch()
+    assert len(result) == 3
+
+
+def test_range_query_with_data_async() -> None:
+    keys = ndb.put_multi([DummyModel(id=f"{i}", int_prop=i) for i in range(0, 5)])
+    assert len(keys) == 5
+
+    query = DummyModelRangeQuery(min=0, max=2)
+    result_future = query.fetch_async()
+    result = result_future.result()
+    assert len(result) == 3

--- a/src/backend/common/typed_future.py
+++ b/src/backend/common/typed_future.py
@@ -1,0 +1,50 @@
+import types
+from google.cloud import ndb
+from typing import Callable, Generic, Optional, TypeVar
+
+
+T = TypeVar("T")
+
+
+class TypedFuture(ndb.Future, Generic[T]):
+    def done(self) -> bool:
+        return super().done()
+
+    def running(self) -> bool:
+        return super().running()
+
+    def wait(self) -> None:
+        super().wait()
+
+    def check_success(self) -> None:
+        super().check_success()
+
+    def set_result(self, result: T) -> None:
+        super().set_result(result)
+
+    def set_exception(self, exception: Exception) -> None:
+        super().set_exception(exception)
+
+    def result(self) -> T:
+        return super().result()
+
+    def get_result(self) -> T:
+        return super().get_result()
+
+    def exception(self) -> Exception:
+        return super().exception()
+
+    def get_exception(self) -> Exception:
+        return super().get_exception()
+
+    def get_traceback(self) -> Optional[types.TracebackType]:
+        return super().get_traceback()
+
+    def add_done_callback(self, callback: Callable[[], None]) -> None:
+        super().add_done_callback(callback)
+
+    def cancel(self) -> None:
+        super().cancel()
+
+    def cancelled(self) -> bool:
+        return super().cancelled()


### PR DESCRIPTION
This is the basis of a db query abstraction - it's a similar pattern to the old one with a few key differences:
 - type hinted! (but uses `TypedFuture` as a wrapper for `ndb.Future` that supports type hinting)
 - uses `abc` to make more clear the fact that subclasses need to implement `_query_async`
 - passes args via `kwargs` rather than the `*args`, since it's more clear what arg means what and passes them through to `_query_async` by name