### PR TITLE
fix ES team detail

### DIFF
--- a/datafeeds/parsers/first_elasticsearch/first_elasticsearch_team_details_parser.py
+++ b/datafeeds/parsers/first_elasticsearch/first_elasticsearch_team_details_parser.py
@@ -34,7 +34,7 @@ class FIRSTElasticSearchTeamDetailsParser(object):
                 website=website,
                 rookie_year=team.get('team_rookieyear', None),
                 first_tpid=first_tpid,
-                first_tpid_year=self.year,
+                first_tpid_year=team.get('profile_year', self.year),
                 motto=team.get('team_motto', None),
             ))
 

--- a/helpers/team_manipulator.py
+++ b/helpers/team_manipulator.py
@@ -65,6 +65,8 @@ class TeamManipulator(ManipulatorBase):
             "website",
             "rookie_year",
             "motto",
+            "first_tpid",
+            "first_tpid_year",
         ]
 
         for attr in attrs:
@@ -74,9 +76,11 @@ class TeamManipulator(ManipulatorBase):
                     old_team.dirty = True
 
         # Take the new tpid and tpid_year iff the year is newer than or equal to the old one
+        """
         if (new_team.first_tpid_year is not None and new_team.first_tpid_year >= old_team.first_tpid_year):
             old_team.first_tpid_year = new_team.first_tpid_year
             old_team.first_tpid = new_team.first_tpid
             old_team.dirty = True
+        """
 
         return old_team

--- a/tests/test_first_elasticsearch_team_parser.py
+++ b/tests/test_first_elasticsearch_team_parser.py
@@ -35,7 +35,7 @@ class TestFIRSTElasticSearchTeamParser(unittest2.TestCase):
                     self.assertEqual(team.postalcode, "95126-1215")
                     self.assertEqual(team.website, "http://www.team254.com")
                     self.assertEqual(team.first_tpid, 357159)
-                    self.assertEqual(team.first_tpid_year, 2015)
+                    self.assertEqual(team.first_tpid_year, 2016)
 
                 if team.key.id() == 'frc604':
                     self.assertEqual(team.key_name, "frc604")
@@ -45,7 +45,7 @@ class TestFIRSTElasticSearchTeamParser(unittest2.TestCase):
                     self.assertEqual(team.postalcode, "95120")
                     self.assertEqual(team.website, "http://604robotics.com")
                     self.assertEqual(team.first_tpid, 357405)
-                    self.assertEqual(team.first_tpid_year, 2015)
+                    self.assertEqual(team.first_tpid_year, 2016)
                     self.assertEqual(team.motto, "It will work - because it has to.")
 
                 # A team who doesn't have 'http' starting their website
@@ -57,7 +57,7 @@ class TestFIRSTElasticSearchTeamParser(unittest2.TestCase):
                     self.assertEqual(team.postalcode, "94010")
                     self.assertEqual(team.website, "http:///gryphonrobotics.org")
                     self.assertEqual(team.first_tpid, 361441)
-                    self.assertEqual(team.first_tpid_year, 2015)
+                    self.assertEqual(team.first_tpid_year, 2016)
                     self.assertEqual(team.motto, None)
 
                 # A team with a blacklisted website


### PR DESCRIPTION
We should search by team number. Also, since we can trust `profile_year` now, we can remove the validation that tpid years only increase