### PR TITLE
Add middleware test to ensure ndb context provided via middleware

### DIFF
--- a/src/backend/common/tests/test_middleware.py
+++ b/src/backend/common/tests/test_middleware.py
@@ -1,5 +1,7 @@
 from backend.common.middleware import NdbMiddleware, install_middleware
+import flask
 from flask import Flask
+from google.cloud.ndb import context as context_module
 
 
 def test_NdbMiddleware_init(app: Flask) -> None:
@@ -8,11 +10,14 @@ def test_NdbMiddleware_init(app: Flask) -> None:
 
 
 def test_NdbMiddleware_callable(app: Flask) -> None:
-    pass
-    # middleware = NdbMiddleware(app)
-    # with app.test_request_context("/") as c:
-    #     # TODO: Test that some ndb context is available
-    #     pass
+    middleware = NdbMiddleware(app)
+
+    def start_response(status, headers):
+        context = context_module.get_context()
+        assert context.client is middleware.ndb_client
+
+    with app.test_request_context("/"):
+        middleware(flask.request.environ, start_response)
 
 
 def test_install_middleware(app: Flask) -> None:


### PR DESCRIPTION
Weirdly tricky to test this one! Basically - create a fake request and ensure that our ndb context is available. This will throw an exception if the ndb context isn't available.