### PR TITLE
Add remote event type for 2021

### DIFF
--- a/consts/event_type.py
+++ b/consts/event_type.py
@@ -6,6 +6,7 @@ class EventType(object):
     CMP_FINALS = 4
     DISTRICT_CMP_DIVISION = 5
     FOC = 6
+    REMOTE = 7
 
     OFFSEASON = 99
     PRESEASON = 100
@@ -21,6 +22,7 @@ class EventType(object):
         FOC: 'Festival of Champions',
         OFFSEASON: 'Offseason',
         PRESEASON: 'Preseason',
+        REMOTE: 'Remote',
         UNLABLED: '--',
     }
 
@@ -34,6 +36,7 @@ class EventType(object):
         FOC: 'FoC',
         OFFSEASON: 'Offseason',
         PRESEASON: 'Preseason',
+        REMOTE: 'Remote',
         UNLABLED: '--',
     }
 
@@ -48,6 +51,7 @@ class EventType(object):
         DISTRICT,
         DISTRICT_CMP_DIVISION,
         DISTRICT_CMP,
+        REMOTE,
     }
 
     CMP_EVENT_TYPES = {
@@ -63,4 +67,5 @@ class EventType(object):
         CMP_DIVISION,
         CMP_FINALS,
         FOC,
+        REMOTE,
     }

--- a/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -27,6 +27,7 @@ class FMSAPIEventListParser(object):
         'championship': EventType.CMP_FINALS,
         'offseason': EventType.OFFSEASON,
         'offseasonwithazuresync': EventType.OFFSEASON,
+        'remote': EventType.REMOTE,
     }
 
     NON_OFFICIAL_EVENT_TYPES = ['offseason']


### PR DESCRIPTION
## How Has This Been Tested?
Verified all 2021 events show up in local dev.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1421884/103421654-859a5500-4b6b-11eb-9692-05251fc07129.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
