### PR TITLE
Port DB Query Cache Clearing

### DIFF
--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -1,0 +1,313 @@
+from typing import Any, List, Set, Tuple, Type
+
+from google.cloud import ndb
+
+from backend.common.models.cached_model import TAffectedReferences
+from backend.common.models.district_team import DistrictTeam
+from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import TeamKey
+from backend.common.queries import (
+    award_query,
+    district_query,
+    event_details_query,
+    event_query,
+    match_query,
+    media_query,
+    robot_query,
+    team_query,
+)
+from backend.common.queries.database_query import CachedDatabaseQuery
+
+TCacheKeyAndQuery = Tuple[str, Type[CachedDatabaseQuery]]
+
+
+def _queries_to_cache_keys_and_queries(
+    queries: List[CachedDatabaseQuery],
+) -> List[TCacheKeyAndQuery]:
+    out = []
+    for query in queries:
+        out.append((query.cache_key, type(query)))
+    return out
+
+
+def _get_team_page_num(team_key: TeamKey) -> int:
+    return int(team_key[3:]) // team_query.TeamListQuery.PAGE_SIZE
+
+
+def _filter(refs: Set[Any]) -> Set[Any]:
+    # Default filter() filters zeros, so we can't use it.
+    return {r for r in refs if r is not None}
+
+
+def award_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    event_keys = _filter(affected_refs["event"])
+    team_keys = _filter(affected_refs["team_list"])
+    years = _filter(affected_refs["year"])
+    event_types = _filter(affected_refs["event_type_enum"])
+    award_types = _filter(affected_refs["award_type_enum"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for event_key in event_keys:
+        queries.append(award_query.EventAwardsQuery(event_key.id()))
+        for team_key in team_keys:
+            queries.append(
+                award_query.TeamEventAwardsQuery(team_key.id(), event_key.id())
+            )
+
+    for team_key in team_keys:
+        queries.append(award_query.TeamAwardsQuery(team_key.id()))
+        for year in years:
+            queries.append(award_query.TeamYearAwardsQuery(team_key.id(), year))
+        for event_type in event_types:
+            for award_type in award_types:
+                queries.append(
+                    award_query.TeamEventTypeAwardsQuery(
+                        team_key.id(), event_type, award_type
+                    )
+                )
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def event_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    event_keys = _filter(affected_refs["key"])
+    years = _filter(affected_refs["year"])
+    event_district_keys = _filter(affected_refs["district_key"])
+
+    event_team_keys_future = EventTeam.query(
+        EventTeam.event.IN([event_key for event_key in event_keys])  # pyre-ignore[16]
+    ).fetch_async(None, keys_only=True)
+    events_future = ndb.get_multi_async(event_keys)
+
+    queries: List[CachedDatabaseQuery] = []
+    for event_key in event_keys:
+        queries.append(event_query.EventQuery(event_key.id()))
+        queries.append(event_query.EventDivisionsQuery(event_key.id()))
+
+    for year in years:
+        queries.append(event_query.EventListQuery(year))
+
+    for event_district_key in event_district_keys:
+        queries.append(event_query.DistrictEventsQuery(event_district_key.id()))
+
+    if event_keys:
+        for et_key in event_team_keys_future.get_result():
+            team_key = et_key.id().split("_")[1]
+            year = int(et_key.id()[:4])
+            queries.append(event_query.TeamEventsQuery(team_key))
+            queries.append(event_query.TeamYearEventsQuery(team_key, year))
+            queries.append(event_query.TeamYearEventTeamsQuery(team_key, year))
+
+    events_with_parents = filter(
+        lambda e: e.get_result() is not None
+        and e.get_result().parent_event is not None,
+        events_future,
+    )
+    parent_keys = set([e.get_result().parent_event for e in events_with_parents])
+    for parent_key in parent_keys:
+        queries.append(event_query.EventDivisionsQuery(parent_key.id()))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def event_details_updated(
+    affected_refs: TAffectedReferences,
+) -> List[TCacheKeyAndQuery]:
+    event_details_keys = _filter(affected_refs["key"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for event_details_key in event_details_keys:
+        queries.append(event_details_query.EventDetailsQuery(event_details_key.id()))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def match_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    match_keys = _filter(affected_refs["key"])
+    event_keys = _filter(affected_refs["event"])
+    team_keys = _filter(affected_refs["team_keys"])
+    years = _filter(affected_refs["year"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for match_key in match_keys:
+        queries.append(match_query.MatchQuery(match_key.id()))
+        # queries.append(match_query.MatchGdcvDataQuery(match_key.id()))
+
+    for event_key in event_keys:
+        queries.append(match_query.EventMatchesQuery(event_key.id()))
+        # queries.append(match_query.EventMatchesGdcvDataQuery(event_key.id()))
+        for team_key in team_keys:
+            queries.append(
+                match_query.TeamEventMatchesQuery(team_key.id(), event_key.id())
+            )
+
+    for team_key in team_keys:
+        for year in years:
+            queries.append(match_query.TeamYearMatchesQuery(team_key.id(), year))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def media_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    reference_keys = _filter(affected_refs["references"])
+    years = _filter(affected_refs["year"])
+    media_tags = _filter(affected_refs["media_tag_enum"])
+
+    team_keys = filter(lambda x: x.kind() == "Team", reference_keys)
+    event_team_keys_future = (
+        EventTeam.query(EventTeam.team.IN(team_keys)).fetch_async(  # pyre-ignore[16]
+            None, keys_only=True
+        )
+        if team_keys
+        else None
+    )
+
+    queries: List[CachedDatabaseQuery] = []
+    for reference_key in reference_keys:
+        if reference_key.kind() == "Team":
+            for year in years:
+                queries.append(media_query.TeamYearMediaQuery(reference_key.id(), year))
+                for media_tag in media_tags:
+                    queries.append(
+                        media_query.TeamYearTagMediasQuery(
+                            reference_key.id(), media_tag, year
+                        )
+                    )
+            for media_tag in media_tags:
+                queries.append(
+                    media_query.TeamTagMediasQuery(reference_key.id(), media_tag)
+                )
+            queries.append(media_query.TeamSocialMediaQuery(reference_key.id()))
+        if reference_key.kind() == "Event":
+            queries.append(media_query.EventMediasQuery(reference_key.id()))
+
+    if event_team_keys_future:
+        for event_team_key in event_team_keys_future.get_result():
+            event_key = event_team_key.id().split("_")[0]
+            year = int(event_key[:4])
+            if year in years:
+                queries.append(media_query.EventTeamsMediasQuery(event_key))
+                queries.append(media_query.EventTeamsPreferredMediasQuery(event_key))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def robot_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    team_keys = _filter(affected_refs["team"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for team_key in team_keys:
+        queries.append(robot_query.TeamRobotsQuery(team_key.id()))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def team_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    team_keys = _filter(affected_refs["key"])
+
+    event_team_keys_future = EventTeam.query(
+        EventTeam.team.IN([team_key for team_key in team_keys])  # pyre-ignore[16]
+    ).fetch_async(None, keys_only=True)
+    district_team_keys_future = DistrictTeam.query(
+        DistrictTeam.team.IN([team_key for team_key in team_keys])
+    ).fetch_async(None, keys_only=True)
+
+    queries: List[CachedDatabaseQuery] = []
+    for team_key in team_keys:
+        queries.append(team_query.TeamQuery(team_key.id()))
+        page_num = _get_team_page_num(team_key.id())
+        queries.append(team_query.TeamListQuery(page_num))
+
+    for et_key in event_team_keys_future.get_result():
+        year = int(et_key.id()[:4])
+        event_key = et_key.id().split("_")[0]
+        page_num = _get_team_page_num(et_key.id().split("_")[1])
+        queries.append(team_query.TeamListYearQuery(year, page_num))
+        queries.append(team_query.EventTeamsQuery(event_key))
+        queries.append(team_query.EventEventTeamsQuery(event_key))
+
+    for dt_key in district_team_keys_future.get_result():
+        district_key = dt_key.id().split("_")[0]
+        queries.append(team_query.DistrictTeamsQuery(district_key))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def eventteam_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    event_keys = _filter(affected_refs["event"])
+    team_keys = _filter(affected_refs["team"])
+    years = _filter(affected_refs["year"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for team_key in team_keys:
+        queries.append(event_query.TeamEventsQuery(team_key.id()))
+        queries.append(team_query.TeamParticipationQuery(team_key.id()))
+        page_num = _get_team_page_num(team_key.id())
+        for year in years:
+            queries.append(event_query.TeamYearEventsQuery(team_key.id(), year))
+            queries.append(event_query.TeamYearEventTeamsQuery(team_key.id(), year))
+            queries.append(team_query.TeamListYearQuery(year, page_num))
+
+    for event_key in event_keys:
+        queries.append(team_query.EventTeamsQuery(event_key.id()))
+        queries.append(team_query.EventEventTeamsQuery(event_key.id()))
+        queries.append(media_query.EventTeamsMediasQuery(event_key.id()))
+        queries.append(media_query.EventTeamsPreferredMediasQuery(event_key.id()))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def districtteam_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    district_keys = _filter(affected_refs["district_key"])
+    team_keys = _filter(affected_refs["team"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for district_key in district_keys:
+        queries.append(team_query.DistrictTeamsQuery(district_key.id()))
+
+    for team_key in team_keys:
+        queries.append(district_query.TeamDistrictsQuery(team_key.id()))
+
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def district_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
+    years = _filter(affected_refs["year"])
+    district_abbrevs = _filter(affected_refs["abbreviation"])
+    district_keys = _filter(affected_refs["key"])
+
+    district_team_keys_future = DistrictTeam.query(
+        DistrictTeam.district_key.IN(list(district_keys))
+    ).fetch_async(None, keys_only=True)
+    district_event_keys_future = Event.query(
+        Event.district_key.IN(list(district_keys))  # pyre-ignore[16]
+    ).fetch_async(keys_only=True)
+
+    queries: List[CachedDatabaseQuery] = []
+    for year in years:
+        queries.append(district_query.DistrictsInYearQuery(year))
+
+    for abbrev in district_abbrevs:
+        queries.append(district_query.DistrictHistoryQuery(abbrev))
+
+    for key in district_keys:
+        queries.append(district_query.DistrictQuery(key.id()))
+
+    for dt_key in district_team_keys_future.get_result():
+        team_key = dt_key.id().split("_")[1]
+        queries.append(district_query.TeamDistrictsQuery(team_key))
+
+    # Necessary because APIv3 Event models include the District model
+    affected_event_refs = {
+        "key": set(),
+        "year": set(),
+        "district_key": district_keys,
+    }
+    for event_key in district_event_keys_future.get_result():
+        affected_event_refs["key"].add(event_key)
+        affected_event_refs["year"].add(int(event_key.id()[:4]))
+
+    return _queries_to_cache_keys_and_queries(queries) + event_updated(
+        affected_event_refs
+    )

--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -154,7 +154,7 @@ def media_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]
     years = _filter(affected_refs["year"])
     media_tags = _filter(affected_refs["media_tag_enum"])
 
-    team_keys = filter(lambda x: x.kind() == "Team", reference_keys)
+    team_keys = list(filter(lambda x: x.kind() == "Team", reference_keys))
     event_team_keys_future = (
         EventTeam.query(EventTeam.team.IN(team_keys)).fetch_async(  # pyre-ignore[16]
             None, keys_only=True
@@ -171,7 +171,7 @@ def media_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]
                 for media_tag in media_tags:
                     queries.append(
                         media_query.TeamYearTagMediasQuery(
-                            reference_key.id(), media_tag, year
+                            reference_key.id(), year, media_tag
                         )
                     )
             for media_tag in media_tags:

--- a/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
+++ b/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
@@ -30,30 +30,30 @@ from backend.common.queries import (
 class TestDatabaseCacheClearer(unittest.TestCase):
     def setUp(self) -> None:
         eventteam_2015casj_frc254 = EventTeam(
-            id='2015casj_frc254',
-            event=ndb.Key(Event, '2015casj'),
-            team=ndb.Key(Team, 'frc254'),
+            id="2015casj_frc254",
+            event=ndb.Key(Event, "2015casj"),
+            team=ndb.Key(Team, "frc254"),
             year=2015,
         )
 
         eventteam_2015cama_frc604 = EventTeam(
-            id='2015cama_frc604',
-            event=ndb.Key(Event, '2015cama'),
-            team=ndb.Key(Team, 'frc604'),
+            id="2015cama_frc604",
+            event=ndb.Key(Event, "2015cama"),
+            team=ndb.Key(Team, "frc604"),
             year=2015,
         )
 
         eventteam_2010cama_frc604 = EventTeam(
-            id='2010cama_frc604',
-            event=ndb.Key(Event, '2010cama'),
-            team=ndb.Key(Team, 'frc604'),
+            id="2010cama_frc604",
+            event=ndb.Key(Event, "2010cama"),
+            team=ndb.Key(Team, "frc604"),
             year=2010,
         )
 
         eventteam_2016necmp_frc125 = EventTeam(
-            id='2016necmp_frc125',
-            event=ndb.Key(Event, '2016necmp'),
-            team=ndb.Key(Team, 'frc125'),
+            id="2016necmp_frc125",
+            event=ndb.Key(Event, "2016necmp"),
+            team=ndb.Key(Team, "frc125"),
             year=2016,
         )
 
@@ -63,23 +63,23 @@ class TestDatabaseCacheClearer(unittest.TestCase):
         eventteam_2016necmp_frc125.put()
 
         districtteam_2015fim_frc254 = DistrictTeam(
-            id='2015fim_frc254',
-            district_key=ndb.Key(District, '2015fim'),
-            team=ndb.Key(Team, 'frc254'),
+            id="2015fim_frc254",
+            district_key=ndb.Key(District, "2015fim"),
+            team=ndb.Key(Team, "frc254"),
             year=2015,
         )
 
         districtteam_2015mar_frc604 = DistrictTeam(
-            id='2015mar_frc604',
-            district_key=ndb.Key(District, '2015mar'),
-            team=ndb.Key(Team, 'frc604'),
+            id="2015mar_frc604",
+            district_key=ndb.Key(District, "2015mar"),
+            team=ndb.Key(Team, "frc604"),
             year=2015,
         )
 
         districtteam_2016ne_frc604 = DistrictTeam(
-            id='2016ne_frc604',
-            district_key=ndb.Key(District, '2016ne'),
-            team=ndb.Key(Team, 'frc604'),
+            id="2016ne_frc604",
+            district_key=ndb.Key(District, "2016ne"),
+            team=ndb.Key(Team, "frc604"),
             year=2016,
         )
 
@@ -88,264 +88,466 @@ class TestDatabaseCacheClearer(unittest.TestCase):
         districtteam_2016ne_frc604.put()
 
         district_2015ne = District(
-            id='2015ne',
+            id="2015ne",
             year=2015,
-            abbreviation='ne',
+            abbreviation="ne",
         )
 
         district_2016chs = District(
-            id='2016chs',
+            id="2016chs",
             year=2016,
-            abbreviation='chs',
+            abbreviation="chs",
         )
         district_2015ne.put()
         district_2016chs.put()
 
         event_2016necmp = Event(
-            id='2016necmp',
+            id="2016necmp",
             year=2016,
-            district_key=ndb.Key(District, '2016ne'),
-            event_short='necmp',
+            district_key=ndb.Key(District, "2016ne"),
+            event_short="necmp",
             event_type_enum=EventType.DISTRICT_CMP,
         )
         event_2016necmp.put()
 
         event_2015casj = Event(
-            id='2015casj',
+            id="2015casj",
             year=2015,
-            event_short='casj',
+            event_short="casj",
             event_type_enum=EventType.REGIONAL,
-            parent_event=ndb.Key(Event, '2015cafoo'),
+            parent_event=ndb.Key(Event, "2015cafoo"),
         )
         event_2015casj.put()
 
     def test_award_updated(self) -> None:
         affected_refs = {
-            'event': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
-            'team_list': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
-            'year': {2014, 2015},
-            'event_type_enum': {EventType.REGIONAL, EventType.DISTRICT},
-            'award_type_enum': {AwardType.WINNER, AwardType.CHAIRMANS},
+            "event": {ndb.Key(Event, "2015casj"), ndb.Key(Event, "2015cama")},
+            "team_list": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
+            "year": {2014, 2015},
+            "event_type_enum": {EventType.REGIONAL, EventType.DISTRICT},
+            "award_type_enum": {AwardType.WINNER, AwardType.CHAIRMANS},
         }
         cache_keys = [q[0] for q in get_affected_queries.award_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 20)
-        self.assertTrue(award_query.EventAwardsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(award_query.EventAwardsQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(award_query.TeamAwardsQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(award_query.TeamAwardsQuery('frc604').cache_key in cache_keys)
-        self.assertTrue(award_query.TeamYearAwardsQuery('frc254', 2014).cache_key in cache_keys)
-        self.assertTrue(award_query.TeamYearAwardsQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(award_query.TeamYearAwardsQuery('frc604', 2014).cache_key in cache_keys)
-        self.assertTrue(award_query.TeamYearAwardsQuery('frc604', 2015).cache_key in cache_keys)
-        self.assertTrue(award_query.TeamEventAwardsQuery('frc254', '2015casj').cache_key in cache_keys)
-        self.assertTrue(award_query.TeamEventAwardsQuery('frc254', '2015cama').cache_key in cache_keys)
-        self.assertTrue(award_query.TeamEventAwardsQuery('frc604', '2015casj').cache_key in cache_keys)
-        self.assertTrue(award_query.TeamEventAwardsQuery('frc604', '2015cama').cache_key in cache_keys)
-        for team_key in ['frc254', 'frc604']:
+        self.assertTrue(
+            award_query.EventAwardsQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            award_query.EventAwardsQuery("2015cama").cache_key in cache_keys
+        )
+        self.assertTrue(award_query.TeamAwardsQuery("frc254").cache_key in cache_keys)
+        self.assertTrue(award_query.TeamAwardsQuery("frc604").cache_key in cache_keys)
+        self.assertTrue(
+            award_query.TeamYearAwardsQuery("frc254", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamYearAwardsQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamYearAwardsQuery("frc604", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamYearAwardsQuery("frc604", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamEventAwardsQuery("frc254", "2015casj").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamEventAwardsQuery("frc254", "2015cama").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamEventAwardsQuery("frc604", "2015casj").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            award_query.TeamEventAwardsQuery("frc604", "2015cama").cache_key
+            in cache_keys
+        )
+        for team_key in ["frc254", "frc604"]:
             for event_type in [EventType.REGIONAL, EventType.DISTRICT]:
                 for award_type in [AwardType.WINNER, AwardType.CHAIRMANS]:
-                    self.assertTrue(award_query.TeamEventTypeAwardsQuery(team_key, event_type, award_type).cache_key in cache_keys)
+                    self.assertTrue(
+                        award_query.TeamEventTypeAwardsQuery(
+                            team_key, event_type, award_type
+                        ).cache_key
+                        in cache_keys
+                    )
 
     def test_event_updated(self) -> None:
         affected_refs = {
-            'key': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
-            'year': {2014, 2015},
-            'district_key': {ndb.Key(District, '2015fim'), ndb.Key(District, '2014mar')}
+            "key": {ndb.Key(Event, "2015casj"), ndb.Key(Event, "2015cama")},
+            "year": {2014, 2015},
+            "district_key": {
+                ndb.Key(District, "2015fim"),
+                ndb.Key(District, "2014mar"),
+            },
         }
         cache_keys = [q[0] for q in get_affected_queries.event_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 15)
-        self.assertTrue(event_query.EventQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(event_query.EventQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(event_query.EventQuery("2015casj").cache_key in cache_keys)
+        self.assertTrue(event_query.EventQuery("2015cama").cache_key in cache_keys)
         self.assertTrue(event_query.EventListQuery(2014).cache_key in cache_keys)
         self.assertTrue(event_query.EventListQuery(2015).cache_key in cache_keys)
-        self.assertTrue(event_query.DistrictEventsQuery('2015fim').cache_key in cache_keys)
-        self.assertTrue(event_query.DistrictEventsQuery('2014mar').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamEventsQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamEventsQuery('frc604').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc604', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.EventDivisionsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(event_query.EventDivisionsQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(event_query.EventDivisionsQuery('2015cafoo').cache_key in cache_keys)
+        self.assertTrue(
+            event_query.DistrictEventsQuery("2015fim").cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.DistrictEventsQuery("2014mar").cache_key in cache_keys
+        )
+        self.assertTrue(event_query.TeamEventsQuery("frc254").cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery("frc604").cache_key in cache_keys)
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc604", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc604", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.EventDivisionsQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.EventDivisionsQuery("2015cama").cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.EventDivisionsQuery("2015cafoo").cache_key in cache_keys
+        )
 
     def test_event_details_updated(self) -> None:
         affected_refs = {
-            'key': {ndb.Key(EventDetails, '2015casj'), ndb.Key(EventDetails, '2015cama')},
+            "key": {
+                ndb.Key(EventDetails, "2015casj"),
+                ndb.Key(EventDetails, "2015cama"),
+            },
         }
-        cache_keys = [q[0] for q in get_affected_queries.event_details_updated(affected_refs)]
+        cache_keys = [
+            q[0] for q in get_affected_queries.event_details_updated(affected_refs)
+        ]
 
         self.assertEqual(len(cache_keys), 2)
-        self.assertTrue(event_details_query.EventDetailsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(event_details_query.EventDetailsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(
+            event_details_query.EventDetailsQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_details_query.EventDetailsQuery("2015cama").cache_key in cache_keys
+        )
 
     def test_match_updated(self) -> None:
         affected_refs = {
-            'key': {ndb.Key(Match, '2015casj_qm1'), ndb.Key(Match, '2015casj_qm2')},
-            'event': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
-            'team_keys': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
-            'year': {2014, 2015},
+            "key": {ndb.Key(Match, "2015casj_qm1"), ndb.Key(Match, "2015casj_qm2")},
+            "event": {ndb.Key(Event, "2015casj"), ndb.Key(Event, "2015cama")},
+            "team_keys": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
+            "year": {2014, 2015},
         }
         cache_keys = [q[0] for q in get_affected_queries.match_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 12)
-        self.assertTrue(match_query.MatchQuery('2015casj_qm1').cache_key in cache_keys)
-        self.assertTrue(match_query.MatchQuery('2015casj_qm2').cache_key in cache_keys)
+        self.assertTrue(match_query.MatchQuery("2015casj_qm1").cache_key in cache_keys)
+        self.assertTrue(match_query.MatchQuery("2015casj_qm2").cache_key in cache_keys)
         # self.assertTrue(match_query.MatchGdcvDataQuery('2015casj_qm1').cache_key in cache_keys)
         # self.assertTrue(match_query.MatchGdcvDataQuery('2015casj_qm2').cache_key in cache_keys)
-        self.assertTrue(match_query.EventMatchesQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(match_query.EventMatchesQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(
+            match_query.EventMatchesQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            match_query.EventMatchesQuery("2015cama").cache_key in cache_keys
+        )
         # self.assertTrue(match_query.EventMatchesGdcvDataQuery('2015casj').cache_key in cache_keys)
         # self.assertTrue(match_query.EventMatchesGdcvDataQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(match_query.TeamEventMatchesQuery('frc254', '2015casj').cache_key in cache_keys)
-        self.assertTrue(match_query.TeamEventMatchesQuery('frc254', '2015cama').cache_key in cache_keys)
-        self.assertTrue(match_query.TeamEventMatchesQuery('frc604', '2015casj').cache_key in cache_keys)
-        self.assertTrue(match_query.TeamEventMatchesQuery('frc604', '2015cama').cache_key in cache_keys)
-        self.assertTrue(match_query.TeamYearMatchesQuery('frc254', 2014).cache_key in cache_keys)
-        self.assertTrue(match_query.TeamYearMatchesQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(match_query.TeamYearMatchesQuery('frc604', 2014).cache_key in cache_keys)
-        self.assertTrue(match_query.TeamYearMatchesQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(
+            match_query.TeamEventMatchesQuery("frc254", "2015casj").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamEventMatchesQuery("frc254", "2015cama").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamEventMatchesQuery("frc604", "2015casj").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamEventMatchesQuery("frc604", "2015cama").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamYearMatchesQuery("frc254", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamYearMatchesQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamYearMatchesQuery("frc604", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            match_query.TeamYearMatchesQuery("frc604", 2015).cache_key in cache_keys
+        )
 
     def test_media_updated_team(self) -> None:
         affected_refs = {
-            'references': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
-            'year': {2014, 2015},
-            'media_tag_enum': {MediaTag.CHAIRMANS_ESSAY, MediaTag.CHAIRMANS_VIDEO},
+            "references": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
+            "year": {2014, 2015},
+            "media_tag_enum": {MediaTag.CHAIRMANS_ESSAY, MediaTag.CHAIRMANS_VIDEO},
         }
         cache_keys = [q[0] for q in get_affected_queries.media_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 22)
-        self.assertTrue(media_query.TeamYearMediaQuery('frc254', 2014).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamYearMediaQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamSocialMediaQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(media_query.TeamYearMediaQuery('frc604', 2014).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamYearMediaQuery('frc604', 2015).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamSocialMediaQuery('frc604').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsMediasQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsMediasQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(media_query.TeamTagMediasQuery('frc254', MediaTag.CHAIRMANS_ESSAY).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamTagMediasQuery('frc604', MediaTag.CHAIRMANS_VIDEO).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamYearTagMediasQuery('frc254', 2014, MediaTag.CHAIRMANS_ESSAY).cache_key in cache_keys)
-        self.assertTrue(media_query.TeamYearTagMediasQuery('frc604', 2015, MediaTag.CHAIRMANS_VIDEO).cache_key in cache_keys)
+        self.assertTrue(
+            media_query.TeamYearMediaQuery("frc254", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamYearMediaQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamSocialMediaQuery("frc254").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamYearMediaQuery("frc604", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamYearMediaQuery("frc604", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamSocialMediaQuery("frc604").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsMediasQuery("2015cama").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsMediasQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsPreferredMediasQuery("2015cama").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsPreferredMediasQuery("2015casj").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamTagMediasQuery("frc254", MediaTag.CHAIRMANS_ESSAY).cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamTagMediasQuery("frc604", MediaTag.CHAIRMANS_VIDEO).cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamYearTagMediasQuery(
+                "frc254", 2014, MediaTag.CHAIRMANS_ESSAY
+            ).cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            media_query.TeamYearTagMediasQuery(
+                "frc604", 2015, MediaTag.CHAIRMANS_VIDEO
+            ).cache_key
+            in cache_keys
+        )
 
     def test_media_updated_event(self) -> None:
         affected_refs = {
-            'references': {ndb.Key(Event, '2016necmp')},
-            'year': {2016},
-            'media_tag_enum': {None, None}
+            "references": {ndb.Key(Event, "2016necmp")},
+            "year": {2016},
+            "media_tag_enum": {None, None},
         }
         cache_keys = [q[0] for q in get_affected_queries.media_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 1)
-        self.assertTrue(media_query.EventMediasQuery('2016necmp').cache_key in cache_keys)
+        self.assertTrue(
+            media_query.EventMediasQuery("2016necmp").cache_key in cache_keys
+        )
 
     def test_robot_updated(self) -> None:
         affected_refs = {
-            'team': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+            "team": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
         }
         cache_keys = [q[0] for q in get_affected_queries.robot_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 2)
-        self.assertTrue(robot_query.TeamRobotsQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(robot_query.TeamRobotsQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(robot_query.TeamRobotsQuery("frc254").cache_key in cache_keys)
+        self.assertTrue(robot_query.TeamRobotsQuery("frc604").cache_key in cache_keys)
 
     def test_team_updated(self) -> None:
         affected_refs = {
-            'key': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+            "key": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
         }
         cache_keys = [q[0] for q in get_affected_queries.team_updated(affected_refs)]
 
         self.assertEqual(len(cache_keys), 16)
-        self.assertTrue(team_query.TeamQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(team_query.TeamQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(team_query.TeamQuery("frc254").cache_key in cache_keys)
+        self.assertTrue(team_query.TeamQuery("frc604").cache_key in cache_keys)
         self.assertTrue(team_query.TeamListQuery(0).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListQuery(1).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListYearQuery(2015, 0).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListYearQuery(2015, 1).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListYearQuery(2010, 1).cache_key in cache_keys)
-        self.assertTrue(team_query.DistrictTeamsQuery('2015fim').cache_key in cache_keys)
-        self.assertTrue(team_query.DistrictTeamsQuery('2015mar').cache_key in cache_keys)
-        self.assertTrue(team_query.DistrictTeamsQuery('2016ne').cache_key in cache_keys)
-        self.assertTrue(team_query.EventTeamsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(team_query.EventTeamsQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(team_query.EventTeamsQuery('2010cama').cache_key in cache_keys)
-        self.assertTrue(team_query.EventEventTeamsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(team_query.EventEventTeamsQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(team_query.EventEventTeamsQuery('2010cama').cache_key in cache_keys)
+        self.assertTrue(
+            team_query.DistrictTeamsQuery("2015fim").cache_key in cache_keys
+        )
+        self.assertTrue(
+            team_query.DistrictTeamsQuery("2015mar").cache_key in cache_keys
+        )
+        self.assertTrue(team_query.DistrictTeamsQuery("2016ne").cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery("2015casj").cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery("2015cama").cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery("2010cama").cache_key in cache_keys)
+        self.assertTrue(
+            team_query.EventEventTeamsQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            team_query.EventEventTeamsQuery("2015cama").cache_key in cache_keys
+        )
+        self.assertTrue(
+            team_query.EventEventTeamsQuery("2010cama").cache_key in cache_keys
+        )
 
     def test_eventteam_updated(self) -> None:
         affected_refs = {
-            'event': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
-            'team': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
-            'year': {2014, 2015}
+            "event": {ndb.Key(Event, "2015casj"), ndb.Key(Event, "2015cama")},
+            "team": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
+            "year": {2014, 2015},
         }
-        cache_keys = [q[0] for q in get_affected_queries.eventteam_updated(affected_refs)]
+        cache_keys = [
+            q[0] for q in get_affected_queries.eventteam_updated(affected_refs)
+        ]
 
         self.assertEqual(len(cache_keys), 24)
-        self.assertTrue(event_query.TeamEventsQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamEventsQuery('frc604').cache_key in cache_keys)
-        self.assertTrue(team_query.TeamParticipationQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(team_query.TeamParticipationQuery('frc604').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc254', 2014).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc604', 2014).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc254', 2014).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc254', 2015).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc604', 2014).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery("frc254").cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery("frc604").cache_key in cache_keys)
+        self.assertTrue(
+            team_query.TeamParticipationQuery("frc254").cache_key in cache_keys
+        )
+        self.assertTrue(
+            team_query.TeamParticipationQuery("frc604").cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc254", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc604", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc604", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc254", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc254", 2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc604", 2014).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc604", 2015).cache_key in cache_keys
+        )
         self.assertTrue(team_query.TeamListYearQuery(2014, 0).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListYearQuery(2014, 1).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListYearQuery(2015, 0).cache_key in cache_keys)
         self.assertTrue(team_query.TeamListYearQuery(2015, 1).cache_key in cache_keys)
-        self.assertTrue(team_query.EventTeamsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(team_query.EventTeamsQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(team_query.EventEventTeamsQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(team_query.EventEventTeamsQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsMediasQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsMediasQuery('2015casj').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015cama').cache_key in cache_keys)
-        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery("2015casj").cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery("2015cama").cache_key in cache_keys)
+        self.assertTrue(
+            team_query.EventEventTeamsQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            team_query.EventEventTeamsQuery("2015cama").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsMediasQuery("2015cama").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsMediasQuery("2015casj").cache_key in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsPreferredMediasQuery("2015cama").cache_key
+            in cache_keys
+        )
+        self.assertTrue(
+            media_query.EventTeamsPreferredMediasQuery("2015casj").cache_key
+            in cache_keys
+        )
 
     def test_districtteam_updated(self) -> None:
         affected_refs = {
-            'district_key': {ndb.Key(District, '2015fim'), ndb.Key(District, '2015mar')},
-            'team': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')}
+            "district_key": {
+                ndb.Key(District, "2015fim"),
+                ndb.Key(District, "2015mar"),
+            },
+            "team": {ndb.Key(Team, "frc254"), ndb.Key(Team, "frc604")},
         }
-        cache_keys = [q[0] for q in get_affected_queries.districtteam_updated(affected_refs)]
+        cache_keys = [
+            q[0] for q in get_affected_queries.districtteam_updated(affected_refs)
+        ]
 
         self.assertEqual(len(cache_keys), 4)
-        self.assertTrue(team_query.DistrictTeamsQuery('2015fim').cache_key in cache_keys)
-        self.assertTrue(team_query.DistrictTeamsQuery('2015mar').cache_key in cache_keys)
-        self.assertTrue(district_query.TeamDistrictsQuery('frc254').cache_key in cache_keys)
-        self.assertTrue(district_query.TeamDistrictsQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(
+            team_query.DistrictTeamsQuery("2015fim").cache_key in cache_keys
+        )
+        self.assertTrue(
+            team_query.DistrictTeamsQuery("2015mar").cache_key in cache_keys
+        )
+        self.assertTrue(
+            district_query.TeamDistrictsQuery("frc254").cache_key in cache_keys
+        )
+        self.assertTrue(
+            district_query.TeamDistrictsQuery("frc604").cache_key in cache_keys
+        )
 
     def test_district_updated(self) -> None:
         affected_refs = {
-            'key': {ndb.Key(District, '2016ne')},
-            'year': {2015, 2016},
-            'abbreviation': {'ne', 'chs'}
+            "key": {ndb.Key(District, "2016ne")},
+            "year": {2015, 2016},
+            "abbreviation": {"ne", "chs"},
         }
-        cache_keys = [q[0] for q in get_affected_queries.district_updated(affected_refs)]
+        cache_keys = [
+            q[0] for q in get_affected_queries.district_updated(affected_refs)
+        ]
 
         self.assertEqual(len(cache_keys), 13)
-        self.assertTrue(district_query.DistrictsInYearQuery(2015).cache_key in cache_keys)
-        self.assertTrue(district_query.DistrictsInYearQuery(2016).cache_key in cache_keys)
-        self.assertTrue(district_query.DistrictHistoryQuery('ne').cache_key in cache_keys)
-        self.assertTrue(district_query.DistrictHistoryQuery('chs').cache_key in cache_keys)
-        self.assertTrue(district_query.DistrictQuery('2016ne').cache_key in cache_keys)
-        self.assertTrue(district_query.TeamDistrictsQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(
+            district_query.DistrictsInYearQuery(2015).cache_key in cache_keys
+        )
+        self.assertTrue(
+            district_query.DistrictsInYearQuery(2016).cache_key in cache_keys
+        )
+        self.assertTrue(
+            district_query.DistrictHistoryQuery("ne").cache_key in cache_keys
+        )
+        self.assertTrue(
+            district_query.DistrictHistoryQuery("chs").cache_key in cache_keys
+        )
+        self.assertTrue(district_query.DistrictQuery("2016ne").cache_key in cache_keys)
+        self.assertTrue(
+            district_query.TeamDistrictsQuery("frc604").cache_key in cache_keys
+        )
 
         # Necessary because APIv3 Event models include the District model
-        self.assertTrue(event_query.EventQuery('2016necmp').cache_key in cache_keys)
+        self.assertTrue(event_query.EventQuery("2016necmp").cache_key in cache_keys)
         self.assertTrue(event_query.EventListQuery(2016).cache_key in cache_keys)
-        self.assertTrue(event_query.DistrictEventsQuery('2016ne').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamEventsQuery('frc125').cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventsQuery('frc125', 2016).cache_key in cache_keys)
-        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc125', 2016).cache_key in cache_keys)
-        self.assertTrue(event_query.EventDivisionsQuery('2016necmp').cache_key in cache_keys)
+        self.assertTrue(
+            event_query.DistrictEventsQuery("2016ne").cache_key in cache_keys
+        )
+        self.assertTrue(event_query.TeamEventsQuery("frc125").cache_key in cache_keys)
+        self.assertTrue(
+            event_query.TeamYearEventsQuery("frc125", 2016).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.TeamYearEventTeamsQuery("frc125", 2016).cache_key in cache_keys
+        )
+        self.assertTrue(
+            event_query.EventDivisionsQuery("2016necmp").cache_key in cache_keys
+        )

--- a/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
+++ b/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
@@ -1,0 +1,351 @@
+import unittest
+
+import pytest
+from google.cloud import ndb
+
+from backend.common.cache_clearing import get_affected_queries
+from backend.common.consts.award_type import AwardType
+from backend.common.consts.event_type import EventType
+from backend.common.consts.media_tag import MediaTag
+from backend.common.models.district import District
+from backend.common.models.district_team import DistrictTeam
+from backend.common.models.event import Event
+from backend.common.models.event_details import EventDetails
+from backend.common.models.event_team import EventTeam
+from backend.common.models.match import Match
+from backend.common.models.team import Team
+from backend.common.queries import (
+    award_query,
+    district_query,
+    event_details_query,
+    event_query,
+    match_query,
+    media_query,
+    robot_query,
+    team_query,
+)
+
+
+@pytest.mark.usefixtures("ndb_context")
+class TestDatabaseCacheClearer(unittest.TestCase):
+    def setUp(self) -> None:
+        eventteam_2015casj_frc254 = EventTeam(
+            id='2015casj_frc254',
+            event=ndb.Key(Event, '2015casj'),
+            team=ndb.Key(Team, 'frc254'),
+            year=2015,
+        )
+
+        eventteam_2015cama_frc604 = EventTeam(
+            id='2015cama_frc604',
+            event=ndb.Key(Event, '2015cama'),
+            team=ndb.Key(Team, 'frc604'),
+            year=2015,
+        )
+
+        eventteam_2010cama_frc604 = EventTeam(
+            id='2010cama_frc604',
+            event=ndb.Key(Event, '2010cama'),
+            team=ndb.Key(Team, 'frc604'),
+            year=2010,
+        )
+
+        eventteam_2016necmp_frc125 = EventTeam(
+            id='2016necmp_frc125',
+            event=ndb.Key(Event, '2016necmp'),
+            team=ndb.Key(Team, 'frc125'),
+            year=2016,
+        )
+
+        eventteam_2015casj_frc254.put()
+        eventteam_2015cama_frc604.put()
+        eventteam_2010cama_frc604.put()
+        eventteam_2016necmp_frc125.put()
+
+        districtteam_2015fim_frc254 = DistrictTeam(
+            id='2015fim_frc254',
+            district_key=ndb.Key(District, '2015fim'),
+            team=ndb.Key(Team, 'frc254'),
+            year=2015,
+        )
+
+        districtteam_2015mar_frc604 = DistrictTeam(
+            id='2015mar_frc604',
+            district_key=ndb.Key(District, '2015mar'),
+            team=ndb.Key(Team, 'frc604'),
+            year=2015,
+        )
+
+        districtteam_2016ne_frc604 = DistrictTeam(
+            id='2016ne_frc604',
+            district_key=ndb.Key(District, '2016ne'),
+            team=ndb.Key(Team, 'frc604'),
+            year=2016,
+        )
+
+        districtteam_2015fim_frc254.put()
+        districtteam_2015mar_frc604.put()
+        districtteam_2016ne_frc604.put()
+
+        district_2015ne = District(
+            id='2015ne',
+            year=2015,
+            abbreviation='ne',
+        )
+
+        district_2016chs = District(
+            id='2016chs',
+            year=2016,
+            abbreviation='chs',
+        )
+        district_2015ne.put()
+        district_2016chs.put()
+
+        event_2016necmp = Event(
+            id='2016necmp',
+            year=2016,
+            district_key=ndb.Key(District, '2016ne'),
+            event_short='necmp',
+            event_type_enum=EventType.DISTRICT_CMP,
+        )
+        event_2016necmp.put()
+
+        event_2015casj = Event(
+            id='2015casj',
+            year=2015,
+            event_short='casj',
+            event_type_enum=EventType.REGIONAL,
+            parent_event=ndb.Key(Event, '2015cafoo'),
+        )
+        event_2015casj.put()
+
+    def test_award_updated(self) -> None:
+        affected_refs = {
+            'event': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
+            'team_list': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+            'year': {2014, 2015},
+            'event_type_enum': {EventType.REGIONAL, EventType.DISTRICT},
+            'award_type_enum': {AwardType.WINNER, AwardType.CHAIRMANS},
+        }
+        cache_keys = [q[0] for q in get_affected_queries.award_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 20)
+        self.assertTrue(award_query.EventAwardsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(award_query.EventAwardsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(award_query.TeamAwardsQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(award_query.TeamAwardsQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(award_query.TeamYearAwardsQuery('frc254', 2014).cache_key in cache_keys)
+        self.assertTrue(award_query.TeamYearAwardsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(award_query.TeamYearAwardsQuery('frc604', 2014).cache_key in cache_keys)
+        self.assertTrue(award_query.TeamYearAwardsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(award_query.TeamEventAwardsQuery('frc254', '2015casj').cache_key in cache_keys)
+        self.assertTrue(award_query.TeamEventAwardsQuery('frc254', '2015cama').cache_key in cache_keys)
+        self.assertTrue(award_query.TeamEventAwardsQuery('frc604', '2015casj').cache_key in cache_keys)
+        self.assertTrue(award_query.TeamEventAwardsQuery('frc604', '2015cama').cache_key in cache_keys)
+        for team_key in ['frc254', 'frc604']:
+            for event_type in [EventType.REGIONAL, EventType.DISTRICT]:
+                for award_type in [AwardType.WINNER, AwardType.CHAIRMANS]:
+                    self.assertTrue(award_query.TeamEventTypeAwardsQuery(team_key, event_type, award_type).cache_key in cache_keys)
+
+    def test_event_updated(self) -> None:
+        affected_refs = {
+            'key': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
+            'year': {2014, 2015},
+            'district_key': {ndb.Key(District, '2015fim'), ndb.Key(District, '2014mar')}
+        }
+        cache_keys = [q[0] for q in get_affected_queries.event_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 15)
+        self.assertTrue(event_query.EventQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(event_query.EventQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(event_query.EventListQuery(2014).cache_key in cache_keys)
+        self.assertTrue(event_query.EventListQuery(2015).cache_key in cache_keys)
+        self.assertTrue(event_query.DistrictEventsQuery('2015fim').cache_key in cache_keys)
+        self.assertTrue(event_query.DistrictEventsQuery('2014mar').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.EventDivisionsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(event_query.EventDivisionsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(event_query.EventDivisionsQuery('2015cafoo').cache_key in cache_keys)
+
+    def test_event_details_updated(self) -> None:
+        affected_refs = {
+            'key': {ndb.Key(EventDetails, '2015casj'), ndb.Key(EventDetails, '2015cama')},
+        }
+        cache_keys = [q[0] for q in get_affected_queries.event_details_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 2)
+        self.assertTrue(event_details_query.EventDetailsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(event_details_query.EventDetailsQuery('2015cama').cache_key in cache_keys)
+
+    def test_match_updated(self) -> None:
+        affected_refs = {
+            'key': {ndb.Key(Match, '2015casj_qm1'), ndb.Key(Match, '2015casj_qm2')},
+            'event': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
+            'team_keys': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+            'year': {2014, 2015},
+        }
+        cache_keys = [q[0] for q in get_affected_queries.match_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 12)
+        self.assertTrue(match_query.MatchQuery('2015casj_qm1').cache_key in cache_keys)
+        self.assertTrue(match_query.MatchQuery('2015casj_qm2').cache_key in cache_keys)
+        # self.assertTrue(match_query.MatchGdcvDataQuery('2015casj_qm1').cache_key in cache_keys)
+        # self.assertTrue(match_query.MatchGdcvDataQuery('2015casj_qm2').cache_key in cache_keys)
+        self.assertTrue(match_query.EventMatchesQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(match_query.EventMatchesQuery('2015cama').cache_key in cache_keys)
+        # self.assertTrue(match_query.EventMatchesGdcvDataQuery('2015casj').cache_key in cache_keys)
+        # self.assertTrue(match_query.EventMatchesGdcvDataQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(match_query.TeamEventMatchesQuery('frc254', '2015casj').cache_key in cache_keys)
+        self.assertTrue(match_query.TeamEventMatchesQuery('frc254', '2015cama').cache_key in cache_keys)
+        self.assertTrue(match_query.TeamEventMatchesQuery('frc604', '2015casj').cache_key in cache_keys)
+        self.assertTrue(match_query.TeamEventMatchesQuery('frc604', '2015cama').cache_key in cache_keys)
+        self.assertTrue(match_query.TeamYearMatchesQuery('frc254', 2014).cache_key in cache_keys)
+        self.assertTrue(match_query.TeamYearMatchesQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(match_query.TeamYearMatchesQuery('frc604', 2014).cache_key in cache_keys)
+        self.assertTrue(match_query.TeamYearMatchesQuery('frc604', 2015).cache_key in cache_keys)
+
+    def test_media_updated_team(self) -> None:
+        affected_refs = {
+            'references': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+            'year': {2014, 2015},
+            'media_tag_enum': {MediaTag.CHAIRMANS_ESSAY, MediaTag.CHAIRMANS_VIDEO},
+        }
+        cache_keys = [q[0] for q in get_affected_queries.media_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 22)
+        self.assertTrue(media_query.TeamYearMediaQuery('frc254', 2014).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamYearMediaQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamSocialMediaQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(media_query.TeamYearMediaQuery('frc604', 2014).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamYearMediaQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamSocialMediaQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsMediasQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsMediasQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(media_query.TeamTagMediasQuery('frc254', MediaTag.CHAIRMANS_ESSAY).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamTagMediasQuery('frc604', MediaTag.CHAIRMANS_VIDEO).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamYearTagMediasQuery('frc254', 2014, MediaTag.CHAIRMANS_ESSAY).cache_key in cache_keys)
+        self.assertTrue(media_query.TeamYearTagMediasQuery('frc604', 2015, MediaTag.CHAIRMANS_VIDEO).cache_key in cache_keys)
+
+    def test_media_updated_event(self) -> None:
+        affected_refs = {
+            'references': {ndb.Key(Event, '2016necmp')},
+            'year': {2016},
+            'media_tag_enum': {None, None}
+        }
+        cache_keys = [q[0] for q in get_affected_queries.media_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 1)
+        self.assertTrue(media_query.EventMediasQuery('2016necmp').cache_key in cache_keys)
+
+    def test_robot_updated(self) -> None:
+        affected_refs = {
+            'team': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+        }
+        cache_keys = [q[0] for q in get_affected_queries.robot_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 2)
+        self.assertTrue(robot_query.TeamRobotsQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(robot_query.TeamRobotsQuery('frc604').cache_key in cache_keys)
+
+    def test_team_updated(self) -> None:
+        affected_refs = {
+            'key': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+        }
+        cache_keys = [q[0] for q in get_affected_queries.team_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 16)
+        self.assertTrue(team_query.TeamQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(team_query.TeamQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListQuery(0).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListQuery(1).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2015, 0).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2015, 1).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2010, 1).cache_key in cache_keys)
+        self.assertTrue(team_query.DistrictTeamsQuery('2015fim').cache_key in cache_keys)
+        self.assertTrue(team_query.DistrictTeamsQuery('2015mar').cache_key in cache_keys)
+        self.assertTrue(team_query.DistrictTeamsQuery('2016ne').cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery('2010cama').cache_key in cache_keys)
+        self.assertTrue(team_query.EventEventTeamsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(team_query.EventEventTeamsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(team_query.EventEventTeamsQuery('2010cama').cache_key in cache_keys)
+
+    def test_eventteam_updated(self) -> None:
+        affected_refs = {
+            'event': {ndb.Key(Event, '2015casj'), ndb.Key(Event, '2015cama')},
+            'team': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')},
+            'year': {2014, 2015}
+        }
+        cache_keys = [q[0] for q in get_affected_queries.eventteam_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 24)
+        self.assertTrue(event_query.TeamEventsQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(team_query.TeamParticipationQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(team_query.TeamParticipationQuery('frc604').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc254', 2014).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc604', 2014).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc254', 2014).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc254', 2015).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc604', 2014).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc604', 2015).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2014, 0).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2014, 1).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2015, 0).cache_key in cache_keys)
+        self.assertTrue(team_query.TeamListYearQuery(2015, 1).cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(team_query.EventTeamsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(team_query.EventEventTeamsQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(team_query.EventEventTeamsQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsMediasQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsMediasQuery('2015casj').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015cama').cache_key in cache_keys)
+        self.assertTrue(media_query.EventTeamsPreferredMediasQuery('2015casj').cache_key in cache_keys)
+
+    def test_districtteam_updated(self) -> None:
+        affected_refs = {
+            'district_key': {ndb.Key(District, '2015fim'), ndb.Key(District, '2015mar')},
+            'team': {ndb.Key(Team, 'frc254'), ndb.Key(Team, 'frc604')}
+        }
+        cache_keys = [q[0] for q in get_affected_queries.districtteam_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 4)
+        self.assertTrue(team_query.DistrictTeamsQuery('2015fim').cache_key in cache_keys)
+        self.assertTrue(team_query.DistrictTeamsQuery('2015mar').cache_key in cache_keys)
+        self.assertTrue(district_query.TeamDistrictsQuery('frc254').cache_key in cache_keys)
+        self.assertTrue(district_query.TeamDistrictsQuery('frc604').cache_key in cache_keys)
+
+    def test_district_updated(self) -> None:
+        affected_refs = {
+            'key': {ndb.Key(District, '2016ne')},
+            'year': {2015, 2016},
+            'abbreviation': {'ne', 'chs'}
+        }
+        cache_keys = [q[0] for q in get_affected_queries.district_updated(affected_refs)]
+
+        self.assertEqual(len(cache_keys), 13)
+        self.assertTrue(district_query.DistrictsInYearQuery(2015).cache_key in cache_keys)
+        self.assertTrue(district_query.DistrictsInYearQuery(2016).cache_key in cache_keys)
+        self.assertTrue(district_query.DistrictHistoryQuery('ne').cache_key in cache_keys)
+        self.assertTrue(district_query.DistrictHistoryQuery('chs').cache_key in cache_keys)
+        self.assertTrue(district_query.DistrictQuery('2016ne').cache_key in cache_keys)
+        self.assertTrue(district_query.TeamDistrictsQuery('frc604').cache_key in cache_keys)
+
+        # Necessary because APIv3 Event models include the District model
+        self.assertTrue(event_query.EventQuery('2016necmp').cache_key in cache_keys)
+        self.assertTrue(event_query.EventListQuery(2016).cache_key in cache_keys)
+        self.assertTrue(event_query.DistrictEventsQuery('2016ne').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamEventsQuery('frc125').cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventsQuery('frc125', 2016).cache_key in cache_keys)
+        self.assertTrue(event_query.TeamYearEventTeamsQuery('frc125', 2016).cache_key in cache_keys)
+        self.assertTrue(event_query.EventDivisionsQuery('2016necmp').cache_key in cache_keys)

--- a/src/backend/common/deferred/__init__.py
+++ b/src/backend/common/deferred/__init__.py
@@ -42,7 +42,6 @@ def defer(
 def _client_for_env() -> TaskClient:
     # If we're running in tests, always return a FakeTestClient
     if os.environ.get("TBA_UNIT_TEST", None) == "true":
-        print("Returning here")
         from backend.common.deferred.clients.fake_client import FakeTaskClient
 
         return FakeTaskClient()

--- a/src/backend/common/deferred/clients/fake_client.py
+++ b/src/backend/common/deferred/clients/fake_client.py
@@ -14,14 +14,14 @@ class InlineRQTaskQueue(RQTaskQueue):
         self._queue.enqueue(task.obj, *task.args, **task.kwargs)
 
 
-class FakeRQTaskClient(RQTaskClient):
+class InlineRQTaskClient(RQTaskClient):
     def queue(self, name) -> InlineRQTaskQueue:
         return InlineRQTaskQueue(
             name, default_service=self.default_service, redis_client=self._client
         )
 
 
-class FakeTaskClient(FakeRQTaskClient):
+class InlineTaskClient(InlineRQTaskClient):
     """
     Similar interface to an in-memory RQTaskClient, except:
      - with a stubbed out Redis client
@@ -41,3 +41,11 @@ class FakeTaskClient(FakeRQTaskClient):
     def drain_pending_jobs(self, queue_name: str) -> None:
         jobs = self.queue(queue_name).jobs()
         [j.perform() for j in jobs]
+
+
+# Similar interface to an in-memory RQTaskClient, except with a stubbed out Redis client
+class FakeTaskClient(RQTaskClient):
+    def __init__(self) -> None:
+        from fakeredis import FakeRedis
+
+        super().__init__(default_service="test", redis_client=FakeRedis())

--- a/src/backend/common/deferred/clients/fake_client.py
+++ b/src/backend/common/deferred/clients/fake_client.py
@@ -1,24 +1,5 @@
-from backend.common.deferred.clients.rq_client import RQTaskClient
-from backend.common.deferred.queues.rq_queue import RQTaskQueue
-from backend.common.deferred.tasks.task import Task
+from backend.common.deferred.clients.rq_client import InlineRQTaskClient, RQTaskClient
 from backend.common.redis import RedisClient
-
-
-class InlineRQTaskQueue(RQTaskQueue):
-    """
-    A RQ-backed queue, but will run jobs inline
-    instead of making a HTTP request callback
-    """
-
-    def enqueue(self, task: Task, *args, **kwargs) -> None:
-        self._queue.enqueue(task.obj, *task.args, **task.kwargs)
-
-
-class InlineRQTaskClient(RQTaskClient):
-    def queue(self, name) -> InlineRQTaskQueue:
-        return InlineRQTaskQueue(
-            name, default_service=self.default_service, redis_client=self._client
-        )
 
 
 class InlineTaskClient(InlineRQTaskClient):

--- a/src/backend/common/deferred/clients/fake_client.py
+++ b/src/backend/common/deferred/clients/fake_client.py
@@ -1,9 +1,43 @@
 from backend.common.deferred.clients.rq_client import RQTaskClient
+from backend.common.deferred.queues.rq_queue import RQTaskQueue
+from backend.common.deferred.tasks.task import Task
+from backend.common.redis import RedisClient
 
 
-# Similar interface to an in-memory RQTaskClient, except with a stubbed out Redis client
-class FakeTaskClient(RQTaskClient):
+class InlineRQTaskQueue(RQTaskQueue):
+    """
+    A RQ-backed queue, but will run jobs inline
+    instead of making a HTTP request callback
+    """
+
+    def enqueue(self, task: Task, *args, **kwargs) -> None:
+        self._queue.enqueue(task.obj, *task.args, **task.kwargs)
+
+
+class FakeRQTaskClient(RQTaskClient):
+    def queue(self, name) -> InlineRQTaskQueue:
+        return InlineRQTaskQueue(
+            name, default_service=self.default_service, redis_client=self._client
+        )
+
+
+class FakeTaskClient(FakeRQTaskClient):
+    """
+    Similar interface to an in-memory RQTaskClient, except:
+     - with a stubbed out Redis client
+     - and will execute functions inline so we can manually run them
+    """
+
     def __init__(self) -> None:
         from fakeredis import FakeRedis
 
-        super().__init__(default_service="test", redis_client=FakeRedis())
+        super().__init__(
+            default_service="test", redis_client=RedisClient.get() or FakeRedis()
+        )
+
+    def pending_job_count(self, queue_name: str) -> int:
+        return len(self.queue(queue_name).jobs())
+
+    def drain_pending_jobs(self, queue_name: str) -> None:
+        jobs = self.queue(queue_name).jobs()
+        [j.perform() for j in jobs]

--- a/src/backend/common/deferred/clients/rq_client.py
+++ b/src/backend/common/deferred/clients/rq_client.py
@@ -1,7 +1,7 @@
 from redis import Redis
 
 from backend.common.deferred.clients.task_client import TaskClient
-from backend.common.deferred.queues.rq_queue import RQTaskQueue
+from backend.common.deferred.queues.rq_queue import InlineRQTaskQueue, RQTaskQueue
 
 
 class RQTaskClient(TaskClient[RQTaskQueue]):
@@ -15,5 +15,12 @@ class RQTaskClient(TaskClient[RQTaskQueue]):
 
     def queue(self, name) -> RQTaskQueue:
         return RQTaskQueue(
+            name, default_service=self.default_service, redis_client=self._client
+        )
+
+
+class InlineRQTaskClient(RQTaskClient):
+    def queue(self, name) -> InlineRQTaskQueue:
+        return InlineRQTaskQueue(
             name, default_service=self.default_service, redis_client=self._client
         )

--- a/src/backend/common/deferred/queues/rq_queue.py
+++ b/src/backend/common/deferred/queues/rq_queue.py
@@ -4,6 +4,7 @@ from redis import Redis
 
 from backend.common.deferred.queues.task_queue import TaskQueue
 from backend.common.deferred.requests.rq_request import RQTaskRequest
+from backend.common.deferred.tasks.task import Task
 
 
 class RQTaskQueue(TaskQueue[RQTaskRequest]):
@@ -35,3 +36,13 @@ class RQTaskQueue(TaskQueue[RQTaskRequest]):
 
     def jobs(self):
         return self._queue.jobs
+
+
+class InlineRQTaskQueue(RQTaskQueue):
+    """
+    A RQ-backed queue, but will run jobs inline
+    instead of making a HTTP request callback
+    """
+
+    def enqueue(self, task: Task, *args, **kwargs) -> None:
+        self._queue.enqueue(task.obj, *task.args, **task.kwargs)

--- a/src/backend/common/deferred/queues/rq_queue.py
+++ b/src/backend/common/deferred/queues/rq_queue.py
@@ -32,3 +32,6 @@ class RQTaskQueue(TaskQueue[RQTaskRequest]):
         self._queue.enqueue(
             requests.post, url=request.url, data=request.body, headers=request.headers
         )
+
+    def jobs(self):
+        return self._queue.jobs

--- a/src/backend/common/deferred/tests/deferred_test.py
+++ b/src/backend/common/deferred/tests/deferred_test.py
@@ -81,12 +81,16 @@ def test_client_for_env_production(set_override_tba_test, set_project):
     assert type(client) is GCloudTaskClient
 
 
-def test_client_for_env_dev_local_no_redis(set_override_tba_test, set_project, set_dev, set_tasks_local):
+def test_client_for_env_dev_local_no_redis(
+    set_override_tba_test, set_project, set_dev, set_tasks_local
+):
     with pytest.raises(Exception, match="Redis is not setup for the environment."):
         _client_for_env()
 
 
-def test_client_for_env_dev_local(set_override_tba_test, set_project, set_dev, set_tasks_local, set_redis):
+def test_client_for_env_dev_local(
+    set_override_tba_test, set_project, set_dev, set_tasks_local, set_redis
+):
     with patch.object(RQTaskClient, "__init__", return_value=None) as rq_client_init:
         client = _client_for_env()
 
@@ -138,7 +142,13 @@ def test_client_for_env_dev_remote_fallback(
 
 
 def test_client_for_env_dev_remote_fallback_service(
-    set_override_tba_test, caplog, set_project, set_dev, set_tasks_remote, set_redis, set_service
+    set_override_tba_test,
+    caplog,
+    set_project,
+    set_dev,
+    set_tasks_remote,
+    set_redis,
+    set_service,
 ):
     with patch.object(RQTaskClient, "__init__", return_value=None) as rq_client_init:
         client = _client_for_env()
@@ -154,7 +164,9 @@ def test_client_for_env_dev_remote_fallback_service(
     assert type(client) is RQTaskClient
 
 
-def test_client_for_env_dev_remote(set_override_tba_test, set_dev, set_tasks_remote, set_tasks_remote_config):
+def test_client_for_env_dev_remote(
+    set_override_tba_test, set_dev, set_tasks_remote, set_tasks_remote_config
+):
     with patch.object(
         GCloudTaskClient, "__init__", return_value=None
     ) as gcloud_client_init:
@@ -170,7 +182,11 @@ def test_client_for_env_dev_remote(set_override_tba_test, set_dev, set_tasks_rem
 
 
 def test_client_for_env_dev_remote_project(
-    set_override_tba_test, set_project, set_dev, set_tasks_remote, set_tasks_remote_config
+    set_override_tba_test,
+    set_project,
+    set_dev,
+    set_tasks_remote,
+    set_tasks_remote_config,
 ):
     with patch.object(
         GCloudTaskClient, "__init__", return_value=None

--- a/src/backend/common/manipulators/award_manipulator.py
+++ b/src/backend/common/manipulators/award_manipulator.py
@@ -1,7 +1,10 @@
 import json
+from typing import List
 
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
 from backend.common.models.award import Award
+from backend.common.models.cached_model import TAffectedReferences
 
 
 class AwardManipulator(ManipulatorBase[Award]):
@@ -9,11 +12,11 @@ class AwardManipulator(ManipulatorBase[Award]):
     Handle Award database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_award_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.award_updated(affected_refs)
 
     """
     @classmethod

--- a/src/backend/common/manipulators/district_manipulator.py
+++ b/src/backend/common/manipulators/district_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.district import District
 
 
@@ -37,11 +41,11 @@ class DistrictManipulator(ManipulatorBase):
                 cls.createOrUpdate(to_put, run_post_update_hook=False)
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_district_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.district_updated(affected_refs)
 
     @classmethod
     def updateMerge(

--- a/src/backend/common/manipulators/district_team_manipulator.py
+++ b/src/backend/common/manipulators/district_team_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.district_team import DistrictTeam
 
 
@@ -7,11 +11,11 @@ class DistrictTeamManipulator(ManipulatorBase[DistrictTeam]):
     Handle DistrictTeam database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_districtteam_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.districtteam_updated(affected_refs)
 
     """
     @classmethod

--- a/src/backend/common/manipulators/event_details_manipulator.py
+++ b/src/backend/common/manipulators/event_details_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.event_details import EventDetails
 
 
@@ -7,11 +11,11 @@ class EventDetailsManipulator(ManipulatorBase[EventDetails]):
     Handle EventDetails database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_event_details_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.event_details_updated(affected_refs)
 
     """ndb
     @classmethod

--- a/src/backend/common/manipulators/event_manipulator.py
+++ b/src/backend/common/manipulators/event_manipulator.py
@@ -1,6 +1,9 @@
 import json
+from typing import List
 
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.event import Event
 
 
@@ -9,11 +12,11 @@ class EventManipulator(ManipulatorBase[Event]):
     Handle Event database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_event_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.event_updated(affected_refs)
 
     """
     @classmethod

--- a/src/backend/common/manipulators/event_team_manipulator.py
+++ b/src/backend/common/manipulators/event_team_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.event_team import EventTeam
 
 
@@ -7,11 +11,11 @@ class EventTeamManipulator(ManipulatorBase[EventTeam]):
     Handle EventTeam database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_eventteam_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.eventteam_updated(affected_refs)
 
     @classmethod
     def updateMerge(

--- a/src/backend/common/manipulators/manipulator_base.py
+++ b/src/backend/common/manipulators/manipulator_base.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     overload,
     Set,
-    Tuple,
     Type,
     TypeVar,
 )
@@ -192,7 +191,6 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
 
     """
     cache clearing hook
-    TODO
     """
 
     @classmethod
@@ -231,10 +229,11 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
             query.delete_cache_multi(cache_keys)
 
     @classmethod
+    @abc.abstractmethod
     def getCacheKeysAndQueries(
         cls, affected_refs: TAffectedReferences
     ) -> List[TCacheKeyAndQuery]:
         """
         Child classes should replace method with appropriate call to CacheClearer.
         """
-        return []
+        ...

--- a/src/backend/common/manipulators/manipulator_base.py
+++ b/src/backend/common/manipulators/manipulator_base.py
@@ -198,7 +198,6 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
         """
         Make deferred calls to clear caches
         Needs to save _affected_references and the dirty flag
-        TODO implement this
         """
         all_affected_references: List[TAffectedReferences] = []
         for model in models:
@@ -212,7 +211,7 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
                 _queue="cache-clearing",
                 # this does not exist in Cloud Tasks
                 # _transactional=ndb.in_transaction(),
-                _target="default",
+                _target="tasks-io",
                 _url="/_ah/queue/deferred_manipulator_clearCache",
             )
 

--- a/src/backend/common/manipulators/match_manipulator.py
+++ b/src/backend/common/manipulators/match_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.match import Match
 
 
@@ -7,11 +11,11 @@ class MatchManipulator(ManipulatorBase[Match]):
     Handle Match database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_match_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.match_updated(affected_refs)
 
     """
     @classmethod

--- a/src/backend/common/manipulators/media_manipulator.py
+++ b/src/backend/common/manipulators/media_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.media import Media
 
 
@@ -7,11 +11,11 @@ class MediaManipulator(ManipulatorBase[Media]):
     Handle Media database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_media_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.media_updated(affected_refs)
 
     @classmethod
     def updateMerge(

--- a/src/backend/common/manipulators/robot_manipulator.py
+++ b/src/backend/common/manipulators/robot_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.robot import Robot
 
 
@@ -7,11 +11,11 @@ class RobotManipulator(ManipulatorBase[Robot]):
     Handle Robot database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_robot_cache_keys_and_controllers(affected_refs)
-    """
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.robot_updated(affected_refs)
 
     @classmethod
     def updateMerge(

--- a/src/backend/common/manipulators/team_manipulator.py
+++ b/src/backend/common/manipulators/team_manipulator.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
 from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.team import Team
 
 
@@ -7,11 +11,13 @@ class TeamManipulator(ManipulatorBase[Team]):
     Handle Team database writes.
     """
 
-    """
     @classmethod
-    def getCacheKeysAndControllers(cls, affected_refs):
-        return CacheClearer.get_team_cache_keys_and_controllers(affected_refs)
+    def getCacheKeysAndControllers(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.team_updated(affected_refs)
 
+    """
     @classmethod
     def postDeleteHook(cls, teams):
         # To run after the team has been deleted.

--- a/src/backend/common/manipulators/team_manipulator.py
+++ b/src/backend/common/manipulators/team_manipulator.py
@@ -12,7 +12,7 @@ class TeamManipulator(ManipulatorBase[Team]):
     """
 
     @classmethod
-    def getCacheKeysAndControllers(
+    def getCacheKeysAndQueries(
         cls, affected_refs: TAffectedReferences
     ) -> List[get_affected_queries.TCacheKeyAndQuery]:
         return get_affected_queries.team_updated(affected_refs)

--- a/src/backend/common/models/cached_model.py
+++ b/src/backend/common/models/cached_model.py
@@ -12,7 +12,7 @@ from google.cloud.ndb._legacy_entity_pb import (
 from google.cloud.ndb.model import _CompressedValue
 
 
-TAffectedReferences = Dict[str, Set[ndb.Key]]
+TAffectedReferences = Dict[str, Set[Any]]
 
 _EPOCH = datetime.datetime.utcfromtimestamp(0)
 _MEANING_URI_COMPRESSED = "ZLIB"

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -10,7 +10,6 @@ from pyre_extensions import safe_cast
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.futures import TypedFuture
 from backend.common.models.cached_query_result import CachedQueryResult
-from backend.common.models.keys import DistrictKey, EventKey, TeamKey, Year
 from backend.common.profiler import Span
 from backend.common.queries.dict_converters.converter_base import ConverterBase
 from backend.common.queries.exceptions import DoesNotExistException
@@ -117,19 +116,3 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
                 yield CachedQueryResult(id=cache_key, result=query_result).put_async()
             return query_result  # pyre-ignore[7]
         return cached_query_result.result
-
-    @classmethod
-    def _event_affected_queries(
-        cls, event_key: EventKey, year: Year, district_key: Optional[DistrictKey]
-    ) -> Set[CachedDatabaseQuery]:
-        return set()
-
-    @classmethod
-    def _eventteam_affected_queries(
-        cls, event_key: EventKey, team_key: TeamKey, year: Year
-    ) -> Set[CachedDatabaseQuery]:
-        return set()
-
-    @classmethod
-    def _team_affected_queries(cls, team_key: TeamKey) -> Set[CachedDatabaseQuery]:
-        return set()

--- a/src/backend/common/queries/media_query.py
+++ b/src/backend/common/queries/media_query.py
@@ -54,7 +54,7 @@ class TeamYearMediaQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
     CACHE_KEY_FORMAT = "team_year_media_{team_key}_{year}"
     DICT_CONVERTER = MediaConverter
 
-    def __init(self, team_key: TeamKey, year: Year) -> None:
+    def __init__(self, team_key: TeamKey, year: Year) -> None:
         super().__init__(team_key=team_key, year=year)
 
     @typed_tasklet

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -16,7 +16,7 @@ from backend.common.queries.dict_converters.team_converter import (
 from backend.common.tasklets import typed_tasklet
 
 
-def _get_team_page_num(team_key: str) -> int:
+def get_team_page_num(team_key: str) -> int:
     return int(int(team_key[3:]) / TeamListQuery.PAGE_SIZE)
 
 

--- a/src/backend/common/queries/tests/event_event_teams_query_test.py
+++ b/src/backend/common/queries/tests/event_event_teams_query_test.py
@@ -30,12 +30,3 @@ def test_get_data() -> None:
 
     event_teams = EventEventTeamsQuery(event_key="2020ct").fetch()
     assert len(event_teams) == 10
-
-
-def test_affected_queries() -> None:
-    assert {
-        q.cache_key
-        for q in EventEventTeamsQuery._eventteam_affected_queries(
-            event_key="2020casj", team_key="frc254", year=2020
-        )
-    } == {EventEventTeamsQuery(event_key="2020casj").cache_key}

--- a/src/backend/common/queries/tests/event_teams_query_test.py
+++ b/src/backend/common/queries/tests/event_teams_query_test.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
 from google.cloud import ndb
-from pyre_extensions import none_throws
 
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
@@ -49,51 +48,3 @@ def test_get_data() -> None:
 
     teams = EventTeamsQuery(event_key="2020ct").fetch()
     assert len(teams) == len(stored_teams)
-
-
-def test_affected_queries() -> None:
-    stored_teams1 = preseed_teams(1, 10)
-    stored_teams2 = preseed_teams(100, 110)
-    preseed_event_teams(stored_teams1, "2020aaa")
-    preseed_event_teams(stored_teams2, "2020bbb")
-    preseed_event_teams(stored_teams1 + stored_teams2, "2020ccc")
-
-    for team_key in stored_teams1:
-        assert {
-            q.cache_key
-            for q in EventTeamsQuery._eventteam_affected_queries(
-                event_key="2020aaa",
-                team_key=none_throws(team_key.string_id()),
-                year=2020,
-            )
-        } == {EventTeamsQuery(event_key="2020aaa").cache_key}
-
-        assert {
-            q.cache_key
-            for q in EventTeamsQuery._team_affected_queries(
-                team_key=none_throws(team_key.string_id())
-            )
-        } == {
-            EventTeamsQuery(event_key="2020aaa").cache_key,
-            EventTeamsQuery(event_key="2020ccc").cache_key,
-        }
-
-    for team_key in stored_teams2:
-        assert {
-            q.cache_key
-            for q in EventTeamsQuery._eventteam_affected_queries(
-                event_key="2020bbb",
-                team_key=none_throws(team_key.string_id()),
-                year=2020,
-            )
-        } == {EventTeamsQuery(event_key="2020bbb").cache_key}
-
-        assert {
-            q.cache_key
-            for q in EventTeamsQuery._team_affected_queries(
-                team_key=none_throws(team_key.string_id())
-            )
-        } == {
-            EventTeamsQuery(event_key="2020bbb").cache_key,
-            EventTeamsQuery(event_key="2020ccc").cache_key,
-        }

--- a/src/backend/common/queries/tests/team_list_query_test.py
+++ b/src/backend/common/queries/tests/team_list_query_test.py
@@ -61,18 +61,3 @@ def test_upper_bound_exclusive() -> None:
     preseed_teams(500)
     teams = TeamListQuery(page=0).fetch()
     assert teams == []
-
-
-def test_affected_queries() -> None:
-    assert {
-        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc254")
-    } == {TeamListQuery(page=0).cache_key}
-    assert {
-        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc604")
-    } == {TeamListQuery(page=1).cache_key}
-    assert {
-        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc1114")
-    } == {TeamListQuery(page=2).cache_key}
-    assert {
-        q.cache_key for q in TeamListQuery._team_affected_queries(team_key="frc9999")
-    } == {TeamListQuery(page=19).cache_key}

--- a/src/backend/common/queries/tests/team_list_year_query_test.py
+++ b/src/backend/common/queries/tests/team_list_year_query_test.py
@@ -1,13 +1,12 @@
 from typing import List, Optional
 
 from google.cloud import ndb
-from pyre_extensions import none_throws
 
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import Year
 from backend.common.models.team import Team
-from backend.common.queries.team_query import TeamListQuery, TeamListYearQuery
+from backend.common.queries.team_query import TeamListYearQuery
 
 
 def preseed_teams(start_team: int, end_team: Optional[int] = None) -> List[ndb.Key]:
@@ -71,24 +70,3 @@ def test_with_event_teams_wrong_page() -> None:
 
     teams = TeamListYearQuery(year=2020, page=10).fetch()
     assert teams == []
-
-
-def test_affected_queries() -> None:
-    stored_teams = preseed_teams(1, 10)
-    preseed_event_teams(stored_teams, 2020)
-
-    for team_key in stored_teams:
-        assert {
-            q.cache_key
-            for q in TeamListYearQuery._eventteam_affected_queries(
-                event_key="2020test",
-                team_key=none_throws(team_key.string_id()),
-                year=2020,
-            )
-        } == {TeamListYearQuery(year=2020, page=0).cache_key}
-        assert {
-            q.cache_key
-            for q in TeamListYearQuery._team_affected_queries(
-                team_key=none_throws(team_key.string_id())
-            )
-        } == {TeamListQuery(page=0).cache_key}

--- a/src/backend/common/queries/tests/team_participation_query_test.py
+++ b/src/backend/common/queries/tests/team_participation_query_test.py
@@ -37,12 +37,3 @@ def test_get_data() -> None:
 
     years = TeamParticipationQuery(team_key="frc254").fetch()
     assert years == {2020, 2019, 2018}
-
-
-def test_affected_queries() -> None:
-    assert {
-        q.cache_key
-        for q in TeamParticipationQuery._eventteam_affected_queries(
-            team_key="frc254", event_key="test", year=2020
-        )
-    } == {TeamParticipationQuery(team_key="frc254").cache_key}

--- a/src/backend/common/queries/tests/team_query_test.py
+++ b/src/backend/common/queries/tests/team_query_test.py
@@ -12,9 +12,3 @@ def test_team_is_found() -> None:
     result = TeamQuery(team_key="frc254").fetch()
     assert result is not None
     assert result.team_number == 254
-
-
-def test_affected_queries() -> None:
-    assert {
-        q.cache_key for q in TeamQuery._team_affected_queries(team_key="frc254")
-    } == {TeamQuery(team_key="frc254").cache_key}


### PR DESCRIPTION
This ports `get_affected_queries` from the old app and hooks it into the manipulators.

The other half of `CacheClearer` was about clearing apiv2 caches, which we're not porting, so I skipped it all