### PR TITLE
Add way to skip CachedQueryResult for models

### DIFF
--- a/src/backend/common/models/tests/subscription_test.py
+++ b/src/backend/common/models/tests/subscription_test.py
@@ -12,11 +12,13 @@ def test_notification_names():
     ]
     shuffle(notification_types)
 
-    subscription = Subscription(
-        notification_types=notification_types
-    )
+    subscription = Subscription(notification_types=notification_types)
     # This order is important - these names should be in a sorted order
-    assert subscription.notification_names == ["Upcoming Match", "Match Score", "Final Results"]
+    assert subscription.notification_names == [
+        "Upcoming Match",
+        "Match Score",
+        "Final Results",
+    ]
 
 
 # def test_users_subscribed_to_event_year(self):

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -73,7 +73,8 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
     )
     CACHE_KEY_FORMAT: str = ""
     CACHE_VERSION: int = 0
-    CACHING_ENABLED: bool = True
+    DICT_CACHING_ENABLED: bool = True
+    MODEL_CACHING_ENABLED: bool = True
     CACHE_WRITES_ENABLED: bool = False
     _cache_key: Optional[str] = None
 
@@ -115,7 +116,7 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
 
     @ndb.tasklet
     def _do_query(self, *args, **kwargs) -> TypedFuture[QueryReturn]:
-        if not self.CACHING_ENABLED:
+        if not self.MODEL_CACHING_ENABLED:
             result = yield self._query_async(*args, **kwargs)
             return result  # pyre-ignore[7]
 
@@ -132,7 +133,7 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
     def _do_dict_query(
         self, _dict_version: ApiMajorVersion, *args, **kwargs
     ) -> TypedFuture[DictQueryReturn]:
-        if not self.CACHING_ENABLED:
+        if not self.DICT_CACHING_ENABLED:
             result = yield self._query_async(*args, **kwargs)
             if result is None:
                 raise DoesNotExistException

--- a/src/backend/common/queries/event_details_query.py
+++ b/src/backend/common/queries/event_details_query.py
@@ -15,6 +15,7 @@ class EventDetailsQuery(
 ):
     CACHE_VERSION = 0
     CACHE_KEY_FORMAT = "event_details_{event_key}"
+    MODEL_CACHING_ENABLED = False  # No need to cache a point query
     DICT_CONVERTER = EventDetailsConverter
 
     def __init__(self, event_key: EventKey) -> None:

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -23,6 +23,7 @@ from backend.common.tasklets import typed_tasklet
 class EventQuery(CachedDatabaseQuery[Optional[Event], Optional[EventDict]]):
     CACHE_VERSION = 3
     CACHE_KEY_FORMAT = "event_{event_key}"
+    MODEL_CACHING_ENABLED = False  # No need to cache a point query
     DICT_CONVERTER = EventConverter
 
     def __init__(self, event_key: EventKey) -> None:

--- a/src/backend/common/queries/match_query.py
+++ b/src/backend/common/queries/match_query.py
@@ -16,6 +16,7 @@ from backend.common.tasklets import typed_tasklet
 class MatchQuery(CachedDatabaseQuery[Optional[Match], Optional[MatchDict]]):
     CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "match_{match_key}"
+    MODEL_CACHING_ENABLED = False  # No need to cache a point query
     DICT_CONVERTER = MatchConverter
 
     def __init__(self, match_key: MatchKey) -> None:

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -23,6 +23,7 @@ def get_team_page_num(team_key: str) -> int:
 class TeamQuery(CachedDatabaseQuery[Optional[Team], Optional[TeamDict]]):
     CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "team_{team_key}"
+    MODEL_CACHING_ENABLED = False  # No need to cache a point query
     DICT_CONVERTER = TeamConverter
 
     def __init__(self, team_key: TeamKey) -> None:

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -61,7 +61,6 @@ class CachedDummyModelRangeQuery(
 ):
     CACKE_KEY_FORMAT = "test_query_{min}_{max}"
     DICT_CONVERTER = DummyConverter
-    CACHING_ENABLED = True
     CACHE_WRITES_ENABLED = True
 
     @ndb.tasklet


### PR DESCRIPTION
For example, if a DB Query just make a point query under the hood, then
there is no reason for us to double the datastore overhead by storing it
a second time. We may as well just always load the single model
regularly.

However, for the API, we want to continue caching the dict format of the
model, so leave that.