### PR TITLE
Fix the FRC API attribution link

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_sidebar_nav.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_sidebar_nav.less
@@ -2,6 +2,7 @@
   @media (min-width: @screen-tablet) {
     position: fixed;
     max-width: 160px;
+    z-index: 1;
   }
 }
 

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -112,7 +112,7 @@
 {% block footer %}
 <div id="footer" class="container">
   <div class="row">
-    <div class="col-sm-12">
+    <div class="row col-sm-12">
       <hr>
       {% block footer_content %}{% endblock %}
     </div>

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -112,7 +112,7 @@
 {% block footer %}
 <div id="footer" class="container">
   <div class="row">
-    <div class="col-sm-12 footer-separator">
+    <div class="col-sm-12">
       <hr>
       {% block footer_content %}{% endblock %}
     </div>

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -450,7 +450,7 @@
 
 {% block footer_content %}
 {% if event.official and event.year >= 2006 %}
-<div class="text-left" style="margin: 2rem 0;">
+<div class="text-left col-xs-12" style="margin-bottom: 2rem;">
   <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank"><em>FIRST</em><sup>®</sup> Events API</a>
 </div>
 {% endif %}

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -450,7 +450,7 @@
 
 {% block footer_content %}
 {% if event.official and event.year >= 2006 %}
-<div class="pull-left">
+<div class="text-left" style="margin: 2rem 0;">
   <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank"><em>FIRST</em><sup>®</sup> Events API</a>
 </div>
 {% endif %}

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -275,7 +275,7 @@
 
 {% block footer_content %}
 {% if year and year >= 2015 %}
-<div class="text-left" style="margin: 2rem 0;">
+<div class="text-left col-xs-12 col-sm-offset-3 col-lg-offset-2" style="margin-bottom: 2rem;">
   <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank"><em>FIRST</em><sup>®</sup> Events API</a><br>
 </div>
 {% endif %}

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -275,7 +275,7 @@
 
 {% block footer_content %}
 {% if year and year >= 2015 %}
-<div class="pull-left">
+<div class="text-left" style="margin: 2rem 0;">
   <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank"><em>FIRST</em><sup>®</sup> Events API</a><br>
 </div>
 {% endif %}


### PR DESCRIPTION
Fix work done in #3625.
The ``footer-separator`` class sets the ``z-index`` to ``-1``, so the link isn't clickable.

Also, it fixes the design on mobile:
**Before:**
![Footer Screenshot](https://user-images.githubusercontent.com/16443111/118487816-c2827500-b723-11eb-875e-b4e97fc50902.png)

**After:**
![Footer Screenshot](https://user-images.githubusercontent.com/16443111/118487692-a7176a00-b723-11eb-873e-b7a4290b3519.png)
