### PR TITLE
Implement Response Caching

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,6 +6,7 @@
   "search_path": [
     "stubs",
     {"site-package": "fakeredis"},
+    {"site-package": "flask_caching"},
     {"site-package": "freezegun"},
     {"site-package": "google/cloud/datastore_v1"},
     {"site-package": "google/cloud/tasks_v2/"},

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -3,6 +3,7 @@ from flask import Flask
 from backend.api.handlers.error import handle_404
 from backend.api.handlers.event import event
 from backend.api.handlers.team import team, team_list
+from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
 
@@ -11,6 +12,8 @@ configure_logging()
 
 app = Flask(__name__)
 install_middleware(app)
+configure_flask_cache(app)
+
 app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True
 
 app.add_url_rule("/api/v3/event/<string:event_key>", view_func=event)

--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -1,6 +1,6 @@
 from functools import partial, wraps
 
-from flask import make_response, request, Response
+from flask import current_app, make_response, request, Response
 
 
 def cached_public(func=None, timeout: int = 61):
@@ -9,10 +9,9 @@ def cached_public(func=None, timeout: int = 61):
 
     @wraps(func)
     def decorated_function(*args, **kwargs):
-        resp = make_response(func(*args, **kwargs))
+        cached = current_app.cache.cached(timeout=timeout)
+        resp = make_response(cached(func)(*args, **kwargs))
         if resp.status_code == 200:  # Only cache OK responses
-            # TODO: hook into Redis
-
             resp.headers["Cache-Control"] = "public, max-age={0}, s-maxage={0}".format(
                 max(
                     timeout, 61

--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -9,8 +9,14 @@ def cached_public(func=None, timeout: int = 61):
 
     @wraps(func)
     def decorated_function(*args, **kwargs):
-        cached = current_app.cache.cached(timeout=timeout)
-        resp = make_response(cached(func)(*args, **kwargs))
+        if hasattr(current_app, "cache"):
+            cached = current_app.cache.cached(
+                timeout=timeout,
+                response_filter=lambda resp: make_response(resp).status_code == 200,
+            )
+            resp = make_response(cached(func)(*args, **kwargs))
+        else:
+            resp = make_response(func(*args, **kwargs))
         if resp.status_code == 200:  # Only cache OK responses
             resp.headers["Cache-Control"] = "public, max-age={0}, s-maxage={0}".format(
                 max(

--- a/src/backend/common/deferred/handlers/tests/test_defer_handler.py
+++ b/src/backend/common/deferred/handlers/tests/test_defer_handler.py
@@ -45,9 +45,9 @@ def test_handle_defer_task_name_header():
     data = task.serialize()
 
     app = Flask(__name__)
-    with app.test_request_context(headers={"X-AppEngine-TaskName": 123}, data=data), patch(
-        "backend.common.deferred.handlers.defer_handler.run"
-    ) as mock_run:
+    with app.test_request_context(
+        headers={"X-AppEngine-TaskName": 123}, data=data
+    ), patch("backend.common.deferred.handlers.defer_handler.run") as mock_run:
         response = handle_defer("/some/path")
 
     assert type(response) is Response

--- a/src/backend/common/flask_cache.py
+++ b/src/backend/common/flask_cache.py
@@ -9,7 +9,7 @@ from backend.common.redis import RedisClient
 def configure_flask_cache(app: Flask) -> None:
     redis_client = RedisClient.get()
     if not redis_client:
-        logging.warn(
+        logging.warning(
             f"Unable to get redis client, not setting up flask cache for {app.import_name}"
         )
         config = {

--- a/src/backend/common/flask_cache.py
+++ b/src/backend/common/flask_cache.py
@@ -1,0 +1,26 @@
+import logging
+
+from flask import Flask
+from flask_caching import Cache
+
+from backend.common.redis import RedisClient
+
+
+def configure_flask_cache(app: Flask) -> None:
+    redis_client = RedisClient.get()
+    if not redis_client:
+        logging.warn(
+            f"Unable to get redis client, not setting up flask cache for {app.import_name}"
+        )
+        config = {
+            "CACHE_TYPE": "null",
+        }
+    else:
+        logging.info("Setting up flask cache with redis client")
+        config = {
+            "CACHE_TYPE": "redis",
+            "CACHE_REDIS_HOST": redis_client,
+        }
+    cache = Cache(config=config)
+    cache.init_app(app)
+    app.cache = cache

--- a/src/backend/common/tests/decorator_test.py
+++ b/src/backend/common/tests/decorator_test.py
@@ -1,6 +1,17 @@
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from fakeredis import FakeRedis
 from flask import Flask
+from flask_caching.backends.nullcache import NullCache
+from flask_caching.backends.rediscache import RedisCache
+from freezegun import freeze_time
 
 from backend.common.decorators import cached_public
+from backend.common.flask_cache import configure_flask_cache
+from backend.common.redis import RedisClient
 
 
 def test_no_cached_public(app: Flask) -> None:
@@ -63,3 +74,85 @@ def test_cached_public_etag(app: Flask) -> None:
     resp3 = app.test_client().get("/", headers={"If-None-Match": "bad-etag"})
     assert resp3.status_code == 200
     assert resp3.get_data(as_text=True) == "Hello!"
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning:flask_caching")
+def test_flask_cache_null_cache_by_default(app: Flask) -> None:
+    configure_flask_cache(app)
+
+    @app.route("/")
+    @cached_public
+    def view():
+        return "Hello!"
+
+    assert hasattr(app, "cache")
+    assert isinstance(app.cache.cache, NullCache)
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 200
+
+
+def test_flask_cache_with_redis(monkeypatch: MonkeyPatch, app: Flask) -> None:
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(RedisClient, "get", MagicMock(return_value=fake_redis))
+    configure_flask_cache(app)
+
+    @app.route("/")
+    @cached_public
+    def view():
+        return "Hello!"
+
+    assert hasattr(app, "cache")
+    assert isinstance(app.cache.cache, RedisCache)
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 200
+
+    assert app.cache.get("view//") == resp.data.decode()
+
+
+def test_flask_cache_with_redis_after_timeout(
+    monkeypatch: MonkeyPatch, app: Flask
+) -> None:
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(RedisClient, "get", MagicMock(return_value=fake_redis))
+    configure_flask_cache(app)
+
+    @app.route("/")
+    @cached_public(timeout=10)
+    def view():
+        return "Hello!"
+
+    assert hasattr(app, "cache")
+    assert isinstance(app.cache.cache, RedisCache)
+
+    with freeze_time() as frozen_time:
+        resp = app.test_client().get("/")
+        assert resp.status_code == 200
+
+        assert app.cache.get("view//") == resp.data.decode()
+
+        # Tick past the expiration, so the next get should return None
+        frozen_time.tick(delta=datetime.timedelta(seconds=15))
+
+        assert app.cache.get("view//") is None
+
+
+def test_flask_cache_with_redis_skips_errors(
+    monkeypatch: MonkeyPatch, app: Flask
+) -> None:
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(RedisClient, "get", MagicMock(return_value=fake_redis))
+    configure_flask_cache(app)
+
+    @app.route("/")
+    @cached_public
+    def view():
+        return "Hello!", 500
+
+    assert hasattr(app, "cache")
+    assert isinstance(app.cache.cache, RedisCache)
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 500
+    assert app.cache.get("view//") is None

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect
 
+from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
 from backend.web.auth import _user_context_processor
@@ -29,6 +30,7 @@ configure_logging()
 
 app = Flask(__name__)
 install_middleware(app)
+configure_flask_cache(app)
 
 csrf = CSRFProtect()
 csrf.init_app(app)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,7 @@
 gunicorn==20.0.4
 firebase_admin==4.5.0
 Flask==1.1.2
+Flask-Caching==1.9.0
 Flask-WTF==0.14.3
 google-api-python-client==1.12.8
 google-cloud-ndb==1.7.2


### PR DESCRIPTION
This uses the [flask-cache](https://pythonhosted.org/Flask-Cache/) library to plug into redis and cache the html outputs of rendered pages.