### PR TITLE
Update Dockerfile to pull py2 pip

### DIFF
--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -26,7 +26,7 @@ RUN ls /usr/bin/python*
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 2
 RUN echo 1 | update-alternatives --config python
-RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py && python get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && python get-pip.py
 
 # Configure ssh server
 RUN mkdir /var/run/sshd


### PR DESCRIPTION
The Docker image fails to build with the following error

```
#10 0.957 ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.
#10 ERROR: executor failed running [/bin/sh -c curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py && python get-pip.py]: exit code: 1
```

We just need to specify the py2 pip URL to download