### PR TITLE
Fix sending GameDay tos as event instead of label

### DIFF
--- a/templates/gameday.html
+++ b/templates/gameday.html
@@ -280,7 +280,7 @@
       return ((parseInt(t[1]) || 0) + 1) + ':00';
     })(tos.split(':').reverse());
     // Collect and send the time to Google Analytics
-    ga('send', 'event', 'gameday_time', 'gameday_time', 'Log', tos);
+    ga('send', 'event', 'gameday_time', 'Log', tos);
     }, 60000);
   })('00');
 </script>

--- a/templates/gameday2.html
+++ b/templates/gameday2.html
@@ -50,7 +50,7 @@
       return ((parseInt(t[1]) || 0) + 1) + ':00';
     })(tos.split(':').reverse());
     // Collect and send the time to Google Analytics
-    ga('send', 'event', 'gameday_time', 'gameday_time', 'Log', tos);
+    ga('send', 'event', 'gameday_time', 'Log', tos);
     }, 60000);
   })('00');
 </script>


### PR DESCRIPTION
Fix to https://github.com/the-blue-alliance/the-blue-alliance/pull/2754 - I was sending the GameDay time as the event value instead of the event label