### PR TITLE
Add cast from optional to non-optional for season_wlt and offseason_wlt for non-2015 years in team renderer

### DIFF
--- a/src/backend/web/renderers/team_renderer.py
+++ b/src/backend/web/renderers/team_renderer.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import cast, Dict, List, Optional, Tuple
 
 from google.cloud import ndb
 
@@ -198,8 +198,8 @@ class TeamRenderer(object):
                 }
             )
 
-        season_wlt = None
-        offseason_wlt = None
+        season_wlt: Optional[WLTRecord] = None
+        offseason_wlt: Optional[WLTRecord] = None
         if year == 2015:
             year_qual_scores = []
             year_elim_scores = []
@@ -220,8 +220,12 @@ class TeamRenderer(object):
         else:
             year_qual_avg = None
             year_elim_avg = None
-            season_wlt: WLTRecord = {"wins": 0, "losses": 0, "ties": 0}
-            offseason_wlt: WLTRecord = {"wins": 0, "losses": 0, "ties": 0}
+
+            season_wlt = {"wins": 0, "losses": 0, "ties": 0}
+            season_wlt = cast(WLTRecord, season_wlt)
+
+            offseason_wlt = {"wins": 0, "losses": 0, "ties": 0}
+            offseason_wlt = cast(WLTRecord, offseason_wlt)
 
             for wlt in season_wlt_list:
                 season_wlt["wins"] += wlt["wins"]


### PR DESCRIPTION
This should fix the issue that is being raised around re-typing the `season_wlt` and `offseason_wlt` from a `None` to a `WLTRecord` when bumping `pyre-check` https://github.com/the-blue-alliance/the-blue-alliance/pull/3150

This change sets `season_wlt`/`offseason_wlt` to be optional, but then casts `season_wlt`/`offseason_wlt` to be `WLTRecord` objects so we can operate on them later on in the non-2015 flow