### PR TITLE
Update docs in codebase to match upstream docs

### DIFF
--- a/docs/Setup/Repo-Setup.md
+++ b/docs/Setup/Repo-Setup.md
@@ -4,14 +4,14 @@ A small amount of repo configuration can be done in order to streamline developm
 ## Install Dependencies
 This optional tooling requires [Python 3](https://www.python.org/downloads/) and [`pip`](https://pip.pypa.io/en/stable/installing/) to install.
 
-1. Install [Python 3](https://www.python.org/downloads/)
+1. Install [Python 3](https://www.python.org/downloads/) (3.8+)
 2. Install [`pip`](https://pip.pypa.io/en/stable/installing/)
 
 If you have both a Python 2 and Python 3 interpreter on your machine, run the `pip3` command instead of `pip`. To confirm, run -
 ```
 $ ls -l `which pip`
 ```
-If the path is a `2.7(.X)` path, run `pip3` instead of `pip`. If the path is a `3.7(.X)` path, run `pip`.
+If the path is a `2.7(.X)` path, run `pip3` instead of `pip`. If the path is a `3.8(.X)` path, run `pip`.
 
 ### Globally Install
 ```

--- a/docs/Setup/Setup-Guide.md
+++ b/docs/Setup/Setup-Guide.md
@@ -31,5 +31,14 @@ To automatically sync changes from your local environment to the container, run 
 
 Connect to the container via `vagrant ssh`. Process in the container run connected to a [tmux](https://github.com/tmux/tmux/wiki) session. You can connect to the `tmux` session via `tmux a`. The first tab is a `bash` session `cd`’d to the project’s working directory, `/tba`. The second tab is the [`dev_appserver.py`](https://cloud.google.com/appengine/docs/standard/python3/testing-and-deploying-your-app#local-dev-server) output which contains Google App Engine logs. Other `tmux` tabs are labeled based on the foregrounded process running.
 
+```
+# Sync changes in one tab
+$ vagrant rsync-auto
+
+# ssh in to dev container in one tab
+$ vagrant ssh
+> tmux attach
+```
+
 ## What’s Next?
 The [[development runbook|Development-Runbook]] has documentation for good next steps when working on The Blue Alliance, including bootstrapping data from production to your development environment, running tests, etc.


### PR DESCRIPTION
I've been editing the Wiki online, which means the `docs/` folder in the codebase and the upstream Wiki have converged. This PR syncs the upstream Wiki docs to the codebase `docs/` folder so the latter stops overwriting the former when pushing changes.