### PR TITLE
Automatically install regex handler when installing defer routes

### DIFF
--- a/docs/Developing/Queues-and-defer.md
+++ b/docs/Developing/Queues-and-defer.md
@@ -42,7 +42,7 @@ install_defer_routes(app)
 Deferred tasks tend to be expensive tasks that can happen asynchronously in order to expedite serving a response for a request.
 
 ```python
-from from backend.common.deferred import defer
+from backend.common.deferred import defer
 
 def do_expensive_work(a, *, b):
     ...

--- a/src/backend/common/tests/url_converters_test.py
+++ b/src/backend/common/tests/url_converters_test.py
@@ -1,7 +1,12 @@
 import pytest
 from flask import Flask
 
-from backend.common.url_converters import install_url_converters
+from backend.common.url_converters import (
+    has_regex_url_converter,
+    install_regex_url_converter,
+    install_url_converters,
+    RegexConverter,
+)
 
 
 def test_regex_route(app: Flask) -> None:
@@ -19,6 +24,22 @@ def test_regex_route(app: Flask) -> None:
     assert client.get("/").status_code == 404
     assert client.get("/123abc").status_code == 404
     assert client.get("/1234ABC").status_code == 404
+
+
+def test_has_regex_url_converter(app: Flask) -> None:
+    assert not has_regex_url_converter(app)
+
+    install_regex_url_converter(app)
+
+    assert has_regex_url_converter(app)
+
+
+def test_install_regex_url_converter(app: Flask) -> None:
+    assert app.url_map.converters.get("regex") is None
+
+    install_regex_url_converter(app)
+
+    assert app.url_map.converters.get("regex") is RegexConverter
 
 
 def test_regex_route_throws_when_not_installed(app: Flask) -> None:

--- a/src/backend/common/url_converters.py
+++ b/src/backend/common/url_converters.py
@@ -3,6 +3,9 @@ from werkzeug.routing import BaseConverter
 
 
 class RegexConverter(BaseConverter):
+
+    key: str = "regex"
+
     def __init__(self, url_map, *items) -> None:
         super(RegexConverter, self).__init__(url_map)
         self.regex = items[0]
@@ -10,4 +13,12 @@ class RegexConverter(BaseConverter):
 
 def install_url_converters(app: Flask) -> None:
     # Also install custom url converters
-    app.url_map.converters["regex"] = RegexConverter
+    install_regex_url_converter(app)
+
+
+def has_regex_url_converter(app: Flask) -> bool:
+    return app.url_map.converters.get(RegexConverter.key) is not None
+
+
+def install_regex_url_converter(app: Flask) -> None:
+    app.url_map.converters[RegexConverter.key] = RegexConverter

--- a/src/backend/tasks_io/main.py
+++ b/src/backend/tasks_io/main.py
@@ -3,12 +3,10 @@ from flask import Flask
 from backend.common.deferred.handlers import install_defer_routes
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
-from backend.common.url_converters import install_url_converters
 
 
 configure_logging()
 
 app = Flask(__name__)
 install_middleware(app)
-install_url_converters(app)
 install_defer_routes(app)


### PR DESCRIPTION
The `install_defer_routes` functionality got a little clobbered when we migrated installing regex routes via the `install_url_converters` method by requiring apps call `install_url_converters` before calling `install_defer_routes`. This PR automatically installs the regex converter in `install_defer_routes` if it is not already installed.

This PR also has the side-effect of fixing https://github.com/the-blue-alliance/the-blue-alliance/issues/3504