### PR TITLE
Add Locally Running Redis to Dev Container

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,11 +38,15 @@ Vagrant.configure("2") do |config|
     d.ports = ports
     d.has_ssh = true
 
-    # By deafult, run with a prebuilt container image
-    d.image = "gcr.io/tbatv-prod-hrd/tba-py3-dev:latest"
+    if ENV['TBA_LOCAL_DOCKERFILE'] != nil
+      # We can build the docker container from the local Dockerfile
+      d.build_dir = "ops/dev/docker"
+    else
+      # But by deafult, run with a prebuilt container image because it's faster
+      d.image = "gcr.io/tbatv-prod-hrd/tba-py3-dev:latest"
+    end
 
-    # Or built it from the local checkout
-    # d.build_dir = "ops/dev/docker"
+
   end
 
   # Configure ssh into container

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y \
   jq \
   tmux \
   vim \
-  openssh-server
+  openssh-server \
+  redis-server
 
 # Setup python environmenets
 # python3 should be the default, but gcloud currently depends on python2

--- a/ops/dev/vagrant/start-devserver.sh
+++ b/ops/dev/vagrant/start-devserver.sh
@@ -20,9 +20,10 @@ echo "Starting devserver in new tmux session..."
 tmux new-session -d -s $session
 tmux new-window -t "$session:1" -n gae "./ops/dev/vagrant/dev_appserver.sh 2>&1 | tee /var/log/tba.log; read"
 tmux new-window -t "$session:2" -n gulp "gulp 2>&1 | tee /var/log/gulp.log; read"
+tmux new-window -t "$session:3" -n redis "redis-server 2>&1 | tee /var/log/redis.log; read"
 if [ ! -z "$instance_name" ]; then
   echo "Starting Cloud SQL proxy to connect to $instance_name"
-  tmux new-window -t "$session:3" -n sql "/cloud_sql_proxy -instances=$instance_name=tcp:3306 -credential_file=$auth_path | tee /var/log/sql.log; read"
+  tmux new-window -t "$session:4" -n sql "/cloud_sql_proxy -instances=$instance_name=tcp:3306 -credential_file=$auth_path | tee /var/log/sql.log; read"
 fi
 tmux select-window -t "$session:1"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ beautifulsoup4
 freezegun
 requests-mock
 blinker==1.4
+redis==3.5.3


### PR DESCRIPTION
We'll need this both for the memcache and task queue replacements.

For running with local docker changes, this also adds a `TBA_LOCAL_DOCKERFILE` env variable you can set to build docker locally. eg
```
$ TBA_LOCAL_DOCKERFILE=true vagrant up
```
