### PR TITLE
Add MyTBA helper model on User model - for myTBA page

### DIFF
--- a/src/backend/web/models/mytba.py
+++ b/src/backend/web/models/mytba.py
@@ -1,0 +1,119 @@
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import groupby
+from typing import Dict, List, Optional, Set, Type
+
+from google.cloud import ndb
+
+from backend.common.consts.model_type import ModelType
+from backend.common.helpers.event_helper import EventHelper
+from backend.common.helpers.match_helper import MatchHelper
+from backend.common.models.event import Event
+from backend.common.models.favorite import Favorite
+from backend.common.models.match import Match
+from backend.common.models.mytba import MyTBAModel
+from backend.common.models.subscription import Subscription
+from backend.common.models.team import Team
+
+
+@dataclass
+class MyTBA:
+    """ A wrapper object for a collection of myTBA models for a given user """
+
+    def __init__(self, models: List[MyTBAModel]) -> None:
+        self.models = models
+
+    @property
+    def event_models(self) -> List[MyTBAModel]:
+        return [model for model in self.models if model.model_type == ModelType.EVENT]
+
+    @staticmethod
+    def _event_keys(models: List[MyTBAModel]) -> Set[ndb.Key]:
+        return {ndb.Key(Event, model.model_key) for model in models}
+
+    @property
+    def events(self) -> List[Event]:
+        event_models = self.event_models
+        wildcard_event_models = [m for m in event_models if m.is_wildcard]
+
+        event_keys = MyTBA._event_keys([m for m in event_models if not m.is_wildcard])
+        futures = ndb.get_multi_async(event_keys)
+        events = [f.get_result() for f in futures]
+
+        for model in wildcard_event_models:
+            event_year = int(model.model_key[:-1])
+            events.append(
+                Event(
+                    id=model.model_key,
+                    short_name="ALL EVENTS",
+                    event_short=model.model_key,
+                    year=event_year,
+                    start_date=datetime(event_year, 1, 1),
+                    end_date=datetime(event_year, 1, 1),
+                )
+            )
+
+        EventHelper.sort_events(events)
+
+        return events
+
+    @property
+    def team_models(self) -> List[MyTBAModel]:
+        return [model for model in self.models if model.model_type == ModelType.TEAM]
+
+    @property
+    def teams(self) -> List[Team]:
+        team_keys = {ndb.Key(Team, model.model_key) for model in self.team_models}
+        futures = ndb.get_multi_async(team_keys)
+        return sorted(
+            [f.get_result() for f in futures], key=lambda team: team.team_number
+        )
+
+    @property
+    def match_models(self) -> List[MyTBAModel]:
+        return [model for model in self.models if model.model_type == ModelType.MATCH]
+
+    @property
+    def matches(self) -> List[Match]:
+        match_keys = {ndb.Key(Match, model.model_key) for model in self.match_models}
+        futures = ndb.get_multi_async(match_keys)
+        matches = [f.get_result() for f in futures]
+        MatchHelper.natural_sort_matches(matches)
+        return matches
+
+    @property
+    def event_matches(self) -> Dict[ndb.Key, List[Match]]:
+        # Key is an Event key, value is a list of Matches for that Event
+        return {
+            group[0]: [match for match in group[1]]
+            for group in groupby(self.matches, key=lambda x: x.event)
+        }
+
+    def favorite(self, model_type: ModelType, model_key: str) -> Optional[Favorite]:
+        return self._first_model(Favorite, model_type, model_key)  # pyre-ignore[7]
+
+    def subscription(
+        self, model_type: ModelType, model_key: str
+    ) -> Optional[Subscription]:
+        return self._first_model(Subscription, model_type, model_key)  # pyre-ignore[7]
+
+    def _first_model(
+        self,
+        mytba_model_type: Type[MyTBAModel],
+        model_type: ModelType,
+        model_key: str,
+    ) -> Optional[MyTBAModel]:
+        # Note: There's probably a way to do this where mytba_model_type is a Generic Type and the return
+        # is that Type. But I couldn't figure it out.
+        # ~ zach
+        return next(
+            iter(
+                [
+                    model
+                    for model in self.models
+                    if type(model) == mytba_model_type
+                    if model.model_type == model_type and model.model_key == model_key
+                ]
+            ),
+            None,
+        )

--- a/src/backend/web/models/tests/mytba_test.py
+++ b/src/backend/web/models/tests/mytba_test.py
@@ -1,0 +1,189 @@
+from datetime import datetime
+from typing import List
+from unittest.mock import ANY, patch
+
+from google.cloud import ndb
+
+from backend.common.consts.comp_level import CompLevel
+from backend.common.consts.event_type import EventType
+from backend.common.consts.model_type import ModelType
+from backend.common.helpers.event_helper import EventHelper
+from backend.common.helpers.match_helper import MatchHelper
+from backend.common.models.event import Event
+from backend.common.models.favorite import Favorite
+from backend.common.models.match import Match
+from backend.common.models.mytba import MyTBAModel
+from backend.common.models.subscription import Subscription
+from backend.common.models.team import Team
+from backend.web.models.mytba import MyTBA
+
+
+def _create_one_of_each_mytba_model() -> List[MyTBAModel]:
+    e1 = Event(
+        id="2020miket",
+        year=2020,
+        event_short="miket",
+        event_type_enum=EventType.DISTRICT,
+    )
+    e1.put()
+    e2 = Event(
+        id="2020mitry",
+        year=2020,
+        event_short="mitry",
+        event_type_enum=EventType.DISTRICT,
+    )
+    e2.put()
+    ef = Favorite(model_key=e1.key.string_id(), model_type=ModelType.EVENT)
+    es = Subscription(model_key=e2.key.string_id(), model_type=ModelType.EVENT)
+
+    team1 = Team(id="frc1", team_number=1)
+    team1.put()
+    team2 = Team(id="frc2", team_number=2)
+    team2.put()
+
+    tf = Favorite(model_key=team1.key.string_id(), model_type=ModelType.TEAM)
+    ts = Subscription(model_key=team2.key.string_id(), model_type=ModelType.TEAM)
+
+    m1 = Match(
+        id="2020miket_qm1",
+        event=e1.key,
+        year=2020,
+        comp_level=CompLevel.QM,
+        set_number=1,
+        match_number=1,
+        alliances_json="",
+    )
+    m1.put()
+    m2 = Match(
+        id="2020miket_qm2",
+        event=e1.key,
+        year=2020,
+        comp_level=CompLevel.QM,
+        set_number=1,
+        match_number=2,
+        alliances_json="",
+    )
+    m2.put()
+    mf = Favorite(model_key=m1.key.string_id(), model_type=ModelType.MATCH)
+    ms = Subscription(model_key=m2.key.string_id(), model_type=ModelType.MATCH)
+
+    return [ef, es, tf, ts, mf, ms]
+
+
+def test_event_models() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+    event_models = mytba.event_models
+
+    assert len(event_models) == 2
+    assert all([model.model_type == ModelType.EVENT for model in event_models])
+
+
+def test_events() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+
+    with patch.object(EventHelper, "sort_events") as mock_sort_events:
+        events = mytba.events
+    mock_sort_events.assert_called_with(ANY)
+
+    assert len(events) == 2
+    assert all([type(event) is Event for event in events])
+    assert {event.key.id() for event in events} == {"2020miket", "2020mitry"}
+
+
+def test_events_wildcard() -> None:
+    wildcard = Subscription(model_key="2019*", model_type=ModelType.EVENT)
+    mytba = MyTBA([wildcard])
+
+    with patch.object(EventHelper, "sort_events") as mock_sort_events:
+        events = mytba.events
+    mock_sort_events.assert_called_with(ANY)
+
+    assert len(events) == 1
+
+    wildcard_event = events.pop()
+    assert wildcard_event.key.id() == "2019*"
+    assert wildcard_event.short_name == "ALL EVENTS"
+    assert wildcard_event.event_short == "2019*"
+    assert wildcard_event.year == 2019
+    assert wildcard_event.start_date == datetime(2019, 1, 1)
+    assert wildcard_event.end_date == datetime(2019, 1, 1)
+
+
+def test_team_models() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+    team_models = mytba.team_models
+
+    assert len(team_models) == 2
+    assert all([model.model_type == ModelType.TEAM for model in team_models])
+
+
+def test_teams() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+    teams = mytba.teams
+
+    assert len(teams) == 2
+    assert all([type(team) is Team for team in teams])
+    assert {team.key.id() for team in teams} == {"frc1", "frc2"}
+
+
+def test_match_models() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+    match_models = mytba.match_models
+
+    assert len(match_models) == 2
+    assert all([model.model_type == ModelType.MATCH for model in match_models])
+
+
+def test_matches() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+
+    with patch.object(MatchHelper, "natural_sort_matches") as mock_natural_sort_matches:
+        matches = mytba.matches
+    mock_natural_sort_matches.assert_called_with(ANY)
+
+    assert len(matches) == 2
+    assert all([type(match) is Match for match in matches])
+    assert {match.key.id() for match in matches} == {"2020miket_qm1", "2020miket_qm2"}
+
+
+def test_event_matches() -> None:
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+    event_matches = mytba.event_matches
+
+    expected_key = ndb.Key(Event, "2020miket")
+
+    keys = event_matches.keys()
+    assert list(keys) == [expected_key]
+
+    values = event_matches[expected_key]
+    assert len(values) == 2
+    assert all([type(value) is Match for value in values])
+
+
+def test_favorite():
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+
+    favorite = mytba.favorite(ModelType.TEAM, "frc2")
+    assert favorite is None
+
+    favorite = mytba.favorite(ModelType.TEAM, "frc1")
+    assert favorite is not None
+
+
+def test_subscription():
+    models = _create_one_of_each_mytba_model()
+    mytba = MyTBA(models)
+
+    subscription = mytba.subscription(ModelType.TEAM, "frc1")
+    assert subscription is None
+
+    subscription = mytba.subscription(ModelType.TEAM, "frc2")
+    assert subscription is not None

--- a/src/backend/web/models/tests/user_test.py
+++ b/src/backend/web/models/tests/user_test.py
@@ -628,3 +628,30 @@ def test_delete_api_key() -> None:
     assert len(user.api_read_keys) == 1
     user.delete_api_key(api_key)
     assert len(user.api_read_keys) == 0
+
+
+def test_mytba() -> None:
+    email = "zach@thebluealliance.com"
+
+    account = Account(id="account", email=email)
+    account.put()
+
+    f = Favorite(
+        parent=account.key,
+        user_id=account.key.id(),
+        model_key="frc7332",
+        model_type=ModelType.TEAM,
+    )
+    f.put()
+    s = Subscription(
+        parent=account.key,
+        user_id=account.key.id(),
+        model_key="frc7332",
+        model_type=ModelType.TEAM,
+    )
+    s.put()
+
+    user = User(session_claims={"email": email})
+    mytba = user.myTBA
+    assert mytba is not None
+    assert mytba.models == [f, s]

--- a/src/backend/web/models/user.py
+++ b/src/backend/web/models/user.py
@@ -3,7 +3,7 @@ import string
 from typing import Any, Dict, List, Optional, Union
 
 from google.cloud import ndb
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, safe_cast
 
 from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.auth_type import AuthType
@@ -12,6 +12,7 @@ from backend.common.models.account import Account
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.favorite import Favorite
 from backend.common.models.mobile_client import MobileClient
+from backend.common.models.mytba import MyTBAModel
 from backend.common.models.subscription import Subscription
 from backend.common.queries.account_query import AccountQuery
 from backend.common.queries.api_auth_access_query import ApiAuthAccessQuery
@@ -19,6 +20,7 @@ from backend.common.queries.favorite_query import FavoriteQuery
 from backend.common.queries.mobile_client_query import MobileClientQuery
 from backend.common.queries.subscription_query import SubscriptionQuery
 from backend.common.queries.suggestion_query import SuggestionQuery
+from backend.web.models.mytba import MyTBA
 
 
 class User:
@@ -96,6 +98,13 @@ class User:
             user_ids=[none_throws(none_throws(self._account).key.string_id())],
             only_verified=False,
         ).fetch()
+
+    @property
+    def myTBA(self) -> MyTBA:
+        models = safe_cast(List[MyTBAModel], self.favorites) + safe_cast(
+            List[MyTBAModel], self.subscriptions
+        )
+        return MyTBA(models)
 
     @property
     def favorites(self) -> List[Favorite]:


### PR DESCRIPTION
This adds a `MyTBA` model to the `web` service to be used for the `/account/mytba` page. It pulls all of the business logic out of the controller that used to be querying the required models for the myTBA page in to a testable helper class. A `MyTBA` model can be created for a `User`'s `favorites` + `subscriptions` via `user.myTBA`