### PR TITLE
Point homepage back to py3

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,11 +1,11 @@
 dispatch:
-# # Start serving certain pages from py3
-# - url: "www.thebluealliance.com/"  # Just the homepage
-#   service: py3-web
-#
-# - url: "www.thebluealliance.com/about"
-#   service: py3-web
-#
+# Start serving certain pages from py3
+- url: "www.thebluealliance.com/"  # Just the homepage
+  service: py3-web
+
+- url: "www.thebluealliance.com/about"
+  service: py3-web
+
 # # Python 3 Migration
 # - url: "py3.thebluealliance.com/api/*"
 #   service: py3-api


### PR DESCRIPTION
This is needed so we can deploy a new homepage with updated code