### PR TITLE
[py3] Don't install python requirements for build job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -153,23 +153,12 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
       - name: Cache node modules
         uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
-      - name: Install Python Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r src/requirements.txt
       - name: Install Node Dependencies
         run: npm install
       - name: Run Build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -159,23 +159,12 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: "10.x"
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
       - name: Cache node modules
         uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
-      - name: Install Python Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r src/requirements.txt
       - name: Install Node Dependencies
         run: npm install
       - name: Run Build


### PR DESCRIPTION
The build job is scripted in Python but we don't rely on any libraries, so we shouldn't need to install them.