### PR TITLE
Fix 'None' v3 API Key in local/bootstrap

### DIFF
--- a/src/backend/common/sitevars/apiv3_key.py
+++ b/src/backend/common/sitevars/apiv3_key.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from typing_extensions import TypedDict
 
 from backend.common.sitevars.sitevar_base import SitevarBase
@@ -25,6 +23,5 @@ class Apiv3Key(SitevarBase[ContentType]):
         )
 
     @classmethod
-    def api_key(cls) -> Optional[str]:
-        api_key = cls.get().get("apiv3_key")
-        return api_key if api_key else None  # Drop empty strings
+    def api_key(cls) -> str:
+        return cls.get().get("apiv3_key", "")

--- a/src/backend/common/sitevars/tests/apiv3_key_test.py
+++ b/src/backend/common/sitevars/tests/apiv3_key_test.py
@@ -19,12 +19,12 @@ def test_default_sitevar():
 
 
 def test_apiv3_key_none():
-    assert Apiv3Key.api_key() is None
+    assert Apiv3Key.api_key() == ""
 
 
 def test_apiv3_key_empty():
     Apiv3Key.put(ContentType(apiv3_key=""))
-    assert Apiv3Key.api_key() is None
+    assert Apiv3Key.api_key() == ""
 
 
 def test_apiv3_key():


### PR DESCRIPTION
Fixing a bug that was introduced in https://github.com/the-blue-alliance/the-blue-alliance/pull/3518 - the apiv3 key sitevar is showing up as `None` in the web page if the API key is unset. This behavior is not desirable for this use case.

Before
<img width="457" alt="Screen Shot 2021-04-24 at 4 38 14 PM" src="https://user-images.githubusercontent.com/516458/115972322-aa03ae00-a51b-11eb-834e-9d86cd7b0c87.png">

After
<img width="504" alt="Screen Shot 2021-04-24 at 4 39 46 PM" src="https://user-images.githubusercontent.com/516458/115972371-e800d200-a51b-11eb-9135-313e98fb748d.png">
