### PR TITLE
Remove InlineTaskClient, wrap code in FakeTaskClient

### DIFF
--- a/src/backend/common/deferred/clients/rq_client.py
+++ b/src/backend/common/deferred/clients/rq_client.py
@@ -1,7 +1,7 @@
 from redis import Redis
 
 from backend.common.deferred.clients.task_client import TaskClient
-from backend.common.deferred.queues.rq_queue import InlineRQTaskQueue, RQTaskQueue
+from backend.common.deferred.queues.rq_queue import RQTaskQueue
 
 
 class RQTaskClient(TaskClient[RQTaskQueue]):
@@ -15,12 +15,5 @@ class RQTaskClient(TaskClient[RQTaskQueue]):
 
     def queue(self, name) -> RQTaskQueue:
         return RQTaskQueue(
-            name, default_service=self.default_service, redis_client=self._client
-        )
-
-
-class InlineRQTaskClient(RQTaskClient):
-    def queue(self, name) -> InlineRQTaskQueue:
-        return InlineRQTaskQueue(
             name, default_service=self.default_service, redis_client=self._client
         )

--- a/src/backend/common/deferred/queues/fake_queue.py
+++ b/src/backend/common/deferred/queues/fake_queue.py
@@ -1,0 +1,11 @@
+from backend.common.deferred.queues.rq_queue import RQTaskQueue
+
+
+class FakeTaskQueue(RQTaskQueue):
+    """
+    A RQ-backed queue, but will run jobs inline
+    instead of making a HTTP request callback
+    """
+
+    def jobs(self):
+        return self._queue.jobs

--- a/src/backend/common/deferred/queues/rq_queue.py
+++ b/src/backend/common/deferred/queues/rq_queue.py
@@ -4,7 +4,6 @@ from redis import Redis
 
 from backend.common.deferred.queues.task_queue import TaskQueue
 from backend.common.deferred.requests.rq_request import RQTaskRequest
-from backend.common.deferred.tasks.task import Task
 
 
 class RQTaskQueue(TaskQueue[RQTaskRequest]):
@@ -33,16 +32,3 @@ class RQTaskQueue(TaskQueue[RQTaskRequest]):
         self._queue.enqueue(
             requests.post, url=request.url, data=request.body, headers=request.headers
         )
-
-    def jobs(self):
-        return self._queue.jobs
-
-
-class InlineRQTaskQueue(RQTaskQueue):
-    """
-    A RQ-backed queue, but will run jobs inline
-    instead of making a HTTP request callback
-    """
-
-    def enqueue(self, task: Task, *args, **kwargs) -> None:
-        self._queue.enqueue(task.obj, *task.args, **task.kwargs)


### PR DESCRIPTION
Note to Zach: We should try to see if we can make our fake client shared for all tests, as opposed to creating it in-memory during `_client_for_env`. It would allow us to remove that patch + allow for a better pattern for executing tasks in tests