### PR TITLE
Remove `typing_extensions` for `TypedDict` references

### DIFF
--- a/docs/common/Sitevars.md
+++ b/docs/common/Sitevars.md
@@ -11,7 +11,7 @@ A Sitevar must extend `Sitevar` and specify some generic content type. Generally
 #### (Example) Dictionary Sitevar
 
 ```python
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from backend.common.sitevars.base import Sitevar
 

--- a/src/backend/common/helpers/playoff_advancement_helper.py
+++ b/src/backend/common/helpers/playoff_advancement_helper.py
@@ -1,9 +1,18 @@
 import copy
 from collections import defaultdict
-from typing import Any, cast, DefaultDict, Dict, List, Mapping, NamedTuple, Optional
+from typing import (
+    Any,
+    cast,
+    DefaultDict,
+    Dict,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    TypedDict,
+)
 
 from pyre_extensions import none_throws
-from typing_extensions import TypedDict
 
 from backend.common.consts.alliance_color import AllianceColor, OPPONENT, TMatchWinner
 from backend.common.consts.comp_level import CompLevel

--- a/src/backend/common/helpers/youtube_video_helper.py
+++ b/src/backend/common/helpers/youtube_video_helper.py
@@ -1,11 +1,10 @@
 import logging
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TypedDict
 from urllib import parse as urlparse
 
 import requests
 from pyre_extensions import none_throws
-from typing_extensions import TypedDict
 
 from backend.common.sitevars.google_api_secret import GoogleApiSecret
 

--- a/src/backend/common/memcache.py
+++ b/src/backend/common/memcache.py
@@ -5,11 +5,10 @@ import enum
 import pickle
 import struct
 from dataclasses import dataclass, field as dataclass_field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict
 
 import redis
 from pyre_extensions import none_throws
-from typing_extensions import TypedDict
 
 from backend.common.redis import RedisClient
 

--- a/src/backend/common/models/alliance.py
+++ b/src/backend/common/models/alliance.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from typing_extensions import TypedDict
+from typing import List, TypedDict
 
 from backend.common.models.keys import TeamKey
 

--- a/src/backend/common/models/award_recipient.py
+++ b/src/backend/common/models/award_recipient.py
@@ -1,6 +1,4 @@
-from typing import Optional, Union
-
-from typing_extensions import TypedDict
+from typing import Optional, TypedDict, Union
 
 
 class AwardRecipient(TypedDict):

--- a/src/backend/common/models/district_advancement.py
+++ b/src/backend/common/models/district_advancement.py
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from typing_extensions import TypedDict
+from typing import Dict, TypedDict
 
 from backend.common.models.keys import TeamKey
 

--- a/src/backend/common/models/district_ranking.py
+++ b/src/backend/common/models/district_ranking.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from typing_extensions import TypedDict
+from typing import List, TypedDict
 
 from backend.common.models.event_district_points import TeamAtEventDistrictPoints
 from backend.common.models.keys import TeamKey

--- a/src/backend/common/models/event_details.py
+++ b/src/backend/common/models/event_details.py
@@ -1,9 +1,8 @@
-from typing import List, Optional, Set
+from typing import List, Optional, Set, TypedDict
 
 from google.cloud import ndb
 from google.cloud.datastore import key as datastore_key
 from pyre_extensions import none_throws, safe_cast
-from typing_extensions import TypedDict
 
 from backend.common.consts.ranking_sort_orders import (
     SORT_ORDER_INFO as RANKING_SORT_ORDERS,

--- a/src/backend/common/models/event_district_points.py
+++ b/src/backend/common/models/event_district_points.py
@@ -1,6 +1,4 @@
-from typing import Dict, List
-
-from typing_extensions import TypedDict
+from typing import Dict, List, TypedDict
 
 from backend.common.models.keys import TeamKey
 

--- a/src/backend/common/models/event_insights.py
+++ b/src/backend/common/models/event_insights.py
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from typing_extensions import TypedDict
+from typing import Dict, TypedDict
 
 
 class EventInsights(TypedDict):

--- a/src/backend/common/models/event_matchstats.py
+++ b/src/backend/common/models/event_matchstats.py
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from typing_extensions import TypedDict
+from typing import Dict, TypedDict
 
 from backend.common.models.keys import TeamKey
 

--- a/src/backend/common/models/event_participation.py
+++ b/src/backend/common/models/event_participation.py
@@ -1,6 +1,4 @@
-from typing import Dict, List, Optional
-
-from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from backend.common.models.event import Event
 

--- a/src/backend/common/models/event_predictions.py
+++ b/src/backend/common/models/event_predictions.py
@@ -1,6 +1,4 @@
-from typing import Any
-
-from typing_extensions import TypedDict
+from typing import Any, TypedDict
 
 
 class EventPredictions(TypedDict):

--- a/src/backend/common/models/event_ranking.py
+++ b/src/backend/common/models/event_ranking.py
@@ -1,6 +1,4 @@
-from typing import List, Optional
-
-from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from backend.common.models.event_team_status import WLTRecord
 from backend.common.models.keys import TeamKey

--- a/src/backend/common/models/event_team_status.py
+++ b/src/backend/common/models/event_team_status.py
@@ -1,7 +1,5 @@
 import enum
-from typing import List, Optional
-
-from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from backend.common.consts.comp_level import CompLevel
 from backend.common.models.alliance import EventAllianceBackup

--- a/src/backend/common/models/match_video.py
+++ b/src/backend/common/models/match_video.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from backend.common.consts.media_type import VideoType
 

--- a/src/backend/common/models/ranking_sort_order_info.py
+++ b/src/backend/common/models/ranking_sort_order_info.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 
 class RankingSortOrderInfo(TypedDict):

--- a/src/backend/common/models/suggestion_dict.py
+++ b/src/backend/common/models/suggestion_dict.py
@@ -1,6 +1,4 @@
-from typing import List, Optional
-
-from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.media_type import MediaType

--- a/src/backend/common/models/webcast.py
+++ b/src/backend/common/models/webcast.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from backend.common.consts.webcast_type import WebcastType
 

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -1,7 +1,6 @@
-from typing import List
+from typing import List, TypedDict
 
 from google.cloud import ndb
-from typing_extensions import TypedDict
 
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.futures import TypedFuture

--- a/src/backend/common/sitevars/apistatus.py
+++ b/src/backend/common/sitevars/apistatus.py
@@ -1,7 +1,5 @@
 import datetime
-from typing import Optional
-
-from typing_extensions import TypedDict
+from typing import Optional, TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 

--- a/src/backend/common/sitevars/apiv3_key.py
+++ b/src/backend/common/sitevars/apiv3_key.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 

--- a/src/backend/common/sitevars/flask_secrets.py
+++ b/src/backend/common/sitevars/flask_secrets.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 

--- a/src/backend/common/sitevars/fms_api_secrets.py
+++ b/src/backend/common/sitevars/fms_api_secrets.py
@@ -1,7 +1,5 @@
 import base64
-from typing import Optional
-
-from typing_extensions import TypedDict
+from typing import Optional, TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 

--- a/src/backend/common/sitevars/google_analytics_id.py
+++ b/src/backend/common/sitevars/google_analytics_id.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from typing_extensions import TypedDict
+from typing import Optional, TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 

--- a/src/backend/common/sitevars/google_api_secret.py
+++ b/src/backend/common/sitevars/google_api_secret.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from typing_extensions import TypedDict
+from typing import Optional, TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 

--- a/src/backend/common/sitevars/landing_config.py
+++ b/src/backend/common/sitevars/landing_config.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from backend.common.consts.landing_type import LandingType
 from backend.common.sitevars.sitevar import Sitevar

--- a/src/backend/common/sitevars/website_blacklist.py
+++ b/src/backend/common/sitevars/website_blacklist.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from typing_extensions import TypedDict
+from typing import List, TypedDict
 
 from backend.common.sitevars.sitevar import Sitevar
 


### PR DESCRIPTION
Now that we're fully on Python 3.8, both `TypedDict` is available to us through `typing`. This PR drops the usage of `typing_extensions` for `TypedDict`.

`Literal` is left, since I can't seem to get `Literal[""]` working as a proper type