### PR TITLE
Add www.thebluealliance.com as a parent for Twitch embeds

### DIFF
--- a/react/gameday2/components/TwitchChatEmbed.js
+++ b/react/gameday2/components/TwitchChatEmbed.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 
 const TwitchChatEmbed = (props) => {
   const id = `twich-chat-${props.channel}`
-  const src = `https://twitch.tv/embed/${props.channel}/chat?parent=thebluealliance.com&parent=www.thebluealliance.com`
+  const src = `https://twitch.tv/embed/${props.channel}/chat?parent=www.thebluealliance.com`
   const style = {
     display: props.visible ? null : 'none',
     width: '100%',

--- a/react/gameday2/components/TwitchChatEmbed.js
+++ b/react/gameday2/components/TwitchChatEmbed.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 
 const TwitchChatEmbed = (props) => {
   const id = `twich-chat-${props.channel}`
-  const src = `https://twitch.tv/embed/${props.channel}/chat?parent=thebluealliance.com`
+  const src = `https://twitch.tv/embed/${props.channel}/chat?parent=thebluealliance.com&parent=www.thebluealliance.com`
   const style = {
     display: props.visible ? null : 'none',
     width: '100%',

--- a/react/gameday2/components/embeds/EmbedTwitch.js
+++ b/react/gameday2/components/embeds/EmbedTwitch.js
@@ -3,7 +3,7 @@ import { webcastPropType } from '../../utils/webcastUtils'
 
 const EmbedTwitch = (props) => {
   const channel = props.webcast.channel
-  const iframeSrc = `https://player.twitch.tv/?channel=${channel}&parent=thebluealliance.com`
+  const iframeSrc = `https://player.twitch.tv/?channel=${channel}&parent=thebluealliance.com&parent=www.thebluealliance.com`
   return (
     <iframe
       src={iframeSrc}

--- a/react/gameday2/components/embeds/EmbedTwitch.js
+++ b/react/gameday2/components/embeds/EmbedTwitch.js
@@ -3,7 +3,7 @@ import { webcastPropType } from '../../utils/webcastUtils'
 
 const EmbedTwitch = (props) => {
   const channel = props.webcast.channel
-  const iframeSrc = `https://player.twitch.tv/?channel=${channel}&parent=thebluealliance.com&parent=www.thebluealliance.com`
+  const iframeSrc = `https://player.twitch.tv/?channel=${channel}&parent=www.thebluealliance.com`
   return (
     <iframe
       src={iframeSrc}

--- a/templates/gameday.html
+++ b/templates/gameday.html
@@ -245,7 +245,7 @@
   <div id="chat-info-background">
     <div id="chat-info" class="alert alert-warning"><button type="button" class="close" data-dismiss="alert">&times;</button><strong>Reminder:</strong> You need to log into a <a href="http://www.twitch.tv/" target="_blank">Twitch.tv</a> account in order to chat.</div>
   </div>
-  <iframe frameborder="0" scrolling="no" id="chat_embed" src="https://twitch.tv/chat/embed?channel=tbagameday&amp;popout_chat=true&amp;parent=thebluealliance.com" height="100%" width="100%"></iframe>
+  <iframe frameborder="0" scrolling="no" id="chat_embed" src="https://twitch.tv/chat/embed?channel=tbagameday&amp;popout_chat=true&amp;parent=thebluealliance.com&amp;parent=www.thebluealliance.com" height="100%" width="100%"></iframe>
 </div>
 {% endblock %}
 

--- a/templates/gameday.html
+++ b/templates/gameday.html
@@ -245,7 +245,7 @@
   <div id="chat-info-background">
     <div id="chat-info" class="alert alert-warning"><button type="button" class="close" data-dismiss="alert">&times;</button><strong>Reminder:</strong> You need to log into a <a href="http://www.twitch.tv/" target="_blank">Twitch.tv</a> account in order to chat.</div>
   </div>
-  <iframe frameborder="0" scrolling="no" id="chat_embed" src="https://twitch.tv/chat/embed?channel=tbagameday&amp;popout_chat=true&amp;parent=thebluealliance.com&amp;parent=www.thebluealliance.com" height="100%" width="100%"></iframe>
+  <iframe frameborder="0" scrolling="no" id="chat_embed" src="https://twitch.tv/chat/embed?channel=tbagameday&amp;popout_chat=true&amp;parent=www.thebluealliance.com" height="100%" width="100%"></iframe>
 </div>
 {% endblock %}
 

--- a/templates/webcast/twitch.html
+++ b/templates/webcast/twitch.html
@@ -1,1 +1,1 @@
-<iframe src="https://player.twitch.tv/?channel={{webcast.channel}}&parent=thebluealliance.com&parent=www.thebluealliance.com" frameborder="0" scrolling="no" height="100%" width="100%" allowfullscreen></iframe>
+<iframe src="https://player.twitch.tv/?channel={{webcast.channel}}&parent=www.thebluealliance.com" frameborder="0" scrolling="no" height="100%" width="100%" allowfullscreen></iframe>

--- a/templates/webcast/twitch.html
+++ b/templates/webcast/twitch.html
@@ -1,1 +1,1 @@
-<iframe src="https://player.twitch.tv/?channel={{webcast.channel}}&parent=thebluealliance.com" frameborder="0" scrolling="no" height="100%" width="100%" allowfullscreen></iframe>
+<iframe src="https://player.twitch.tv/?channel={{webcast.channel}}&parent=thebluealliance.com&parent=www.thebluealliance.com" frameborder="0" scrolling="no" height="100%" width="100%" allowfullscreen></iframe>


### PR DESCRIPTION
## Description
Add `www.thebluealliance.com` as a parent for Twitch embeds

## Motivation and Context
`GameDay` is kill.  Plz no kill `GameDay`.  🙏 

## How Has This Been Tested?
I manually changed the embeds in the source, and they worked.  👀 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1204591/84964474-35313d80-b0da-11ea-8cf1-801e4e13a62f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
