### PR TITLE
Bypass global cache for insert/get sitevars

### DIFF
--- a/src/backend/common/sitevars/sitevar_base.py
+++ b/src/backend/common/sitevars/sitevar_base.py
@@ -29,6 +29,7 @@ class SitevarBase(abc.ABC, Generic[SVType]):
             cls.key(),
             description=cls.description(),
             values_json=json.dumps(cls.default_value()),
+            use_global_cache=False
         )
 
     @classmethod


### PR DESCRIPTION
Part of https://github.com/the-blue-alliance/the-blue-alliance/pull/3528 - we don't have to clear the cache for the `api/status` endpoint if we don't cache sitevars.