### PR TITLE
Do not install app requirements during container boostrap - will be installed by dev_appserver

### DIFF
--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -8,7 +8,6 @@ mkdir -p /datastore
 pip2 install grpcio
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-pip install -r src/requirements.txt
 
 # nodejs dependencies
 npm install uglify-js --silent


### PR DESCRIPTION
Noted in the comment but - this PR looks to speed up bootstrapping a development container but not installing the app dependencies. `dev_appserver` does an install of these for us, so we don't need to be installing them globally in the container.