### PR TITLE
Bootstrap event year data in queue

### DIFF
--- a/docs/Developing/Queues-and-defer.md
+++ b/docs/Developing/Queues-and-defer.md
@@ -92,6 +92,8 @@ def do_later():
 Custom URLs can be supported as well using a more manual process. A route must be created that calls to `deferred.application` to handle the original request. This is not recommended, but can be done.
 
 ```python
+from google.appengine.ext import deferred
+
 @app.route("/do_the_thing")
 def do_the_thing():
     # Providing a custom URL.

--- a/src/backend/web/local/blueprint.py
+++ b/src/backend/web/local/blueprint.py
@@ -55,5 +55,9 @@ def maybe_register(app: Flask, csrf: CSRFProtect) -> None:
     if Environment.is_dev():
         app.register_blueprint(local_routes)
 
+        from backend.common.deferred import install_defer_routes
+
+        install_defer_routes(app)
+
         # Since we only install this on devservers, CSRF isn't necessary
         csrf.exempt(local_routes)


### PR DESCRIPTION
Doing a bootstrap for an entire year can be VERY expensive, and usually the request times out before finishing. This PR moves the year task to a `bootstrap` queue to happen in the background.