### PR TITLE
Re-style event page headers

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_base.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_base.less
@@ -147,9 +147,3 @@ body {
 .tba-auth-text-apple {
   color: white;
 }
-
-@media (min-width: 768px) {
-  .pull-right-not-xs {
-    text-align: right;
-  }
-}

--- a/src/backend/web/static/css/less_css/less/tba/tba_base.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_base.less
@@ -147,3 +147,9 @@ body {
 .tba-auth-text-apple {
   color: white;
 }
+
+@media (min-width: 768px) {
+  .pull-right-not-xs {
+    text-align: right;
+  }
+}

--- a/src/backend/web/static/css/less_css/less/tba/tba_event_page.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_event_page.less
@@ -32,3 +32,19 @@ tr td.bluescorecell {
   color: #fff;
   background: #2222cc;
 }
+
+@media (min-width: 768px) {
+  .pull-right-not-xs {
+    text-align: right;
+  }
+}
+
+.bottomless {
+  padding-bottom: 0;
+  margin-bottom: 0
+}
+
+.topless {
+  padding-top: 0;
+  margin-top: 0
+}

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -56,42 +56,53 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-sm-12">
+    <div class="col-sm-8" style="padding-bottom: 0; margin-bottom: 0">
+      {% if district_name %}
+        <span class="glyphicon glyphicon-globe"></span> <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a> Event<br />
+      {% endif %}
+      {% if parent_event %}
+        <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
+      {% endif %}
+      {{ em.showEventDates(event) }}
+      {% if event.nl and event.nl.name and event.nl.city_state_country %}
+        <br><span class="glyphicon glyphicon-map-marker"></span>
+        <span itemprop="location">
+        {% if event.nl and event.nl.name %}
+          <a href="{{event.nl.place_details.url}}" target="_blank">{{event.nl.name}}</a> in {{event.nl.city_state_country}}
+        {% else %}
+          <a href="//maps.google.com/maps?q={{ event.city_state_country|urlencode }}" target="_blank">{{event.city_state_country}}</a>
+        {% endif %}
+        </span>
+      {% elif event.location or event.venue_address_safe %}
+        <br><span class="glyphicon glyphicon-map-marker"></span>
+        <span itemprop="location">
+        {% if event.venue_address_safe %}
+          <a href="http://maps.google.com/maps?q={{ event.venue_address_safe|urlencode }}" target="_blank">{{ event.venue_or_venue_from_address }}</a>{% if event.location %} in {{event.location}}{% endif %}
+        {% else %}
+          <a href="http://maps.google.com/maps?q={{ event.location|urlencode }}" target="_blank">{{event.location}}</a>
+        {% endif %}
+        </span>
+      {% endif %}
+      {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank">RSVP on Facebook</a><br>{% endif %}
+    </div>
+    <div class="col-sm-4" style="padding-bottom: 0; margin-bottom: 0">
       <a class="btn btn-success pull-right hidden-xs" href="/suggest/event/video?event_key={{event.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add Match Videos!</a>
-      <p>
-        {% if district_name %}
-          <span class="glyphicon glyphicon-globe"></span> <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a> Event<br />
-        {% endif %}
-        {% if parent_event %}
-          <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
-        {% endif %}
-        {{ em.showEventDates(event) }}
-        {% if event.nl and event.nl.name and event.nl.city_state_country %}
-          <br><span class="glyphicon glyphicon-map-marker"></span>
-          <span itemprop="location">
-          {% if event.nl and event.nl.name %}
-            <a href="{{event.nl.place_details.url}}" target="_blank">{{event.nl.name}}</a> in {{event.nl.city_state_country}}
-          {% else %}
-            <a href="//maps.google.com/maps?q={{ event.city_state_country|urlencode }}" target="_blank">{{event.city_state_country}}</a>
-          {% endif %}
-          </span>
-        {% elif event.location or event.venue_address_safe %}
-          <br><span class="glyphicon glyphicon-map-marker"></span>
-          <span itemprop="location">
-          {% if event.venue_address_safe %}
-            <a href="http://maps.google.com/maps?q={{ event.venue_address_safe|urlencode }}" target="_blank">{{ event.venue_or_venue_from_address }}</a>{% if event.location %} in {{event.location}}{% endif %}
-          {% else %}
-            <a href="http://maps.google.com/maps?q={{ event.location|urlencode }}" target="_blank">{{event.location}}</a>
-          {% endif %}
-          </span>
-        {% endif %}
-        {% if event.website %}<br><span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
-        {% if event.first_eid or event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="{% if event.first_eid %}https://www.firstinspires.org/team-event-search/event?id={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank">firstinspires.org</a>{% endif %}
-        {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank">RSVP on Facebook</a><br>{% endif %}
-        {% if event.official and event.year >= 2006 %}<br><span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank">FIRST Events API</a>{% endif %}
-      </p>
     </div>
   </div>
+  <div class="row">
+      <div class="col-sm-7" style="padding-top: 0; margin-top: 0">
+        {% if event.website %}<span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
+        {% if event.first_eid or event.official %}{% if not event.website %}<span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} Details on <a href="{% if event.first_eid %}https://www.firstinspires.org/team-event-search/event?id={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank">firstinspires.org</a>{% endif %}
+      </div>
+      <div class="col-sm-5" style="padding-top: 0; margin-top: 0">
+        {% if event.official and event.year >= 2006 %}
+          <div class="pull-right-not-xs">
+            <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank">FIRST Events API</a>
+          </div>
+        {% endif %}
+      </div>
+  </div>
+  <br>
 
   <div class="row">
     <div class="col-sm-12">

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -56,7 +56,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-sm-8" style="padding-bottom: 0; margin-bottom: 0">
+    <div class="col-sm-8 bottomless">
       {% if district_name %}
         <span class="glyphicon glyphicon-globe"></span> <a href="/events/{{district_abbrev}}/{{event.year}}">{{district_name}} District</a> Event<br />
       {% endif %}
@@ -85,16 +85,16 @@
       {% endif %}
       {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank">RSVP on Facebook</a><br>{% endif %}
     </div>
-    <div class="col-sm-4" style="padding-bottom: 0; margin-bottom: 0">
+    <div class="col-sm-4 bottomless">
       <a class="btn btn-success pull-right hidden-xs" href="/suggest/event/video?event_key={{event.key_name}}" target="_blank"><span class="glyphicon glyphicon-plus"></span> Add Match Videos!</a>
     </div>
   </div>
   <div class="row">
-      <div class="col-sm-7" style="padding-top: 0; margin-top: 0">
+      <div class="col-sm-7 topless">
         {% if event.website %}<span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank">{{ event.website }}</a>{% endif %}
         {% if event.first_eid or event.official %}{% if not event.website %}<span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} Details on <a href="{% if event.first_eid %}https://www.firstinspires.org/team-event-search/event?id={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank">firstinspires.org</a>{% endif %}
       </div>
-      <div class="col-sm-5" style="padding-top: 0; margin-top: 0">
+      <div class="col-sm-5 topless">
         {% if event.official and event.year >= 2006 %}
           <div class="pull-right-not-xs">
             <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank">FIRST Events API</a>


### PR DESCRIPTION
This is a slight refactor to event page headers that contain info about the event (eg dates, website).

## Description
* Introduces another grid row to event page header, which has 2 columns: one for a firstinspires link, and another for the FRC API attribution.
* The attribution col is has a `text-align: right` on large screens, but does not on small screens.
* Capitalized a word (`details` -> `Details`) that looked out of place when an event does not have a website

## Motivation and Context
Users are not immediately sure which FIRST link is which. Clicking on the wrong one is common in my experience. This more clearly separates attribution and the firstinspires link.

## How Has This Been Tested?
Just manually going to localhost event web pages with a regional, offseason, cmp division, and cmp parent event (`2019nytr`, `2019nyrr`, `2019dar`, `2019cmpmi` respectively).

## Screenshots (if appropriate):
![C9PU2DA](https://user-images.githubusercontent.com/7595639/118346132-5deace80-b507-11eb-9c84-556ffefaa4ed.png)
![3y3BkTY](https://user-images.githubusercontent.com/7595639/118346133-5deace80-b507-11eb-8219-92b41305300f.png)
![xKUTfef](https://user-images.githubusercontent.com/7595639/118346134-5deace80-b507-11eb-98c4-8df4a9765249.png)
![eyiennz](https://user-images.githubusercontent.com/7595639/118346135-5deace80-b507-11eb-98cd-5b369a58e9b7.png)
![mSguRMj](https://user-images.githubusercontent.com/7595639/118346136-5deace80-b507-11eb-8458-4a407052f367.png)
![R6PRXpZ](https://user-images.githubusercontent.com/7595639/118346137-5e836500-b507-11eb-9c40-72015baad185.png)
![mmMU2JV](https://user-images.githubusercontent.com/7595639/118346138-5e836500-b507-11eb-8f8f-22abf60a71cc.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
