### PR TITLE
Fix JavaScript on macOS Big Sur

### DIFF
--- a/src/backend/web/static/javascript/utils/client_detection.js
+++ b/src/backend/web/static/javascript/utils/client_detection.js
@@ -145,7 +145,7 @@
 
         switch (os) {
             case 'Mac OS X':
-                osVersion = /Mac OS X (10[\.\_\d]+)/.exec(nAgt)[1];
+                osVersion = /Mac OS X ([\.\_\d]+)/.exec(nAgt)[1];
                 break;
 
             case 'Android':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The client detection script tries to parse the macOS version that starts with ``10.`` but macOS Big Sur is ``11.`` - it throws an error that interferes with the rest of the JavsScript code so parts of the pages don't work.
This change should be merged with both ``master`` and ``py3``.

## How Has This Been Tested?
Testing UAs from different versions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
