### PR TITLE
Update rq worker to run currently-used queues

### DIFF
--- a/docs/Developing/Queues-and-defer.md
+++ b/docs/Developing/Queues-and-defer.md
@@ -99,6 +99,8 @@ See the [gcloud tasks queues create](https://cloud.google.com/sdk/gcloud/referen
 
 In development, `defer` use Redis + RQ as opposed to Google Cloud Tasks to execute deferred tasks. A Redis server, RQ worker, and dashboard are spun up when the development container is booted and can be seen when attaching to the container's tmux session. The RQ Dashboard can be found at [0.0.0.0:9181](http://0.0.0.0:9181/) be used to monitor failed tasks. Tasks that execute successfully will not show up in the RQ Dashboard, but they can be seen as successfully executed in the `rq-worker` tmux tab.
 
+Note: The rq worker must be invoked with a list of queues to execute tasks on. The current list of supported queues can be found in the [`start-devserver.sh`](https://github.com/the-blue-alliance/the-blue-alliance/blob/py3/ops/dev/vagrant/start-devserver.sh) script. If tasks are being deffered locally on an unsupported queue, add the queue to the list of queues the rq worker should monitor and restart the worker.
+
 ### Google Cloud Tasks + ngrok
 
 Sometimes, Google Cloud Tasks semantics are necessary when testing a feature. It is possible to enqueue a task from a local development instance to an upstream project's Google Cloud Tasks queue to be executed in the local development instance. This process leverages [ngrok](https://ngrok.com/) to expose a public URL that routes back to the host machine.

--- a/ops/dev/vagrant/start-devserver.sh
+++ b/ops/dev/vagrant/start-devserver.sh
@@ -21,7 +21,7 @@ tmux new-session -d -s $session
 tmux new-window -t "$session:1" -n gae "./ops/dev/vagrant/dev_appserver.sh 2>&1 | tee /var/log/tba.log; read"
 tmux new-window -t "$session:2" -n gulp "gulp 2>&1 | tee /var/log/gulp.log; read"
 tmux new-window -t "$session:3" -n redis "redis-server 2>&1 | tee /var/log/redis.log; read"
-tmux new-window -t "$session:4" -n rq-worker "rq worker 2>&1 | tee /var/log/rq-worker.log; read"
+tmux new-window -t "$session:4" -n rq-worker "rq worker default cache-clearing post-update-hooks 2>&1 | tee /var/log/rq-worker.log; read"
 tmux new-window -t "$session:5" -n rq-dashboard "rq-dashboard 2>&1 | tee /var/log/rq-dashboard.log; read"
 if [ -n "$instance_name" ]; then
     echo "Starting Cloud SQL proxy to connect to $instance_name"


### PR DESCRIPTION
Right now the rq worker is only running the `default` queue, which isn't very helpful. This PR adds all other currently-used queues to the rq workers task load.