### PR TITLE
[py3] Add tasks-io service

### DIFF
--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -51,4 +51,4 @@ dev_appserver.py \
     --env_var TBA_LOG_LEVEL="$tba_log_level" \
     --env_var NDB_LOG_LEVEL="$ndb_log_level" \
     --dev_appserver_log_level=$log_level \
-    src/default.yaml src/web.yaml src/api.yaml src/dispatch.yaml
+    src/default.yaml src/web.yaml src/api.yaml src/tasks_io.yaml src/dispatch.yaml

--- a/src/backend/tasks_io/main.py
+++ b/src/backend/tasks_io/main.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+from backend.common.logging import configure_logging
+from backend.common.middleware import install_middleware
+
+
+configure_logging()
+
+app = Flask(__name__)
+install_middleware(app)

--- a/src/backend/tasks_io/tests/main_test.py
+++ b/src/backend/tasks_io/tests/main_test.py
@@ -1,0 +1,4 @@
+def test_app() -> None:
+    from backend.tasks_io.main import app
+
+    assert app is not None

--- a/src/dispatch.yaml
+++ b/src/dispatch.yaml
@@ -2,5 +2,8 @@ dispatch:
   - url: "*/api/*"
     service: py3-api
 
+  - url: "*/tasks-io/*"
+    service: py3-tasks-io
+
   - url: "*/*"
     service: py3-web

--- a/src/tasks_io.yaml
+++ b/src/tasks_io.yaml
@@ -1,0 +1,11 @@
+service: py3-tasks-io
+runtime: python37
+entrypoint: gunicorn -b :$PORT backend.tasks_io.main:app
+
+instance_class: F1
+automatic_scaling:
+  max_idle_instances: 1
+
+handlers:
+  - url: .*
+    script: auto


### PR DESCRIPTION
In an attempt to slim down the `zorr/py3/queues` branch, this adds the default `tasks-io` service to be run locally (not yet deployed)