### PR TITLE
Py3 team detail events

### DIFF
--- a/src/backend/common/models/event_participation.py
+++ b/src/backend/common/models/event_participation.py
@@ -1,0 +1,17 @@
+from typing import Dict, List, Optional
+
+from typing_extensions import TypedDict
+
+from backend.common.models.event import Event
+
+
+class EventParticipation(TypedDict):
+    event: Event
+    matches: Dict
+    wlt: Optional[Dict]
+    qual_avg: Optional[float]
+    elim_avg: Optional[float]
+    rank: Optional[int]
+    awards: List[Dict]
+    playlist: str
+    district_points: Optional[Dict]

--- a/src/backend/web/handlers/team.py
+++ b/src/backend/web/handlers/team.py
@@ -32,6 +32,14 @@ def team_canonical(team_number: int) -> str:
     return render_template("team_details.html", template_values)
 
 
+def team_detail(team_number: int, year: int) -> str:
+    pass
+
+
+def team_history(team_number: int) -> str:
+    pass
+
+
 def team_list(page: int) -> str:
     page_labels = []
     cur_page_label = ""

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+from typing import List, NamedTuple, Optional
+
+import bs4
+from google.cloud import ndb
+
+from backend.common.consts.event_type import EventType
+from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
+from backend.common.models.team import Team
+
+
+class TeamInfo(NamedTuple):
+    header: str
+    location: Optional[str]
+    full_name: Optional[str]
+    rookie_year: Optional[str]
+    last_competed: Optional[str]
+    website: Optional[str]
+    home_cmp: Optional[str]
+    hof: Optional[str]
+
+
+class TeamEventParticipation(NamedTuple):
+    event_name: str
+
+
+def preseed_team(ndb_client: ndb.Client, team_number: int) -> None:
+    with ndb_client.context():
+        Team(
+            id=f"frc{team_number}",
+            team_number=team_number,
+            nickname=f"The {team_number} Team",
+            name="The Blue Alliance / Some High School",
+            city="New York",
+            state_prov="NY",
+            country="USA",
+            website="https://www.thebluealliance.com",
+            rookie_year=2008,
+        ).put()
+
+
+def preseed_event_for_team(
+    ndb_client: ndb.Client, team_number: int, event_key: str
+) -> None:
+    with ndb_client.context():
+        Event(
+            id=event_key,
+            event_short=event_key[4:],
+            year=int(event_key[:4]),
+            name="Test Event",
+            event_type_enum=EventType.REGIONAL,
+            start_date=datetime(2020, 3, 1),
+            end_date=datetime(2020, 3, 5),
+        ).put()
+        EventTeam(
+            id=f"{event_key}_frc{team_number}",
+            event=ndb.Key(Event, event_key),
+            team=ndb.Key(Team, f"frc{team_number}"),
+            year=int(event_key[:4]),
+        ).put()
+
+
+def get_team_info(resp_data: str) -> TeamInfo:
+    soup = bs4.BeautifulSoup(resp_data, "html.parser")
+    header = soup.find("h2")
+    location = soup.find(id="team-location")
+    full_name = soup.find(id="team-name")
+    rookie_year = soup.find(id="team-rookie-year")
+    last_competed = soup.find(id="team-last-competed")
+    website = soup.find(id="team-website")
+    home_cmp = soup.find(id="team-home-cmp")
+    hof = soup.find(id="team-hof")
+
+    return TeamInfo(
+        header=header.string.strip(),
+        location=location.string.strip() if location else None,
+        full_name=full_name.string.strip() if full_name else None,
+        rookie_year=rookie_year.string.strip() if rookie_year else None,
+        last_competed=last_competed.string.strip() if last_competed else None,
+        website=website.string.strip() if website else None,
+        home_cmp=home_cmp.string.strip() if home_cmp else None,
+        hof=hof.string.strip() if hof else None,
+    )
+
+
+def get_page_title(resp_data: str) -> str:
+    soup = bs4.BeautifulSoup(resp_data, "html.parser")
+    title = soup.find("title")
+    return title.string.strip()
+
+
+def get_years_participated_dropdown(resp_data: str) -> List[str]:
+    soup = bs4.BeautifulSoup(resp_data, "html.parser")
+    dropdown = soup.find("ul", id="team-year-dropdown")
+    print(f"{dropdown.contents}")
+    return [li.string.strip() for li in dropdown.contents if li.name == "li"]
+
+
+def get_team_event_participation(
+    resp_data: str, event_key: str
+) -> TeamEventParticipation:
+    soup = bs4.BeautifulSoup(resp_data, "html.parser")
+    event = soup.find(id=event_key)
+    return TeamEventParticipation(event_name=event.find("h3").string.strip(),)

--- a/src/backend/web/handlers/tests/team_canonical_test.py
+++ b/src/backend/web/handlers/tests/team_canonical_test.py
@@ -1,0 +1,50 @@
+from freezegun import freeze_time
+from google.cloud import ndb
+from werkzeug.test import Client
+
+from backend.web.handlers.tests import helpers
+
+
+def test_et_bad_team_num(web_client: Client) -> None:
+    resp = web_client.get("/team/0")
+    assert resp.status_code == 404
+
+
+def test_team_not_found(web_client: Client) -> None:
+    resp = web_client.get("/team/254")
+    assert resp.status_code == 404
+
+
+def test_team_found_no_events(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    resp = web_client.get("/team/254")
+    # This should render team history, but it's not implemented yet
+    assert resp.status_code == 501
+
+
+@freeze_time("2020-02-01")
+def test_page_title(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    # We need an event to not render the history page
+    helpers.preseed_event_for_team(ndb_client, 254, "2020test")
+    resp = web_client.get("/team/254")
+    assert resp.status_code == 200
+    assert (
+        helpers.get_page_title(resp.data)
+        == "The 254 Team - Team 254 - The Blue Alliance"
+    )
+
+
+@freeze_time("2020-02-01")
+def test_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    # We need an event to not render the history page
+    helpers.preseed_event_for_team(ndb_client, 254, "2020test")
+    resp = web_client.get("/team/254")
+    assert resp.status_code == 200
+
+    team_info = helpers.get_team_info(resp.data)
+    assert team_info.header == "Team 254 - The 254 Team"
+    assert team_info.location == "New York, NY, USA"
+    assert team_info.full_name == "The Blue Alliance / Some High School"
+    assert team_info.rookie_year == "Rookie Year: 2008"

--- a/src/backend/web/handlers/tests/team_detail_test.py
+++ b/src/backend/web/handlers/tests/team_detail_test.py
@@ -1,145 +1,70 @@
-from datetime import datetime
-from typing import NamedTuple, Optional
-
-import bs4
-from freezegun import freeze_time
 from google.cloud import ndb
 from werkzeug.test import Client
 
-from backend.common.consts.event_type import EventType
-from backend.common.models.event import Event
-from backend.common.models.event_team import EventTeam
-from backend.common.models.team import Team
+from backend.web.handlers.tests import helpers
 
 
-class TeamInfo(NamedTuple):
-    header: str
-    location: Optional[str]
-    full_name: Optional[str]
-    rookie_year: Optional[str]
-    last_competed: Optional[str]
-    website: Optional[str]
-    home_cmp: Optional[str]
-    hof: Optional[str]
-
-
-def preseed_team(ndb_client: ndb.Client, team_number: int) -> None:
-    with ndb_client.context():
-        Team(
-            id=f"frc{team_number}",
-            team_number=team_number,
-            nickname=f"The {team_number} Team",
-            name="The Blue Alliance / Some High School",
-            city="New York",
-            state_prov="NY",
-            country="USA",
-            website="https://www.thebluealliance.com",
-            rookie_year=2008,
-        ).put()
-
-
-def preseed_event_for_team(
-    ndb_client: ndb.Client, team_number: int, event_key: str
-) -> None:
-    with ndb_client.context():
-        Event(
-            id=event_key,
-            event_short=event_key[4:],
-            year=int(event_key[:4]),
-            event_type_enum=EventType.REGIONAL,
-            start_date=datetime(2020, 3, 1),
-            end_date=datetime(2020, 3, 5),
-        ).put()
-        EventTeam(
-            id=f"{event_key}_frc{team_number}",
-            event=ndb.Key(Event, event_key),
-            team=ndb.Key(Team, f"frc{team_number}"),
-            year=int(event_key[:4]),
-        ).put()
-
-
-def get_team_info(resp_data: str) -> TeamInfo:
-    soup = bs4.BeautifulSoup(resp_data, "html.parser")
-    header = soup.find("h2")
-    location = soup.find(id="team-location")
-    full_name = soup.find(id="team-name")
-    rookie_year = soup.find(id="team-rookie-year")
-    last_competed = soup.find(id="team-last-competed")
-    website = soup.find(id="team-website")
-    home_cmp = soup.find(id="team-home-cmp")
-    hof = soup.find(id="team-hof")
-
-    return TeamInfo(
-        header=header.string.strip(),
-        location=location.string.strip() if location else None,
-        full_name=full_name.string.strip() if full_name else None,
-        rookie_year=rookie_year.string.strip() if rookie_year else None,
-        last_competed=last_competed.string.strip() if last_competed else None,
-        website=website.string.strip() if website else None,
-        home_cmp=home_cmp.string.strip() if home_cmp else None,
-        hof=hof.string.strip() if hof else None,
-    )
-
-
-def test_canonical_get_bad_team_num(web_client: Client) -> None:
-    resp = web_client.get("/team/0")
-    assert resp.status_code == 404
-
-
-def test_detail_get_bad_team_num(web_client: Client) -> None:
+def test_get_bad_team_num(web_client: Client) -> None:
     resp = web_client.get("/team/0/2020")
     assert resp.status_code == 404
 
 
-def test_canonical_team_not_found(web_client: Client) -> None:
-    resp = web_client.get("/team/254")
-    assert resp.status_code == 404
-
-
-def test_detail_team_not_found(web_client: Client) -> None:
+def test_team_not_found(web_client: Client) -> None:
     resp = web_client.get("/team/254/2020")
     assert resp.status_code == 404
 
 
-def test_canonical_team_found_no_events(
-    web_client: Client, ndb_client: ndb.Client
-) -> None:
-    preseed_team(ndb_client, 254)
-    resp = web_client.get("/team/254")
-    # This should render team history, but it's not implemented yet
-    assert resp.status_code == 501
+def test_team_found_no_events(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 404
 
 
-def test_detail_team_found_no_events(
-    web_client: Client, ndb_client: ndb.Client
-) -> None:
-    preseed_team(ndb_client, 254)
+def test_page_title(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    helpers.preseed_event_for_team(ndb_client, 254, "2020test")
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 200
+    assert (
+        helpers.get_page_title(resp.data)
+        == "The 254 Team - Team 254 (2020) - The Blue Alliance"
+    )
+
+
+def test_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    helpers.preseed_event_for_team(ndb_client, 254, "2020test")
     resp = web_client.get("/team/254/2020")
     assert resp.status_code == 200
 
-
-@freeze_time("2020-02-01")
-def test_canonical_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
-    preseed_team(ndb_client, 254)
-    # We need an event to not render the history page
-    preseed_event_for_team(ndb_client, 254, "2020test")
-    resp = web_client.get("/team/254")
-    assert resp.status_code == 200
-
-    team_info = get_team_info(resp.data)
+    team_info = helpers.get_team_info(resp.data)
     assert team_info.header == "Team 254 - The 254 Team"
     assert team_info.location == "New York, NY, USA"
     assert team_info.full_name == "The Blue Alliance / Some High School"
     assert team_info.rookie_year == "Rookie Year: 2008"
 
 
-def test_detail_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
-    preseed_team(ndb_client, 254)
+def test_team_year_dropdown(web_client: Client, ndb_client: ndb.Client) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    # Use out-of-order years here to make sure they're sorted properly
+    [
+        helpers.preseed_event_for_team(ndb_client, 254, f"{year}test")
+        for year in [2019, 2020, 2018]
+    ]
+
     resp = web_client.get("/team/254/2020")
     assert resp.status_code == 200
+    dropdown_years = helpers.get_years_participated_dropdown(resp.data)
+    assert dropdown_years == ["History", "2020 Season", "2019 Season", "2018 Season"]
 
-    team_info = get_team_info(resp.data)
-    assert team_info.header == "Team 254 - The 254 Team"
-    assert team_info.location == "New York, NY, USA"
-    assert team_info.full_name == "The Blue Alliance / Some High School"
-    assert team_info.rookie_year == "Rookie Year: 2008"
+
+def test_team_participation_event_details(
+    web_client: Client, ndb_client: ndb.Client
+) -> None:
+    helpers.preseed_team(ndb_client, 254)
+    helpers.preseed_event_for_team(ndb_client, 254, "2020test")
+
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 200
+    event_info = helpers.get_team_event_participation(resp.data, "2020test")
+    assert event_info.event_name == "Test Event"

--- a/src/backend/web/handlers/tests/team_detail_test.py
+++ b/src/backend/web/handlers/tests/team_detail_test.py
@@ -1,9 +1,14 @@
+from datetime import datetime
 from typing import NamedTuple, Optional
 
 import bs4
+from freezegun import freeze_time
 from google.cloud import ndb
 from werkzeug.test import Client
 
+from backend.common.consts.event_type import EventType
+from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
 from backend.common.models.team import Team
 
 
@@ -33,6 +38,26 @@ def preseed_team(ndb_client: ndb.Client, team_number: int) -> None:
         ).put()
 
 
+def preseed_event_for_team(
+    ndb_client: ndb.Client, team_number: int, event_key: str
+) -> None:
+    with ndb_client.context():
+        Event(
+            id=event_key,
+            event_short=event_key[4:],
+            year=int(event_key[:4]),
+            event_type_enum=EventType.REGIONAL,
+            start_date=datetime(2020, 3, 1),
+            end_date=datetime(2020, 3, 5),
+        ).put()
+        EventTeam(
+            id=f"{event_key}_frc{team_number}",
+            event=ndb.Key(Event, event_key),
+            team=ndb.Key(Team, f"frc{team_number}"),
+            year=int(event_key[:4]),
+        ).put()
+
+
 def get_team_info(resp_data: str) -> TeamInfo:
     soup = bs4.BeautifulSoup(resp_data, "html.parser")
     header = soup.find("h2")
@@ -56,25 +81,61 @@ def get_team_info(resp_data: str) -> TeamInfo:
     )
 
 
-def test_get_bad_team_num(web_client: Client) -> None:
+def test_canonical_get_bad_team_num(web_client: Client) -> None:
     resp = web_client.get("/team/0")
     assert resp.status_code == 404
 
 
-def test_team_not_found(web_client: Client) -> None:
+def test_detail_get_bad_team_num(web_client: Client) -> None:
+    resp = web_client.get("/team/0/2020")
+    assert resp.status_code == 404
+
+
+def test_canonical_team_not_found(web_client: Client) -> None:
     resp = web_client.get("/team/254")
     assert resp.status_code == 404
 
 
-def test_team_found(web_client: Client, ndb_client: ndb.Client) -> None:
+def test_detail_team_not_found(web_client: Client) -> None:
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 404
+
+
+def test_canonical_team_found_no_events(
+    web_client: Client, ndb_client: ndb.Client
+) -> None:
     preseed_team(ndb_client, 254)
     resp = web_client.get("/team/254")
+    # This should render team history, but it's not implemented yet
+    assert resp.status_code == 501
+
+
+def test_detail_team_found_no_events(
+    web_client: Client, ndb_client: ndb.Client
+) -> None:
+    preseed_team(ndb_client, 254)
+    resp = web_client.get("/team/254/2020")
     assert resp.status_code == 200
 
 
-def test_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
+@freeze_time("2020-02-01")
+def test_canonical_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
     preseed_team(ndb_client, 254)
+    # We need an event to not render the history page
+    preseed_event_for_team(ndb_client, 254, "2020test")
     resp = web_client.get("/team/254")
+    assert resp.status_code == 200
+
+    team_info = get_team_info(resp.data)
+    assert team_info.header == "Team 254 - The 254 Team"
+    assert team_info.location == "New York, NY, USA"
+    assert team_info.full_name == "The Blue Alliance / Some High School"
+    assert team_info.rookie_year == "Rookie Year: 2008"
+
+
+def test_detail_team_info(web_client: Client, ndb_client: ndb.Client) -> None:
+    preseed_team(ndb_client, 254)
+    resp = web_client.get("/team/254/2020")
     assert resp.status_code == 200
 
     team_info = get_team_info(resp.data)

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -4,7 +4,12 @@ from backend.common.middleware import install_middleware
 from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.gameday import gameday
 from backend.web.handlers.index import index
-from backend.web.handlers.team import team_canonical, team_list
+from backend.web.handlers.team import (
+    team_canonical,
+    team_detail,
+    team_history,
+    team_list,
+)
 from backend.web.jinja2_filters import register_template_filters
 
 
@@ -14,6 +19,8 @@ install_middleware(app)
 app.add_url_rule("/", view_func=index)
 app.add_url_rule("/gameday", view_func=gameday)
 app.add_url_rule("/team/<int:team_number>", view_func=team_canonical)
+app.add_url_rule("/team/<int:team_number>/<int:year>", view_func=team_detail)
+app.add_url_rule("/team/<int:team_number>/history", view_func=team_history)
 app.add_url_rule("/teams/<int:page>", view_func=team_list)
 app.add_url_rule("/teams", view_func=team_list, defaults={"page": 1})
 

--- a/src/backend/web/templates/team_partials/team_year_dropdown.html
+++ b/src/backend/web/templates/team_partials/team_year_dropdown.html
@@ -4,7 +4,7 @@
       {{ dropdown_label }}
       <span class="caret"></span>
     </a>
-    <ul class="dropdown-menu tba-dropdown-menu-limited">
+    <ul class="dropdown-menu tba-dropdown-menu-limited" id="team-year-dropdown">
       <li><a href="/team/{{team.team_number}}/history">History</a></li>
       {% for a_year in years|reverse %}
         <li><a href="/team/{{team.team_number}}/{{a_year}}">{{a_year}} Season</a></li>


### PR DESCRIPTION
 - implement the same distinction between the canonical/detail handlers as the existing site
 - implement the year choice dropdown
 - show stubs for event participation
 - unit tests