### PR TITLE
Add firstinspires link to team page

### DIFF
--- a/src/backend/web/templates/team_partials/team_info.html
+++ b/src/backend/web/templates/team_partials/team_info.html
@@ -28,6 +28,7 @@
       {% if team.rookie_year %}<span class="glyphicon glyphicon-calendar"></span> <span id="team-rookie-year">Rookie Year: {{ team.rookie_year }}</span><br>{% endif %}
       {% if last_competed and last_competed < max_year %}<span class="glyphicon glyphicon-time"></span> <span id="team-last-competed">Last competed in {{ last_competed }}</span><br>{% endif %}
       {% if team.website %}<span class="glyphicon glyphicon-globe"></span> <a id="team-website" href="{{team.website}}" target="_blank">{{ team.website }}</a><br>{% endif %}
+      <span class="glyphicon glyphicon-link"></span> Details on <a href="https://frc-events.firstinspires.org/team/{{team.team_number}}">firstinspires.org</a><br>
       {% if team.championship_location and team.championship_location[year] %}<span class="glyphicon glyphicon-flag"></span> <span id="team-home-cmp">Home Championship: {{team.championship_location[year]}}</span><br>{% endif %}
       {% if hof.is_hof %}<span id="team-hof" class="hall-of-fame"><span class="glyphicon glyphicon-certificate"></span> Hall of Fame ({% for year in hof.years %}{{ year }}{{ ", " if not loop.last }}{% endfor %}){% if hof.media.video or hof.media.presentation or hof.media.essay %}:{% endif %}{% if hof.media.video %} <a href="{{hof.media.video}}">Video</a>{% endif %}{% if hof.media.presentation %}, <a href="{{hof.media.presentation}}">Presentation</a>{% endif %}{% if hof.media.essay %}, <a href="{{hof.media.essay}}">Essay</a>{% endif %}</span><br>{% endif %}
       {% if year %}


### PR DESCRIPTION
## Description
This adds a link to `https://frc-events.firstinspires.org/team/{{ team.team_number }}` on team pages.

## Motivation and Context
Better UI parity with event pages, which already have equivalent firstinspires links.

## How Has This Been Tested?
Manually going to team pages.

## Screenshots (if appropriate):
![0PU1rGz](https://user-images.githubusercontent.com/7595639/118346416-24b35e00-b509-11eb-8df5-295ea1f7139c.png)
![zUu4Dx9](https://user-images.githubusercontent.com/7595639/118346418-24b35e00-b509-11eb-95d6-635c815282d6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
