### PR TITLE
 Make EventHelper.sort_events clearer how it sorts, add description in comment, and rename to sorted_events, and return the sorted events as opposed to in-place sort

### DIFF
--- a/src/backend/common/helpers/event_helper.py
+++ b/src/backend/common/helpers/event_helper.py
@@ -31,13 +31,24 @@ class TeamAvgScore(NamedTuple):
 
 class EventHelper(object):
     @classmethod
-    def sort_events(cls, events: List[Event]) -> None:
+    def sorted_events(cls, events: List[Event]) -> List[Event]:
         """
-        Sorts by start date then end date
-        Sort is stable
+        Sort events first by end date (ascending), and break ties by start date (ascending)
+        Ex:
+            e1 = Event(start_date=(2010, 3, 1), end_date=(2010, 3, 3))
+            e2 = Event(start_date=(2010, 3, 2), end_date=(2010, 3, 4))
+            e3 = Event(start_date=(2010, 3, 1), end_date=(2010, 3, 4))
+
+            EventHelper.sorted_events([e1, e2, e3])
+            > [e1, e3, e2]
         """
-        events.sort(key=cls.start_date_or_distant_future)
-        events.sort(key=cls.end_date_or_distant_future)
+        return sorted(
+            events,
+            key=lambda x: (
+                cls.end_date_or_distant_future(x),
+                cls.start_date_or_distant_future(x),
+            ),
+        )
 
     @classmethod
     def start_date_or_distant_future(cls, event: Event) -> datetime:
@@ -217,5 +228,4 @@ class EventHelper(object):
                 ):
                     events.append(event)
 
-        cls.sort_events(events)
-        return events
+        return cls.sorted_events(events)

--- a/src/backend/common/helpers/tests/event_helper_test.py
+++ b/src/backend/common/helpers/tests/event_helper_test.py
@@ -229,7 +229,7 @@ def test_calculate_wlt(ndb_context) -> None:
     assert wlt == WLTRecord(wins=1, losses=1, ties=1)
 
 
-def test_sort_events_start_date(ndb_context) -> None:
+def test_sorted_events_start_date(ndb_context) -> None:
     e1 = Event(
         start_date=datetime.datetime(2010, 2, 21),
         end_date=datetime.datetime(2010, 3, 2),
@@ -239,16 +239,11 @@ def test_sort_events_start_date(ndb_context) -> None:
         end_date=datetime.datetime(2010, 3, 2),
     )
 
-    events = [e2, e1]
-    EventHelper.sort_events(events)
-    assert events == [e1, e2]
-
-    events = [e1, e2]
-    EventHelper.sort_events(events)
+    events = EventHelper.sorted_events([e2, e1])
     assert events == [e1, e2]
 
 
-def test_sort_events_end_date(ndb_context) -> None:
+def test_sorted_events_end_date(ndb_context) -> None:
     e1 = Event(
         start_date=datetime.datetime(2010, 3, 1),
         end_date=datetime.datetime(2010, 3, 2),
@@ -258,28 +253,48 @@ def test_sort_events_end_date(ndb_context) -> None:
         end_date=datetime.datetime(2010, 3, 3),
     )
 
-    events = [e1, e2]
-    EventHelper.sort_events(events)
-    assert events == [e1, e2]
-
-    events = [e2, e1]
-    EventHelper.sort_events(events)
+    events = EventHelper.sorted_events([e2, e1])
     assert events == [e1, e2]
 
 
-def test_sort_events_distant_future_event(ndb_context) -> None:
+def test_sorted_events_start_date_end_date(ndb_context) -> None:
+    e1 = Event(
+        start_date=datetime.datetime(2010, 3, 1),
+        end_date=datetime.datetime(2010, 3, 3),
+    )
+    e2 = Event(
+        start_date=datetime.datetime(2010, 3, 2),
+        end_date=datetime.datetime(2010, 3, 4),
+    )
+    e3 = Event(
+        start_date=datetime.datetime(2010, 3, 1),
+        end_date=datetime.datetime(2010, 3, 4),
+    )
+    e4 = Event(
+        start_date=datetime.datetime(2002, 3, 1),
+        end_date=datetime.datetime(2002, 3, 2),
+    )
+
+    expected_order = [e4, e1, e3, e2]
+
+    events = [e1, e2, e3, e4]
+    # Ensure compatability with the previous sorting
+    events.sort(key=EventHelper.start_date_or_distant_future)
+    events.sort(key=EventHelper.end_date_or_distant_future)
+    assert events == expected_order
+
+    events = EventHelper.sorted_events([e1, e2, e3, e4])
+    assert events == expected_order
+
+
+def test_sorted_events_distant_future_event(ndb_context) -> None:
     e1 = Event()
     e2 = Event(
         start_date=datetime.datetime(2010, 3, 1),
         end_date=datetime.datetime(2010, 3, 2),
     )
 
-    events = [e1, e2]
-    EventHelper.sort_events(events)
-    assert events == [e2, e1]
-
-    events = [e2, e1]
-    EventHelper.sort_events(events)
+    events = EventHelper.sorted_events([e1, e2])
     assert events == [e2, e1]
 
 

--- a/src/backend/web/handlers/district.py
+++ b/src/backend/web/handlers/district.py
@@ -60,8 +60,7 @@ def district_detail(
     for event in live_events:
         live_eventteams_futures.append(EventTeamsQuery(event.key_name).fetch_async())
 
-    events = events_future.get_result()
-    EventHelper.sort_events(events)
+    events = EventHelper.sorted_events(events_future.get_result())
     events_by_key = {}
     for event in events:
         events_by_key[event.key.id()] = event

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -43,11 +43,9 @@ def event_list(year: Optional[Year] = None) -> Response:
     else:
         events_future = all_events_future
 
-    events = events_future.get_result()
+    events = EventHelper.sorted_events(events_future.get_result())
     if state_prov == "" or (state_prov and not events):
         return redirect(request.path)
-
-    EventHelper.sort_events(events)
 
     week_events = EventHelper.group_by_week(events)
 

--- a/src/backend/web/models/mytba.py
+++ b/src/backend/web/models/mytba.py
@@ -53,9 +53,7 @@ class MyTBA:
                 )
             )
 
-        EventHelper.sort_events(events)
-
-        return events
+        return EventHelper.sorted_events(events)
 
     @property
     def team_models(self) -> List[MyTBAModel]:

--- a/src/backend/web/models/tests/mytba_test.py
+++ b/src/backend/web/models/tests/mytba_test.py
@@ -7,7 +7,6 @@ from google.cloud import ndb
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.event_type import EventType
 from backend.common.consts.model_type import ModelType
-from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.models.event import Event
 from backend.common.models.favorite import Favorite
@@ -83,9 +82,7 @@ def test_events() -> None:
     models = _create_one_of_each_mytba_model()
     mytba = MyTBA(models)
 
-    with patch.object(EventHelper, "sort_events") as mock_sort_events:
-        events = mytba.events
-    mock_sort_events.assert_called_with(ANY)
+    events = mytba.events
 
     assert len(events) == 2
     assert all([type(event) is Event for event in events])
@@ -96,10 +93,7 @@ def test_events_wildcard() -> None:
     wildcard = Subscription(model_key="2019*", model_type=ModelType.EVENT)
     mytba = MyTBA([wildcard])
 
-    with patch.object(EventHelper, "sort_events") as mock_sort_events:
-        events = mytba.events
-    mock_sort_events.assert_called_with(ANY)
-
+    events = mytba.events
     assert len(events) == 1
 
     wildcard_event = events.pop()


### PR DESCRIPTION
After a long Slack conversation - this method was unclear as to how it was suppose to be working. The changes here should make it more obvious how this method should function.