### PR TITLE
Add docs about vagrant-gatling-rsync for WSL

### DIFF
--- a/docs/Setup/WSL-Guide.md
+++ b/docs/Setup/WSL-Guide.md
@@ -97,42 +97,8 @@ Try running `vagrant up`. If you see an error regarding unable to find the direc
 
 You may find that rsync is especially slow on WSL; currently, I/O speed is a problem for WSL. A simple workaround is to use [vagrant-gatling-rsync](https://github.com/smerrill/vagrant-gatling-rsync).
 
-Install with the following command:
+A bash script exists that will install said plugin, modify `Vagrantfile`, and modify `ops/dev/host.sh` in order to improve rsync speed.
 
 ```
-$ vagrant plugin install vagrant-gatling-rsync
-```
-
-Modify `Vagrantfile` to contain the following:
-
-```
-  # This is the *existing* rsync config in Vagrantfile
-  config.vm.synced_folder "./", "/tba",
-    type: "rsync",
-    owner: "root",
-    group: "root",
-    rsync__rsync_path: "rsync",
-    rsync__exclude: [
-      ".git/",
-      "node_modules/",
-      "src/build/*",
-      "*__pycache__*",
-      "venv/*",
-      ".pyre/*",
-    ],
-    rsync__auto: true
-
-  # Add the following here:
-  if Vagrant.has_plugin?("vagrant-gatling-rsync")
-    config.gatling.latency = 2.5
-    config.gatling.time_format = "%H:%M:%S"
-  end
-  config.gatling.rsync_on_startup = false
-```
-
-Additionally, modify `ops/dev/host.sh` to run `vagrant-gatling-rsync` rather than `rsync`:
-
-```
-declare -a cmds=("vagrant gatling-rsync-auto" "./ops/dev/print-gae-logs.sh" "./ops/dev/print-webpack-logs.sh")
-# ...
+$ ./ops/dev/vagrant/fix_wsl_rsync.sh
 ```

--- a/ops/dev/vagrant/fix_wsl_rsync.sh
+++ b/ops/dev/vagrant/fix_wsl_rsync.sh
@@ -13,4 +13,3 @@ sed -i 's/  # Forward GAE modules.*$/  if Vagrant.has_plugin?("vagrant-gatling-r
 \n&/' Vagrantfile
 
 sed -i 's/rsync-auto/gatling-rsync-auto/' ops/dev/host.sh
-

--- a/ops/dev/vagrant/fix_wsl_rsync.sh
+++ b/ops/dev/vagrant/fix_wsl_rsync.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# shellcheck disable=SC1004
+# Ignore Shellcheck error 1004
+# https://github.com/koalaman/shellcheck/wiki/SC1004
 
 vagrant plugin install vagrant-gatling-rsync
 

--- a/ops/dev/vagrant/fix_wsl_rsync.sh
+++ b/ops/dev/vagrant/fix_wsl_rsync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+vagrant plugin install vagrant-gatling-rsync
+
+sed -i 's/  # Forward GAE modules.*$/  if Vagrant.has_plugin?("vagrant-gatling-rsync") \
+    config.gatling.latency = 2.5 \
+    config.gatling.time_format = "%H:%M:%S" \
+  end \
+  config.gatling.rsync_on_startup = false \
+\n&/' Vagrantfile
+
+sed -i 's/rsync-auto/gatling-rsync-auto/' ops/dev/host.sh
+


### PR DESCRIPTION
## Description
Adds docs about using a Vagrant plugin to improve rsync speeds on WSL.

## Motivation and Context
On WSL2, I/O speed is a particular pain point, especially with rsync and vagrant (and more so when combined). This gives devs a workaround for local development.

## How Has This Been Tested?
Running commands locally, but only `vagrant up`, `vagrant destroy`, `vagrant halt`, and `ops/dev/host.sh`.

## Screenshots (if appropriate):
![gia2AJL](https://user-images.githubusercontent.com/7595639/118346601-a5bf2500-b50a-11eb-80b7-8751fb21990f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
