### PR TITLE
Update competition season event page to be not-Covid. Update offseason event page to work for weird 2021ish season

### DIFF
--- a/src/backend/web/handlers/index.py
+++ b/src/backend/web/handlers/index.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, cast, Dict
 
 from backend.common.consts.landing_type import LandingType
 from backend.common.decorators import cached_public
+from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.sitevars.landing_config import LandingConfig
 from backend.web.profiled_render import render_template
@@ -116,14 +117,14 @@ def index_champs(template_values: Dict[str, Any]) -> str:
 
 def index_offseason(template_values: Dict[str, Any]) -> str:
     # special_webcasts = FirebasePusher.get_special_webcasts()
-    # effective_season_year = SeasonHelper.effective_season_year()
-    #
-    # template_values.update({
-    #     "events": EventHelper.week_events(),
-    #     "kickoff_datetime_utc": SeasonHelper.kickoff_datetime_utc(effective_season_year),
-    #     "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
-    #     "special_webcasts": special_webcasts,
-    # })
+    effective_season_year = SeasonHelper.effective_season_year()
+
+    template_values.update({
+        "events": EventHelper.week_events(),
+        "kickoff_datetime_utc": SeasonHelper.kickoff_datetime_utc(effective_season_year),
+        # "any_webcast_online": any(w.get('status') == 'online' for w in special_webcasts),
+        # "special_webcasts": special_webcasts,
+    })
     return render_template("index/index_offseason.html", template_values)
 
 

--- a/src/backend/web/templates/index/index_competitionseason.html
+++ b/src/backend/web/templates/index/index_competitionseason.html
@@ -11,10 +11,8 @@
       {% include "index_partials/index_lhc.html" %}
     </div>
     <div class="col-sm-8">
-<div class="alert alert-dismissible alert-danger ">
-<a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>Due to COVID-19 (Coronavirus), FIRST has decided to suspend all season play across all Programs worldwide, effective immediately, including the cancellation of both FIRST Championship events. Refer to <a href="https://www.firstinspires.org/covid-19" title="firstinspires.org/covid-19">firstinspires.org/covid-19</a> for more information.</div>
       {% include "media_partials/live_special_webcast_partial.html" %}
-      <!-- {% if events %}
+      {% if events %}
         {% with first_event = events|first %}
         {% with last_event = events|last %}
         {% if first_event.week != None and last_event.week != None %}
@@ -108,7 +106,7 @@
           <iframe width="420" height="315" src="https://www.youtube.com/embed/{{game_animation_youtube_id}}" frameborder="0" allowfullscreen></iframe>
         </div>
       {% endif %}
-    </div> -->
+    </div>
   </div>
 </div>
 

--- a/src/backend/web/templates/index/index_offseason.html
+++ b/src/backend/web/templates/index/index_offseason.html
@@ -11,6 +11,15 @@
       {% include "index_partials/index_lhc_offseason.html" %}
     </div>
     <div class="col-xs-12 col-sm-7 col-lg-8">
+      <div class="btn-group game-manual">
+        <a class="btn btn-default" href="http://www.firstinspires.org/resource-library/frc/competition-manual-qa-system" target="_blank"><span class="glyphicon glyphicon-file"></span> {{game_name}} Game Manual and Materials</a>
+      </div>
+      <div>
+        <a class="btn btn-default" href="https://www.firstinspires.org/covid-19" target="_blank"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> COVID-19 Resources</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2021 Game and Season Resources</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/game-and-season-info/competition-manual/2021/2021-frc-season-details.pdf" target="_blank"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2021 Season Details</a>
+      </div>
+
       {% include "media_partials/live_special_webcast_partial.html" %}
 
       {% if events and events|length > 0 %}
@@ -19,7 +28,7 @@
       <hr>
       {% endif %}
 
-      <h2>Only <span class="countdown-number countdown-days">--</span><span class="countdown-label day-label"> days</span> until {{kickoff_datetime_utc|strftime("%Y")}} Kickoff!</h2>
+      <!-- <h2>Only <span class="countdown-number countdown-days">--</span><span class="countdown-label day-label"> days</span> until {{kickoff_datetime_utc|strftime("%Y")}} Kickoff!</h2>
       <div id="countdown-finish-time">{{kickoff_datetime_utc|isoformat}}</div>
       <p>Watch the {{kickoff_datetime_utc|strftime("%Y")}} Kickoff LIVE on GameDay on The Blue Alliance on {{kickoff_datetime_utc|strftime("%B %-d%t")}}!</p>
 
@@ -32,7 +41,7 @@
       <div class="fitvids">
         <iframe width="560" height="315" src="https://www.youtube.com/embed/{{game_teaser_youtube_id}}" frameborder="0" allowfullscreen></iframe>
       </div>
-      {%endif%}
+      {%endif%} -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
This shows the events at the bottom, and keeps the game/season data at the top. Once all scores for IRAH have been submitted, we can probably flip over to only showing events, as opposed to showing game/season info.
<img width="1195" alt="Screen Shot 2021-03-24 at 12 39 32 PM" src="https://user-images.githubusercontent.com/516458/112348582-56910c80-8c9e-11eb-90c7-1413883b7319.png">
