### PR TITLE
Revert "Do not install app requirements during container boostrap - will be installed by dev_appserver (#3333)"

### DIFF
--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -8,6 +8,7 @@ mkdir -p /datastore
 pip2 install grpcio
 python -m pip install --upgrade pip
 pip install -r requirements.txt
+pip install -r src/requirements.txt
 
 # nodejs dependencies
 npm install uglify-js --silent


### PR DESCRIPTION
I forgot this means we can't run pytest in the container 😅 Reverting this change