### PR TITLE
Create constructors for db queries

### DIFF
--- a/src/backend/common/queries/award_query.py
+++ b/src/backend/common/queries/award_query.py
@@ -16,6 +16,9 @@ from backend.common.tasklets import typed_tasklet
 class EventAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Award]:
         awards = yield Award.query(
@@ -26,6 +29,9 @@ class EventAwardsQuery(DatabaseQuery[List[Award]]):
 
 class TeamAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
+
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[Award]:
@@ -38,6 +44,9 @@ class TeamAwardsQuery(DatabaseQuery[List[Award]]):
 class TeamYearAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
 
+    def __init__(self, team_key: TeamKey, year: Year) -> None:
+        super().__init__(team_key=team_key, year=year)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, year: Year) -> List[Award]:
         awards = yield Award.query(
@@ -48,6 +57,9 @@ class TeamYearAwardsQuery(DatabaseQuery[List[Award]]):
 
 class TeamEventAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
+
+    def __init__(self, team_key: TeamKey, event_key: EventKey) -> None:
+        super().__init__(team_key=team_key, event_key=event_key)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, event_key: EventKey) -> List[Award]:
@@ -60,6 +72,13 @@ class TeamEventAwardsQuery(DatabaseQuery[List[Award]]):
 
 class TeamEventTypeAwardsQuery(DatabaseQuery[List[Award]]):
     DICT_CONVERTER = AwardConverter
+
+    def __init__(
+        self, team_key: TeamKey, event_type: EventType, award_type: AwardType
+    ) -> None:
+        super().__init__(
+            team_key=team_key, event_type=event_type, award_type=award_type
+        )
 
     @typed_tasklet
     def _query_async(

--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -15,6 +15,9 @@ from backend.common.tasklets import typed_tasklet
 class DistrictQuery(DatabaseQuery[Optional[District]]):
     DICT_CONVERTER = DistrictConverter
 
+    def __init__(self, district_key: DistrictKey) -> None:
+        super().__init__(district_key=district_key)
+
     @typed_tasklet
     def _query_async(self, district_key: DistrictKey) -> Optional[District]:
         # Fetch all equivalent keys
@@ -30,6 +33,9 @@ class DistrictQuery(DatabaseQuery[Optional[District]]):
 class DistrictsInYearQuery(DatabaseQuery[List[District]]):
     DICT_CONVERTER = DistrictConverter
 
+    def __init__(self, year: Year) -> None:
+        super().__init__(year=year)
+
     @typed_tasklet
     def _query_async(self, year: Year) -> List[District]:
         district_keys = yield District.query(District.year == year).fetch_async(
@@ -41,6 +47,9 @@ class DistrictsInYearQuery(DatabaseQuery[List[District]]):
 
 class DistrictHistoryQuery(DatabaseQuery[List[District]]):
     DICT_CONVERTER = DistrictConverter
+
+    def __init__(self, abbreviation: DistrictAbbreviation) -> None:
+        super().__init__(abbreviation=abbreviation)
 
     @typed_tasklet
     def _query_async(self, abbreviation: DistrictAbbreviation) -> List[District]:
@@ -55,6 +64,9 @@ class DistrictHistoryQuery(DatabaseQuery[List[District]]):
 
 class TeamDistrictsQuery(DatabaseQuery[List[District]]):
     DICT_CONVERTER = DistrictConverter
+
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[District]:

--- a/src/backend/common/queries/event_details_query.py
+++ b/src/backend/common/queries/event_details_query.py
@@ -12,6 +12,9 @@ from backend.common.tasklets import typed_tasklet
 class EventDetailsQuery(DatabaseQuery[Optional[EventDetails]]):
     DICT_CONVERTER = EventDetailsConverter
 
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> Optional[EventDetails]:
         event_details = yield EventDetails.get_by_id_async(event_key)

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -16,6 +16,9 @@ from backend.common.tasklets import typed_tasklet
 class EventQuery(DatabaseQuery[Optional[Event]]):
     DICT_CONVERTER = EventConverter
 
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> Optional[Event]:
         event = yield Event.get_by_id_async(event_key)
@@ -25,6 +28,9 @@ class EventQuery(DatabaseQuery[Optional[Event]]):
 class EventListQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
 
+    def __init__(self, year: Year) -> None:
+        super().__init__(year=year)
+
     @typed_tasklet
     def _query_async(self, year: Year) -> List[Event]:
         events = yield Event.query(Event.year == year).fetch_async()
@@ -32,6 +38,9 @@ class EventListQuery(DatabaseQuery[List[Event]]):
 
 
 class DistrictEventsQuery(DatabaseQuery[List[Event]]):
+    def __init__(self, district_key: DistrictKey) -> None:
+        super().__init__(district_key=district_key)
+
     @typed_tasklet
     def _query_async(self, district_key: DistrictKey) -> List[Event]:
         events = yield Event.query(
@@ -42,6 +51,9 @@ class DistrictEventsQuery(DatabaseQuery[List[Event]]):
 
 class DistrictChampsInYearQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
+
+    def __init__(self, year: Year) -> None:
+        super().__init__(year=year)
 
     @typed_tasklet
     def _query_async(self, year: Year) -> List[Event]:
@@ -54,6 +66,9 @@ class DistrictChampsInYearQuery(DatabaseQuery[List[Event]]):
 
 class TeamEventsQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
+
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[Event]:
@@ -68,6 +83,9 @@ class TeamEventsQuery(DatabaseQuery[List[Event]]):
 class TeamYearEventsQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
 
+    def __init__(self, team_key: TeamKey, year: Year) -> None:
+        super().__init__(team_key=team_key, year=year)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, year: Year) -> List[Event]:
         event_teams = yield EventTeam.query(
@@ -81,6 +99,9 @@ class TeamYearEventsQuery(DatabaseQuery[List[Event]]):
 class TeamYearEventTeamsQuery(DatabaseQuery[List[EventTeam]]):
     DICT_CONVERTER = EventConverter
 
+    def __init__(self, team_key: TeamKey, year: Year) -> None:
+        super().__init__(team_key=team_key, year=year)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, year: Year) -> List[EventTeam]:
         event_teams = yield EventTeam.query(
@@ -91,6 +112,9 @@ class TeamYearEventTeamsQuery(DatabaseQuery[List[EventTeam]]):
 
 class EventDivisionsQuery(DatabaseQuery[List[Event]]):
     DICT_CONVERTER = EventConverter
+
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
 
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Event]:

--- a/src/backend/common/queries/match_query.py
+++ b/src/backend/common/queries/match_query.py
@@ -13,6 +13,9 @@ from backend.common.tasklets import typed_tasklet
 class MatchQuery(DatabaseQuery[Optional[Match]]):
     DICT_CONVERTER = MatchConverter
 
+    def __init__(self, match_key: MatchKey) -> None:
+        super().__init__(match_key=match_key)
+
     @typed_tasklet
     def _query_async(self, match_key: MatchKey) -> Optional[Match]:
         match = yield Match.get_by_id_async(match_key)
@@ -21,6 +24,9 @@ class MatchQuery(DatabaseQuery[Optional[Match]]):
 
 class EventMatchesQuery(DatabaseQuery[List[Match]]):
     DICT_CONVERTER = MatchConverter
+
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
 
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Match]:
@@ -34,6 +40,9 @@ class EventMatchesQuery(DatabaseQuery[List[Match]]):
 class TeamEventMatchesQuery(DatabaseQuery[List[Match]]):
     DICT_CONVERTER = MatchConverter
 
+    def __init__(self, team_key: TeamKey, event_key: EventKey) -> None:
+        super().__init__(team_key=team_key, event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, event_key: EventKey) -> List[Match]:
         match_keys = yield Match.query(
@@ -45,6 +54,9 @@ class TeamEventMatchesQuery(DatabaseQuery[List[Match]]):
 
 class TeamYearMatchesQuery(DatabaseQuery[List[Match]]):
     DICT_CONVERTER = MatchConverter
+
+    def __init__(self, team_key: TeamKey, year: Year) -> None:
+        super().__init__(team_key=team_key, year=year)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, year: Year) -> List[Match]:

--- a/src/backend/common/queries/media_query.py
+++ b/src/backend/common/queries/media_query.py
@@ -16,6 +16,9 @@ from backend.common.tasklets import typed_tasklet
 class TeamSocialMediaQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[Media]:
         medias = yield Media.query(
@@ -28,6 +31,9 @@ class TeamSocialMediaQuery(DatabaseQuery[List[Media]]):
 class TeamMediaQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[Media]:
         medias = yield Media.query(
@@ -39,6 +45,9 @@ class TeamMediaQuery(DatabaseQuery[List[Media]]):
 class TeamYearMediaQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
+    def __init(self, team_key: TeamKey, year: Year) -> None:
+        super().__init__(team_key=team_key, year=year)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, year: Year) -> List[Media]:
         medias = yield Media.query(
@@ -49,6 +58,9 @@ class TeamYearMediaQuery(DatabaseQuery[List[Media]]):
 
 class EventTeamsMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
+
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
 
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Media]:
@@ -73,6 +85,9 @@ class EventTeamsMediasQuery(DatabaseQuery[List[Media]]):
 class EventTeamsPreferredMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Media]:
         year = int(event_key[:4])
@@ -96,6 +111,9 @@ class EventTeamsPreferredMediasQuery(DatabaseQuery[List[Media]]):
 class EventMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
 
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Media]:
         medias = yield Media.query(
@@ -106,6 +124,9 @@ class EventMediasQuery(DatabaseQuery[List[Media]]):
 
 class TeamTagMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
+
+    def __init__(self, team_key: TeamKey, media_tag: MediaTag) -> None:
+        super().__init__(team_key=team_key, media_tag=media_tag)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey, media_tag: MediaTag) -> List[Media]:
@@ -118,6 +139,9 @@ class TeamTagMediasQuery(DatabaseQuery[List[Media]]):
 
 class TeamYearTagMediasQuery(DatabaseQuery[List[Media]]):
     DICT_CONVERTER = MediaConverter
+
+    def __init__(self, team_key: TeamKey, year: Year, media_tag: MediaTag) -> None:
+        super().__init__(team_key=team_key, year=year, media_tag=media_tag)
 
     @typed_tasklet
     def _query_async(

--- a/src/backend/common/queries/mobile_client_query.py
+++ b/src/backend/common/queries/mobile_client_query.py
@@ -7,9 +7,14 @@ from backend.common.tasklets import typed_tasklet
 
 
 class MobileClientListQuery(DatabaseQuery[List[MobileClient]]):
+    def __init__(
+        self, users: List[str], client_types: List[ClientType] = list(ClientType)
+    ) -> None:
+        super().__init__(users=users, client_types=client_types)
+
     @typed_tasklet
     def _query_async(
-        self, users: List[str], client_types: List[ClientType] = list(ClientType)
+        self, users: List[str], client_types: List[ClientType]
     ) -> List[MobileClient]:
         if not users or not client_types:
             return []

--- a/src/backend/common/queries/robot_query.py
+++ b/src/backend/common/queries/robot_query.py
@@ -13,6 +13,9 @@ from backend.common.tasklets import typed_tasklet
 class TeamRobotsQuery(DatabaseQuery[List[Robot]]):
     DICT_CONVERTER = RobotConverter
 
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> List[Robot]:
         robots = yield Robot.query(Robot.team == ndb.Key(Team, team_key)).fetch_async()

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -16,6 +16,9 @@ from backend.common.tasklets import typed_tasklet
 class TeamQuery(DatabaseQuery[Optional[Team]]):
     DICT_CONVERTER = TeamConverter
 
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
+
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> Optional[Team]:
         team = yield Team.get_by_id_async(team_key)
@@ -25,6 +28,9 @@ class TeamQuery(DatabaseQuery[Optional[Team]]):
 class TeamListQuery(DatabaseQuery[List[Team]]):
     DICT_CONVERTER = TeamConverter
     PAGE_SIZE: int = 500
+
+    def __init__(self, page: int) -> None:
+        super().__init__(page=page)
 
     @typed_tasklet
     def _query_async(self, page: int) -> List[Team]:
@@ -40,6 +46,9 @@ class TeamListQuery(DatabaseQuery[List[Team]]):
 
 class TeamListYearQuery(DatabaseQuery[List[Team]]):
     DICT_CONVERTER = TeamConverter
+
+    def __init__(self, year: Year, page: int) -> None:
+        super().__init__(year=year, page=page)
 
     @typed_tasklet
     def _query_async(self, year: Year, page: int) -> List[Team]:
@@ -62,6 +71,9 @@ class TeamListYearQuery(DatabaseQuery[List[Team]]):
 class DistrictTeamsQuery(DatabaseQuery[List[Team]]):
     DICT_CONVERTER = TeamConverter
 
+    def __init__(self, district_key: DistrictKey) -> None:
+        super().__init__(district_key=district_key)
+
     @typed_tasklet
     def _query_async(self, district_key: DistrictKey) -> List[Team]:
         district_teams = yield DistrictTeam.query(
@@ -74,6 +86,9 @@ class DistrictTeamsQuery(DatabaseQuery[List[Team]]):
 
 class EventTeamsQuery(DatabaseQuery[List[Team]]):
     DICT_CONVERTER = TeamConverter
+
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
 
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[Team]:
@@ -88,6 +103,9 @@ class EventTeamsQuery(DatabaseQuery[List[Team]]):
 class EventEventTeamsQuery(DatabaseQuery[List[EventTeam]]):
     DICT_CONVERTER = TeamConverter
 
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__(event_key=event_key)
+
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> List[EventTeam]:
         event_teams = yield EventTeam.query(
@@ -98,6 +116,9 @@ class EventEventTeamsQuery(DatabaseQuery[List[EventTeam]]):
 
 class TeamParticipationQuery(DatabaseQuery[Set[int]]):
     DICT_CONVERTER = TeamConverter
+
+    def __init__(self, team_key: TeamKey) -> None:
+        super().__init__(team_key=team_key)
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> Set[int]:


### PR DESCRIPTION
This lets the typechecker make sure we're setting the args correctly instead of letting the base class's `*args, **kwargs` consume everything and end up with runtime errors if you do it wrong.