### PR TITLE
Add Interface to Replace Legacy Memcache

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -8,6 +8,7 @@
     {"site-package": "google/cloud/datastore_v1"},
     {"site-package": "numpy"},
     {"site-package": "freezegun"},
+    {"site-package": "redis"},
     {"site-package": "requests_mock"},
     {"site-package": "pytest"},
     {"site-package": "_pytest"}

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -7,6 +7,7 @@
     {"site-package": "InMemoryCloudDatastoreStub"},
     {"site-package": "google/cloud/datastore_v1"},
     {"site-package": "numpy"},
+    {"site-package": "fakeredis"},
     {"site-package": "freezegun"},
     {"site-package": "redis"},
     {"site-package": "requests_mock"},

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 filterwarnings =
+    ignore::DeprecationWarning:google.api
     ignore::DeprecationWarning:google.cloud
+    ignore::DeprecationWarning:google.rpc
+    ignore::DeprecationWarning:google.type
+    ignore::DeprecationWarning:urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ freezegun
 requests-mock
 blinker==1.4
 redis==3.5.3
+fakeredis

--- a/src/backend/common/environment/environment.py
+++ b/src/backend/common/environment/environment.py
@@ -55,3 +55,7 @@ class Environment(object):
     @staticmethod
     def ndb_log_level() -> Optional[str]:
         return os.environ.get("NDB_LOG_LEVEL")
+
+    @staticmethod
+    def redis_url() -> Optional[str]:
+        return os.environ.get("REDIS_CACHE_URL")

--- a/src/backend/common/memcache.py
+++ b/src/backend/common/memcache.py
@@ -104,6 +104,22 @@ class CacheIf(abc.ABC):
         """
 
     @abc.abstractmethod
+    def delete(self, key: bytes) -> None:
+        """Deletes a key from memcache.
+
+        Args:
+        key: Key to delete.  See docs on Client for detils.
+        """
+
+    @abc.abstractmethod
+    def delete_multi(self, keys: List[bytes]) -> None:
+        """Delete multiple keys at once.
+
+        Args:
+        keys: List of keys to delete.
+        """
+
+    @abc.abstractmethod
     def get_stats(self) -> Optional[CacheStats]:
         """Gets memcache statistics for this application.
 
@@ -160,6 +176,12 @@ class NoopCache(CacheIf):
     ) -> Dict[bytes, Optional[Any]]:
         self.miss_count += len(keys)
         return {k: None for k in keys}
+
+    def delete(self, key: bytes) -> None:
+        return None
+
+    def delete_multi(self, keys: List[bytes]) -> None:
+        return None
 
     def get_stats(self) -> Optional[CacheStats]:
         return CacheStats(
@@ -228,6 +250,12 @@ class RedisCache(CacheIf):
         return {
             k: pickle.loads(v) if v is not None else None for k, v in zip(keys, values)
         }
+
+    def delete(self, key: bytes) -> None:
+        self.redis_client.delete(key)
+
+    def delete_multi(self, keys: List[bytes]) -> None:
+        self.redis_client.delete(*keys)
 
     def get_stats(self) -> Optional[CacheStats]:
         info = self.redis_client.info(section="stats")

--- a/src/backend/common/memcache.py
+++ b/src/backend/common/memcache.py
@@ -1,0 +1,231 @@
+import abc
+import pickle
+from typing import Any, Dict, List, Optional
+
+import redis
+from typing_extensions import TypedDict
+
+
+"""
+A shim for the Legacy GAE memcache module
+
+Primarily backed by Redis, but also with a noop implementation, for when caching is disabled
+
+Implementats this API https://cloud.google.com/appengine/docs/standard/python/refdocs/google.appengine.api.memcache
+"""
+
+
+class CacheStats(TypedDict):
+    hits: int
+    misses: int
+
+
+class CacheIf(abc.ABC):
+    @abc.abstractmethod
+    def set(self, key: bytes, value: Any, time: Optional[int] = None) -> bool:
+        """Sets a key's value, regardless of previous contents in cache.
+
+        Unlike add() and replace(), this method always sets (or
+        overwrites) the value in memcache, regardless of previous
+        contents.
+
+        Args:
+        key: Key to set.  See docs on Client for details.
+        value: Value to set.  Any type.  If complex, will be pickled.
+        time: Optional expiration time, a relative number of seconds
+            from current time (up to 1 month).
+            By default, items never expire, though items may be evicted due to
+            memory pressure.
+
+        Returns:
+        True if set.  False on error.
+        """
+
+    @abc.abstractmethod
+    def set_multi(
+        self,
+        mapping: Dict[bytes, Any],
+        time: Optional[int] = None,
+    ) -> None:
+        """Set multiple keys' values at once, regardless of previous contents.
+
+        Args:
+        mapping: Dictionary of keys to values.
+        time: Optional expiration time, a relative number of seconds
+            from current time (up to 1 month).
+            By default, items never expire, though items may be evicted due to
+            memory pressure.
+
+        Returns:
+        A list of keys whose values were NOT set.  On total success,
+        this list should be empty.
+        """
+
+    @abc.abstractmethod
+    def get(self, key: bytes) -> Optional[Any]:
+        """Looks up a single key in memcache.
+
+        If you have multiple items to load, though, it's much more efficient
+        to use get_multi() instead, which loads them in one bulk operation,
+        reducing the networking latency that'd otherwise be required to do
+        many serialized get() operations.
+
+        Args:
+        key: The key in memcache to look up.  See docs on Client
+            for details of format.
+
+        Returns:
+        The value of the key, if found in memcache, else None.
+        """
+
+    @abc.abstractmethod
+    def get_multi(
+        self,
+        keys: List[bytes],
+    ) -> Dict[bytes, Optional[Any]]:
+        """Looks up multiple keys from memcache in one operation.
+
+        This is the recommended way to do bulk loads.
+
+        Args:
+        keys: List of keys to look up.  Keys may be strings or
+            tuples of (hash_value, string).  Google App Engine
+            does the sharding and hashing automatically, though, so the hash
+            value is ignored.  To memcache, keys are just series of bytes,
+            and not in any particular encoding.
+
+        Returns:
+        A dictionary of the keys and values that were present in memcache.
+        Even if the key_prefix was specified, that key_prefix won't be on
+        the keys in the returned dictionary.
+        """
+
+    @abc.abstractmethod
+    def get_stats(self) -> Optional[CacheStats]:
+        """Gets memcache statistics for this application.
+
+        All of these statistics may reset due to various transient conditions. They
+        provide the best information available at the time of being called.
+
+        Returns:
+        Dictionary mapping statistic names to associated values. Statistics and
+        their associated meanings:
+
+            hits: Number of cache get requests resulting in a cache hit.
+            misses: Number of cache get requests resulting in a cache miss.
+            byte_hits: Sum of bytes transferred on get requests. Rolls over to
+            zero on overflow.
+            items: Number of key/value pairs in the cache.
+            bytes: Total size of all items in the cache.
+            oldest_item_age: How long in seconds since the oldest item in the
+            cache was accessed. Effectively, this indicates how long a new
+            item will survive in the cache without being accessed. This is
+            _not_ the amount of time that has elapsed since the item was
+            created.
+
+        On error, returns None.
+        """
+
+
+class NoopCache(CacheIf):
+    """
+    A noop implementation of the memcache interface, where all writes succeed and all reads miss
+    """
+
+    miss_count: int
+
+    def __init__(self) -> None:
+        self.miss_count = 0
+
+    def set(self, key: bytes, value: Any, time: Optional[int] = None) -> bool:
+        return True
+
+    def set_multi(
+        self,
+        mapping: Dict[bytes, Any],
+        time: Optional[int] = None,
+    ) -> None:
+        return None
+
+    def get(self, key: bytes) -> Optional[Any]:
+        self.miss_count += 1
+        return None
+
+    def get_multi(
+        self,
+        keys: List[bytes],
+    ) -> Dict[bytes, Optional[Any]]:
+        self.miss_count += len(keys)
+        return {k: None for k in keys}
+
+    def get_stats(self) -> Optional[CacheStats]:
+        return CacheStats(
+            hits=0,
+            misses=self.miss_count,
+        )
+
+
+class RedisCache(CacheIf):
+    """
+    A cache implementation backed by redis
+
+    The GAE memcache service will transparently (de)pickle objects that get stored,
+    so we do the same here, but a bit simpler (where we bindly pickle everything, instead
+    of checking the value's type)
+    """
+
+    redis: redis.Redis
+
+    def __init__(self, redis_url: str) -> None:
+        self.redis = redis.Redis.from_url(redis_url)
+
+    def set(self, key: bytes, value: Any, time: Optional[int] = None) -> bool:
+        if time is not None and time < 0:
+            raise ValueError("Expiration must not be negative")
+
+        pickled_value = pickle.dumps(value)
+        ret = self.redis.set(key, pickled_value, ex=time)
+        if ret is None:
+            return False
+        return ret
+
+    def set_multi(
+        self,
+        mapping: Dict[bytes, Any],
+        time: Optional[int] = None,
+    ) -> None:
+        if time is not None and time < 0:
+            raise ValueError("Expiration must not be negative")
+
+        mapping_to_set = {k: pickle.dumps(v) for k, v in mapping.items()}
+        pipeline = self.redis.pipeline()
+        pipeline.mset(mapping_to_set)
+        if time is not None:
+            # Redis doesn't support mset + TTL, so we do it
+            # ourselves manually in a transaction, if necessary
+            for k in mapping.keys():
+                pipeline.expire(k, time)
+        pipeline.execute()
+
+    def get(self, key: bytes) -> Optional[Any]:
+        value = self.redis.get(key)
+        if value is None:
+            return None
+
+        return pickle.loads(value)
+
+    def get_multi(
+        self,
+        keys: List[bytes],
+    ) -> Dict[bytes, Optional[Any]]:
+        values = self.redis.mget(keys)
+        return {
+            k: pickle.loads(v) if v is not None else None for k, v in zip(keys, values)
+        }
+
+    def get_stats(self) -> Optional[CacheStats]:
+        info = self.redis.info(section="stats")
+        return CacheStats(
+            hits=info["keyspace_hits"],
+            misses=info["keyspace_misses"],
+        )

--- a/src/backend/common/redis.py
+++ b/src/backend/common/redis.py
@@ -1,0 +1,24 @@
+import os
+from typing import Optional
+
+import redis
+from pyre_extensions import none_throws
+
+
+class RedisClient:
+    """
+    This will let us share redis clients across use cases in the code
+    """
+
+    client: Optional[redis.Redis] = None
+
+    @classmethod
+    def get(cls) -> Optional[redis.Redis]:
+        redis_url = os.environ.get("REDIS_CACHE_URL")
+        if not redis_url:
+            return None
+
+        if cls.client is None:
+            cls.client = redis.Redis.from_url(redis_url)
+
+        return none_throws(cls.client)

--- a/src/backend/common/redis.py
+++ b/src/backend/common/redis.py
@@ -1,8 +1,9 @@
-import os
 from typing import Optional
 
 import redis
 from pyre_extensions import none_throws
+
+from backend.common.environment import Environment
 
 
 class RedisClient:
@@ -10,15 +11,19 @@ class RedisClient:
     This will let us share redis clients across use cases in the code
     """
 
-    client: Optional[redis.Redis] = None
+    _client: Optional[redis.Redis] = None
 
     @classmethod
     def get(cls) -> Optional[redis.Redis]:
-        redis_url = os.environ.get("REDIS_CACHE_URL")
+        redis_url = Environment.redis_url()
         if not redis_url:
             return None
 
-        if cls.client is None:
-            cls.client = redis.Redis.from_url(redis_url)
+        if cls._client is None:
+            cls._client = redis.Redis.from_url(redis_url)
 
-        return none_throws(cls.client)
+        return none_throws(cls._client)
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._client = None

--- a/src/backend/common/tests/memcache_test.py
+++ b/src/backend/common/tests/memcache_test.py
@@ -1,0 +1,98 @@
+import datetime
+from unittest.mock import Mock
+
+import fakeredis
+import pytest
+import redis
+from _pytest.monkeypatch import MonkeyPatch
+from freezegun import freeze_time
+
+from backend.common.memcache import CacheIf, MemcacheClient, NoopCache, RedisCache
+from backend.common.redis import RedisClient
+
+
+@pytest.fixture
+def redis_client() -> redis.Redis:
+    return fakeredis.FakeStrictRedis()
+
+
+@pytest.fixture
+def redis_cache(redis_client: redis.Redis) -> CacheIf:
+    return RedisCache(redis_client)
+
+
+@pytest.fixture(autouse=True)
+def clear_state() -> None:
+    RedisClient.reset()
+    MemcacheClient.reset()
+
+
+def test_noop_cache() -> None:
+    cache = NoopCache()
+
+    assert cache.get(b"key") is None
+    assert cache.set(b"key", "value") is True
+    assert cache.get(b"key") is None
+
+    stats = cache.get_stats()
+    assert stats is not None
+    assert stats["misses"] == 2
+
+    assert cache.get_multi([b"key"]) == {b"key": None}
+    assert cache.set_multi({b"key": "value"}) is None
+    assert cache.get_multi([b"key"]) == {b"key": None}
+
+    stats = cache.get_stats()
+    assert stats is not None
+    assert stats["misses"] == 4
+
+
+def test_redis_ttl(redis_cache: CacheIf) -> None:
+    start_time = datetime.datetime.now()
+    with freeze_time(start_time) as frozen_time:
+        redis_cache.set(b"key", "value", time=10)
+        assert redis_cache.get(b"key") == "value"
+
+        frozen_time.move_to(start_time + datetime.timedelta(seconds=40))
+        assert redis_cache.get(b"key") is None
+
+
+def test_redis_multi_set_ttl(redis_cache: CacheIf) -> None:
+    start_time = datetime.datetime.now()
+    with freeze_time(start_time) as frozen_time:
+        redis_cache.set_multi({b"key1": "value1", b"key2": "value2"}, time=10)
+        assert redis_cache.get(b"key1") == "value1"
+        assert redis_cache.get(b"key2") == "value2"
+
+        frozen_time.move_to(start_time + datetime.timedelta(seconds=40))
+        assert redis_cache.get(b"key1") is None
+        assert redis_cache.get(b"key2") is None
+
+
+def test_redis_pickle_round_trip(redis_cache: CacheIf) -> None:
+    values = [1, "a", 3.14, {"abc": 123}]
+    for i, value in enumerate(values):
+        assert redis_cache.set(f"key_{i}".encode(), value) is True
+        assert redis_cache.get(f"key_{i}".encode()) == value
+
+
+def test_memcache_client_no_env() -> None:
+    client = MemcacheClient.get()
+    assert isinstance(client, NoopCache)
+
+
+def test_memcache_client_empty_env(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("REDIS_CACHE_URL", "")
+    client = MemcacheClient.get()
+    assert isinstance(client, NoopCache)
+
+def test_memcache_client_with_env(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("REDIS_CACHE_URL", "redis://localhost:1234")
+
+    def from_url_patch(url):
+        return Mock()
+
+    monkeypatch.setattr(redis.Redis, "from_url", from_url_patch)
+
+    client = MemcacheClient.get()
+    assert isinstance(client, RedisCache)


### PR DESCRIPTION
This PR copies the legacy GAE memcache interface (ish, limited to the feature we currently use elsewhere in the code).

We add an interface so we can have multiple implementations. Namely, a noop one that will miss 100% of the time. This will be our default client for "raw" memcache, for cases where we can't/don't run redis locally.

~Still todo: write some tests, and refactor redis client creation so we can create a single one and share it with the ndb cache~