### PR TITLE
Revert dispatch.yaml to point to py2 site

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,17 +1,17 @@
 dispatch:
-# Start serving certain pages from py3
-- url: "www.thebluealliance.com/"  # Just the homepage
-  service: py3-web
-
-- url: "www.thebluealliance.com/about"
-  service: py3-web
-
-# Python 3 Migration
-- url: "py3.thebluealliance.com/api/*"
-  service: py3-api
-
-- url: "py3.thebluealliance.com/*"
-  service: py3-web
+# # Start serving certain pages from py3
+# - url: "www.thebluealliance.com/"  # Just the homepage
+#   service: py3-web
+#
+# - url: "www.thebluealliance.com/about"
+#   service: py3-web
+#
+# # Python 3 Migration
+# - url: "py3.thebluealliance.com/api/*"
+#   service: py3-api
+#
+# - url: "py3.thebluealliance.com/*"
+#   service: py3-web
 
 # Beta PWA
 - url: "beta.thebluealliance.com/*"


### PR DESCRIPTION
Seeing if we can revert our dispatch.yaml to support the off season event