### PR TITLE
Fix py3 not loading liveevent JS

### DIFF
--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -451,6 +451,6 @@
 
 {% block inline_javascript %}
 {% if event.now %}
-<script type="text/javascript" src="/javascript/liveevent.min.js"></script>
+<script type="text/javascript" src="/py3_javascript/liveevent.min.js"></script>
 {% endif %}
 {% endblock %}

--- a/src/backend/web/templates/index/index_champs.html
+++ b/src/backend/web/templates/index/index_champs.html
@@ -98,5 +98,5 @@
 {% endblock %}
 
 {% block inline_javascript %}
-<script type="text/javascript" src="/javascript/liveevent.min.js"></script>
+<script type="text/javascript" src="/py3_javascript/liveevent.min.js"></script>
 {% endblock %}


### PR DESCRIPTION
In py3 the live event information is failing to load for live events

<img width="1295" alt="Screen Shot 2021-04-17 at 11 09 16 AM" src="https://user-images.githubusercontent.com/516458/115118237-36d4c780-9f70-11eb-8037-9892694a1b26.png">

This is because we're failing to load the `liveevent.js` bundle in py3

<img width="588" alt="Screen Shot 2021-04-17 at 11 23 37 AM" src="https://user-images.githubusercontent.com/516458/115118245-3e946c00-9f70-11eb-9e32-544d1f5dcbf2.png">

Updating the routes to point at `py3_javascript/...` fixes this issue

<img width="1242" alt="Screen Shot 2021-04-17 at 11 26 55 AM" src="https://user-images.githubusercontent.com/516458/115118251-48b66a80-9f70-11eb-86db-0bbd89eaace3.png">

