### PR TITLE
Install RegexConverter on all handlers

### DIFF
--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -7,12 +7,14 @@ from backend.api.handlers.team import team, team_list, team_list_all, team_list_
 from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
+from backend.common.url_converters import install_url_converters
 
 
 configure_logging()
 
 app = Flask(__name__)
 install_middleware(app)
+install_url_converters(app)
 configure_flask_cache(app)
 
 app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True

--- a/src/backend/common/deferred/handlers/defer_handler.py
+++ b/src/backend/common/deferred/handlers/defer_handler.py
@@ -3,13 +3,6 @@ import pickle
 from typing import Any
 
 from flask import abort, Flask, request, Response
-from werkzeug.routing import BaseConverter
-
-
-class RegexConverter(BaseConverter):
-    def __init__(self, url_map, *items) -> None:
-        super(RegexConverter, self).__init__(url_map)
-        self.regex = items[0]
 
 
 class PermanentTaskFailure(Exception):
@@ -44,7 +37,6 @@ def handle_defer(path: str) -> Response:
 
 
 def install_defer_routes(app: Flask) -> None:
-    app.url_map.converters["regex"] = RegexConverter
     app.add_url_rule(
         '/_ah/queue/<regex("deferred.*"):path>',
         view_func=handle_defer,

--- a/src/backend/common/deferred/handlers/tests/test_defer_handler.py
+++ b/src/backend/common/deferred/handlers/tests/test_defer_handler.py
@@ -12,6 +12,7 @@ from backend.common.deferred.handlers.defer_handler import (
     run,
 )
 from backend.common.deferred.tasks.task import Task
+from backend.common.url_converters import install_url_converters
 
 
 def test_install_defer_routes():
@@ -19,6 +20,7 @@ def test_install_defer_routes():
     app = Flask(__name__)
     rules = [r for r in app.url_map.iter_rules() if str(r) == route]
     assert len(rules) == 0
+    install_url_converters(app)
     install_defer_routes(app)
     rules = [r for r in app.url_map.iter_rules() if str(r) == route]
     assert len(rules) == 1

--- a/src/backend/common/tests/url_converters_test.py
+++ b/src/backend/common/tests/url_converters_test.py
@@ -1,0 +1,31 @@
+import pytest
+from flask import Flask
+
+from backend.common.url_converters import install_url_converters
+
+
+def test_regex_route(app: Flask) -> None:
+    install_url_converters(app)
+
+    @app.route('/<regex("[0-9]{4}[a-z]+"):event_key>')
+    def view(event_key: str):
+        return event_key
+
+    client = app.test_client()
+    resp = client.get("/2020nyny")
+    assert resp.status_code == 200
+    assert resp.data == b"2020nyny"
+
+    assert client.get("/").status_code == 404
+    assert client.get("/123abc").status_code == 404
+    assert client.get("/1234ABC").status_code == 404
+
+
+def test_regex_route_throws_when_not_installed(app: Flask) -> None:
+    # Do not install the converter, expect we get an error
+
+    with pytest.raises(LookupError):
+
+        @app.route('/<regex("[0-9]{4}[a-z]+"):event_key>')
+        def view(event_key: str):
+            return event_key

--- a/src/backend/common/url_converters.py
+++ b/src/backend/common/url_converters.py
@@ -1,0 +1,13 @@
+from flask import Flask
+from werkzeug.routing import BaseConverter
+
+
+class RegexConverter(BaseConverter):
+    def __init__(self, url_map, *items) -> None:
+        super(RegexConverter, self).__init__(url_map)
+        self.regex = items[0]
+
+
+def install_url_converters(app: Flask) -> None:
+    # Also install custom url converters
+    app.url_map.converters["regex"] = RegexConverter

--- a/src/backend/tasks_io/main.py
+++ b/src/backend/tasks_io/main.py
@@ -3,10 +3,12 @@ from flask import Flask
 from backend.common.deferred.handlers import install_defer_routes
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
+from backend.common.url_converters import install_url_converters
 
 
 configure_logging()
 
 app = Flask(__name__)
 install_middleware(app)
+install_url_converters(app)
 install_defer_routes(app)

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -4,6 +4,7 @@ from flask_wtf.csrf import CSRFProtect
 from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
+from backend.common.url_converters import install_url_converters
 from backend.web.auth import _user_context_processor
 from backend.web.handlers.account import blueprint as account_blueprint
 from backend.web.handlers.error import handle_404, handle_500
@@ -30,6 +31,7 @@ configure_logging()
 
 app = Flask(__name__)
 install_middleware(app)
+install_url_converters(app)
 configure_flask_cache(app)
 
 csrf = CSRFProtect()


### PR DESCRIPTION
I'll need this in order to port the district detail url handlers, and it
just seems like a good idea for us to have available everywhere

## How Has This Been Tested?
defer tests cover this + write some explicit ones
