### PR TITLE
Add support for post update/delete hooks in ManipulatorBase

### DIFF
--- a/src/backend/common/deferred/clients/fake_client.py
+++ b/src/backend/common/deferred/clients/fake_client.py
@@ -6,17 +6,19 @@ from backend.common.deferred.queues.fake_queue import FakeTaskQueue
 class FakeTaskClient(RQTaskClient):
 
     _instance = None
+    _redis = None
 
     def __new__(cls):
         if cls._instance is None:
+            from fakeredis import FakeRedis
+
             cls._instance = super(FakeTaskClient, cls).__new__(cls)
+            cls._redis = FakeRedis()
 
         return cls._instance
 
     def __init__(self) -> None:
-        from fakeredis import FakeRedis
-
-        super().__init__(default_service="test", redis_client=FakeRedis())
+        super().__init__(default_service="test", redis_client=self._redis)
 
     def pending_job_count(self, queue_name: str) -> int:
         return len(self.queue(queue_name).jobs())

--- a/src/backend/common/manipulators/manipulator_base.py
+++ b/src/backend/common/manipulators/manipulator_base.py
@@ -202,10 +202,6 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
                 ].union(val)
 
     @classmethod
-    def post_delete_hook(cls, models: List[TModel]):
-        pass
-
-    @classmethod
     def _run_post_delete_hook(cls, models: List[TModel]) -> None:
         """
         Asynchronously runs the manipulator's post delete hooks if available.

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -39,8 +39,10 @@ def ndb_stub(monkeypatch: MonkeyPatch) -> datastore_stub.LocalDatastoreStub:
 
 
 @pytest.fixture()
-def task_client() -> FakeTaskClient:
-    return FakeTaskClient()
+def task_client():
+    client = FakeTaskClient()
+    client._redis.flushall()
+    yield client
 
 
 @pytest.fixture()


### PR DESCRIPTION
This will be the new pattern for porting post update/delete hooks.

I'm thinking that the decorator registration approach is best, and will allow us to support splitting the hooks into simpler functions (so we can have multiple).