### PR TITLE
Update Event.validate_key_name to support new 2021 participation event keys

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -641,7 +641,7 @@ class Event(CachedModel):
 
     @classmethod
     def validate_key_name(cls, event_key: str) -> bool:
-        key_name_regex = re.compile(r"^[1-9]\d{3}[a-z]+[0-9]{0,2}$")
+        key_name_regex = re.compile(r"^[1-9]\d{3}(\d{2})?[a-z]+[0-9]{0,2}$")
         match = re.match(key_name_regex, event_key)
         return True if match else False
 

--- a/src/backend/common/models/tests/event_test.py
+++ b/src/backend/common/models/tests/event_test.py
@@ -27,7 +27,7 @@ from backend.common.models.tests.util import (
 from backend.conftest import clear_cached_queries  # noqa: ETBA0
 
 
-@pytest.mark.parametrize("key", ["2010ct", "2014onto2"])
+@pytest.mark.parametrize("key", ["2010ct", "2014onto2", "202121fim"])
 def test_valid_key_names(key: str) -> None:
     assert Event.validate_key_name(key) is True
 


### PR DESCRIPTION
Currently the API is failing due to validation issues with `Event.validate_key_name`. This fixes that.

Will confirm this works in `py3` and then setup a PR for `master`