### PR TITLE
Remove code to create districts when fetching teams - rely on Events for Districts

### DIFF
--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -331,28 +331,13 @@ class TeamDetailsGet(webapp.RequestHandler):
         fms_details = fms_df.getTeamDetails(year, key_name)
 
         if fms_details:
-            team, district_team, robot = fms_details[0]
+            team, robot = fms_details[0]
         else:
             team = None
-            district_team = None
             robot = None
 
         if team:
             team = TeamManipulator.createOrUpdate(team)
-
-        # Clean up junk district teams
-        # https://www.facebook.com/groups/moardata/permalink/1310068625680096/
-        dt_keys = DistrictTeam.query(
-            DistrictTeam.team == existing_team.key,
-            DistrictTeam.year == year).fetch(keys_only=True)
-        keys_to_delete = set()
-        for dt_key in dt_keys:
-            if not district_team or dt_key.id() != district_team.key.id():
-                keys_to_delete.add(dt_key)
-        DistrictTeamManipulator.delete_keys(keys_to_delete)
-
-        if district_team:
-            district_team = DistrictTeamManipulator.createOrUpdate(district_team)
 
         if robot:
             robot = RobotManipulator.createOrUpdate(robot)
@@ -361,7 +346,6 @@ class TeamDetailsGet(webapp.RequestHandler):
             'key_name': key_name,
             'team': team,
             'success': team is not None,
-            'district': district_team,
             'robot': robot,
         }
 

--- a/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -3,10 +3,7 @@ import urlparse
 
 from google.appengine.ext import ndb
 
-from consts.district_type import DistrictType
 from helpers.website_helper import WebsiteHelper
-from models.district import District
-from models.district_team import DistrictTeam
 from models.robot import Robot
 from models.team import Team
 from sitevars.website_blacklist import WebsiteBlacklist
@@ -19,7 +16,7 @@ class FMSAPITeamDetailsParser(object):
     def parse(self, response):
         """
         Parse team info from FMSAPI
-        Returns a tuple of: list of models (Team, DistrictTeam, Robot),
+        Returns a tuple of: list of models (Team, Robot),
         and a Boolean indicating if there are more pages to be fetched
         """
 
@@ -54,16 +51,6 @@ class FMSAPITeamDetailsParser(object):
                 rookie_year=teamData['rookieYear']
             )
 
-            districtTeam = None
-            if teamData['districtCode']:
-                districtKey = District.renderKeyName(self.year, teamData['districtCode'].lower())
-                districtTeam = DistrictTeam(
-                    id=DistrictTeam.renderKeyName(districtKey, team.key_name),
-                    team=ndb.Key(Team, team.key_name),
-                    year=self.year,
-                    district_key=ndb.Key(District, districtKey),
-                )
-
             robot = None
             if teamData['robotName'] and self.year not in [2019]:
                 # FIRST did not support entering robot names  in 2019, so the
@@ -76,6 +63,6 @@ class FMSAPITeamDetailsParser(object):
                     robot_name=teamData['robotName'].strip()
                 )
 
-            ret_models.append((team, districtTeam, robot))
+            ret_models.append((team, robot))
 
         return (ret_models, (current_page < total_pages))

--- a/templates/datafeeds/usfirst_team_details_get.html
+++ b/templates/datafeeds/usfirst_team_details_get.html
@@ -22,7 +22,6 @@
         <li>Postal Code: {{team.postalcode}}</li>
         <li>Country: {{team.country}}</li>
         <li>Website: {{team.website}}</li>
-        <li>District: {{district}}</li>
         <li>Robot: {{robot}}</li>
     </ul>
     {% else %}

--- a/tests/test_fms_api_team_parser.py
+++ b/tests/test_fms_api_team_parser.py
@@ -6,7 +6,6 @@ from datafeeds.parsers.fms_api.fms_api_team_details_parser import FMSAPITeamDeta
 from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
-from models.district import District
 from models.sitevar import Sitevar
 
 
@@ -29,7 +28,7 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertFalse(more_pages)
             self.assertEqual(len(models), 1)
 
-            team, districtTeam, robot = models[0]
+            team, robot = models[0]
 
             # Ensure we get the proper Team model back
             self.assertEqual(team.key_name, "frc1124")
@@ -41,12 +40,6 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertEqual(team.country, "USA")
             self.assertEqual(team.rookie_year, 2003)
             self.assertEqual(team.website, "http://uberbots.org")
-
-            # Test the DistrictTeam model we get back
-            self.assertNotEqual(districtTeam, None)
-            self.assertEqual(districtTeam.key_name, "2015ne_frc1124")
-            self.assertEqual(districtTeam.team.id(), "frc1124")
-            self.assertEqual(districtTeam.district_key, ndb.Key(District, '2015ne'))
 
             # Test the Robot model we get back
             self.assertNotEqual(robot, None)
@@ -61,7 +54,7 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertFalse(more_pages)
             self.assertEqual(len(models), 1)
 
-            team, districtTeam, robot = models[0]
+            team, robot = models[0]
 
             # Ensure we get the proper Team model back
             self.assertEqual(team.key_name, "frc254")
@@ -73,9 +66,6 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertEqual(team.country, "USA")
             self.assertEqual(team.rookie_year, 1999)
             self.assertEqual(team.website, "http://team254.com/")
-
-            # Test the DistrictTeam model we get back
-            self.assertEqual(districtTeam, None)
 
             # Test the Robot model we get back
             self.assertNotEqual(robot, None)
@@ -98,7 +88,7 @@ class TestFMSAPITeamParser(unittest2.TestCase):
                 self.assertFalse(more_pages)
                 self.assertEqual(len(models), 1)
 
-                team, districtTeam, robot = models[0]
+                team, robot = models[0]
 
                 # Ensure we get the proper Team model back
                 self.assertEqual(team.key_name, "frc1124")
@@ -118,7 +108,7 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertFalse(more_pages)
             self.assertEqual(len(models), 1)
 
-            team, districtTeam, robot = models[0]
+            team, robot = models[0]
 
             # Ensure we get the proper Team model back
             self.assertEqual(team.key_name, "frc604")
@@ -130,9 +120,6 @@ class TestFMSAPITeamParser(unittest2.TestCase):
             self.assertEqual(team.country, "USA")
             self.assertEqual(team.rookie_year, 2001)
             self.assertEqual(team.website, "http://604Robotics.com")
-
-            # Test the DistrictTeam model we get back
-            self.assertEqual(districtTeam, None)
 
             # Test the Robot model we get back
             self.assertNotEqual(robot, None)


### PR DESCRIPTION
Part one of #3261 - we should stop creating Districts when fetching Teams. If we're relying on Events to be the indicator of Districts, then we need to stop creating Districts when fetching a Team details.