### PR TITLE
Rename EventHelper methods to be snake_case instead of camelCase, and to be less verbose. Add EventHelper.*_or_distant_future tests

### DIFF
--- a/old_py2/controllers/district_controller.py
+++ b/old_py2/controllers/district_controller.py
@@ -65,7 +65,7 @@ class DistrictDetail(CacheableHandler):
         # needed for active team statuses
         live_events = []
         if year == datetime.datetime.now().year:  # Only show active teams for current year
-            live_events = EventHelper.getWeekEvents()
+            live_events = EventHelper.week_events()
         live_eventteams_futures = []
         for event in live_events:
             live_eventteams_futures.append(EventTeamsQuery(event.key_name).fetch_async())
@@ -75,7 +75,7 @@ class DistrictDetail(CacheableHandler):
         events_by_key = {}
         for event in events:
             events_by_key[event.key.id()] = event
-        week_events = EventHelper.groupByWeek(events)
+        week_events = EventHelper.group_by_week(events)
 
         valid_districts = set()
         districts_in_year = districts_in_year_future.get_result()
@@ -124,8 +124,8 @@ class DistrictDetail(CacheableHandler):
                 teams_and_statuses.sort(key=lambda x: x[0].team_number)
                 live_events_with_teams.append((event, teams_and_statuses))
         live_events_with_teams.sort(key=lambda x: x[0].name)
-        live_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoStartDate(x[0]))
-        live_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoEndDate(x[0]))
+        live_events_with_teams.sort(key=lambda x: EventHelper.start_date_or_distant_future(x[0]))
+        live_events_with_teams.sort(key=lambda x: EventHelper.end_date_or_distant_future(x[0]))
 
         # Get valid years
         district_history = history_future.get_result()

--- a/old_py2/controllers/event_controller.py
+++ b/old_py2/controllers/event_controller.py
@@ -82,7 +82,7 @@ class EventList(CacheableHandler):
 
         EventHelper.sort_events(events)
 
-        week_events = EventHelper.groupByWeek(events)
+        week_events = EventHelper.group_by_week(events)
 
         districts = []  # a tuple of (district abbrev, district name)
         for district in districts_future.get_result():

--- a/old_py2/controllers/gameday_controller.py
+++ b/old_py2/controllers/gameday_controller.py
@@ -81,7 +81,7 @@ class GamedayHandler(CacheableHandler):
 
         ongoing_events = []
         ongoing_events_w_webcasts = []
-        week_events = EventHelper.getWeekEvents()
+        week_events = EventHelper.week_events()
         for event in week_events:
             if event.now and event.key.id() not in special_webcast_keys:
                 ongoing_events.append(event)

--- a/old_py2/controllers/mytba_controller.py
+++ b/old_py2/controllers/mytba_controller.py
@@ -92,8 +92,8 @@ class MyTBALiveController(LoggedInHandler):
             teams_and_statuses.sort(key=lambda x: x[0].team_number)
             past_events_with_teams.append((event, teams_and_statuses))
         past_events_with_teams.sort(key=lambda x: x[0].name)
-        past_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoStartDate(x[0]))
-        past_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoEndDate(x[0]))
+        past_events_with_teams.sort(key=lambda x: EventHelper.start_date_or_distant_future(x[0]))
+        past_events_with_teams.sort(key=lambda x: EventHelper.end_date_or_distant_future(x[0]))
 
         live_events_with_teams = []
         for event, teams in live_events_by_event.itervalues():
@@ -112,16 +112,16 @@ class MyTBALiveController(LoggedInHandler):
             teams_and_statuses.sort(key=lambda x: x[0].team_number)
             live_events_with_teams.append((event, teams_and_statuses))
         live_events_with_teams.sort(key=lambda x: x[0].name)
-        live_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoStartDate(x[0]))
-        live_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoEndDate(x[0]))
+        live_events_with_teams.sort(key=lambda x: EventHelper.start_date_or_distant_future(x[0]))
+        live_events_with_teams.sort(key=lambda x: EventHelper.end_date_or_distant_future(x[0]))
 
         future_events_with_teams = []
         for event, teams in future_events_by_event.itervalues():
             teams.sort(key=lambda t: t.team_number)
             future_events_with_teams.append((event, teams))
         future_events_with_teams.sort(key=lambda x: x[0].name)
-        future_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoStartDate(x[0]))
-        future_events_with_teams.sort(key=lambda x: EventHelper.distantFutureIfNoEndDate(x[0]))
+        future_events_with_teams.sort(key=lambda x: EventHelper.start_date_or_distant_future(x[0]))
+        future_events_with_teams.sort(key=lambda x: EventHelper.end_date_or_distant_future(x[0]))
 
         self.template_values.update({
             'year': year,

--- a/old_py2/helpers/event_helper.py
+++ b/old_py2/helpers/event_helper.py
@@ -53,10 +53,10 @@ class EventHelper(object):
         Given a team_key, and an event, find the team's Win Loss Tie.
         """
         match_keys = Match.query(Match.event == event.key, Match.team_key_names == team_key).fetch(500, keys_only=True)
-        return self.calculateTeamWLTFromMatches(team_key, ndb.get_multi(match_keys))
+        return self.calculate_wlt(team_key, ndb.get_multi(match_keys))
 
     @classmethod
-    def getWeekEvents(self):
+    def week_events(self):
         """
         Get events this week
         In general, if an event is currently going on, it shows up in this query
@@ -65,7 +65,7 @@ class EventHelper(object):
         OR
         b) The event.start_date is on or within 4 days after the closest Wednesday/Monday (pre-2020/post-2020)
         """
-        event_keys = memcache.get('EventHelper.getWeekEvents():event_keys')
+        event_keys = memcache.get('EventHelper.week_events():event_keys')
         if event_keys is not None:
             return ndb.get_multi(event_keys)
 
@@ -93,7 +93,7 @@ class EventHelper(object):
                     events.append(event)
 
         EventHelper.sort_events(events)
-        memcache.set('EventHelper.getWeekEvents():event_keys', [e.key for e in events], 60*60)
+        memcache.set('EventHelper.week_events():event_keys', [e.key for e in events], 60*60)
         return events
 
     @classmethod
@@ -102,7 +102,7 @@ class EventHelper(object):
         if event_keys is not None:
             return ndb.get_multi(event_keys)
 
-        events = filter(lambda e: e.within_a_day, self.getWeekEvents())
+        events = filter(lambda e: e.within_a_day, self.week_events())
         memcache.set('EventHelper.getEventsWithinADay():event_keys', [e.key for e in events], 60*60)
         return events
 

--- a/old_py2/helpers/firebase/firebase_pusher.py
+++ b/old_py2/helpers/firebase/firebase_pusher.py
@@ -259,7 +259,7 @@ class FirebasePusher(object):
     @classmethod
     @ndb.toplevel
     def _update_live_events_helper(cls):
-        week_events = EventHelper.getWeekEvents()
+        week_events = EventHelper.week_events()
         events_by_key = {}
         live_events = []
         for event in week_events:

--- a/old_py2/helpers/insights_helper.py
+++ b/old_py2/helpers/insights_helper.py
@@ -32,7 +32,7 @@ class InsightsHelper(object):
         """
         # Only fetch from DB once
         official_events = Event.query(Event.year == year).order(Event.start_date).fetch(1000)
-        events_by_week = EventHelper.groupByWeek(official_events)
+        events_by_week = EventHelper.group_by_week(official_events)
         week_event_matches = []  # Tuples of: (week, events) where events are tuples of (event, matches)
         for week, events in events_by_week.items():
             if week in {OFFSEASON_EVENTS_LABEL, PRESEASON_EVENTS_LABEL}:

--- a/old_py2/tests/test_event_group_by_week.py
+++ b/old_py2/tests/test_event_group_by_week.py
@@ -13,7 +13,7 @@ from helpers.event_helper import EventHelper, CHAMPIONSHIP_EVENTS_LABEL,\
 from models.event import Event
 
 
-class TestEventGroupByWeek(unittest2.TestCase):
+class TestEventgroup_by_week(unittest2.TestCase):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
@@ -203,8 +203,8 @@ class TestEventGroupByWeek(unittest2.TestCase):
         ndb.put_multi(events)
 
         # Begin testing
-        events.sort(key=EventHelper.distantFutureIfNoStartDate)
-        week_events = EventHelper.groupByWeek(events)
+        events.sort(key=EventHelper.start_date_or_distant_future)
+        week_events = EventHelper.group_by_week(events)
 
         for key in events_by_week.keys():
             try:

--- a/src/backend/common/helpers/event_helper.py
+++ b/src/backend/common/helpers/event_helper.py
@@ -36,25 +36,25 @@ class EventHelper(object):
         Sorts by start date then end date
         Sort is stable
         """
-        events.sort(key=cls.distantFutureIfNoStartDate)
-        events.sort(key=cls.distantFutureIfNoEndDate)
+        events.sort(key=cls.start_date_or_distant_future)
+        events.sort(key=cls.end_date_or_distant_future)
 
     @classmethod
-    def distantFutureIfNoStartDate(cls, event: Event) -> datetime:
+    def start_date_or_distant_future(cls, event: Event) -> datetime:
         if not event.start_date:
             return datetime(2177, 1, 1, 1, 1, 1)
         else:
             return event.time_as_utc(event.start_date)
 
     @classmethod
-    def distantFutureIfNoEndDate(cls, event: Event) -> datetime:
+    def end_date_or_distant_future(cls, event: Event) -> datetime:
         if not event.end_date:
             return datetime(2177, 1, 1, 1, 1, 1)
         else:
             return event.end_date
 
     @classmethod
-    def groupByWeek(cls, events: List[Event]) -> Dict[str, List[Event]]:
+    def group_by_week(cls, events: List[Event]) -> Dict[str, List[Event]]:
         """
         Events should already be ordered by start_date
         """
@@ -120,7 +120,7 @@ class EventHelper(object):
         return year == "2015" and event_short not in {"cc", "cacc", "mttd"}
 
     @staticmethod
-    def calculateTeamAvgScoreFromMatches(
+    def calculate_team_avg_score(
         team_key: TeamKey, matches: List[Match]
     ) -> TeamAvgScore:
         """
@@ -155,9 +155,7 @@ class EventHelper(object):
         )
 
     @staticmethod
-    def calculateTeamWLTFromMatches(
-        team_key: TeamKey, matches: List[Match]
-    ) -> WLTRecord:
+    def calculate_wlt(team_key: TeamKey, matches: List[Match]) -> WLTRecord:
         """
         Given a team_key and some matches, find the Win Loss Tie.
         """
@@ -180,7 +178,7 @@ class EventHelper(object):
 
     @classmethod
     @memoize(timeout=3600)  # 1 hour
-    def getWeekEvents(cls) -> List[Event]:
+    def week_events(cls) -> List[Event]:
         """
         Get events this week
         In general, if an event is currently going on, it shows up in this query

--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -261,8 +261,8 @@ def _set_account_status(status: str) -> None:
 #             subs = match_subs.get(match.key.id(), None)
 #             match_fav_subs_by_event[event_key][1].append((match, fav, subs))
 #
-#         event_match_fav_subs = sorted(match_fav_subs_by_event.values(), key=lambda x: EventHelper.distantFutureIfNoStartDate(x[0]))
-#         event_match_fav_subs = sorted(event_match_fav_subs, key=lambda x: EventHelper.distantFutureIfNoEndDate(x[0]))
+#         event_match_fav_subs = sorted(match_fav_subs_by_event.values(), key=lambda x: EventHelper.start_date_or_distant_future(x[0]))
+#         event_match_fav_subs = sorted(event_match_fav_subs, key=lambda x: EventHelper.end_date_or_distant_future(x[0]))
 #
 #         self.template_values['team_fav_subs'] = team_fav_subs
 #         self.template_values['event_fav_subs'] = event_fav_subs

--- a/src/backend/web/handlers/district.py
+++ b/src/backend/web/handlers/district.py
@@ -53,7 +53,7 @@ def district_detail(
     live_eventteams_futures = []
 
     if year == datetime.datetime.now().year:  # Only show active teams for current year
-        live_events = EventHelper.getWeekEvents()
+        live_events = EventHelper.week_events()
     for event in live_events:
         live_eventteams_futures.append(EventTeamsQuery(event.key_name).fetch_async())
     """
@@ -63,7 +63,7 @@ def district_detail(
     events_by_key = {}
     for event in events:
         events_by_key[event.key.id()] = event
-    week_events = EventHelper.groupByWeek(events)
+    week_events = EventHelper.group_by_week(events)
 
     valid_districts: List[Tuple[str, DistrictAbbreviation]] = []
     districts_in_year = districts_in_year_future.get_result()
@@ -125,10 +125,10 @@ def district_detail(
 
     live_events_with_teams.sort(key=lambda x: x[0].name)
     live_events_with_teams.sort(
-        key=lambda x: EventHelper.distantFutureIfNoStartDate(x[0])
+        key=lambda x: EventHelper.start_date_or_distant_future(x[0])
     )
     live_events_with_teams.sort(
-        key=lambda x: EventHelper.distantFutureIfNoEndDate(x[0])
+        key=lambda x: EventHelper.end_date_or_distant_future(x[0])
     )
 
     # Get valid years

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -49,7 +49,7 @@ def event_list(year: Optional[Year] = None) -> Response:
 
     EventHelper.sort_events(events)
 
-    week_events = EventHelper.groupByWeek(events)
+    week_events = EventHelper.group_by_week(events)
 
     districts = []  # a tuple of (district abbrev, district name)
     for district in districts_future.get_result():

--- a/src/backend/web/handlers/index.py
+++ b/src/backend/web/handlers/index.py
@@ -39,7 +39,7 @@ def index_kickoff(template_values: Dict[str, Any]) -> str:
             ),
         }
     )
-    # "events": EventHelper.getWeekEvents(),
+    # "events": EventHelper.week_events(),
     # "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
     # "special_webcasts": special_webcasts
     return render_template("index/index_kickoff.html", template_values)
@@ -56,14 +56,14 @@ def index_buildseason(template_values: Dict[str, Any]) -> str:
             ),
         }
     )
-    # "events": EventHelper.getWeekEvents(),
+    # "events": EventHelper.week_events(),
     # "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
     # "special_webcasts": special_webcasts,
     return render_template("index/index_buildseason.html", template_values)
 
 
 def index_competitionseason(template_values: Dict[str, Any]) -> str:
-    # week_events = EventHelper.getWeekEvents()
+    # week_events = EventHelper.week_events()
     # popular_teams_events = TeamHelper.getPopularTeamsEvents(week_events)
     #
     # # Only show special webcasts that aren't also hosting an event
@@ -119,7 +119,7 @@ def index_offseason(template_values: Dict[str, Any]) -> str:
     # effective_season_year = SeasonHelper.effective_season_year()
     #
     # template_values.update({
-    #     "events": EventHelper.getWeekEvents(),
+    #     "events": EventHelper.week_events(),
     #     "kickoff_datetime_utc": SeasonHelper.kickoff_datetime_utc(effective_season_year),
     #     "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
     #     "special_webcasts": special_webcasts,
@@ -128,7 +128,7 @@ def index_offseason(template_values: Dict[str, Any]) -> str:
 
 
 def index_insights(template_values: Dict[str, Any]) -> str:
-    # week_events = EventHelper.getWeekEvents()
+    # week_events = EventHelper.week_events()
     # year = datetime.datetime.now().year
     # special_webcasts = FirebasePusher.get_special_webcasts()
     # template_values.update({

--- a/src/backend/web/handlers/tests/account_overview_test.py
+++ b/src/backend/web/handlers/tests/account_overview_test.py
@@ -776,6 +776,10 @@ def test_overview_api_write_add_button(
     assert template.name == "account_overview.html"
 
     soup = bs4.BeautifulSoup(response.data, "html.parser")
-    api_write_key_row = soup.find("div", attrs={"class": "row"}, id="api-write-keys-row")
-    api_write_key_row_button = api_write_key_row.find("a", attrs={"href": "request/apiwrite", "class": "btn btn-success pull-right"})
+    api_write_key_row = soup.find(
+        "div", attrs={"class": "row"}, id="api-write-keys-row"
+    )
+    api_write_key_row_button = api_write_key_row.find(
+        "a", attrs={"href": "request/apiwrite", "class": "btn btn-success pull-right"}
+    )
     assert api_write_key_row_button.text == " Request Tokens"

--- a/src/backend/web/renderers/team_renderer.py
+++ b/src/backend/web/renderers/team_renderer.py
@@ -133,7 +133,7 @@ class TeamRenderer(object):
 
             if year == 2015:
                 display_wlt = None
-                match_avg = EventHelper.calculateTeamAvgScoreFromMatches(
+                match_avg = EventHelper.calculate_team_avg_score(
                     team.key_name, event_matches
                 )
                 year_match_avg_list.append(match_avg)
@@ -141,9 +141,7 @@ class TeamRenderer(object):
             else:
                 qual_avg = None
                 elim_avg = None
-                wlt = EventHelper.calculateTeamWLTFromMatches(
-                    team.key_name, event_matches
-                )
+                wlt = EventHelper.calculate_wlt(team.key_name, event_matches)
                 if event.event_type_enum in event_type.SEASON_EVENT_TYPES:
                     season_wlt_list.append(wlt)
                 else:


### PR DESCRIPTION
The `EventHelper` methods have peev'd me for a while now, since they're named pretty poorly. I also added some tests, since it looked like these methods didn't have complete test coverage (but pretty good!)