### PR TITLE
Small updates for Dockerfile around Python 2 + Google Cloud SDK

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN echo 1 | update-alternatives --config python
 
 # Add gcloud repository and Cloud SDK dependencies
 RUN apt-get update && apt-get install -y apt-transport-https curl
-RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk-xenial main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 RUN apt-get update && apt-get install -y \
     google-cloud-sdk \
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get install -y nodejs npm
 
 # Install pip2 for gcloud dependencies
-RUN curl https://bootstrap.pypa.io/get-pip.py | python2
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2
 
 # Configure ssh server
 RUN mkdir /var/run/sshd


### PR DESCRIPTION
A partial cherry-pick of https://github.com/the-blue-alliance/the-blue-alliance/commit/1d05f3bb147b26e228efe40801f13a0692a97153

Drops pulling `cloud-sdk-xenial` to just pulling `cloud-sdk`, since the Ubuntu version the Docker container uses is set to `latest`, which is 20.04, not 16.04