### PR TITLE
Bump GH Actions setup-node to v2.1.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
       - name: Cache node modules
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
       - name: Cache node modules
@@ -122,7 +122,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
       - name: Cache pip

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
       - name: Cache node modules
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
       - name: Cache node modules
@@ -129,7 +129,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
       - name: Cache pip


### PR DESCRIPTION
CI is failing when calling the `setup-node` action due to GH Actions changes https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Bumping to setup-node@v2.1.2 should fix this issue for us https://github.com/actions/setup-node/releases/tag/v2.1.2