### PR TITLE
Add type aliases for common key types

### DIFF
--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -3,11 +3,12 @@ from flask import jsonify, Response
 from backend.api.handlers.decorators import api_authenticated, validate_event_key
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
+from backend.common.models.keys import EventKey
 from backend.common.queries.event_query import EventQuery
 
 
 @api_authenticated
 @cached_public
 @validate_event_key
-def event(event_key: str) -> Response:
+def event(event_key: EventKey) -> Response:
     return jsonify(EventQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3))

--- a/src/backend/api/handlers/team.py
+++ b/src/backend/api/handlers/team.py
@@ -3,13 +3,14 @@ from flask import jsonify, Response
 from backend.api.handlers.decorators import api_authenticated, validate_team_key
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
+from backend.common.models.keys import TeamKey
 from backend.common.queries.team_query import TeamListQuery, TeamQuery
 
 
 @api_authenticated
 @cached_public
 @validate_team_key
-def team(team_key: str) -> Response:
+def team(team_key: TeamKey) -> Response:
     return jsonify(TeamQuery(team_key=team_key).fetch_dict(ApiMajorVersion.API_V3))
 
 

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -9,6 +9,7 @@ from pyre_extensions import none_throws, safe_cast
 from backend.common.consts import event_type
 from backend.common.consts.event_type import EventType
 from backend.common.consts.playoff_type import PlayoffType
+from backend.common.models.keys import EventKey
 from backend.common.models.location import Location
 from backend.common.models.webcast import Webcast
 
@@ -519,7 +520,7 @@ class Event(ndb.Model):
         return json.dumps(keys)
 
     @property
-    def key_name(self) -> str:
+    def key_name(self) -> EventKey:
         """
         Returns the string of the key_name of the Event object before writing it.
         """

--- a/src/backend/common/models/event_team.py
+++ b/src/backend/common/models/event_team.py
@@ -3,6 +3,7 @@ from pyre_extensions import safe_cast
 
 from backend.common.models.event import Event
 from backend.common.models.event_team_status import EventTeamStatus
+from backend.common.models.keys import EventTeamKey
 from backend.common.models.team import Team
 
 
@@ -42,5 +43,5 @@ class EventTeam(ndb.Model):
         )
 
     @property
-    def key_name(self) -> str:
+    def key_name(self) -> EventTeamKey:
         return self.event.id() + "_" + self.team.id()

--- a/src/backend/common/models/keys.py
+++ b/src/backend/common/models/keys.py
@@ -1,0 +1,9 @@
+"""
+Some type aliases that'll make it clearer what
+kind of keys we end up passing around and depending on
+"""
+
+
+TeamKey = str
+EventKey = str
+EventTeamKey = str

--- a/src/backend/common/models/team.py
+++ b/src/backend/common/models/team.py
@@ -2,6 +2,7 @@ import re
 
 from google.cloud import ndb
 
+from backend.common.models.keys import TeamKey
 from backend.common.models.location import Location
 
 
@@ -109,7 +110,7 @@ class Team(ndb.Model):
         return "/team/%s" % self.team_number
 
     @property
-    def key_name(self):
+    def key_name(self) -> TeamKey:
         return "frc%s" % self.team_number
 
     @classmethod

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -5,6 +5,7 @@ from google.cloud import ndb
 from backend.common.futures import TypedFuture
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey, TeamKey
 from backend.common.models.team import Team
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.event_converter import EventConverter
@@ -14,7 +15,7 @@ class EventQuery(DatabaseQuery[Optional[Event]]):
     DICT_CONVERTER = EventConverter
 
     @ndb.tasklet
-    def _query_async(self, event_key: str) -> TypedFuture[Optional[Event]]:
+    def _query_async(self, event_key: EventKey) -> TypedFuture[Optional[Event]]:
         event = yield Event.get_by_id_async(event_key)
         return event
 
@@ -43,7 +44,7 @@ class TeamEventsQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
 
     @ndb.tasklet
-    def _query_async(self, team_key: str) -> List[Event]:
+    def _query_async(self, team_key: TeamKey) -> List[Event]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key)
         ).fetch_async()
@@ -56,7 +57,7 @@ class TeamYearEventsQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
 
     @ndb.tasklet
-    def _query_async(self, team_key: str, year: int) -> List[Event]:
+    def _query_async(self, team_key: TeamKey, year: int) -> List[Event]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key), EventTeam.year == year
         ).fetch_async()
@@ -69,7 +70,9 @@ class TeamYearEventTeamsQuery(DatabaseQuery[List[EventTeam]]):
     DICT_CONVERTER = EventConverter
 
     @ndb.tasklet
-    def _query_async(self, team_key: str, year: int) -> TypedFuture[List[EventTeam]]:
+    def _query_async(
+        self, team_key: TeamKey, year: int
+    ) -> TypedFuture[List[EventTeam]]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key), EventTeam.year == year
         ).fetch_async()
@@ -80,7 +83,7 @@ class EventDivisionsQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
 
     @ndb.tasklet
-    def _query_async(self, event_key: str) -> List[Event]:
+    def _query_async(self, event_key: EventKey) -> List[Event]:
         event = yield Event.get_by_id_async(event_key)
         if event is None:
             return []

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -5,6 +5,7 @@ from google.cloud import ndb
 from backend.common.futures import TypedFuture
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey, TeamKey
 from backend.common.models.team import Team
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.team_converter import TeamConverter
@@ -14,7 +15,7 @@ class TeamQuery(DatabaseQuery[Optional[Team]]):
     DICT_CONVERTER = TeamConverter
 
     @ndb.tasklet
-    def _query_async(self, team_key: str) -> TypedFuture[Optional[Team]]:
+    def _query_async(self, team_key: TeamKey) -> TypedFuture[Optional[Team]]:
         team = yield Team.get_by_id_async(team_key)
         return team
 
@@ -73,7 +74,7 @@ class EventTeamsQuery(DatabaseQuery[List[Team]]):
     DICT_CONVERTER = TeamConverter
 
     @ndb.tasklet
-    def _query_async(self, event_key: str) -> List[Team]:
+    def _query_async(self, event_key: EventKey) -> List[Team]:
         event_teams = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
         ).fetch_async()
@@ -86,7 +87,7 @@ class EventEventTeamsQuery(DatabaseQuery[List[EventTeam]]):
     DICT_CONVERTER = TeamConverter
 
     @ndb.tasklet
-    def _query_async(self, event_key: str) -> List[EventTeam]:
+    def _query_async(self, event_key: EventKey) -> List[EventTeam]:
         event_teams = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
         ).fetch_async()
@@ -97,7 +98,7 @@ class TeamParticipationQuery(DatabaseQuery[Set[int]]):
     DICT_CONVERTER = TeamConverter
 
     @ndb.tasklet
-    def _query_async(self, team_key: str) -> Set[int]:
+    def _query_async(self, team_key: TeamKey) -> Set[int]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key)
         ).fetch_async(keys_only=True)

--- a/src/backend/common/queries/tests/event_event_teams_query_test.py
+++ b/src/backend/common/queries/tests/event_event_teams_query_test.py
@@ -2,11 +2,12 @@ from google.cloud import ndb
 
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey
 from backend.common.models.team import Team
 from backend.common.queries.team_query import EventEventTeamsQuery
 
 
-def preseed_event_teams(start_team: int, end_team: int, event_key: str) -> None:
+def preseed_event_teams(start_team: int, end_team: int, event_key: EventKey) -> None:
     event_teams = [
         EventTeam(
             id=f"{event_key}_frc{t}",

--- a/src/backend/common/queries/tests/event_teams_query_test.py
+++ b/src/backend/common/queries/tests/event_teams_query_test.py
@@ -4,6 +4,7 @@ from google.cloud import ndb
 
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey
 from backend.common.models.team import Team
 from backend.common.queries.team_query import EventTeamsQuery
 
@@ -17,7 +18,7 @@ def preseed_teams(start_team: int, end_team: Optional[int] = None) -> List[ndb.K
     return stored
 
 
-def preseed_event_teams(team_keys: List[ndb.Key], event_key: str) -> None:
+def preseed_event_teams(team_keys: List[ndb.Key], event_key: EventKey) -> None:
     event_teams = [
         EventTeam(
             id=f"{event_key}_{t.id()}",

--- a/src/backend/common/queries/tests/team_events_query_test.py
+++ b/src/backend/common/queries/tests/team_events_query_test.py
@@ -5,6 +5,7 @@ from google.cloud import ndb
 from backend.common.consts.event_type import EventType
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey, TeamKey
 from backend.common.models.team import Team
 from backend.common.queries.event_query import (
     TeamEventsQuery,
@@ -37,7 +38,7 @@ def preseed_teams(start_team: int, end_team: Optional[int] = None) -> None:
     assert len(stored) == (end_team - start_team + 1)
 
 
-def preseed_event_team(team_key: str, event_keys: List[str]) -> None:
+def preseed_event_team(team_key: TeamKey, event_keys: List[EventKey]) -> None:
     [
         EventTeam(
             id=f"{event_key}_{team_key}",

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -7,6 +7,7 @@ from google.cloud import ndb
 from backend.common.consts.event_type import EventType
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey
 from backend.common.models.team import Team
 
 
@@ -41,7 +42,7 @@ def preseed_team(ndb_client: ndb.Client, team_number: int) -> None:
 
 
 def preseed_event_for_team(
-    ndb_client: ndb.Client, team_number: int, event_key: str
+    ndb_client: ndb.Client, team_number: int, event_key: EventKey
 ) -> None:
     with ndb_client.context():
         Event(
@@ -98,7 +99,7 @@ def get_years_participated_dropdown(resp_data: str) -> List[str]:
 
 
 def get_team_event_participation(
-    resp_data: str, event_key: str
+    resp_data: str, event_key: EventKey
 ) -> TeamEventParticipation:
     soup = bs4.BeautifulSoup(resp_data, "html.parser")
     event = soup.find(id=event_key)

--- a/src/backend/web/local/bootstrap.py
+++ b/src/backend/web/local/bootstrap.py
@@ -7,6 +7,7 @@ from google.cloud import ndb
 
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey, TeamKey
 from backend.common.models.team import Team
 
 
@@ -175,11 +176,11 @@ class LocalDataBootstrap:
         return r.json()
 
     @classmethod
-    def fetch_team(cls, team_key: str, auth_token: str) -> Dict:
+    def fetch_team(cls, team_key: TeamKey, auth_token: str) -> Dict:
         return cls.fetch_endpoint(f"team/{team_key}", auth_token)
 
     @classmethod
-    def fetch_event(cls, event_key: str, auth_token: str) -> Dict:
+    def fetch_event(cls, event_key: EventKey, auth_token: str) -> Dict:
         return cls.fetch_endpoint(f"event/{event_key}", auth_token)
 
     """
@@ -188,11 +189,13 @@ class LocalDataBootstrap:
     """
 
     @classmethod
-    def fetch_event_detail(cls, event_key: str, detail: str, auth_token: str) -> Dict:
+    def fetch_event_detail(
+        cls, event_key: EventKey, detail: str, auth_token: str
+    ) -> Dict:
         return cls.fetch_endpoint(f"event/{event_key}/{detail}", auth_token)
 
     @classmethod
-    def update_event(cls, key: str, auth_token: str) -> None:
+    def update_event(cls, key: EventKey, auth_token: str) -> None:
         event_data = cls.fetch_event(key, auth_token)
         event = cls.store_event(event_data)
 

--- a/src/backend/web/local/tests/bootstrap_test.py
+++ b/src/backend/web/local/tests/bootstrap_test.py
@@ -9,6 +9,7 @@ from backend.common.consts.event_type import EventType
 from backend.common.consts.playoff_type import PlayoffType
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey, TeamKey
 from backend.common.models.team import Team
 from backend.common.queries.dict_converters.event_converter import EventConverter
 from backend.common.queries.dict_converters.team_converter import TeamConverter
@@ -31,7 +32,7 @@ def make_team(team_num: int) -> Team:
     )
 
 
-def make_event(event_key: str) -> Event:
+def make_event(event_key: EventKey) -> Event:
     return Event(
         id=event_key,
         year=int(event_key[:4]),
@@ -47,7 +48,7 @@ def make_event(event_key: str) -> Event:
     )
 
 
-def make_eventteam(event_key: str, team_key: str) -> EventTeam:
+def make_eventteam(event_key: EventKey, team_key: TeamKey) -> EventTeam:
     return EventTeam(
         id=f"{event_key}_{team_key}",
         event=ndb.Key(Event, event_key),
@@ -74,7 +75,9 @@ def mock_event_detail_url(m: RequestsMocker, event: Event) -> None:
     )
 
 
-def mock_event_teams_url(m: RequestsMocker, event_key: str, teams: List[Team]) -> None:
+def mock_event_teams_url(
+    m: RequestsMocker, event_key: EventKey, teams: List[Team]
+) -> None:
     m.register_uri(
         "GET",
         f"https://www.thebluealliance.com/api/v3/event/{event_key}/teams",


### PR DESCRIPTION
When passing around random `str` keys, we can leverage the typechecker to help us keep track of what's what. We could also in theory add validation to an overridden `__new__` to enforce data shape as well, but that can come later.