### PR TITLE
[py3] Adds tasks_mode to tba_dev_config for local or remote Cloud Tasks

### DIFF
--- a/src/backend/common/environment.py
+++ b/src/backend/common/environment.py
@@ -1,5 +1,12 @@
+import enum
 import os
 from typing import Optional
+
+
+@enum.unique
+class EnvironmentMode(enum.Enum):
+    LOCAL = "local"
+    REMOTE = "remote"
 
 
 class Environment(object):
@@ -19,6 +26,10 @@ class Environment(object):
     @staticmethod
     def log_level() -> Optional[str]:
         return os.environ.get("TBA_LOG_LEVEL")
+
+    @staticmethod
+    def tasks_mode() -> EnvironmentMode:
+        return EnvironmentMode(os.environ.get("TASKS_MODE", "local"))
 
     @staticmethod
     def ndb_log_level() -> Optional[str]:

--- a/src/backend/common/tests/environment_test.py
+++ b/src/backend/common/tests/environment_test.py
@@ -1,7 +1,7 @@
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from backend.common.environment import Environment
+from backend.common.environment import Environment, EnvironmentMode
 
 
 @pytest.fixture
@@ -14,6 +14,16 @@ def set_prod(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("GAE_ENV", "standard")
 
 
+@pytest.fixture
+def set_tasks_local(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("TASKS_MODE", "local")
+
+
+@pytest.fixture
+def set_tasks_remote(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("TASKS_MODE", "remote")
+
+
 def test_dev_env(set_dev) -> None:
     assert Environment.is_dev() is True
     assert Environment.is_prod() is False
@@ -22,6 +32,26 @@ def test_dev_env(set_dev) -> None:
 def test_prod_env(set_prod) -> None:
     assert Environment.is_dev() is False
     assert Environment.is_prod() is True
+
+
+def test_tasks_mode_prod(set_prod) -> None:
+    assert Environment.tasks_mode() is EnvironmentMode.LOCAL
+
+
+def test_tasks_mode_prod_remote(set_prod, set_tasks_remote) -> None:
+    assert Environment.tasks_mode() is EnvironmentMode.REMOTE
+
+
+def test_tasks_mode_local_empty() -> None:
+    assert Environment.tasks_mode() is EnvironmentMode.LOCAL
+
+
+def test_tasks_mode_local(set_tasks_local) -> None:
+    assert Environment.tasks_mode() is EnvironmentMode.LOCAL
+
+
+def test_tasks_mode_remote(set_tasks_remote) -> None:
+    assert Environment.tasks_mode() is EnvironmentMode.REMOTE
 
 
 def test_other_env(monkeypatch: MonkeyPatch) -> None:

--- a/tba_dev_config.json
+++ b/tba_dev_config.json
@@ -1,5 +1,6 @@
 {
     "datastore_mode": "local",
+    "tasks_mode": "local",
     "log_level": "info",
     "tba_log_level": "debug",
     "ndb_log_level": "warning"


### PR DESCRIPTION
Adds a `tasks_mode` field to `tba_dev_config.json` to allow users to use local Cloud Tasks, or to communicate with an upstream server to dispatch Cloud Tasks.