### PR TITLE
Bump cache versions relying on RenamedDistricts

### DIFF
--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -16,7 +16,7 @@ from backend.common.tasklets import typed_tasklet
 
 
 class DistrictQuery(CachedDatabaseQuery[Optional[District], Optional[DistrictDict]]):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "district_{district_key}"
     DICT_CONVERTER = DistrictConverter
 
@@ -53,7 +53,7 @@ class DistrictsInYearQuery(CachedDatabaseQuery[List[District], List[DistrictDict
 
 
 class DistrictHistoryQuery(CachedDatabaseQuery[List[District], List[DistrictDict]]):
-    CACHE_VERSION = 1
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "district_history_{abbreviation}"
     DICT_CONVERTER = DistrictConverter
 


### PR DESCRIPTION
When we added FIN<-->IN in
https://github.com/the-blue-alliance/the-blue-alliance/commit/5a73e405efd2159773b5ff50e2f5c31a00a79a79
we should have also bumped these, because it's possible we had poisoned
data stored from before the mapping where we're be returning `None`
without taking the mapping into consideration.

And indeed, this will fix #3316