### PR TITLE
Add checks around saving 'None' match breakdown strings from admin console

### DIFF
--- a/controllers/admin/admin_match_controller.py
+++ b/controllers/admin/admin_match_controller.py
@@ -153,6 +153,11 @@ class AdminMatchEdit(LoggedInHandler):
         self._require_admin()
         alliances_json = self.request.get("alliances_json")
         score_breakdown_json = self.request.get("score_breakdown_json")
+        # Ignore u'None' from form POST
+        score_breakdown_json = score_breakdown_json if score_breakdown_json != "None" else None
+        # Fake JSON load of the score breakdown to ensure the JSON is proper before attempting to save to the DB
+        if score_breakdown_json:
+            json.loads(score_breakdown_json)
         alliances = json.loads(alliances_json)
         tba_videos = json.loads(self.request.get("tba_videos")) if self.request.get("tba_videos") else []
         youtube_videos = json.loads(self.request.get("youtube_videos")) if self.request.get("youtube_videos") else []

--- a/models/match.py
+++ b/models/match.py
@@ -147,7 +147,10 @@ class Match(ndb.Model):
         Lazy load score_breakdown_json
         """
         if self._score_breakdown is None and self.score_breakdown_json is not None:
-            self._score_breakdown = json.loads(self.score_breakdown_json)
+            try:
+                self._score_breakdown = json.loads(self.score_breakdown_json)
+            except:
+                return None
 
             if self.has_been_played:
                 # Add in RP calculations


### PR DESCRIPTION
A two part approach on this one - first, treat u'None' strings as `None` from the post. Second, do a JSON load *before* attempting to save the JSON to the model (we do this for other JSON from the form, just not this field)