### PR TITLE
Install Python deps to Vagrant container

### DIFF
--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -6,9 +6,12 @@ mkdir -p /datastore
 
 # The datastore emulator requires grpcio
 pip2 install grpcio
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install -r src/requirements.txt
 
 # nodejs dependencies
-npm install uglify-js  --silent
+npm install uglify-js --silent
 npm install -g npx gulp-cli uglify-es uglifycss less tslib request swagger-cli --silent
 
 

--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -7,7 +7,7 @@ function get_config_prop {
     if [ -f "tba_dev_config.local.json" ]; then
         local dev_config_file="tba_dev_config.local.json"
     fi
-    
+
     jq -r -s ".[0] * (.[1] // {}) | .$prop_name" tba_dev_config.json $dev_config_file
 }
 


### PR DESCRIPTION
Right now we're not installing dependencies to the Vagrant container from the setup script.