### PR TITLE
[py3] Cache Clearing Base

### DIFF
--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -45,3 +45,19 @@ class DatabaseQuery(abc.ABC, Generic[QueryReturn]):
             safe_cast(QueryReturn, query_result)
         ).convert(version)
         return safe_cast(TypedFuture[Dict], res)
+
+    @classmethod
+    def _event_affected_queries(
+        cls, event_key: str, year: int, district_key: str
+    ) -> Set[Any]:
+        return set()
+
+    @classmethod
+    def _eventteam_affected_queries(
+        cls, event_key: str, team_key: str, year: int
+    ) -> Set[Any]:
+        return set()
+
+    @classmethod
+    def _team_affected_queries(cls, team_key: str) -> Set[Any]:
+        return set()

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 from typing import Any, Dict, Generic, Optional, Set, Type
 
@@ -6,6 +8,7 @@ from pyre_extensions import safe_cast
 
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.futures import TypedFuture
+from backend.common.models.keys import DistrictKey, EventKey, TeamKey, Year
 from backend.common.profiler import Span
 from backend.common.queries.dict_converters.converter_base import ConverterBase
 from backend.common.queries.exceptions import DoesNotExistException
@@ -56,6 +59,9 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn]):
     CACHE_VERSION: int = 0
     _cache_key: Optional[str] = None
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     @property
     def cache_key(self) -> Optional[str]:
         if not self._cache_key:
@@ -68,16 +74,16 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn]):
 
     @classmethod
     def _event_affected_queries(
-        cls, event_key: str, year: int, district_key: str
-    ) -> Set[Any]:
+        cls, event_key: EventKey, year: Year, district_key: Optional[DistrictKey]
+    ) -> Set[CachedDatabaseQuery]:
         return set()
 
     @classmethod
     def _eventteam_affected_queries(
-        cls, event_key: str, team_key: str, year: int
-    ) -> Set[Any]:
+        cls, event_key: EventKey, team_key: TeamKey, year: Year
+    ) -> Set[CachedDatabaseQuery]:
         return set()
 
     @classmethod
-    def _team_affected_queries(cls, team_key: str) -> Set[Any]:
+    def _team_affected_queries(cls, team_key: TeamKey) -> Set[CachedDatabaseQuery]:
         return set()

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -13,11 +13,29 @@ from backend.common.queries.types import QueryReturn
 
 
 class DatabaseQuery(abc.ABC, Generic[QueryReturn]):
+    _cache_key: str = ""
     _query_args: Dict[str, Any]
+    DATABASE_QUERY_VERSION = 0
+    BASE_CACHE_KEY_FORMAT: str = (
+        "{}:{}:{}"  # (partial_cache_key, cache_version, database_query_version)
+    )
+    CACHE_KEY_FORMAT: str = ""
+    CACHE_VERSION: int = 0
     DICT_CONVERTER: Type[ConverterBase[QueryReturn]] = ConverterBase
 
     def __init__(self, *args, **kwargs) -> None:
         self._query_args = kwargs
+
+    @property
+    def cache_key(self) -> str:
+        if self._cache_key == "":
+            self._cache_key = self.BASE_CACHE_KEY_FORMAT.format(
+                self.CACHE_KEY_FORMAT.format(**self._query_args),
+                self.CACHE_VERSION,
+                self.DATABASE_QUERY_VERSION,
+            )
+
+        return self._cache_key
 
     @abc.abstractmethod
     def _query_async(self) -> TypedFuture[QueryReturn]:

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -31,7 +31,7 @@ class TeamQuery(CachedDatabaseQuery[Optional[Team]]):
         return team
 
     @classmethod
-    def _team_affected_queries(cls, team_key: str) -> Set[CachedDatabaseQuery]:
+    def _team_affected_queries(cls, team_key: TeamKey) -> Set[CachedDatabaseQuery]:
         return {cls(team_key=team_key)}
 
 
@@ -56,7 +56,7 @@ class TeamListQuery(CachedDatabaseQuery[List[Team]]):
         return list(teams)
 
     @classmethod
-    def _team_affected_queries(cls, team_key: str) -> Set[CachedDatabaseQuery]:
+    def _team_affected_queries(cls, team_key: TeamKey) -> Set[CachedDatabaseQuery]:
         return {cls(page=_get_team_page_num(team_key))}
 
 
@@ -87,7 +87,7 @@ class TeamListYearQuery(CachedDatabaseQuery[List[Team]]):
 
     @classmethod
     def _eventteam_affected_queries(
-        cls, event_key: str, team_key: str, year: int
+        cls, event_key: EventKey, team_key: TeamKey, year: Year
     ) -> Set[CachedDatabaseQuery]:
         return {cls(year=year, page=_get_team_page_num(team_key))}
 
@@ -141,7 +141,7 @@ class EventTeamsQuery(CachedDatabaseQuery[List[Team]]):
         return {cls(event_key=event_key)}
 
     @classmethod
-    def _team_affected_queries(cls, team_key: str) -> Set[CachedDatabaseQuery]:
+    def _team_affected_queries(cls, team_key: TeamKey) -> Set[CachedDatabaseQuery]:
         event_team_keys_future = EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key)
         ).fetch_async(keys_only=True)
@@ -169,7 +169,7 @@ class EventEventTeamsQuery(CachedDatabaseQuery[List[EventTeam]]):
 
     @classmethod
     def _eventteam_affected_queries(
-        cls, event_key: str, team_key: str, year: int
+        cls, event_key: EventKey, team_key: TeamKey, year: Year
     ) -> Set[CachedDatabaseQuery]:
         return {cls(event_key=event_key)}
 
@@ -192,7 +192,7 @@ class TeamParticipationQuery(CachedDatabaseQuery[Set[int]]):
 
     @classmethod
     def _eventteam_affected_queries(
-        cls, event_key: str, team_key: str, year: int
+        cls, event_key: EventKey, team_key: TeamKey, year: Year
     ) -> Set[CachedDatabaseQuery]:
         return {cls(team_key=team_key)}
 

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -96,7 +96,7 @@ class TeamListYearQuery(CachedDatabaseQuery[List[Team]]):
         return TeamListQuery._team_affected_queries(team_key=team_key)
 
 
-class DistrictTeamsQuery(DatabaseQuery[List[Team]]):
+class DistrictTeamsQuery(CachedDatabaseQuery[List[Team]]):
     CACHE_KEY_FORMAT = "district_teams_{district_key}"
     CACHE_VERSION = 0
     DICT_CONVERTER = TeamConverter

--- a/src/backend/common/queries/tests/event_event_teams_query_test.py
+++ b/src/backend/common/queries/tests/event_event_teams_query_test.py
@@ -30,3 +30,12 @@ def test_get_data() -> None:
 
     event_teams = EventEventTeamsQuery(event_key="2020ct").fetch()
     assert len(event_teams) == 10
+
+
+def test_affected_queries() -> None:
+    assert {
+        q.cache_key
+        for q in EventEventTeamsQuery._eventteam_affected_queries(
+            event_key="2020casj", team_key="frc254", year=2020
+        )
+    } == {EventEventTeamsQuery(event_key="2020casj").cache_key}

--- a/src/backend/common/queries/tests/event_teams_query_test.py
+++ b/src/backend/common/queries/tests/event_teams_query_test.py
@@ -42,3 +42,43 @@ def test_get_data() -> None:
 
     teams = EventTeamsQuery(event_key="2020ct").fetch()
     assert len(teams) == len(stored_teams)
+
+
+def test_affected_queries() -> None:
+    stored_teams1 = preseed_teams(1, 10)
+    stored_teams2 = preseed_teams(100, 110)
+    preseed_event_teams(stored_teams1, "2020aaa")
+    preseed_event_teams(stored_teams2, "2020bbb")
+    preseed_event_teams(stored_teams1 + stored_teams2, "2020ccc")
+
+    for team_key in stored_teams1:
+        assert {
+            q.cache_key
+            for q in EventTeamsQuery._eventteam_affected_queries(
+                event_key="2020aaa", team_key=team_key.id(), year=2020
+            )
+        } == {EventTeamsQuery(event_key="2020aaa").cache_key}
+
+        assert {
+            q.cache_key
+            for q in EventTeamsQuery._team_affected_queries(team_key=team_key.id())
+        } == {
+            EventTeamsQuery(event_key="2020aaa").cache_key,
+            EventTeamsQuery(event_key="2020ccc").cache_key,
+        }
+
+    for team_key in stored_teams2:
+        assert {
+            q.cache_key
+            for q in EventTeamsQuery._eventteam_affected_queries(
+                event_key="2020bbb", team_key=team_key.id(), year=2020
+            )
+        } == {EventTeamsQuery(event_key="2020bbb").cache_key}
+
+        assert {
+            q.cache_key
+            for q in EventTeamsQuery._team_affected_queries(team_key=team_key.id())
+        } == {
+            EventTeamsQuery(event_key="2020bbb").cache_key,
+            EventTeamsQuery(event_key="2020ccc").cache_key,
+        }

--- a/src/backend/common/queries/tests/team_list_query_test.py
+++ b/src/backend/common/queries/tests/team_list_query_test.py
@@ -55,3 +55,18 @@ def test_upper_bound_exclusive() -> None:
     preseed_teams(500)
     teams = TeamListQuery(page=0).fetch()
     assert teams == []
+
+
+def test_affected_queries() -> None:
+    assert {
+        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc254")
+    } == {TeamListQuery(page=0).cache_key}
+    assert {
+        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc604")
+    } == {TeamListQuery(page=1).cache_key}
+    assert {
+        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc1114")
+    } == {TeamListQuery(page=2).cache_key}
+    assert {
+        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc9999")
+    } == {TeamListQuery(page=19).cache_key}

--- a/src/backend/common/queries/tests/team_list_year_query_test.py
+++ b/src/backend/common/queries/tests/team_list_year_query_test.py
@@ -6,7 +6,7 @@ from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import Year
 from backend.common.models.team import Team
-from backend.common.queries.team_query import TeamListYearQuery
+from backend.common.queries.team_query import TeamListQuery, TeamListYearQuery
 
 
 def preseed_teams(start_team: int, end_team: Optional[int] = None) -> List[ndb.Key]:
@@ -64,3 +64,20 @@ def test_with_event_teams_wrong_page() -> None:
 
     teams = TeamListYearQuery(year=2020, page=10).fetch()
     assert teams == []
+
+
+def test_affected_queries() -> None:
+    stored_teams = preseed_teams(1, 10)
+    preseed_event_teams(stored_teams, 2020)
+
+    for team_key in stored_teams:
+        assert {
+            q.cache_key
+            for q in TeamListYearQuery._eventteam_affected_queries(
+                event_key="2020test", team_key=team_key.id(), year=2020
+            )
+        } == {TeamListYearQuery(year=2020, page=0).cache_key}
+        assert {
+            q.cache_key
+            for q in TeamListYearQuery._team_affected_queries(team_key=team_key.id())
+        } == {TeamListQuery(page=0).cache_key}

--- a/src/backend/common/queries/tests/team_participation_query_test.py
+++ b/src/backend/common/queries/tests/team_participation_query_test.py
@@ -37,3 +37,12 @@ def test_get_data() -> None:
 
     years = TeamParticipationQuery(team_key="frc254").fetch()
     assert years == {2020, 2019, 2018}
+
+
+def test_affected_queries() -> None:
+    assert {
+        q.cache_key
+        for q in TeamParticipationQuery._eventteam_affected_queries(
+            team_key="frc254", event_key="test", year=2020
+        )
+    } == {TeamParticipationQuery(team_key="frc254").cache_key}

--- a/src/backend/common/queries/tests/team_query_test.py
+++ b/src/backend/common/queries/tests/team_query_test.py
@@ -12,3 +12,9 @@ def test_team_is_found() -> None:
     result = TeamQuery(team_key="frc254").fetch()
     assert result is not None
     assert result.team_number == 254
+
+
+def test_affected_queries() -> None:
+    assert {
+        q.cache_key for q in TeamQuery._team_affected_queries(team_key="frc254")
+    } == {TeamQuery(team_key="frc254").cache_key}


### PR DESCRIPTION
Adds a set of `_<model>_affected_queries` methods that returns the set of `DatabaseQueries` affected by the change.

Later, model manipulators will call all of the `_*_affected_queries` methods of all the `DatabaseQueries` whenever a model is updated to clear appropriate caches.