### PR TITLE
update to nodejs 14

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: "10.x"
+          node-version: "14"
       - name: Cache node modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: "10.x"
+          node-version: "14"
       - name: Cache node modules
         uses: actions/cache@v2
         with:
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: "10.x"
+          node-version: "14"
       - name: Cache node modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: "10.x"
+          node-version: "14"
       - name: Cache node modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: "10.x"
+          node-version: "14"
       - name: Cache node modules
         uses: actions/cache@v2
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: "10.x"
+          node-version: "14"
       - name: Cache node modules
         uses: actions/cache@v2
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -36,8 +36,14 @@ RUN apt-get update && apt-get install -y \
     google-cloud-sdk-datastore-emulator \
     google-cloud-sdk-pubsub-emulator
 
-# Install nodejs
-RUN apt-get install -y nodejs npm
+# Set up nvm and nodejs
+ENV NVM_DIR /nvm
+ENV NODE_VERSION 14
+RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION --silent \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default --silent
 
 # Install pip2 for gcloud dependencies
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 # Set up nvm and nodejs
 ENV NVM_DIR /nvm
 ENV NODE_VERSION 14
-RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash \
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION --silent \
     && nvm alias default $NODE_VERSION \

--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -11,6 +11,10 @@ pip install -r requirements.txt
 pip install -r src/requirements.txt
 
 # nodejs dependencies
+NVM_DIR="/nvm"
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+nvm use default
 npm install
 
 ./ops/build/run_buildweb.sh

--- a/ops/dev/vagrant/run_webpack.sh
+++ b/ops/dev/vagrant/run_webpack.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+set -e
+
+NVM_DIR="/nvm"
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+nvm use default
+npm run dev

--- a/ops/dev/vagrant/start-devserver.sh
+++ b/ops/dev/vagrant/start-devserver.sh
@@ -19,7 +19,7 @@ fi
 echo "Starting devserver in new tmux session..."
 tmux new-session -d -s $session
 tmux new-window -t "$session:1" -n gae "./ops/dev/vagrant/dev_appserver.sh 2>&1 | tee /var/log/tba.log; read"
-tmux new-window -t "$session:2" -n webpack "npm run dev 2>&1 | tee /var/log/webpack.log; read"
+tmux new-window -t "$session:2" -n webpack "./ops/dev/vagrant/run_webpack.sh 2>&1 | tee /var/log/webpack.log; read"
 tmux new-window -t "$session:3" -n redis "redis-server 2>&1 | tee /var/log/redis.log; read"
 tmux new-window -t "$session:4" -n rq-worker "rq worker default cache-clearing post-update-hooks 2>&1 | tee /var/log/rq-worker.log; read"
 tmux new-window -t "$session:5" -n rq-dashboard "rq-dashboard 2>&1 | tee /var/log/rq-dashboard.log; read"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "tba-react",
   "version": "0.0.0",
+  "engines": {
+    "node": "^14"
+  },
   "dependencies": {
     "classnames": "^2.3.1",
     "element-resize-event": "^3.0.3",

--- a/src/frontend/gameday2/selectors/index.js
+++ b/src/frontend/gameday2/selectors/index.js
@@ -32,8 +32,8 @@ export const getWebcastIdsInDisplayOrder = createSelector(
     const orderedWebcasts = webcastsArray.filter((webcast) =>
       ({}.hasOwnProperty.call(webcast, "sortOrder"))
     );
-    const sortedOrderedWebcasts = orderedWebcasts.sort(
-      (a, b) => a.sortOrder > b.sortOrder
+    const sortedOrderedWebcasts = orderedWebcasts.sort((a, b) =>
+      a.sortOrder > b.sortOrder ? 1 : -1
     );
     sortedOrderedWebcasts.forEach((webcast) =>
       displayOrderWebcastIds.push(webcast.id)


### PR DESCRIPTION
This is the current LTS version. It appears dependabot can't manage this for us :(

Fixes:
 - node 12 includes a change to `Array.sort`, the previous iteration we had was relying on the call order, which was unspecified
 - get node 14 to run in CI
 - update dev container to run node 14 too via `nvm` so it'll be easier for us to change in the future, I'll publish a new artifact as well