### PR TITLE
Do not delete EventTeam models for teams who won awards at an Event if the team did not attend the Event

### DIFF
--- a/controllers/datafeed_controller.py
+++ b/controllers/datafeed_controller.py
@@ -584,12 +584,22 @@ class EventDetailsGet(webapp.RequestHandler):
 
         # Delete eventteams of teams that are no longer registered
         if event_teams and not skip_eventteams:
-            existing_event_team_keys = set(EventTeam.query(EventTeam.event == event.key).fetch(1000, keys_only=True))
-            event_team_keys = set([et.key for et in event_teams])
-            et_keys_to_delete = existing_event_team_keys.difference(event_team_keys)
+            existing_event_teams = EventTeam.query(EventTeam.event == event.key).fetch()
+
+            # Don't delete EventTeam models for teams who won Awards at the Event, but who did not attend the Event
+            award_teams = set()
+            for award in event.awards:
+                for team in award.team_list:
+                    award_teams.add(team.id())
+            award_event_teams = {et.key for et in existing_event_teams if et.team.id() in award_teams}
+
+            event_team_keys = {et.key for et in event_teams}
+            existing_event_team_keys = {et.key for et in existing_event_teams}
+
+            et_keys_to_delete = existing_event_team_keys.difference(event_team_keys.union(award_event_teams))
             EventTeamManipulator.delete_keys(et_keys_to_delete)
 
-            event_teams = EventTeamManipulator.createOrUpdate(event_teams)
+        event_teams = EventTeamManipulator.createOrUpdate(event_teams)
         if type(event_teams) is not list:
             event_teams = [event_teams]
 

--- a/templates_jinja2/team_details.html
+++ b/templates_jinja2/team_details.html
@@ -44,7 +44,7 @@
             </li>
             <li>
               <a class="smooth-scroll" href="#media">Photos &amp; Videos</a>
-              <li><a class="smooth-scroll" href="#robot-profile">Robot Profile</a></li>
+              <a class="smooth-scroll" href="#robot-profile">Robot Profile</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Should fix a bug we're having with 2020 events (specifically https://www.thebluealliance.com/event/2020oncmp) where an `EventDetailsGet` is deleting `EventTeam` models for teams who are not listed as attending the event, but who won awards at the event