### PR TITLE
Rename MatchHelper methods from camelCase to snake_case, change `sort` to `sorted`/`organize` to `organized`

### DIFF
--- a/old_py2/api/apiv3/api_event_controller.py
+++ b/old_py2/api/apiv3/api_event_controller.py
@@ -132,8 +132,8 @@ class ApiEventPlayoffAdvancementController(ApiBaseController):
         matches, matches_updated = matches_future.get_result()
         self._last_modified = max(event_updated, matches_updated)
 
-        cleaned_matches = MatchHelper.deleteInvalidMatches(matches, event)
-        matches = MatchHelper.organizeMatches(cleaned_matches)
+        cleaned_matches = MatchHelper.delete_invalid_matches(matches, event)
+        matches = MatchHelper.organized_matches(cleaned_matches)
         bracket_table = event.playoff_bracket
         playoff_advancement = event.playoff_advancement
 

--- a/old_py2/controllers/admin/admin_cron_controller.py
+++ b/old_py2/controllers/admin/admin_cron_controller.py
@@ -376,7 +376,7 @@ class AdminPostEventTasksDo(LoggedInHandler):
         awards = []
         event = event_future.get_result()
         if event.event_type_enum in {EventType.OFFSEASON, EventType.FOC}:
-            matches = MatchHelper.organizeMatches(matches_future.get_result())
+            matches = MatchHelper.organized_matches(matches_future.get_result())
             bracket = PlayoffAdvancementHelper.generateBracket(matches, event, event.alliance_selections)
             if 'f' in bracket:
                 winning_alliance = '{}_alliance'.format(bracket['f']['f1']['winning_alliance'])

--- a/old_py2/controllers/admin/admin_event_controller.py
+++ b/old_py2/controllers/admin/admin_event_controller.py
@@ -126,8 +126,8 @@ class AdminPlayoffAdvancementAddController(LoggedInHandler):
         parsed_advancement = CSVAdvancementParser.parse(advancement_csv, matches_per_team)
         advancement = PlayoffAdvancementHelper.generatePlayoffAdvancementFromCSV(event, parsed_advancement, comp_level)
 
-        cleaned_matches = MatchHelper.deleteInvalidMatches(event.matches, event)
-        matches = MatchHelper.organizeMatches(cleaned_matches)
+        cleaned_matches = MatchHelper.delete_invalid_matches(event.matches, event)
+        matches = MatchHelper.organized_matches(cleaned_matches)
         bracket_table = PlayoffAdvancementHelper.generateBracket(matches, event, event.alliance_selections)
         comp_levels = bracket_table.keys()
         for comp_level in comp_levels:
@@ -409,7 +409,7 @@ class AdminEventDeleteMatches(LoggedInHandler):
         if not event:
             self.abort(404)
 
-        organized_matches = MatchHelper.organizeMatches(event.matches)
+        organized_matches = MatchHelper.organized_matches(event.matches)
         if comp_level not in organized_matches:
             self.abort(400)
             return
@@ -456,7 +456,7 @@ class AdminEventDetail(LoggedInHandler):
                 "bracket_table": event.playoff_bracket
             }) if playoff_template else "None"
 
-        organized_matches = MatchHelper.organizeMatches(event.matches)
+        organized_matches = MatchHelper.organized_matches(event.matches)
         match_stats = []
         for comp_level in Match.COMP_LEVELS:
             level_matches = organized_matches[comp_level]

--- a/old_py2/controllers/cron_controller.py
+++ b/old_py2/controllers/cron_controller.py
@@ -176,7 +176,7 @@ class EventMatchstatsDo(webapp.RequestHandler):
 
         predictions_dict = None
         if event.year in {2016, 2017, 2018, 2019, 2020} and event.event_type_enum in EventType.SEASON_EVENT_TYPES or event.enable_predictions:
-            sorted_matches = MatchHelper.play_order_sort_matches(event.matches)
+            sorted_matches = MatchHelper.play_order_sorted_matches(event.matches)
             match_predictions, match_prediction_stats, stat_mean_vars = PredictionHelper.get_match_predictions(sorted_matches)
             ranking_predictions, ranking_prediction_stats = PredictionHelper.get_ranking_predictions(sorted_matches, match_predictions)
 
@@ -673,7 +673,7 @@ class MatchTimePredictionsDo(webapp.RequestHandler):
             return
 
         timezone = pytz.timezone(event.timezone_id)
-        played_matches = MatchHelper.recentMatches(matches, num=0)
+        played_matches = MatchHelper.recent_matches(matches, num=0)
         unplayed_matches = MatchHelper.upcomingMatches(matches, num=len(matches))
         MatchTimePredictionHelper.predict_future_matches(event_key, played_matches, unplayed_matches, timezone, event.within_a_day)
 
@@ -736,8 +736,8 @@ class RebuildPlayoffAdvancementDo(webapp.RequestHandler):
         event, _ = event_future.get_result()
         matches, _ = matches_future.get_result()
 
-        cleaned_matches = MatchHelper.deleteInvalidMatches(matches, event)
-        matches = MatchHelper.organizeMatches(cleaned_matches)
+        cleaned_matches = MatchHelper.delete_invalid_matches(matches, event)
+        matches = MatchHelper.organized_matches(cleaned_matches)
         bracket_table, playoff_advancement, _, _ = PlayoffAdvancementHelper.generatePlayoffAdvancement(event, matches)
 
         event_details = EventDetails(

--- a/old_py2/controllers/datafeed_controller.py
+++ b/old_py2/controllers/datafeed_controller.py
@@ -268,7 +268,7 @@ class FMSAPIMatchesGet(webapp.RequestHandler):
         df = DatafeedFMSAPI('v2.0', save_response=True)
         event = Event.get_by_id(event_key)
 
-        matches = MatchHelper.deleteInvalidMatches(
+        matches = MatchHelper.delete_invalid_matches(
             df.getMatches(event_key),
             Event.get_by_id(event_key)
         )

--- a/old_py2/controllers/event_controller.py
+++ b/old_py2/controllers/event_controller.py
@@ -162,8 +162,8 @@ class EventDetail(CacheableHandler):
             event_codivisions_future = EventDivisionsQuery(event.parent_event.id()).fetch_async()
 
         awards = AwardHelper.organizeAwards(event.awards)
-        cleaned_matches = MatchHelper.deleteInvalidMatches(event.matches, event)
-        matches = MatchHelper.organizeMatches(cleaned_matches)
+        cleaned_matches = MatchHelper.delete_invalid_matches(event.matches, event)
+        matches = MatchHelper.organized_matches(cleaned_matches)
         teams = TeamHelper.sortTeams(event.teams)
 
         # Organize medias by team
@@ -187,7 +187,7 @@ class EventDetail(CacheableHandler):
         oprs = oprs[:15]  # get the top 15 OPRs
 
         if event.now:
-            matches_recent = MatchHelper.recentMatches(cleaned_matches)
+            matches_recent = MatchHelper.recent_matches(cleaned_matches)
             matches_upcoming = MatchHelper.upcomingMatches(cleaned_matches)
         else:
             matches_recent = None
@@ -292,8 +292,8 @@ class EventInsights(CacheableHandler):
         ranking_predictions = event.details.predictions.get('ranking_predictions', None)
         ranking_prediction_stats = event.details.predictions.get('ranking_prediction_stats', None)
 
-        cleaned_matches = MatchHelper.deleteInvalidMatches(event.matches, event)
-        matches = MatchHelper.organizeMatches(cleaned_matches)
+        cleaned_matches = MatchHelper.delete_invalid_matches(event.matches, event)
+        matches = MatchHelper.organized_matches(cleaned_matches)
 
         # If no matches but there are match predictions, create fake matches
         # For cases where FIRST doesn't allow posting of match schedule
@@ -388,7 +388,7 @@ class EventRss(CacheableHandler):
         if not event:
             self.abort(404)
 
-        matches = MatchHelper.organizeMatches(event.matches)
+        matches = MatchHelper.organized_matches(event.matches)
 
         self.template_values.update({
             "event": event,

--- a/old_py2/controllers/match_suggestion_controller.py
+++ b/old_py2/controllers/match_suggestion_controller.py
@@ -57,7 +57,7 @@ class MatchSuggestionHandler(LoggedInHandler):
         for event in current_events:
             if not event.details:
                 continue
-            finished_matches += MatchHelper.recentMatches(event.matches, num=1)
+            finished_matches += MatchHelper.recent_matches(event.matches, num=1)
             for i, match in enumerate(MatchHelper.upcomingMatches(event.matches, num=3)):
                 if not match.time:
                     continue

--- a/old_py2/controllers/nightbot_controller.py
+++ b/old_py2/controllers/nightbot_controller.py
@@ -74,7 +74,7 @@ class NightbotTeamNextmatchHandler(CacheableHandler):
         event_code_upper = event.event_short.upper()
 
         matches_future = TeamEventMatchesQuery('frc{}'.format(team_number), event.key.id()).fetch_async()
-        matches = MatchHelper.play_order_sort_matches(matches_future.get_result())
+        matches = MatchHelper.play_order_sorted_matches(matches_future.get_result())
 
         # No match schedule yet
         if not matches:

--- a/old_py2/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/old_py2/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -210,7 +210,7 @@ class FMSAPIHybridScheduleParser(object):
         if self.year == 2015:
             # Fix null teams in elims (due to FMS API failure, some info not complete)
             # Should only happen for sf and f matches
-            organized_matches = MatchHelper.organizeMatches(parsed_matches)
+            organized_matches = MatchHelper.organized_matches(parsed_matches)
             for level in ['sf', 'f']:
                 playoff_advancement = PlayoffAdvancementHelper.generatePlayoffAdvancement2015(organized_matches)
                 if playoff_advancement[LAST_LEVEL[level]] != []:

--- a/old_py2/helpers/apiai_helper.py
+++ b/old_py2/helpers/apiai_helper.py
@@ -279,7 +279,7 @@ class APIAIHelper(object):
             for event in events:
                 if event.now:
                     matches = TeamEventMatchesQuery(team_key, event.key.id()).fetch()
-                    matches = MatchHelper.play_order_sort_matches(matches)
+                    matches = MatchHelper.play_order_sorted_matches(matches)
                     if matches:
                         next_match = None
                         for match in matches:

--- a/old_py2/helpers/district_helper.py
+++ b/old_py2/helpers/district_helper.py
@@ -300,7 +300,7 @@ class DistrictHelper(object):
         else:
             logging.info("Event {} has no rankings for qual_points calculations!".format(event.key.id()))
 
-        matches = MatchHelper.organizeMatches(matches)
+        matches = MatchHelper.organized_matches(matches)
 
         # qual match calculations. only used for tiebreaking
         for match in matches['qm']:

--- a/old_py2/helpers/event_simulator.py
+++ b/old_py2/helpers/event_simulator.py
@@ -111,8 +111,8 @@ class EventSimulator(object):
         self._event_details = event.details
         self._alliance_selections_without_backup = copy.deepcopy(event.details.alliance_selections)
         self._alliance_selections_without_backup[1]['backup'] = None
-        self._played_matches = MatchHelper.organizeMatches(event.matches)
-        self._all_matches = MatchHelper.organizeMatches(event.matches + unplayed_matches)
+        self._played_matches = MatchHelper.organized_matches(event.matches)
+        self._all_matches = MatchHelper.organized_matches(event.matches + unplayed_matches)
 
         # Delete data
         event.details.key.delete()
@@ -212,7 +212,7 @@ class EventSimulator(object):
                 MatchManipulator.createOrUpdate(match)
             self._step += 1
         elif self._step == 4:  # After each QF match
-            new_match = MatchHelper.play_order_sort_matches(self._played_matches['qf'])[self._substep]
+            new_match = MatchHelper.play_order_sorted_matches(self._played_matches['qf'])[self._substep]
             MatchManipulator.createOrUpdate(new_match)
 
             if not self._batch_advance:
@@ -267,7 +267,7 @@ class EventSimulator(object):
                     MatchManipulator.createOrUpdate(match)
                 self._step += 1
         elif self._step == 6:  # After each SF match
-            new_match = MatchHelper.play_order_sort_matches(self._played_matches['sf'])[self._substep]
+            new_match = MatchHelper.play_order_sorted_matches(self._played_matches['sf'])[self._substep]
             MatchManipulator.createOrUpdate(new_match)
 
             if not self._batch_advance:
@@ -323,7 +323,7 @@ class EventSimulator(object):
                 self._step += 1
         elif self._step == 8:  # After each F match
             MatchManipulator.createOrUpdate(
-                MatchHelper.play_order_sort_matches(
+                MatchHelper.play_order_sorted_matches(
                     self._played_matches['f'])[self._substep])
             if self._substep < len(self._played_matches['f']) - 1:
                 self._substep += 1
@@ -334,6 +334,6 @@ class EventSimulator(object):
         ndb.get_context().clear_cache()
         # Re fetch event matches
         event = Event.get_by_id('2016nytr')
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         ndb.get_context().clear_cache()
         self._update_rankings()

--- a/old_py2/helpers/event_team_status_helper.py
+++ b/old_py2/helpers/event_team_status_helper.py
@@ -199,15 +199,15 @@ class EventTeamStatusHelper(object):
         Generate a dict containing team@event status information
         :param team_key: Key name of the team to focus on
         :param event: Event object
-        :param matches: Organized matches (via MatchHelper.organizeMatches) from the event, optional
+        :param matches: Organized matches (via MatchHelper.organized_matches) from the event, optional
         """
         event_details = event.details
         if not matches:
             matches = event.matches
         team_matches = [m for m in matches if team_key in m.team_key_names]
         next_match = MatchHelper.upcomingMatches(team_matches, num=1)
-        last_match = MatchHelper.recentMatches(team_matches, num=1)
-        matches = MatchHelper.organizeMatches(matches)
+        last_match = MatchHelper.recent_matches(team_matches, num=1)
+        matches = MatchHelper.organized_matches(matches)
         return copy.deepcopy({
             'qual': cls._build_qual_info(team_key, event_details, matches, event.year),
             'alliance': cls._build_alliance_info(team_key, event_details, matches),

--- a/old_py2/helpers/event_team_updater.py
+++ b/old_py2/helpers/event_team_updater.py
@@ -95,7 +95,7 @@ class EventTeamUpdater(object):
         """
         First alliance to win two finals matches is the winner
         """
-        matches_by_type = MatchHelper.organizeMatches(matches)
+        matches_by_type = MatchHelper.organized_matches(matches)
         if 'f' not in matches_by_type or not matches_by_type['f']:
             return set()
         finals_matches = matches_by_type['f']

--- a/old_py2/helpers/match_helper.py
+++ b/old_py2/helpers/match_helper.py
@@ -27,7 +27,7 @@ class MatchHelper(object):
             logging.warning('Cannot compute match time for event with no timezone_id: {}'.format(event.key_name))
             return
 
-        matches_reversed = cls.play_order_sort_matches(matches, reverse=True)
+        matches_reversed = cls.play_order_sorted_matches(matches, reverse=True)
         tz = pytz.timezone(event.timezone_id)
 
         last_match_time = None
@@ -59,7 +59,7 @@ class MatchHelper(object):
         if event.year < 2008 or event.event_type_enum not in EventType.SEASON_EVENT_TYPES:
             return
 
-        qual_matches = cls.organizeMatches(event.matches)['qm']
+        qual_matches = cls.organized_matches(event.matches)['qm']
         if not qual_matches:
             return
 
@@ -102,7 +102,7 @@ class MatchHelper(object):
         return matches
 
     @classmethod
-    def deleteInvalidMatches(self, match_list, event):
+    def delete_invalid_matches(self, match_list, event):
         """
         A match is invalid iff it is an elim match that has not been played
         and the same alliance already won in 2 match numbers in the same set.
@@ -210,4 +210,3 @@ class MatchHelper(object):
             return True
         else:
             return valid_breakdowns
-    

--- a/old_py2/helpers/notification_helper.py
+++ b/old_py2/helpers/notification_helper.py
@@ -83,7 +83,7 @@ class NotificationHelper(object):
             matches = event.matches
             if not matches:
                 continue
-            last_matches = MatchHelper.recentMatches(matches, num=1)
+            last_matches = MatchHelper.recent_matches(matches, num=1)
             next_matches = MatchHelper.upcomingMatches(matches, num=2)
 
             # First, compare the difference between scheduled times of next/last match

--- a/old_py2/helpers/prediction_helper.py
+++ b/old_py2/helpers/prediction_helper.py
@@ -609,7 +609,7 @@ class PredictionHelper(object):
 
     @classmethod
     def get_ranking_predictions(cls, matches, match_predictions, n=1000):
-        matches = MatchHelper.organizeMatches(matches)['qm']
+        matches = MatchHelper.organized_matches(matches)['qm']
         if not matches or not match_predictions:
             return None, None
 

--- a/old_py2/tests/test_event_simulator.py
+++ b/old_py2/tests/test_event_simulator.py
@@ -55,7 +55,7 @@ class TestEventSimulator(unittest2.TestCase):
             self.assertEqual(event.details.alliance_selections, None)
             self.assertEqual(len(event.matches), 72)
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if j <= i:
                     self.assertTrue(match.has_been_played)
@@ -103,7 +103,7 @@ class TestEventSimulator(unittest2.TestCase):
             else:
                 self.assertEqual(len(event.matches), 88)  # 1 match removed, 3 added
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if match.key.id() in {'2016nytr_qf1m3', '2016nytr_qf3m3'}:
                     # Unneeded tiebreak matches
@@ -144,7 +144,7 @@ class TestEventSimulator(unittest2.TestCase):
             else:
                 self.assertEqual(len(event.matches), 90)  # 1 match removed, 3 added
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if match.key.id() == '2016nytr_sf1m3':
                     # Unneeded tiebreak matches
@@ -177,7 +177,7 @@ class TestEventSimulator(unittest2.TestCase):
             self.assertEqual(event.details.alliance_selections, self._alliance_selections_with_backup)
             self.assertEqual(len(event.matches), 90)
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if j <= i:
                     self.assertTrue(match.has_been_played)
@@ -216,7 +216,7 @@ class TestEventSimulator(unittest2.TestCase):
             self.assertEqual(event.details.alliance_selections, None)
             self.assertEqual(len(event.matches), 72)
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if j <= i:
                     self.assertTrue(match.has_been_played)
@@ -263,7 +263,7 @@ class TestEventSimulator(unittest2.TestCase):
             else:
                 self.assertEqual(len(event.matches), 82)
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if match.key.id() in {'2016nytr_qf1m3', '2016nytr_qf3m3'}:
                     # Unneeded tiebreak matches
@@ -305,7 +305,7 @@ class TestEventSimulator(unittest2.TestCase):
             else:
                 self.assertEqual(len(event.matches), 87)
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if match.key.id() == '2016nytr_sf1m3':
                     # Unneeded tiebreak matches
@@ -339,7 +339,7 @@ class TestEventSimulator(unittest2.TestCase):
             self.assertEqual(event.details.alliance_selections, self._alliance_selections_with_backup)
             self.assertEqual(len(event.matches), 90)
 
-            matches = MatchHelper.play_order_sort_matches(event.matches)
+            matches = MatchHelper.play_order_sorted_matches(event.matches)
             for j, match in enumerate(matches):
                 if j <= i:
                     self.assertTrue(match.has_been_played)

--- a/old_py2/tests/test_fms_api_hybrid_schedule_parser.py
+++ b/old_py2/tests/test_fms_api_hybrid_schedule_parser.py
@@ -65,7 +65,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEqual(len(matches), 88)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["qm"]), 88)
 
         # Changed format in 2018
@@ -76,7 +76,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEqual(len(matches), 88)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["qm"]), 88)
 
     def test_parse_playoff(self):
@@ -100,7 +100,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEqual(len(matches), 15)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["ef"]), 0)
             self.assertEqual(len(clean_matches["qf"]), 9)
             self.assertEqual(len(clean_matches["sf"]), 4)
@@ -130,7 +130,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEquals(len(matches), 36)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["ef"]), 20)
             self.assertEqual(len(clean_matches["qf"]), 10)
             self.assertEqual(len(clean_matches["sf"]), 4)
@@ -158,7 +158,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEqual(len(matches), 17)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["ef"]), 0)
             self.assertEqual(len(clean_matches["qf"]), 8)
             self.assertEqual(len(clean_matches["sf"]), 6)
@@ -189,7 +189,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEquals(len(matches), 6)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["ef"]), 0)
             self.assertEqual(len(clean_matches["qf"]), 0)
             self.assertEqual(len(clean_matches["sf"]), 4)
@@ -219,7 +219,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEquals(len(matches), 18)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["ef"]), 0)
             self.assertEqual(len(clean_matches["qf"]), 0)
             self.assertEqual(len(clean_matches["sf"]), 15)
@@ -250,7 +250,7 @@ class TestFMSAPIEventListParser(unittest2.TestCase):
             self.assertEquals(len(matches), 5)
 
             # Assert we get enough of each match type
-            clean_matches = MatchHelper.organizeMatches(matches)
+            clean_matches = MatchHelper.organized_matches(matches)
             self.assertEqual(len(clean_matches["ef"]), 0)
             self.assertEqual(len(clean_matches["qf"]), 0)
             self.assertEqual(len(clean_matches["sf"]), 0)

--- a/old_py2/tests/test_fms_api_match_tiebreaker.py
+++ b/old_py2/tests/test_fms_api_match_tiebreaker.py
@@ -49,7 +49,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
             file_time = datetime.datetime.strptime(time_str, "%Y-%m-%d %H:%M:%S.%f")
             query_time = file_time + datetime.timedelta(seconds=30)
             MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=query_time).getMatches('2017{}'.format(event_code)), run_post_update_hook=False)
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
 
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017flwp'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 7)
@@ -90,7 +90,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         event.put()
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 04, 21, 22)).getMatches('2017flwp'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
 
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017flwp'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 5)
@@ -104,7 +104,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 04, 21, 35)).getMatches('2017flwp'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
 
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017flwp'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 6)
@@ -133,7 +133,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         event.put()
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 05, 20, 45)).getMatches('2017pahat'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         f_matches = Match.query(Match.event == ndb.Key(Event, '2017pahat'), Match.comp_level == 'f').fetch()
         self.assertEqual(len(f_matches), 3)
         old_match = Match.get_by_id('2017pahat_f1m2')
@@ -146,7 +146,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 05, 21, 02)).getMatches('2017pahat'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         f_matches = Match.query(Match.event == ndb.Key(Event, '2017pahat'), Match.comp_level == 'f').fetch()
         self.assertEqual(len(f_matches), 4)
         new_match = Match.get_by_id('2017pahat_f1m2')
@@ -185,7 +185,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
             file_time = datetime.datetime.strptime(time_str, "%Y-%m-%d %H:%M:%S.%f")
             query_time = file_time + datetime.timedelta(seconds=30)
             MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=query_time).getMatches('2017{}'.format(event_code)), run_post_update_hook=False)
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
 
         qf_matches = Match.query(Match.event == ndb.Key(Event, '2017scmb'), Match.comp_level == 'qf').fetch()
         self.assertEqual(len(qf_matches), 11)
@@ -227,7 +227,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         event.put()
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 04, 19, 17)).getMatches('2017scmb'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         qf_matches = Match.query(Match.event == ndb.Key(Event, '2017scmb'), Match.comp_level == 'qf').fetch()
         self.assertEqual(len(qf_matches), 12)
 
@@ -239,7 +239,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 04, 19, 50)).getMatches('2017scmb'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         qf_matches = Match.query(Match.event == ndb.Key(Event, '2017scmb'), Match.comp_level == 'qf').fetch()
         self.assertEqual(len(qf_matches), 12)
 
@@ -255,7 +255,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 04, 20, 12)).getMatches('2017scmb'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         qf_matches = Match.query(Match.event == ndb.Key(Event, '2017scmb'), Match.comp_level == 'qf').fetch()
         self.assertEqual(len(qf_matches), 12)
 
@@ -275,7 +275,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 04, 20, 48)).getMatches('2017scmb'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         qf_matches = Match.query(Match.event == ndb.Key(Event, '2017scmb'), Match.comp_level == 'qf').fetch()
         self.assertEqual(len(qf_matches), 13)
 
@@ -307,7 +307,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         event.put()
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 05, 21, 2)).getMatches('2017ncwin'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017ncwin'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 6)
 
@@ -319,7 +319,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 05, 21, 30)).getMatches('2017ncwin'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017ncwin'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 6)
 
@@ -335,7 +335,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 05, 21, 35)).getMatches('2017ncwin'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017ncwin'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 6)
 
@@ -355,7 +355,7 @@ class TestFMSAPIMatchTiebreaker(unittest2.TestCase):
         ndb.get_context().clear_cache()  # Prevent data from leaking between tests
 
         MatchManipulator.createOrUpdate(DatafeedFMSAPI('v2.0', sim_time=datetime.datetime(2017, 3, 05, 21, 51)).getMatches('2017ncwin'))
-        MatchHelper.deleteInvalidMatches(event.matches, event)
+        MatchHelper.delete_invalid_matches(event.matches, event)
         sf_matches = Match.query(Match.event == ndb.Key(Event, '2017ncwin'), Match.comp_level == 'sf').fetch()
         self.assertEqual(len(sf_matches), 7)
 

--- a/old_py2/tests/test_match_cleanup.py
+++ b/old_py2/tests/test_match_cleanup.py
@@ -47,7 +47,7 @@ class TestMatchCleanup(unittest2.TestCase):
 
     def test_cleanup(self):
         matches = self.setupMatches('test_data/cleanup_matches.csv')
-        cleaned_matches = MatchHelper.deleteInvalidMatches(matches, self.event)
+        cleaned_matches = MatchHelper.delete_invalid_matches(matches, self.event)
         indices = {9, 12, 26}
         correct_matches = []
         for i, match in enumerate(matches):

--- a/src/backend/common/helpers/event_team_status_helper.py
+++ b/src/backend/common/helpers/event_team_status_helper.py
@@ -305,15 +305,15 @@ class EventTeamStatusHelper:
         Generate a dict containing team@event status information
         :param team_key: Key name of the team to focus on
         :param event: Event object
-        :param matches: Organized matches (via MatchHelper.organizeMatches) from the event, optional
+        :param matches: Organized matches (via MatchHelper.organized_matches) from the event, optional
         """
         event_details = event.details
         if not match_list:
             match_list = event.matches
         team_matches = [m for m in match_list if team_key in m.team_key_names]
-        next_match = MatchHelper.upcomingMatches(team_matches, num=1)
-        last_match = MatchHelper.recentMatches(team_matches, num=1)
-        matches = MatchHelper.organizeMatches(match_list)[1]
+        next_match = MatchHelper.upcoming_matches(team_matches, num=1)
+        last_match = MatchHelper.recent_matches(team_matches, num=1)
+        matches = MatchHelper.organized_matches(match_list)[1]
         status = EventTeamStatus(
             qual=cls._build_qual_info(team_key, event_details, matches, event.year),
             alliance=cls._build_alliance_info(team_key, event_details, matches),

--- a/src/backend/common/helpers/match_helper.py
+++ b/src/backend/common/helpers/match_helper.py
@@ -25,7 +25,7 @@ class MatchHelper(object):
     """
 
     @classmethod
-    def natural_sort_matches(cls, matches: List[Match]) -> List[Match]:
+    def natural_sorted_matches(cls, matches: List[Match]) -> List[Match]:
         def convert(text):
             return int(text) if text.isdigit() else text.lower()
 
@@ -35,14 +35,16 @@ class MatchHelper(object):
         return sorted(matches, key=alphanum_key)
 
     @classmethod
-    def play_order_sort_matches(
+    def play_order_sorted_matches(
         cls, matches: List[Match], reverse: bool = False
     ) -> List[Match]:
         return sorted(matches, key=lambda m: m.play_order, reverse=reverse)
 
     @classmethod
-    def organizeMatches(cls, match_list: List[Match]) -> Tuple[int, TOrganizedMatches]:
-        match_list = cls.natural_sort_matches(match_list)
+    def organized_matches(
+        cls, match_list: List[Match]
+    ) -> Tuple[int, TOrganizedMatches]:
+        match_list = cls.natural_sorted_matches(match_list)
         matches = dict([(comp_level, list()) for comp_level in COMP_LEVELS])
         count = len(match_list)
         while len(match_list) > 0:
@@ -51,9 +53,9 @@ class MatchHelper(object):
 
         return count, matches
 
-    # Assumed that organizeMatches is called first
+    # Assumed that organized_matches is called first
     @classmethod
-    def organizeDoubleElimMatches(
+    def organized_double_elim_matches(
         cls, organized_matches: TOrganizedMatches
     ) -> TOrganizedDoubleElimMatches:
         matches = collections.defaultdict(lambda: collections.defaultdict(list))
@@ -69,14 +71,14 @@ class MatchHelper(object):
         return matches
 
     @classmethod
-    def recentMatches(cls, matches: List[Match], num: int = 3) -> List[Match]:
+    def recent_matches(cls, matches: List[Match], num: int = 3) -> List[Match]:
         matches = list(filter(lambda x: x.has_been_played, matches))
-        matches = cls.play_order_sort_matches(matches)
+        matches = cls.play_order_sorted_matches(matches)
         return matches[-num:]
 
     @classmethod
-    def upcomingMatches(cls, matches: List[Match], num: int = 3) -> List[Match]:
-        matches = cls.play_order_sort_matches(matches)
+    def upcoming_matches(cls, matches: List[Match], num: int = 3) -> List[Match]:
+        matches = cls.play_order_sorted_matches(matches)
 
         last_played_match_index = None
         for i, match in enumerate(reversed(matches)):
@@ -94,7 +96,7 @@ class MatchHelper(object):
 
     """
     @classmethod
-    def deleteInvalidMatches(cls, match_list: List[Match], event: Event) -> List[Match]:
+    def delete_invalid_matches(cls, match_list: List[Match], event: Event) -> List[Match]:
         \"""
         A match is invalid iff it is an elim match that has not been played
         and the same alliance already won in 2 match numbers in the same set.

--- a/src/backend/common/helpers/playoff_advancement_helper.py
+++ b/src/backend/common/helpers/playoff_advancement_helper.py
@@ -92,7 +92,7 @@ class PlayoffAdvancementHelper(object):
     ) -> Optional[TOrganizedDoubleElimMatches]:
         double_elim_matches = None
         if event.playoff_type == PlayoffType.DOUBLE_ELIM_8_TEAM:
-            double_elim_matches = MatchHelper.organizeDoubleElimMatches(matches)
+            double_elim_matches = MatchHelper.organized_double_elim_matches(matches)
         return double_elim_matches
 
     @classmethod

--- a/src/backend/common/helpers/tests/match_helper_test.py
+++ b/src/backend/common/helpers/tests/match_helper_test.py
@@ -13,12 +13,12 @@ def auto_add_ndb_context(ndb_context) -> None:
     pass
 
 
-def test_organize_matches_counts(test_data_importer) -> None:
+def test_organized_matches_counts(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019nyny_matches.json"
     )
 
-    count, organized_matches = MatchHelper.organizeMatches(matches)
+    count, organized_matches = MatchHelper.organized_matches(matches)
     assert count == 94
     assert len(organized_matches[CompLevel.QM]) == 77
     assert len(organized_matches[CompLevel.QF]) == 11
@@ -27,12 +27,12 @@ def test_organize_matches_counts(test_data_importer) -> None:
     assert len(organized_matches[CompLevel.F]) == 2
 
 
-def test_organize_matches_sorted(test_data_importer) -> None:
+def test_organized_matches_sorted(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019nyny_matches.json"
     )
 
-    _, organized_matches = MatchHelper.organizeMatches(matches)
+    _, organized_matches = MatchHelper.organized_matches(matches)
     quals = organized_matches[CompLevel.QM]
     quarters = organized_matches[CompLevel.QF]
     assert all(
@@ -45,13 +45,13 @@ def test_organize_matches_sorted(test_data_importer) -> None:
     )
 
 
-def test_organize_double_elim_matches(test_data_importer) -> None:
+def test_organized_double_elim_matches(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2017wiwi_matches.json"
     )
 
-    _, organized_matches = MatchHelper.organizeMatches(matches)
-    double_elim_matches = MatchHelper.organizeDoubleElimMatches(organized_matches)
+    _, organized_matches = MatchHelper.organized_matches(matches)
+    double_elim_matches = MatchHelper.organized_double_elim_matches(organized_matches)
 
     assert DoubleElimBracket.WINNER in double_elim_matches
     assert DoubleElimBracket.LOSER in double_elim_matches
@@ -70,7 +70,7 @@ def test_play_order_sort(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019nyny_matches.json"
     )
-    sorted_matches = MatchHelper.play_order_sort_matches(matches)
+    sorted_matches = MatchHelper.play_order_sorted_matches(matches)
     assert len(sorted_matches) == 94
     assert all(
         sorted_matches[i].play_order <= sorted_matches[i + 1].play_order
@@ -90,7 +90,7 @@ def test_recent_matches(test_data_importer) -> None:
             m.alliances_json = json.dumps(m.alliances)
             m._alliances = None
 
-    recent_matches = MatchHelper.recentMatches(quals, num=3)
+    recent_matches = MatchHelper.recent_matches(quals, num=3)
     assert [m.key_name for m in recent_matches] == [
         "2019nyny_qm68",
         "2019nyny_qm69",
@@ -109,7 +109,7 @@ def test_recent_matches_none_played(test_data_importer) -> None:
         m.alliances_json = json.dumps(m.alliances)
         m._alliances = None
 
-    recent_matches = MatchHelper.recentMatches(quals, num=3)
+    recent_matches = MatchHelper.recent_matches(quals, num=3)
     assert recent_matches == []
 
 
@@ -125,7 +125,7 @@ def test_upcoming_matches(test_data_importer) -> None:
             m.alliances_json = json.dumps(m.alliances)
             m._alliances = None
 
-    upcoming_matches = MatchHelper.upcomingMatches(quals, num=3)
+    upcoming_matches = MatchHelper.upcoming_matches(quals, num=3)
     assert [m.key_name for m in upcoming_matches] == [
         "2019nyny_qm71",
         "2019nyny_qm72",
@@ -139,5 +139,5 @@ def test_upcoming_matches_all_played(test_data_importer) -> None:
     )
     quals = [m for m in matches if m.comp_level == CompLevel.QM]
 
-    upcoming_matches = MatchHelper.upcomingMatches(quals, num=3)
+    upcoming_matches = MatchHelper.upcoming_matches(quals, num=3)
     assert upcoming_matches == []

--- a/src/backend/common/helpers/tests/playoff_advancement_helper_test.py
+++ b/src/backend/common/helpers/tests/playoff_advancement_helper_test.py
@@ -30,7 +30,7 @@ def test_standard_bracket(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019nyny_matches.json"
     )
-    organized_matches = MatchHelper.organizeMatches(matches)[1]
+    organized_matches = MatchHelper.organized_matches(matches)[1]
 
     advancement = PlayoffAdvancementHelper.generatePlayoffAdvancement(
         event, organized_matches
@@ -46,7 +46,7 @@ def test_2015_event(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2015nyny_matches.json"
     )
-    organized_matches = MatchHelper.organizeMatches(matches)[1]
+    organized_matches = MatchHelper.organized_matches(matches)[1]
 
     advancement = PlayoffAdvancementHelper.generatePlayoffAdvancement(
         event, organized_matches
@@ -62,7 +62,7 @@ def test_round_robin(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019cmptx_matches.json"
     )
-    organized_matches = MatchHelper.organizeMatches(matches)[1]
+    organized_matches = MatchHelper.organized_matches(matches)[1]
 
     advancement = PlayoffAdvancementHelper.generatePlayoffAdvancement(
         event, organized_matches
@@ -78,7 +78,7 @@ def test_best_of_3_finals(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019nyny_matches.json"
     )
-    organized_matches = MatchHelper.organizeMatches(matches)[1]
+    organized_matches = MatchHelper.organized_matches(matches)[1]
 
     advancement = PlayoffAdvancementHelper.generatePlayoffAdvancement(
         event, organized_matches
@@ -94,7 +94,7 @@ def test_best_of_5_finals(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2019nyny_matches.json"
     )
-    organized_matches = MatchHelper.organizeMatches(matches)[1]
+    organized_matches = MatchHelper.organized_matches(matches)[1]
 
     advancement = PlayoffAdvancementHelper.generatePlayoffAdvancement(
         event, organized_matches

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -720,7 +720,7 @@ class Event(CachedModel):
     @property
     def next_match(self):
         from helpers.match_helper import MatchHelper
-        upcoming_matches = MatchHelper.upcomingMatches(self.matches, 1)
+        upcoming_matches = MatchHelper.upcoming_matches(self.matches, 1)
         if upcoming_matches:
             return upcoming_matches[0]
         else:
@@ -729,7 +729,7 @@ class Event(CachedModel):
     @property
     def previous_match(self):
         from helpers.match_helper import MatchHelper
-        recent_matches = MatchHelper.recentMatches(self.matches, 1)[0]
+        recent_matches = MatchHelper.recent_matches(self.matches, 1)[0]
         if recent_matches:
             return recent_matches[0]
         else:

--- a/src/backend/common/tests/event_simulator.py
+++ b/src/backend/common/tests/event_simulator.py
@@ -127,8 +127,8 @@ class EventSimulator:
             event.details.alliance_selections
         )
         self._alliance_selections_without_backup[1]["backup"] = None
-        self._played_matches = MatchHelper.organizeMatches(event.matches)[1]
-        self._all_matches = MatchHelper.organizeMatches(
+        self._played_matches = MatchHelper.organized_matches(event.matches)[1]
+        self._all_matches = MatchHelper.organized_matches(
             event.matches + unplayed_matches
         )[1]
 
@@ -239,7 +239,7 @@ class EventSimulator:
                 MatchManipulator.createOrUpdate(match)
             self._step += 1
         elif self._step == 4:  # After each QF match
-            new_match = MatchHelper.play_order_sort_matches(
+            new_match = MatchHelper.play_order_sorted_matches(
                 self._played_matches[CompLevel.QF]
             )[self._substep]
             MatchManipulator.createOrUpdate(new_match)
@@ -310,7 +310,7 @@ class EventSimulator:
                     MatchManipulator.createOrUpdate(match)
                 self._step += 1
         elif self._step == 6:  # After each SF match
-            new_match = MatchHelper.play_order_sort_matches(
+            new_match = MatchHelper.play_order_sorted_matches(
                 self._played_matches[CompLevel.SF]
             )[self._substep]
             MatchManipulator.createOrUpdate(new_match)
@@ -384,9 +384,9 @@ class EventSimulator:
                 self._step += 1
         elif self._step == 8:  # After each F match
             MatchManipulator.createOrUpdate(
-                MatchHelper.play_order_sort_matches(self._played_matches[CompLevel.F])[
-                    self._substep
-                ]
+                MatchHelper.play_order_sorted_matches(
+                    self._played_matches[CompLevel.F]
+                )[self._substep]
             )
             if self._substep < len(self._played_matches[CompLevel.F]) - 1:
                 self._substep += 1
@@ -397,6 +397,6 @@ class EventSimulator:
         ndb.get_context().clear_cache()
         # Re fetch event matches
         # event = Event.get_by_id("2016nytr")
-        # MatchHelper.deleteInvalidMatches(event.matches, event)
+        # MatchHelper.delete_invalid_matches(event.matches, event)
         # ndb.get_context().clear_cache()
         self._update_rankings()

--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -193,7 +193,7 @@ def mytba() -> str:
         [event_key.get() for event_key in mytba_event_matches.keys()]
     )
     event_matches = [
-        (event, MatchHelper.natural_sort_matches(mytba_event_matches[event.key]))
+        (event, MatchHelper.natural_sorted_matches(mytba_event_matches[event.key]))
         for event in mytba_event_matches_events
     ]
 

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -107,8 +107,8 @@ def event_detail(event_key: EventKey) -> Response:
 
     awards = AwardHelper.organizeAwards(event.awards)
     cleaned_matches = event.matches
-    # MatchHelper.deleteInvalidMatches(event.matches, event)
-    match_count, matches = MatchHelper.organizeMatches(cleaned_matches)
+    # MatchHelper.delete_invalid_matches(event.matches, event)
+    match_count, matches = MatchHelper.organized_matches(cleaned_matches)
     teams = TeamHelper.sortTeams(event.teams)
 
     # Organize medias by team
@@ -138,8 +138,8 @@ def event_detail(event_key: EventKey) -> Response:
     oprs = oprs[:15]  # get the top 15 OPRs
 
     if event.now:
-        matches_recent = MatchHelper.recentMatches(cleaned_matches)
-        matches_upcoming = MatchHelper.upcomingMatches(cleaned_matches)
+        matches_recent = MatchHelper.recent_matches(cleaned_matches)
+        matches_upcoming = MatchHelper.upcoming_matches(cleaned_matches)
     else:
         matches_recent = None
         matches_upcoming = None

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -664,9 +664,9 @@ def test_mytba(
         return_value=[mock_event_sorted],
     ) as mock_sorted_events, patch.object(
         backend.common.helpers.match_helper.MatchHelper,
-        "natural_sort_matches",
+        "natural_sorted_matches",
         return_value=[mock_match_sorted],
-    ) as mock_natural_sort_matches, patch.object(
+    ) as mock_natural_sorted_matches, patch.object(
         backend.common.helpers.season_helper.SeasonHelper,
         "effective_season_year",
         return_value=mock_year,
@@ -681,7 +681,7 @@ def test_mytba(
     assert template.name == "mytba.html"
 
     mock_sorted_events.assert_called_with(mock_events)
-    mock_natural_sort_matches.assert_called_with(mock_matches)
+    mock_natural_sorted_matches.assert_called_with(mock_matches)
     mock_effective_season_year.assert_called()
 
     assert context["event_fav_sub"] == [
@@ -691,6 +691,9 @@ def test_mytba(
         (mock_team, mock_team_favorite, mock_team_subscription)
     ]
     assert context["event_match_fav_sub"] == [
-        (mock_event_sorted, [(mock_match_sorted, mock_match_favorite, mock_match_subscription)])
+        (
+            mock_event_sorted,
+            [(mock_match_sorted, mock_match_favorite, mock_match_subscription)],
+        )
     ]
     assert context["year"] == mock_year

--- a/src/backend/web/renderers/team_renderer.py
+++ b/src/backend/web/renderers/team_renderer.py
@@ -120,11 +120,13 @@ class TeamRenderer(object):
             event_awards = AwardHelper.organizeAwards(
                 awards_by_event_key.get(event.key, [])
             )
-            match_count, matches_organized = MatchHelper.organizeMatches(event_matches)
+            match_count, matches_organized = MatchHelper.organized_matches(
+                event_matches
+            )
 
             if event.now:
                 current_event = event
-                matches_upcoming = MatchHelper.upcomingMatches(event_matches)
+                matches_upcoming = MatchHelper.upcoming_matches(event_matches)
 
             """
             if event.within_a_day:
@@ -360,7 +362,7 @@ class TeamRenderer(object):
                 matches = match_query.TeamEventMatchesQuery(
                     team.key_name, event.key_name
                 ).fetch()
-                matches_upcoming = MatchHelper.upcomingMatches(matches)
+                matches_upcoming = MatchHelper.upcoming_matches(matches)
 
             """
             if event.within_a_day:


### PR DESCRIPTION
Part of an ongoing effort to de-camel case the *Helper classes. Also changed the verb tense (is that right?) on the methods that return new values to have a clearer API. `sort`/`organize` notates an in-place operation, whereas `sorted`/`organized` notates a returned value.