### PR TITLE
Return sorted render names for myTBA Subscription notification types

### DIFF
--- a/src/backend/common/models/subscription.py
+++ b/src/backend/common/models/subscription.py
@@ -28,7 +28,7 @@ class Subscription(MyTBAModel):
     def notification_names(self) -> List[str]:
         return [
             NOTIFICATION_RENDER_NAMES[NotificationType(index)]
-            for index in self.notification_types
+            for index in sorted(self.notification_types)
         ]
 
     # @classmethod

--- a/src/backend/common/models/tests/subscription_test.py
+++ b/src/backend/common/models/tests/subscription_test.py
@@ -1,15 +1,22 @@
+from random import shuffle
+
 from backend.common.consts.notification_type import NotificationType
 from backend.common.models.subscription import Subscription
 
 
 def test_notification_names():
+    notification_types = [
+        NotificationType.MATCH_SCORE,
+        NotificationType.UPCOMING_MATCH,
+        NotificationType.FINAL_RESULTS,
+    ]
+    shuffle(notification_types)
+
     subscription = Subscription(
-        notification_types=[
-            NotificationType.UPCOMING_MATCH,
-            NotificationType.MATCH_SCORE,
-        ]
+        notification_types=notification_types
     )
-    assert subscription.notification_names == ["Upcoming Match", "Match Score"]
+    # This order is important - these names should be in a sorted order
+    assert subscription.notification_names == ["Upcoming Match", "Match Score", "Final Results"]
 
 
 # def test_users_subscribed_to_event_year(self):


### PR DESCRIPTION
These names not being in the same order makes the myTBA page a little wonky, since you get subscriptions with the same notification types next to each other but in a different order