### PR TITLE
Configure Redis in Prod

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -170,6 +170,20 @@ jobs:
     if: contains(github.event.commits[0].message, '[nodeploy]') == false
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Download production artifacts
         uses: actions/download-artifact@v2
         with:
@@ -181,8 +195,14 @@ jobs:
           version: "294.0.0"
           project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
+      - name: Install gcloud beta
+        # gcloud beta is needed to use the VPC connector needed for redis
+        run: gcloud components install beta
       - name: Deploy
-        run: gcloud components install beta && gcloud beta app deploy src/web.yaml --version 1 --quiet
+        env:
+          REDIS_CACHE_URL: ${{ secrets.REDIS_CACHE_URL }}
+          VPC_CONNECTOR_NAME: ${{ secrets.VPC_CONNECTOR_NAME }}
+        run: ./ops/deploy/deploy_module.sh src/web.yaml
   deploy-api:
     name: Deploy API Service
     runs-on: ubuntu-latest
@@ -190,11 +210,31 @@ jobs:
     if: contains(github.event.commits[0].message, '[nodeploy]') == false
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Setup Google Cloud Platform
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: "294.0.0"
           project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
+      - name: Install gcloud beta
+        # gcloud beta is needed to use the VPC connector needed for redis
+        run: gcloud components install beta
       - name: Deploy
-        run: gcloud components install beta && gcloud beta app deploy src/api.yaml --version 1 --quiet
+        env:
+          REDIS_CACHE_URL: ${{ secrets.REDIS_CACHE_URL }}
+          VPC_CONNECTOR_NAME: ${{ secrets.VPC_CONNECTOR_NAME }}
+        run: ./ops/deploy/deploy_module.sh src/api.yaml

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,5 +1,6 @@
 {
   "source_directories": [
+    "ops",
     "src"
   ],
   "search_path": [

--- a/docs/Deployment/CI-CD-Setup.md
+++ b/docs/Deployment/CI-CD-Setup.md
@@ -13,3 +13,12 @@ Under your repository Settings > Secrets on GitHub, set the following secrets:
   e.g. `cat my-key.json | base64`
 
   More info on [creating and managing service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+
+
+- `REDIS_CACHE_URL`: A url pointing to a redis instance running in [Cloud Memorystore](https://cloud.google.com/memorystore).
+
+  You'll need to have created an instance and VPC Network Connector (see the [[Prod Setup Guide|Prod-Setup]]). The redis URL will look something like: `redis://<REDIS IP>:<REDIS PORT>`.
+
+- `VPC_CONNECTOR_NAME`: This is the name of the [VPC Access Connector](https://cloud.google.com/appengine/docs/standard/python/connecting-vpc) that allows App Engine to connect to the redis instance.
+
+  This will be of the format `projects/<PROJECT_ID>/locations/<REGION>/connectors/<CONNECTOR_NAME>`

--- a/docs/Deployment/Prod-Setup.md
+++ b/docs/Deployment/Prod-Setup.md
@@ -1,0 +1,13 @@
+This document lists the items that need to be configured on production Google Cloud in order for The Blue Alliance to run.
+
+## Task Queues
+
+Task queues need to be created in advance. See [this section](https://github.com/the-blue-alliance/the-blue-alliance/wiki/Queues-and-defer#creating-queues) for the queues we need to set up.
+
+### Memorystore (redis)
+
+Roughly, the setup is outlined in [this page](https://cloud.google.com/appengine/docs/standard/python/migrate-to-python3/migrate-to-cloud-ndb#caching). We need the following steps:
+ 1. Create a [VPC Network](https://cloud.google.com/vpc/docs/vpc)
+ 2. Create a [VPC Access Connector](https://cloud.google.com/vpc/docs/configure-serverless-vpc-access#creating_a_connector)
+ 3. Create a [Redis Instance](https://cloud.google.com/memorystore/docs/redis/creating-managing-instances#creating_redis_instances) using the network
+ 4. Make note of the `REDIS_CACHE_URL` and VPC Connector name to set as deploy secrets

--- a/docs/Developing/Redis.md
+++ b/docs/Developing/Redis.md
@@ -1,0 +1,28 @@
+The Blue Alliance uses [redis](https://redis.io/) to act as a fast cache for data that would be otherwise expensive to load. Examples of applications for redis are:
+ - an [NDB global cache](https://googleapis.dev/python/python-ndb/latest/global_cache.html) implementation to reduce the number of queries that have to hit the backing datastore
+ - storing rendered HTML output pages to avoid repetitive work
+ - in local development mode, backing [https://github.com/the-blue-alliance/the-blue-alliance/wiki/Queues-and-defer#redis--rq](`rq`) to run task queues
+
+
+The application shares a single redis connection (using the standard [library](https://pypi.org/project/redis/)) among all of these instances. This is managed by the `RedisClient` class, which reads the connection location from the `REDIS_CACHE_URL` environment variable. If this variable is unset, caching should be considered disabled.
+
+### Using Redis
+
+Redis exposes a standard Key-Value Store interface. The [redis-py](https://pypi.org/project/redis/) library has a quick getting started guide.
+
+```python
+from backend.common.redis import RedisClient
+redis_client = RedisClient.get()
+# if redis_client is None, then caching is disabled
+
+redis_client.set('foo', 'bar')  # will return True
+redis_client.get('foo')  # will return 'bar'
+```
+
+### Local Setup
+
+The development container has a running instance of redis by default. It can be found running on `localhost:6379` (the default port). The URL for redis connection can be configured using the `redis_cache_url` field in the local property file.
+
+### Production Setup
+
+In production, we run managed redis [Google Cloud Memorystore](https://cloud.google.com/memorystore). The deploy process will configure the `REDIS_CACHE_URL` and other networking components to set up the connection.

--- a/ops/deploy/deploy_module.sh
+++ b/ops/deploy/deploy_module.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+set -e
+
+SERVICE=$1
+
+# Post-Process YAML to set up redis connections
+python3 ops/deploy/postprocess_yaml.py "$SERVICE"
+
+gcloud beta app deploy "$SERVICE" --version 1 --quiet

--- a/ops/deploy/postprocess_yaml.py
+++ b/ops/deploy/postprocess_yaml.py
@@ -1,0 +1,48 @@
+#! /usr/loca/bin/python3
+import argparse
+import os
+import sys
+
+import yaml
+
+
+"""
+There are some aspects of GAE YAML files that we don't want to have
+committed to the repo and that we need to generate on the fly at deploy
+time, based on secret environment variables
+
+This script will parse the YAML file passed and add in those new fields.
+The are:
+ - set the REDIS_CACHE_URL environment variable
+ - set up a vpc_access_connector to connect to Cloud Memorystore
+
+This script depends on pyyaml
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("service", help="Path to yaml file for this service")
+
+    args = parser.parse_args()
+
+    with open(args.service) as service_file:
+        service_config = yaml.safe_load(service_file)
+
+    if "env_variables" not in service_config:
+        service_config["env_variables"] = {}
+
+    service_config["env_variables"]["REDIS_CACHE_URL"] = os.environ["REDIS_CACHE_URL"]
+
+    service_config["vpc_access_connector"] = {
+        "name": os.environ["VPC_CONNECTOR_NAME"],
+    }
+
+    with open(args.service, "w") as output_file:
+        yaml.dump(service_config, output_file)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pytest
 pytest-cov
 pytest-custom_exit_code
 pytest-testmon
+PyYAML==5.3.1
 redis==3.5.3
 rq-dashboard
 requests-mock


### PR DESCRIPTION
After defeating my own stupidity and fixing the incorrect port (h/t @fletch3555), let's get redis working in prod.

https://cloud.google.com/appengine/docs/standard/python/migrate-to-python3/migrate-to-cloud-ndb#caching is the guide of what we configured on the server side (I'll also add some wiki docs to this pull before merging)

In short, we need to configure two things:
 - the `REDIS_CACHE_URL` environment variable for our application code to pick up the fact we want to use redis (this is the same way we get the url for the dev app)
  - a VPC network connector to tell Google Cloud that our GAE instance is allowed to talk to the network containing the redis resources

Both of these things are to be configured in the service YAML files. The downside is, we don't really want anything tied to the prod deployment committed in the repo, so we need to dynamically generate those two items.

Enter the service postprocessing script that is our new deploy entry point (I wrapped that and the `gcloud` invocation in a simple bash script). This python script will read those two values from secrets and add them into the YAML file at deploy time