### PR TITLE
Add a type hinted wrapper for ndb.tasklet

### DIFF
--- a/src/backend/common/queries/award_query.py
+++ b/src/backend/common/queries/award_query.py
@@ -4,20 +4,20 @@ from google.cloud import ndb
 
 from backend.common.consts.award_type import AwardType
 from backend.common.consts.event_type import EventType
-from backend.common.futures import TypedFuture
 from backend.common.models.award import Award
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, TeamKey, Year
 from backend.common.models.team import Team
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.award_converter import AwardConverter
+from backend.common.tasklets import typed_tasklet
 
 
 class EventAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
-    @ndb.tasklet
-    def _query_async(self, event_key: EventKey) -> TypedFuture[List[Award]]:
+    @typed_tasklet
+    def _query_async(self, event_key: EventKey) -> List[Award]:
         awards = yield Award.query(
             Award.event == ndb.Key(Event, event_key)
         ).fetch_async()
@@ -27,8 +27,8 @@ class EventAwardsQuery(DatabaseQuery[List[Award]]):
 class TeamAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
-    @ndb.tasklet
-    def _query_async(self, team_key: TeamKey) -> TypedFuture[List[Award]]:
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey) -> List[Award]:
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key)
         ).fetch_async()
@@ -38,8 +38,8 @@ class TeamAwardsQuery(DatabaseQuery[List[Award]]):
 class TeamYearAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
-    @ndb.tasklet
-    def _query_async(self, team_key: TeamKey, year: Year) -> TypedFuture[List[Award]]:
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey, year: Year) -> List[Award]:
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key), Award.year == year
         ).fetch_async()
@@ -49,10 +49,8 @@ class TeamYearAwardsQuery(DatabaseQuery[List[Award]]):
 class TeamEventAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
-    @ndb.tasklet
-    def _query_async(
-        self, team_key: TeamKey, event_key: EventKey
-    ) -> TypedFuture[List[Award]]:
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey, event_key: EventKey) -> List[Award]:
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key),
             Award.event == ndb.Key(Event, event_key),
@@ -63,10 +61,10 @@ class TeamEventAwardsQuery(DatabaseQuery[List[Award]]):
 class TeamEventTypeAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(
         self, team_key: TeamKey, event_type: EventType, award_type: AwardType
-    ) -> TypedFuture[List[Award]]:
+    ) -> List[Award]:
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key),
             Award.event_type_enum == event_type,

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, Generic, Type, Union
+from typing import Any, Dict, Generic, Type
 
 from google.cloud import ndb
 from pyre_extensions import safe_cast
@@ -13,15 +13,14 @@ from backend.common.queries.types import QueryReturn
 
 
 class DatabaseQuery(abc.ABC, Generic[QueryReturn]):
-    _query_args: int
+    _query_args: Dict[str, Any]
     DICT_CONVERTER: Type[ConverterBase[QueryReturn]] = ConverterBase
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self._query_args = kwargs
 
     @abc.abstractmethod
-    def _query_async(self) -> Union[QueryReturn, TypedFuture[QueryReturn]]:
-        # The tasklet wrapper will wrap a raw value in a future if necessary
+    def _query_async(self) -> TypedFuture[QueryReturn]:
         ...
 
     def fetch(self) -> QueryReturn:

--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -9,12 +9,13 @@ from backend.common.models.keys import DistrictAbbreviation, DistrictKey, TeamKe
 from backend.common.models.team import Team
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.district_converter import DistrictConverter
+from backend.common.tasklets import typed_tasklet
 
 
 class DistrictQuery(DatabaseQuery[Optional[District]]):
     DICT_CONVERTER = DistrictConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, district_key: DistrictKey) -> Optional[District]:
         # Fetch all equivalent keys
         keys = RenamedDistricts.get_equivalent_keys(district_key)
@@ -29,7 +30,7 @@ class DistrictQuery(DatabaseQuery[Optional[District]]):
 class DistrictsInYearQuery(DatabaseQuery[List[District]]):
     DICT_CONVERTER = DistrictConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, year: Year) -> List[District]:
         district_keys = yield District.query(District.year == year).fetch_async(
             keys_only=True
@@ -41,7 +42,7 @@ class DistrictsInYearQuery(DatabaseQuery[List[District]]):
 class DistrictHistoryQuery(DatabaseQuery[List[District]]):
     DICT_CONVERTER = DistrictConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, abbreviation: DistrictAbbreviation) -> List[District]:
         district_keys = yield District.query(
             District.abbreviation.IN(
@@ -55,7 +56,7 @@ class DistrictHistoryQuery(DatabaseQuery[List[District]]):
 class TeamDistrictsQuery(DatabaseQuery[List[District]]):
     DICT_CONVERTER = DistrictConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[District]:
         district_team_keys = yield DistrictTeam.query(
             DistrictTeam.team == ndb.Key(Team, team_key)

--- a/src/backend/common/queries/event_details_query.py
+++ b/src/backend/common/queries/event_details_query.py
@@ -1,20 +1,18 @@
 from typing import Optional
 
-from google.cloud import ndb
-
-from backend.common.futures import TypedFuture
 from backend.common.models.event_details import EventDetails
 from backend.common.models.keys import EventKey
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.event_details_converter import (
     EventDetailsConverter,
 )
+from backend.common.tasklets import typed_tasklet
 
 
 class EventDetailsQuery(DatabaseQuery[Optional[EventDetails]]):
     DICT_CONVERTER = EventDetailsConverter
 
-    @ndb.tasklet
-    def _query_async(self, event_key: EventKey) -> TypedFuture[Optional[EventDetails]]:
+    @typed_tasklet
+    def _query_async(self, event_key: EventKey) -> Optional[EventDetails]:
         event_details = yield EventDetails.get_by_id_async(event_key)
         return event_details

--- a/src/backend/common/queries/match_query.py
+++ b/src/backend/common/queries/match_query.py
@@ -2,19 +2,19 @@ from typing import List, Optional
 
 from google.cloud import ndb
 
-from backend.common.futures import TypedFuture
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, MatchKey, TeamKey, Year
 from backend.common.models.match import Match
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.match_converter import MatchConverter
+from backend.common.tasklets import typed_tasklet
 
 
 class MatchQuery(DatabaseQuery[Optional[Match]]):
     DICT_CONVERTER = MatchConverter
 
-    @ndb.tasklet
-    def _query_async(self, match_key: MatchKey) -> TypedFuture[Optional[Match]]:
+    @typed_tasklet
+    def _query_async(self, match_key: MatchKey) -> Optional[Match]:
         match = yield Match.get_by_id_async(match_key)
         return match
 
@@ -22,8 +22,8 @@ class MatchQuery(DatabaseQuery[Optional[Match]]):
 class EventMatchesQuery(DatabaseQuery[List[Match]]):
     DICT_CONVERTER = MatchConverter
 
-    @ndb.tasklet
-    def _query_async(self, event_key: EventKey):
+    @typed_tasklet
+    def _query_async(self, event_key: EventKey) -> List[Match]:
         match_keys = yield Match.query(
             Match.event == ndb.Key(Event, event_key)
         ).fetch_async(keys_only=True)
@@ -34,7 +34,7 @@ class EventMatchesQuery(DatabaseQuery[List[Match]]):
 class TeamEventMatchesQuery(DatabaseQuery[List[Match]]):
     DICT_CONVERTER = MatchConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, team_key: TeamKey, event_key: EventKey) -> List[Match]:
         match_keys = yield Match.query(
             Match.team_key_names == team_key, Match.event == ndb.Key(Event, event_key)
@@ -46,7 +46,7 @@ class TeamEventMatchesQuery(DatabaseQuery[List[Match]]):
 class TeamYearMatchesQuery(DatabaseQuery[List[Match]]):
     DICT_CONVERTER = MatchConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, team_key: TeamKey, year: Year) -> List[Match]:
         match_keys = yield Match.query(
             Match.team_key_names == team_key, Match.year == year

--- a/src/backend/common/queries/media_query.py
+++ b/src/backend/common/queries/media_query.py
@@ -1,9 +1,8 @@
-from typing import List, Union
+from typing import List
 
 from google.cloud import ndb
 
 from backend.common.consts.media_tag import MediaTag
-from backend.common.futures import TypedFuture
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import EventKey, TeamKey, Year
@@ -11,13 +10,14 @@ from backend.common.models.media import Media
 from backend.common.models.team import Team
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.media_converter import MediaConverter
+from backend.common.tasklets import typed_tasklet
 
 
 class TeamSocialMediaQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(self, team_key: TeamKey) -> TypedFuture[List[Media]]:
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey) -> List[Media]:
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key),
             Media.year == None,  # noqa: E711
@@ -28,8 +28,8 @@ class TeamSocialMediaQuery(DatabaseQuery[List[Media]]):
 class TeamMediaQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(self, team_key: TeamKey) -> TypedFuture[List[Media]]:
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey) -> List[Media]:
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key)
         ).fetch_async()
@@ -39,8 +39,8 @@ class TeamMediaQuery(DatabaseQuery[List[Media]]):
 class TeamYearMediaQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(self, team_key: TeamKey, year: Year) -> TypedFuture[List[Media]]:
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey, year: Year) -> List[Media]:
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key), Media.year == year
         ).fetch_async()
@@ -50,10 +50,8 @@ class TeamYearMediaQuery(DatabaseQuery[List[Media]]):
 class EventTeamsMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(
-        self, event_key: EventKey
-    ) -> Union[List[Media], TypedFuture[List[Media]]]:
+    @typed_tasklet
+    def _query_async(self, event_key: EventKey) -> List[Media]:
         year = int(event_key[:4])
         event_team_keys = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
@@ -75,10 +73,8 @@ class EventTeamsMediasQuery(DatabaseQuery[List[Media]]):
 class EventTeamsPreferredMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(
-        self, event_key: EventKey
-    ) -> Union[List[Media], TypedFuture[List[Media]]]:
+    @typed_tasklet
+    def _query_async(self, event_key: EventKey) -> List[Media]:
         year = int(event_key[:4])
         event_team_keys = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
@@ -100,8 +96,8 @@ class EventTeamsPreferredMediasQuery(DatabaseQuery[List[Media]]):
 class EventMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(self, event_key: EventKey) -> TypedFuture[List[Media]]:
+    @typed_tasklet
+    def _query_async(self, event_key: EventKey) -> List[Media]:
         medias = yield Media.query(
             Media.references == ndb.Key(Event, event_key)
         ).fetch_async()
@@ -111,8 +107,8 @@ class EventMediasQuery(DatabaseQuery[List[Media]]):
 class TeamTagMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
-    def _query_async(self, team_key: TeamKey, media_tag: MediaTag):
+    @typed_tasklet
+    def _query_async(self, team_key: TeamKey, media_tag: MediaTag) -> List[Media]:
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key),
             Media.media_tag_enum == media_tag,
@@ -123,10 +119,10 @@ class TeamTagMediasQuery(DatabaseQuery[List[Media]]):
 class TeamYearTagMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(
         self, team_key: TeamKey, year: Year, media_tag: MediaTag
-    ) -> TypedFuture[List[Media]]:
+    ) -> List[Media]:
         team_ndb_key = ndb.Key(Team, team_key)
         medias = yield Media.query(
             Media.references == team_ndb_key,

--- a/src/backend/common/queries/mobile_client_query.py
+++ b/src/backend/common/queries/mobile_client_query.py
@@ -1,18 +1,16 @@
 from typing import List
 
-from google.cloud import ndb
-
 from backend.common.consts.client_type import ClientType
-from backend.common.futures import TypedFuture
 from backend.common.models.mobile_client import MobileClient
 from backend.common.queries.database_query import DatabaseQuery
+from backend.common.tasklets import typed_tasklet
 
 
-class MobileClientListQuery(DatabaseQuery[List[TypedFuture[MobileClient]]]):
-    @ndb.tasklet
+class MobileClientListQuery(DatabaseQuery[List[MobileClient]]):
+    @typed_tasklet
     def _query_async(
         self, users: List[str], client_types: List[ClientType] = list(ClientType)
-    ) -> List[TypedFuture[MobileClient]]:
+    ) -> List[MobileClient]:
         if not users or not client_types:
             return []
 

--- a/src/backend/common/queries/robot_query.py
+++ b/src/backend/common/queries/robot_query.py
@@ -7,12 +7,13 @@ from backend.common.models.robot import Robot
 from backend.common.models.team import Team
 from backend.common.queries.database_query import DatabaseQuery
 from backend.common.queries.dict_converters.robot_converter import RobotConverter
+from backend.common.tasklets import typed_tasklet
 
 
 class TeamRobotsQuery(DatabaseQuery[List[Robot]]):
     DICT_CONVERTER = RobotConverter
 
-    @ndb.tasklet
+    @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[Robot]:
         robots = yield Robot.query(Robot.team == ndb.Key(Team, team_key)).fetch_async()
         return robots

--- a/src/backend/common/tasklets.py
+++ b/src/backend/common/tasklets.py
@@ -1,0 +1,19 @@
+from typing import Callable, cast, TypeVar
+
+from google.cloud import ndb
+from pyre_extensions import ParameterSpecification
+
+from backend.common.futures import TypedFuture
+
+TParams = ParameterSpecification("TParams")
+TReturn = TypeVar("TReturn")
+
+
+def typed_tasklet(
+    f: Callable[TParams, TReturn]
+) -> Callable[TParams, TypedFuture[TReturn]]:
+    @ndb.tasklet
+    def inner(*args: TParams.args, **kwargs: TParams.kwargs) -> TReturn:
+        return f(*args, **kwargs)
+
+    return cast(Callable[TParams, TypedFuture[TReturn]], inner)


### PR DESCRIPTION
This can help us clean up how we typehint dbqueries, by formalizing `ndb.tasklet`'s typing contract in a wrapper.

This should let us define queries with a consistent return type, and remove the need to do stuff with unions/futures ourselves.