### PR TITLE
Enable CachedQueryResult writes from py3

### DIFF
--- a/src/backend/common/helpers/tests/event_team_status_helper_test.py
+++ b/src/backend/common/helpers/tests/event_team_status_helper_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from google.cloud import ndb
 
 from backend.common.helpers.event_team_status_helper import EventTeamStatusHelper
@@ -10,6 +11,15 @@ from backend.common.models.event_team_status import EventTeamLevelStatus
 from backend.common.models.match import Match
 from backend.common.tests.event_simulator import EventSimulator
 from backend.common.tests.fixture_loader import load_fixture
+
+
+@pytest.fixture(autouse=True)
+def disable_db_query_cache(monkeypatch: MonkeyPatch):
+    # This test doesn't fully clear all the DB caches it needs to, s
+    # just disable writing cached query results for it
+    from backend.common.queries.database_query import CachedDatabaseQuery
+
+    monkeypatch.setattr(CachedDatabaseQuery, "CACHE_WRITES_ENABLED", False)
 
 
 @pytest.mark.usefixtures("ndb_context")

--- a/src/backend/common/legacy_protobuf/legacy_gae_entity_model_encoder.py
+++ b/src/backend/common/legacy_protobuf/legacy_gae_entity_model_encoder.py
@@ -16,6 +16,7 @@
 import datetime
 from typing import Any, Optional
 
+import pytz
 from google.cloud import datastore
 from google.cloud import ndb
 from google.cloud.datastore.helpers import GeoPoint
@@ -255,6 +256,11 @@ class NdbModelEncoder:
                 "DatetimeProperty %s can only be set to datetime values; "
                 "received %r" % (self._name, value)
             )
+        if value.tzinfo == pytz.utc:
+            # There are differences between datastores about naive vs UTC timestamps
+            # So we just account for it here. See https://github.com/googleapis/python-ndb/pull/167
+            value = value.replace(tzinfo=None)  # pyre-ignore[6]
+
         if value.tzinfo is not None:
             raise NotImplementedError(
                 "DatetimeProperty %s can only support UTC. "

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -75,7 +75,7 @@ class CachedDatabaseQuery(DatabaseQuery, Generic[QueryReturn, DictQueryReturn]):
     CACHE_VERSION: int = 0
     DICT_CACHING_ENABLED: bool = True
     MODEL_CACHING_ENABLED: bool = True
-    CACHE_WRITES_ENABLED: bool = False
+    CACHE_WRITES_ENABLED: bool = True
     _cache_key: Optional[str] = None
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/backend/common/queries/tests/last_season_event_test.py
+++ b/src/backend/common/queries/tests/last_season_event_test.py
@@ -5,7 +5,7 @@ from backend.common.models.event import Event
 from backend.common.queries.event_query import LastSeasonEventQuery
 
 
-def test_last_season_event() -> None:
+def test_last_season_event_ignores_offseason() -> None:
     Event(
         id="2020tes3",
         event_short="test 3",
@@ -16,6 +16,8 @@ def test_last_season_event() -> None:
     last_event = LastSeasonEventQuery(year=2020).fetch()
     assert last_event is None
 
+
+def test_last_season_event_one_event() -> None:
     tes1 = Event(
         id="2020tes1",
         event_short="test 1",
@@ -26,6 +28,16 @@ def test_last_season_event() -> None:
     tes1.put()
     assert LastSeasonEventQuery(year=2020).fetch() == tes1
 
+
+def test_last_season_event_two_events() -> None:
+    tes1 = Event(
+        id="2020tes1",
+        event_short="test 1",
+        year=2020,
+        end_date=datetime.datetime(2020, 4, 1, 0, 0),
+        event_type_enum=EventType.REGIONAL,
+    )
+    tes1.put()
     tes2 = Event(
         id="2020tes2",
         event_short="test 2",


### PR DESCRIPTION
We should be good to go on this.
https://github.com/the-blue-alliance/the-blue-alliance/commit/0f79f5ff1202bc1d9d45f3161334cd0ed211510e
should mean that py2 can read data written by py2, and the test suite
we've got here should be making sure that our serialization works round
trip. I can't think of any more testing we can do on this without
enabling it on prod, so here goes.