### PR TITLE
Implement custom serialization for memcache

### DIFF
--- a/src/backend/common/memcache.py
+++ b/src/backend/common/memcache.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import abc
+import enum
 import pickle
+import struct
+from dataclasses import dataclass, field as dataclass_field
 from typing import Any, Dict, List, Optional
 
 import redis
@@ -190,6 +195,108 @@ class NoopCache(CacheIf):
         )
 
 
+REDIS_CACHE_ITEM_VERSION = 0
+
+
+class _RedisCacheValueType(enum.IntEnum):
+    BYTES = 0
+    UNICODE = 1
+    PICKLED = 2
+    INT = 3
+    BOOL = 4
+
+
+@dataclass
+class _RedisCacheItem:
+    value_type: _RedisCacheValueType
+    value: Any
+    version: int
+
+    # This will pack the data type + version into unsigned chars
+    # (one byte, so 0-255 values)
+    HEADER_PACK_FMT: str = dataclass_field(
+        default="<BB", init=False, repr=False, compare=False, hash=None
+    )
+    HEADER_LEN: int = dataclass_field(
+        default=2, init=False, repr=False, compare=False, hash=None
+    )
+
+    def __bytes__(self) -> bytes:
+        # First, pack a brief header that includes the version and data type
+        header = struct.pack(self.HEADER_PACK_FMT, self.version, int(self.value_type))
+
+        value_bytes: Optional[bytes] = None
+        if self.value_type == _RedisCacheValueType.BYTES:
+            value_bytes = self.value
+        elif self.value_type == _RedisCacheValueType.UNICODE:
+            value_bytes = self.value.encode("utf-8")
+        elif self.value_type == _RedisCacheValueType.PICKLED:
+            value_bytes = pickle.dumps(self.value, protocol=pickle.HIGHEST_PROTOCOL)
+        elif self.value_type == _RedisCacheValueType.INT:
+            value_bytes = bytes(
+                self.value.to_bytes(
+                    (self.value.bit_length() + 7) // 8,
+                    byteorder="little",
+                    signed=True,
+                )
+            )
+        elif self.value_type == _RedisCacheValueType.BOOL:
+            value_bytes = bytes(
+                int(self.value).to_bytes(1, byteorder="little", signed=False)
+            )
+        else:
+            raise ValueError(f"Can't turn value type {self.value_type} into bytes!")
+        return header + none_throws(value_bytes)
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> _RedisCacheItem:
+        header = struct.unpack(cls.HEADER_PACK_FMT, raw_data[: cls.HEADER_LEN])
+        version = header[0]
+        value_type = _RedisCacheValueType(header[1])
+        value_data = raw_data[cls.HEADER_LEN :]
+
+        value = None
+        if value_type == _RedisCacheValueType.BYTES:
+            value = value_data
+        elif value_type == _RedisCacheValueType.UNICODE:
+            value = value_data.decode("utf-8")
+        elif value_type == _RedisCacheValueType.PICKLED:
+            value = pickle.loads(value_data)
+        elif value_type == _RedisCacheValueType.INT:
+            value = int.from_bytes(value_data, byteorder="little", signed=True)
+        elif value_type == _RedisCacheValueType.BOOL:
+            value = bool(int.from_bytes(value_data, byteorder="little", signed=False))
+        else:
+            raise ValueError(f"Unable to get value of type {value_type}")
+
+        return cls(
+            version=version,
+            value_type=value_type,
+            value=none_throws(value),
+        )
+
+    @classmethod
+    def from_value(cls, value: Any) -> _RedisCacheItem:
+        value_type: Optional[_RedisCacheValueType] = None
+
+        if isinstance(value, bytes):
+            value_type = _RedisCacheValueType.BYTES
+        elif isinstance(value, str):
+            value_type = _RedisCacheValueType.UNICODE
+        elif isinstance(value, bool):
+            value_type = _RedisCacheValueType.BOOL
+        elif isinstance(value, int):
+            value_type = _RedisCacheValueType.INT
+        else:
+            value_type = _RedisCacheValueType.PICKLED
+
+        return cls(
+            version=REDIS_CACHE_ITEM_VERSION,
+            value_type=none_throws(value_type),
+            value=value,
+        )
+
+
 class RedisCache(CacheIf):
     """
     A cache implementation backed by redis
@@ -208,8 +315,8 @@ class RedisCache(CacheIf):
         if time is not None and time < 0:
             raise ValueError("Expiration must not be negative")
 
-        pickled_value = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
-        ret = self.redis_client.set(key, pickled_value, ex=time)
+        encoded_value = bytes(_RedisCacheItem.from_value(value))
+        ret = self.redis_client.set(key, encoded_value, ex=time)
         if ret is None:
             return False
         return ret
@@ -223,8 +330,7 @@ class RedisCache(CacheIf):
             raise ValueError("Expiration must not be negative")
 
         mapping_to_set = {
-            k: pickle.dumps(v, protocol=pickle.HIGHEST_PROTOCOL)
-            for k, v in mapping.items()
+            k: bytes(_RedisCacheItem.from_value(v)) for k, v in mapping.items()
         }
         pipeline = self.redis_client.pipeline()
         pipeline.mset(mapping_to_set)
@@ -240,15 +346,25 @@ class RedisCache(CacheIf):
         if value is None:
             return None
 
-        return pickle.loads(value)
+        data = _RedisCacheItem.from_bytes(value)
+        if data.version < REDIS_CACHE_ITEM_VERSION:
+            return None
+        return data.value
 
     def get_multi(
         self,
         keys: List[bytes],
     ) -> Dict[bytes, Optional[Any]]:
         values = self.redis_client.mget(keys)
+        data_map = {
+            k: _RedisCacheItem.from_bytes(v) if v is not None else None
+            for k, v in zip(keys, values)
+        }
         return {
-            k: pickle.loads(v) if v is not None else None for k, v in zip(keys, values)
+            k: v.value
+            if v is not None and v.version == REDIS_CACHE_ITEM_VERSION
+            else None
+            for k, v in data_map.items()
         }
 
     def delete(self, key: bytes) -> None:

--- a/src/backend/common/memcache.py
+++ b/src/backend/common/memcache.py
@@ -125,6 +125,38 @@ class CacheIf(abc.ABC):
         """
 
     @abc.abstractmethod
+    def incr(self, key: bytes) -> Optional[int]:
+        """Atomically increments a key's value.
+
+        Internally, the value is a unsigned 64-bit integer.  Memcache
+        doesn't check 64-bit overflows.  The value, if too large, will
+        wrap around.
+
+
+        Args:
+        key: Key to increment.
+
+        Returns:
+        The new integer value of the key
+        """
+
+    @abc.abstractmethod
+    def decr(self, key: bytes) -> Optional[int]:
+        """Atomically decrements a key's value.
+
+        Internally, the value is a unsigned 64-bit integer.  Memcache
+        doesn't check 64-bit overflows.  The value, if too large, will
+        wrap around.
+
+
+        Args:
+        key: Key to decrement.
+
+        Returns:
+        The new integer value of the key
+        """
+
+    @abc.abstractmethod
     def get_stats(self) -> Optional[CacheStats]:
         """Gets memcache statistics for this application.
 
@@ -186,6 +218,12 @@ class NoopCache(CacheIf):
         return None
 
     def delete_multi(self, keys: List[bytes]) -> None:
+        return None
+
+    def incr(self, key: bytes) -> Optional[int]:
+        return None
+
+    def decr(self, key: bytes) -> Optional[int]:
         return None
 
     def get_stats(self) -> Optional[CacheStats]:
@@ -372,6 +410,12 @@ class RedisCache(CacheIf):
 
     def delete_multi(self, keys: List[bytes]) -> None:
         self.redis_client.delete(*keys)
+
+    def incr(self, key: bytes) -> Optional[int]:
+        return self.redis_client.incr(key)
+
+    def decr(self, key: bytes) -> Optional[int]:
+        return self.redis_client.decr(key)
 
     def get_stats(self) -> Optional[CacheStats]:
         info = self.redis_client.info(section="stats")


### PR DESCRIPTION
The previous iteration of just pickling everything will be a little too naive. For two main reasons:

 1. In order to support `INCR` and `DECR` commands (which I missed yesterday), we'll need to write raw int values to redis. Obviously, this won't work if the data is pickled
 2. For space efficiency reasons, we can more cheaply store primitive types if we avoid pickling them.
```
>>> len(pickle.dumps(True))
4
>>> len(pickle.dumps(255))
5
```

Instead, do a custom thing where we store a two byte header in front of the data, one byte for a version, and one byte for a type indicator, and then pack the data on after that.

This is actually similar to what the old ndb memcache library did transparently for us, see the [encoding](https://chromium.googlesource.com/external/googleappengine/python/+/master/google/appengine/api/memcache/__init__.py#183) and [decode](https://chromium.googlesource.com/external/googleappengine/python/+/master/google/appengine/api/memcache/__init__.py#242) implementations. I made the header format up, since that's abstracted away by the old memcache service (the flags were just a separate field in the protobuf).