### PR TITLE
Use render names for Subscription.notification_names

### DIFF
--- a/src/backend/common/models/subscription.py
+++ b/src/backend/common/models/subscription.py
@@ -5,7 +5,7 @@ from pyre_extensions import safe_cast
 
 from backend.common.consts.notification_type import NotificationType
 from backend.common.consts.notification_type import (
-    TYPE_NAMES as NOTIFICATION_TYPE_NAMES,
+    RENDER_NAMES as NOTIFICATION_RENDER_NAMES,
 )
 from backend.common.models.mytba import MyTBAModel
 
@@ -27,7 +27,7 @@ class Subscription(MyTBAModel):
     @property
     def notification_names(self) -> List[str]:
         return [
-            NOTIFICATION_TYPE_NAMES[NotificationType(index)]
+            NOTIFICATION_RENDER_NAMES[NotificationType(index)]
             for index in self.notification_types
         ]
 

--- a/src/backend/common/models/tests/subscription_test.py
+++ b/src/backend/common/models/tests/subscription_test.py
@@ -9,7 +9,7 @@ def test_notification_names():
             NotificationType.MATCH_SCORE,
         ]
     )
-    assert subscription.notification_names == ["upcoming_match", "match_score"]
+    assert subscription.notification_names == ["Upcoming Match", "Match Score"]
 
 
 # def test_users_subscribed_to_event_year(self):


### PR DESCRIPTION
The `TYPE_NAMES` are not what we want, since we're using the `notification_names` method for display purposes (the myTBA page). We should use `RENDER_NAMES` instead.