### PR TITLE
Fix bug in myTBA render where matches were not sorting properly

### DIFF
--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -189,16 +189,13 @@ def mytba() -> str:
     mytba_teams = sorted(mytba.teams, key=lambda team: team.team_number)
 
     mytba_event_matches = mytba.event_matches
-    mytba_event_matches_events = [
-        event_key.get() for event_key in mytba_event_matches.keys()
+    mytba_event_matches_events = EventHelper.sorted_events(
+        [event_key.get() for event_key in mytba_event_matches.keys()]
+    )
+    event_matches = [
+        (event, MatchHelper.natural_sort_matches(mytba_event_matches[event.key]))
+        for event in mytba_event_matches_events
     ]
-    mytba_event_matches_events = EventHelper.sorted_events(mytba_event_matches_events)
-
-    event_matches = []
-    for event in mytba_event_matches_events:
-        matches = mytba_event_matches[event.key]
-        MatchHelper.natural_sort_matches(matches)
-        event_matches.append((event, matches))
 
     template_values = {
         "event_fav_sub": [

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -605,6 +605,7 @@ def test_mytba(
     mock_mytba = Mock()
 
     mock_event = Mock()
+    mock_event_sorted = Mock()
     mock_events = [mock_event]
     mock_mytba.events = mock_events
 
@@ -613,9 +614,10 @@ def test_mytba(
 
     mock_event_key = Mock()
     mock_event_key.configure_mock(**{"get.return_value": mock_event})
-    mock_event.key = mock_event_key
+    mock_event_sorted.key = mock_event_key
 
     mock_match = Mock()
+    mock_match_sorted = Mock()
     mock_matches = [mock_match]
     mock_event_matches = {mock_event_key: mock_matches}
     mock_mytba.event_matches = mock_event_matches
@@ -659,11 +661,11 @@ def test_mytba(
     ), patch.object(
         backend.common.helpers.event_helper.EventHelper,
         "sorted_events",
-        return_value=mock_events,
+        return_value=[mock_event_sorted],
     ) as mock_sorted_events, patch.object(
         backend.common.helpers.match_helper.MatchHelper,
         "natural_sort_matches",
-        return_value=mock_matches,
+        return_value=[mock_match_sorted],
     ) as mock_natural_sort_matches, patch.object(
         backend.common.helpers.season_helper.SeasonHelper,
         "effective_season_year",
@@ -683,12 +685,12 @@ def test_mytba(
     mock_effective_season_year.assert_called()
 
     assert context["event_fav_sub"] == [
-        (mock_event, mock_event_favorite, mock_event_subscription)
+        (mock_event_sorted, mock_event_favorite, mock_event_subscription)
     ]
     assert context["team_fav_sub"] == [
         (mock_team, mock_team_favorite, mock_team_subscription)
     ]
     assert context["event_match_fav_sub"] == [
-        (mock_event, [(mock_match, mock_match_favorite, mock_match_subscription)])
+        (mock_event_sorted, [(mock_match_sorted, mock_match_favorite, mock_match_subscription)])
     ]
     assert context["year"] == mock_year


### PR DESCRIPTION
I don't want to set up *even more* state in this test, but our test coverage wasn't good enough to ensure that the myTBA method was using the return of `MatchHelper.natural_sort_matches` as opposed to just calling it. This fixes that bug, and adds tests to ensure we're using the returns of these helper methods as expected.