### PR TITLE
Group 2021 events by type

### DIFF
--- a/src/backend/common/helpers/event_helper.py
+++ b/src/backend/common/helpers/event_helper.py
@@ -79,7 +79,10 @@ class EventHelper(object):
                 EventType.CMP_DIVISION,
                 EventType.CMP_FINALS,
             }:
-                if event.year >= 2017:
+                if event.year == 2021:
+                    # 2021 had a remote CMP - so only a single CMP
+                    champs_label = CHAMPIONSHIP_EVENTS_LABEL
+                elif event.year >= 2017:
                     champs_label = TWO_CHAMPS_LABEL.format(event.city)
                 else:
                     champs_label = CHAMPIONSHIP_EVENTS_LABEL
@@ -92,6 +95,7 @@ class EventHelper(object):
                 EventType.DISTRICT,
                 EventType.DISTRICT_CMP_DIVISION,
                 EventType.DISTRICT_CMP,
+                EventType.REMOTE,
             }:
                 if event.start_date is None or (
                     event.start_date.month == 12 and event.start_date.day == 31

--- a/src/backend/common/helpers/tests/event_helper_test.py
+++ b/src/backend/common/helpers/tests/event_helper_test.py
@@ -320,6 +320,15 @@ def test_group_by_week_old_champs(ndb_context) -> None:
     }
 
 
+def test_group_by_week_2021_champs(ndb_context) -> None:
+    e1 = Event(event_type_enum=EventType.CMP_FINALS, year=2021, official=True)
+    e2 = Event(event_type_enum=EventType.CMP_FINALS, year=2021, official=True)
+    events = EventHelper.group_by_week([e1, e2])
+    assert events == {
+        "FIRST Championship": [e1, e2],
+    }
+
+
 def test_group_by_week_two_champs(ndb_context) -> None:
     e1 = Event(
         event_type_enum=EventType.CMP_DIVISION, year=2018, official=True, city="Detriot"

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -393,9 +393,23 @@ class Event(CachedModel):
     def week_str(self) -> Optional[str]:
         if self.week is None:
             return None
+
+        week = none_throws(self.week)
         if self.year == 2016:
-            return "Week {}".format(0.5 if self.week == 0 else self.week)
-        return "Week {}".format(none_throws(self.week) + 1)
+            return "Week {}".format(0.5 if week == 0 else week)
+        elif self.year == 2021:
+            # Group 2021 Events by their type - depends on both
+            if week == 0:
+                return "Participation"
+            elif week == 2:
+                return "FIRST Innovation Challenge"
+            elif week == 3:
+                return "INFINITE RECHARGE At Home Challenge"
+            elif week == 4:
+                return "Game Design Challenge"
+            else:
+                return "Awards"
+        return "Week {}".format(week + 1)
 
     @ndb.tasklet
     def get_teams_async(self) -> TypedFuture[List["Team"]]:

--- a/src/backend/common/models/tests/event_test.py
+++ b/src/backend/common/models/tests/event_test.py
@@ -193,6 +193,12 @@ def test_past_future_start_end_today(
         (2016, EventType.REGIONAL, True, 1, 1, "Week 1"),
         (2020, EventType.OFFSEASON, False, 2, None, None),
         (2020, EventType.REGIONAL, False, 2, None, None),
+        (2021, EventType.REGIONAL, True, 0, 0, "Participation"),
+        (2021, EventType.DISTRICT, True, 0, 0, "Participation"),
+        (2021, EventType.REMOTE, True, 2, 2, "FIRST Innovation Challenge"),
+        (2021, EventType.REMOTE, True, 3, 3, "INFINITE RECHARGE At Home Challenge"),
+        (2021, EventType.REMOTE, True, 4, 4, "Game Design Challenge"),
+        (2021, EventType.REMOTE, True, 5, 5, "Awards"),
     ],
 )
 def test_week(


### PR DESCRIPTION
FINALLY - logical groupings for 2021 Events. The goal is to eventually remove the participation events altogether. But that'll happen in a follow-up PR.

<img width="1249" alt="Screen Shot 2021-04-20 at 12 28 37 AM" src="https://user-images.githubusercontent.com/516458/115337709-7a495480-a16f-11eb-898f-12fa85e0f970.png">
