### PR TITLE
Add 2021 to record-less years

### DIFF
--- a/src/backend/common/helpers/rankings_helper.py
+++ b/src/backend/common/helpers/rankings_helper.py
@@ -28,7 +28,7 @@ class RankingsHelper:
         2007: [6, 7, 8],
     }
 
-    NO_RECORD_YEARS = {2010, 2015}
+    NO_RECORD_YEARS = {2010, 2015, 2021}
 
     QUAL_AVERAGE_YEARS = {2015}
 


### PR DESCRIPTION
Related to https://github.com/the-blue-alliance/the-blue-alliance/issues/3497 - the `rankings2` models for 2021 events were populated with `record` fields, which is causing records to show for 2021 events. After merging, we should re-scrape rankings for 2021 so we can get the models in a consistent state.