### PR TITLE
Support read only CachedQueryResult

### DIFF
--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -64,7 +64,8 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
     )
     CACHE_KEY_FORMAT: str = ""
     CACHE_VERSION: int = 0
-    CACHING_ENABLED: bool = False
+    CACHING_ENABLED: bool = True
+    CACHE_WRITES_ENABLED: bool = False
     _cache_key: Optional[str] = None
 
     def __init__(self, *args, **kwargs) -> None:
@@ -90,7 +91,8 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
         cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
         if cached_query_result is None:
             query_result = yield self._query_async(*args, **kwargs)
-            yield CachedQueryResult(id=cache_key, result=query_result).put_async()
+            if self.CACHE_WRITES_ENABLED:
+                yield CachedQueryResult(id=cache_key, result=query_result).put_async()
             return query_result  # pyre-ignore[7]
         return cached_query_result.result
 

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -45,6 +45,7 @@ class CachedDummyModelRangeQuery(
     CACKE_KEY_FORMAT = "test_query_{min}_{max}"
     DICT_CONVERTER = DummyConverter
     CACHING_ENABLED = True
+    CACHE_WRITES_ENABLED = True
 
     @ndb.tasklet
     def _query_async(self, min: int, max: int) -> TypedFuture[List[DummyModel]]:


### PR DESCRIPTION
After https://github.com/the-blue-alliance/the-blue-alliance/pull/3234 we can now read `CachedQueryResult` items that were written by the legacy ndb library.

So this will let use CachedQueryResult, but in a read-only way.

I'll have to implement a bunch of protbuf code to get writes working, so that's a project for another day