### PR TITLE
Remove migrated code from old_py2/event_helper

### DIFF
--- a/old_py2/helpers/event_helper.py
+++ b/old_py2/helpers/event_helper.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import collections
 import datetime
 import re
 
@@ -213,12 +212,6 @@ class EventHelper(object):
         # An event slipped through!
         logging.warn("Event type '{}' not recognized!".format(event_type_str))
         return EventType.UNLABLED
-
-    @classmethod
-    def is_2015_playoff(Cls, event_key):
-        year = event_key[:4]
-        event_short = event_key[4:]
-        return year == '2015' and event_short not in {'cc', 'cacc', 'mttd'}
 
     @classmethod
     def remapteams_matches(cls, matches, remap_teams):


### PR DESCRIPTION
A bit of a drive-by PR but - removes some already-migrated code from the old_py2/event_helper file so we can better keep track of what still needs to be migrated.