### PR TITLE
Remove migrated routes from old_py2/main.py

### DIFF
--- a/old_py2/main.py
+++ b/old_py2/main.py
@@ -5,9 +5,8 @@ from webapp2_extras.routes import RedirectRoute
 import tba_config
 
 from consts.landing_type import LandingType
-from controllers.account_controller import AccountEdit, AccountLoginRequired, AccountLogin, AccountLogout, \
-AccountOverview, AccountRegister, MyTBAController, myTBAAddHotMatchesController, MyTBAEventController, \
-MyTBAMatchController, MyTBATeamController, AccountAPIReadKeyAdd, AccountAPIReadKeyDelete
+from controllers.account_controller import myTBAAddHotMatchesController, MyTBAEventController, \
+MyTBAMatchController, MyTBATeamController
 from controllers.advanced_search_controller import AdvancedSearchController
 from controllers.ajax_controller import AccountInfoHandler, AccountRegisterFCMToken, AccountFavoritesHandler, AccountFavoritesAddHandler, AccountFavoritesDeleteHandler, \
       YouTubePlaylistHandler, AllowedApiWriteEventsHandler, PlayoffTypeGetHandler
@@ -73,13 +72,6 @@ class Webapp2HandlerAdapter(webapp2.BaseHandlerAdapter):
 
 app = webapp2.WSGIApplication([
       RedirectRoute(r'/2champs', TwoChampsHandler, '2champs', strict_slash=True),
-      RedirectRoute(r'/account', AccountOverview, 'account-overview', strict_slash=True),
-      RedirectRoute(r'/account/api/read_key_add', AccountAPIReadKeyAdd, 'account-api-read-key-add', strict_slash=True),
-      RedirectRoute(r'/account/api/read_key_delete', AccountAPIReadKeyDelete, 'account-api-read-key-delete', strict_slash=True),
-      RedirectRoute(r'/account/edit', AccountEdit, 'account-edit', strict_slash=True),
-      RedirectRoute(r'/account/register', AccountRegister, 'account-register', strict_slash=True),
-      RedirectRoute(r'/account/login_required', AccountLoginRequired, 'account-login-required', strict_slash=True),
-      RedirectRoute(r'/account/mytba', MyTBAController, 'account-mytba', strict_slash=True),
       RedirectRoute(r'/account/mytba/add_hot_matches/<event_key>', myTBAAddHotMatchesController, 'account-mytba-add-hot-matches', strict_slash=True),
       RedirectRoute(r'/account/mytba/add_hot_matches', myTBAAddHotMatchesController, 'account-mytba-add-hot-matches', strict_slash=True),
       RedirectRoute(r'/account/mytba/event/<event_key>', MyTBAEventController, 'account-mytba-event', strict_slash=True),


### PR DESCRIPTION
Pretty boring but - removing the migrated routes will help us figure out which routes still need to be migrated moving forward.