### PR TITLE
Add --env to run_buildweb.sh to generate tba_secrets.js from environment variables

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,4 +145,4 @@ jobs:
       - name: Install Node Dependencies
         run: npm install
       - name: Run Build
-        run: ./ops/build/run_buildweb.sh
+        run: ./ops/build/run_buildweb.sh --env

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Install Node Dependencies
         run: npm install
       - name: Run Build
-        run: ./ops/build/run_buildweb.sh
+        run: ./ops/build/run_buildweb.sh --env
         env:
           GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}

--- a/ops/build/run_buildweb.sh
+++ b/ops/build/run_buildweb.sh
@@ -2,9 +2,13 @@ set -e
 
 npx -p less@3.11.3 lessc src/backend/web/static/css/less_css/tba_style.main.less src/build/temp/tba_style.main.css
 
-# Create tba_keys.js from environment secrets
-touch ./src/backend/web/static/javascript/tba_js/tba_keys.js
-cat > ./src/backend/web/static/javascript/tba_js/tba_keys.js <<EOF
+# Create tba_keys.js from environment secrets if the --env flag is passed
+while test $# -gt 0; do
+  echo "$1"
+  case "$1" in
+    --env)
+      touch ./src/backend/web/static/javascript/tba_js/tba_keys.js
+      cat > ./src/backend/web/static/javascript/tba_js/tba_keys.js <<EOF
 var firebaseApiKey = "${FIREBASE_API_KEY}";
 var firebaseAppId = "${FIREBASE_APP_ID}";
 var firebaseAuthDomain = "${GCLOUD_PROJECT_ID}.firebaseapp.com";
@@ -13,6 +17,13 @@ var firebaseStorageBucket = "${GCLOUD_PROJECT_ID}.appspot.com";
 var firebaseMessagingSenderId = "${FIREBASE_MESSAGING_SENDER_ID}";
 var firebaseProjectId = "${GCLOUD_PROJECT_ID}";
 EOF
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 python ./ops/build/do_compress.py
 npm run build


### PR DESCRIPTION
## Description
Adds a `--env` flag to the `run_buildweb.sh` script to generate the `tba_secrets.js` using environment variables for CI

## Motivation and Context
From Slack - [this PR](https://github.com/the-blue-alliance/the-blue-alliance/pull/3005) to generate `tba_secrets.js` on CI introduced a problem that when running `run_buildweb.sh` locally when re-building JS would overwrite your `tba_secrets.js` key with empty variables.

## How Has This Been Tested?
Tested locally - seems to work!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)