### PR TITLE
Add safe redirect methods to web

### DIFF
--- a/src/backend/web/redirect.py
+++ b/src/backend/web/redirect.py
@@ -1,0 +1,18 @@
+from urllib.parse import urljoin, urlparse
+
+from flask import redirect, request
+from werkzeug.wrappers import Response
+
+
+def is_safe_url(target: str) -> bool:
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(urljoin(request.host_url, target))
+    return test_url.scheme in ("http", "https") and ref_url.netloc == test_url.netloc
+
+
+def safe_next_redirect(fallback_url: str) -> Response:
+    next_response = redirect(fallback_url)
+    next = request.args.get("next")
+    if next and is_safe_url(next):
+        next_response = redirect(next)
+    return next_response

--- a/src/backend/web/tests/redirect_test.py
+++ b/src/backend/web/tests/redirect_test.py
@@ -1,0 +1,47 @@
+from backend.web.redirect import is_safe_url, safe_next_redirect
+
+
+def test_is_safe_url_scheme() -> None:
+    from backend.web.main import app
+
+    with app.test_request_context("/"):
+        assert not is_safe_url("ftp://localhost/")
+
+
+def test_is_safe_url_netloc() -> None:
+    from backend.web.main import app
+
+    with app.test_request_context("/"):
+        assert not is_safe_url("https://thebluealliance.com/")
+
+
+def test_is_safe_url() -> None:
+    from backend.web.main import app
+
+    with app.test_request_context("/"):
+        assert is_safe_url("/account")
+        assert is_safe_url("https://localhost/account")
+
+
+def test_safe_next_redirect_no_next() -> None:
+    from backend.web.main import app
+
+    with app.test_request_context("/"):
+        response = safe_next_redirect("/")
+        assert response.headers["Location"] == "/"
+
+
+def test_safe_next_redirect_not_safe() -> None:
+    from backend.web.main import app
+
+    with app.test_request_context("/?next=http%3A%2F%2Fthebluealliance.com%2Faccount"):
+        response = safe_next_redirect("/")
+        assert response.headers["Location"] == "/"
+
+
+def test_safe_next_redirect() -> None:
+    from backend.web.main import app
+
+    with app.test_request_context("/?next=http%3A%2F%2Flocalhost%2Faccount"):
+        response = safe_next_redirect("/")
+        assert response.headers["Location"] == "http://localhost/account"


### PR DESCRIPTION
The `safe_next_redirect` method uses the `next` parameter for a request and ensures that the URL 1) matches the current host and 2) is a http/s link. This should be used when accepting user input for a redirect.