### PR TITLE
Revert "Adds tasks_mode to tba_dev_config for local or remote Cloud Tasks"

### DIFF
--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -20,7 +20,6 @@ log_level=$(get_config_prop log_level)
 tba_log_level=$(get_config_prop tba_log_level)
 ndb_log_level=$(get_config_prop ndb_log_level)
 datastore_mode=$(get_config_prop datastore_mode)
-tasks_mode=$(get_config_prop tasks_mode)
 datastore_args=""
 application=""
 env=""
@@ -58,17 +57,6 @@ else
     exit -1
 fi
 
-# Setup Google Cloud Tasks local/remote
-if [ "$tasks_mode" == "local" ]; then
-    echo "Using local tasks (rq + Redis)"
-elif [ "$tasks_mode" == "remote" ]; then
-    echo "Using remote tasks (Cloud Tasks + ngrok)"
-    assert_google_application_credentials
-else
-    echo "Unknown tasks mode $tasks_mode! Must be one of [local, remote]"
-    exit -1
-fi
-
 set -x
 dev_appserver.py \
     --admin_host=0.0.0.0 \
@@ -78,6 +66,5 @@ dev_appserver.py \
     $env \
     --env_var TBA_LOG_LEVEL="$tba_log_level" \
     --env_var NDB_LOG_LEVEL="$ndb_log_level" \
-    --env_var TASKS_MODE="$tasks_mode" \
     --dev_appserver_log_level=$log_level \
     src/default.yaml src/web.yaml src/api.yaml src/tasks_io.yaml src/dispatch.yaml

--- a/src/backend/common/environment.py
+++ b/src/backend/common/environment.py
@@ -1,12 +1,5 @@
-import enum
 import os
 from typing import Optional
-
-
-@enum.unique
-class EnvironmentMode(enum.Enum):
-    LOCAL = "local"
-    REMOTE = "remote"
 
 
 # Mostly GAE env variables
@@ -32,10 +25,6 @@ class Environment(object):
     @staticmethod
     def log_level() -> Optional[str]:
         return os.environ.get("TBA_LOG_LEVEL")
-
-    @staticmethod
-    def tasks_mode() -> EnvironmentMode:
-        return EnvironmentMode(os.environ.get("TASKS_MODE", "local"))
 
     @staticmethod
     def ndb_log_level() -> Optional[str]:

--- a/src/backend/common/tests/environment_test.py
+++ b/src/backend/common/tests/environment_test.py
@@ -1,7 +1,7 @@
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from backend.common.environment import Environment, EnvironmentMode
+from backend.common.environment import Environment
 
 
 @pytest.fixture
@@ -12,16 +12,6 @@ def set_dev(monkeypatch: MonkeyPatch) -> None:
 @pytest.fixture
 def set_prod(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("GAE_ENV", "standard")
-
-
-@pytest.fixture
-def set_tasks_local(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("TASKS_MODE", "local")
-
-
-@pytest.fixture
-def set_tasks_remote(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("TASKS_MODE", "remote")
 
 
 @pytest.fixture
@@ -58,26 +48,6 @@ def test_service_none() -> None:
 
 def test_service(set_service) -> None:
     assert Environment.service() == "default"
-
-
-def test_tasks_mode_prod(set_prod) -> None:
-    assert Environment.tasks_mode() is EnvironmentMode.LOCAL
-
-
-def test_tasks_mode_prod_remote(set_prod, set_tasks_remote) -> None:
-    assert Environment.tasks_mode() is EnvironmentMode.REMOTE
-
-
-def test_tasks_mode_local_empty() -> None:
-    assert Environment.tasks_mode() is EnvironmentMode.LOCAL
-
-
-def test_tasks_mode_local(set_tasks_local) -> None:
-    assert Environment.tasks_mode() is EnvironmentMode.LOCAL
-
-
-def test_tasks_mode_remote(set_tasks_remote) -> None:
-    assert Environment.tasks_mode() is EnvironmentMode.REMOTE
 
 
 def test_other_env(monkeypatch: MonkeyPatch) -> None:

--- a/tba_dev_config.json
+++ b/tba_dev_config.json
@@ -1,6 +1,5 @@
 {
     "datastore_mode": "local",
-    "tasks_mode": "local",
     "log_level": "info",
     "tba_log_level": "debug",
     "ndb_log_level": "warning"


### PR DESCRIPTION
This reverts commit 61bbd2799e9ddc0ce72cf12b8d4bb72f9333ca67.

I'm going to pull this work out and do it as a whole later. But for now - this is going to be confusing for setup, so let's remove it altogether.