### PR TITLE
Add Environment.service_for_current_service to get current service name with default fallback

### DIFF
--- a/src/backend/common/environment/environment.py
+++ b/src/backend/common/environment/environment.py
@@ -2,7 +2,7 @@ import enum
 import os
 from typing import Optional
 
-from backend.common.environment.tasks.tasks_remote_config import TasksRemoteConfig
+from backend.common.environment.tasks import TasksRemoteConfig
 
 
 @enum.unique
@@ -26,6 +26,12 @@ class Environment(object):
     @staticmethod
     def service() -> Optional[str]:
         return os.environ.get("GAE_SERVICE", None)
+
+    @staticmethod
+    def service_for_current_service() -> str:
+        # Get current service - otherwise, fallback on default service
+        service = Environment.service()
+        return service if service else "default"
 
     @staticmethod
     def project() -> Optional[str]:

--- a/src/backend/common/environment/tasks/__init__.py
+++ b/src/backend/common/environment/tasks/__init__.py
@@ -1,0 +1,1 @@
+from .tasks_remote_config import TasksRemoteConfig  # noqa: F401

--- a/src/backend/common/environment/tasks/tests/tasks_remote_config_test.py
+++ b/src/backend/common/environment/tasks/tests/tasks_remote_config_test.py
@@ -1,4 +1,4 @@
-from backend.common.environment.tasks.tasks_remote_config import TasksRemoteConfig
+from backend.common.environment.tasks import TasksRemoteConfig
 
 
 def test_ngrok_url() -> None:

--- a/src/backend/common/environment/tests/environment_test.py
+++ b/src/backend/common/environment/tests/environment_test.py
@@ -4,7 +4,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from backend.common.environment import Environment, EnvironmentMode
-from backend.common.environment.tasks.tasks_remote_config import TasksRemoteConfig
+from backend.common.environment.tasks import TasksRemoteConfig
 
 
 @pytest.fixture
@@ -42,6 +42,11 @@ def set_service(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("GAE_SERVICE", "default")
 
 
+@pytest.fixture
+def set_service_test(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("GAE_SERVICE", "test")
+
+
 def test_dev_env(set_dev) -> None:
     assert Environment.is_dev() is True
     assert Environment.is_prod() is False
@@ -66,6 +71,18 @@ def test_service_none() -> None:
 
 def test_service(set_service) -> None:
     assert Environment.service() == "default"
+
+
+def test_service_for_current_service_none() -> None:
+    assert Environment.service_for_current_service() == "default"
+
+
+def test_service_for_current_service_default(set_service) -> None:
+    assert Environment.service_for_current_service() == "default"
+
+
+def test_service_for_current_service(set_service_test) -> None:
+    assert Environment.service_for_current_service() == "test"
 
 
 def test_tasks_mode_prod(set_prod) -> None:


### PR DESCRIPTION
Pulling some code out of https://github.com/the-blue-alliance/the-blue-alliance/pull/3162 - this DRYs attempting to get the current service name, and otherwise returning "default" as the service name (used for the task queue stuff)