### PR TITLE
Point production Event/Team/Match pages back at py3

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -6,12 +6,12 @@ dispatch:
 - url: "www.thebluealliance.com/about"
   service: py3-web
 
-# # Python 3 Migration
-# - url: "py3.thebluealliance.com/api/*"
-#   service: py3-api
-#
-# - url: "py3.thebluealliance.com/*"
-#   service: py3-web
+# Python 3 Migration
+- url: "py3.thebluealliance.com/api/*"
+  service: py3-api
+
+- url: "py3.thebluealliance.com/*"
+  service: py3-web
 
 # Beta PWA
 - url: "beta.thebluealliance.com/*"

--- a/ops/standalone/dispatch-empty.yaml
+++ b/ops/standalone/dispatch-empty.yaml
@@ -6,17 +6,17 @@ dispatch:
   - url: "www.thebluealliance.com/about"
     service: py3-web
 
-  #- url: "www.thebluealliance.com/event*"
-  #  service: py3-web
+  - url: "www.thebluealliance.com/event*"
+    service: py3-web
 
-  #- url: "www.thebluealliance.com/teams"
-  #  service: py3-web
+  - url: "www.thebluealliance.com/teams"
+    service: py3-web
 
-  #- url: "www.thebluealliance.com/team/*"
-  #  service: py3-web
+  - url: "www.thebluealliance.com/team/*"
+    service: py3-web
 
-  #- url: "www.thebluealliance.com/match/*"
-  #  service: py3-web
+  - url: "www.thebluealliance.com/match/*"
+    service: py3-web
     
   - url: "www.thebluealliance.com/py3_css/*"
     service: py3-web


### PR DESCRIPTION
With https://github.com/the-blue-alliance/the-blue-alliance/pull/3485 merged, I'm fairly confident we can point the Event and Team pages back at the py3 pages.

Should be good to merge once https://github.com/the-blue-alliance/the-blue-alliance/pull/3486 is merged