### PR TITLE
Add fmsapi.secrets sitevar

### DIFF
--- a/src/backend/common/sitevars/fmsapi_secrets.py
+++ b/src/backend/common/sitevars/fmsapi_secrets.py
@@ -1,0 +1,45 @@
+import base64
+from typing import Optional
+
+from typing_extensions import TypedDict
+
+from backend.common.sitevars.base import SitevarBase
+
+
+class ContentType(TypedDict):
+    username: str
+    authkey: str
+
+
+class FMSAPISecrets(SitevarBase[ContentType]):
+    @staticmethod
+    def key() -> str:
+        return "fmsapi.secrets"
+
+    @staticmethod
+    def default_value() -> ContentType:
+        return ContentType(username="", authkey="")
+
+    @classmethod
+    def username(cls) -> Optional[str]:
+        username = cls.get().get("username")
+        return username if username else None  # Drop empty strings
+
+    @classmethod
+    def authkey(cls) -> Optional[str]:
+        authkey = cls.get().get("authkey")
+        return authkey if authkey else None  # Drop empty strings
+
+    @classmethod
+    def auth_token(cls) -> Optional[str]:
+        """ The base64 encoded username + auth key - used to authenticate with the FMS API """
+
+        username = cls.username()
+        authkey = cls.authkey()
+        if not username or not authkey:
+            return None
+
+        # py3 needs byte-strings for b64 - will convert back/forth from ascii for strings
+        return base64.b64encode(
+            "{}:{}".format(username, authkey).encode("ascii")
+        ).decode("ascii")

--- a/src/backend/common/sitevars/tests/fmsapi_secrets_test.py
+++ b/src/backend/common/sitevars/tests/fmsapi_secrets_test.py
@@ -1,0 +1,59 @@
+import json
+
+import pytest
+
+from backend.common.models.sitevar import Sitevar
+from backend.common.sitevars.fmsapi_secrets import FMSAPISecrets
+
+
+def test_key():
+    assert FMSAPISecrets.key() == "fmsapi.secrets"
+
+
+def test_default_sitevar():
+    default_sitevar = FMSAPISecrets._fetch_sitevar()
+    assert default_sitevar is not None
+
+    default_json = {"username": "", "authkey": ""}
+    assert default_sitevar.contents == default_json
+
+
+def test_username_default():
+    assert FMSAPISecrets.username() is None
+
+
+def test_username():
+    username = "zach"
+    Sitevar.get_or_insert(
+        FMSAPISecrets.key(), values_json=json.dumps({"username": username})
+    )
+    assert FMSAPISecrets.username() == username
+
+
+def test_authkey_default():
+    assert FMSAPISecrets.authkey() is None
+
+
+def test_authkey():
+    authkey = "authkey"
+    Sitevar.get_or_insert(
+        FMSAPISecrets.key(), values_json=json.dumps({"authkey": authkey})
+    )
+    assert FMSAPISecrets.authkey() == authkey
+
+
+@pytest.mark.parametrize(
+    "username, authkey, auth_token",
+    [
+        ("", "", None),
+        ("zach", "", None),
+        ("", "authkey", None),
+        ("zach", "authkey", "emFjaDphdXRoa2V5"),
+    ],
+)
+def test_auth_token(username, authkey, auth_token):
+    Sitevar.get_or_insert(
+        FMSAPISecrets.key(),
+        values_json=json.dumps({"username": username, "authkey": authkey}),
+    )
+    assert FMSAPISecrets.auth_token() == auth_token


### PR DESCRIPTION
Prepping for moving the FMS API datafeed to py3 - this PR adds the `fmsapi.secrets` sitevar