### PR TITLE
Fix local shell connecting to local datastore

### DIFF
--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -27,7 +27,6 @@ flask_response_cache_enabled=$(get_config_prop flask_response_cache_enabled)
 storage_mode=$(get_config_prop storage_mode)
 storage_path=$(get_config_prop storage_path)
 application=""
-datastore_args=()
 tasks_args=()
 env=()
 
@@ -67,8 +66,6 @@ function assert_local_storage_path {
 if [ "$datastore_mode" == "local" ]; then
     echo "Starting with datastore emulator"
     emulator_port=8089
-    datastore_path="/datastore/tba.db"
-    datastore_args=("--support_datastore_emulator=true" "--datastore_emulator_port=$emulator_port" "--datastore_path=$datastore_path")
     env+=("--env_var=DATASTORE_EMULATOR_HOST=localhost:$emulator_port" "--env_var=DATASTORE_DATASET=test")
 elif [ "$datastore_mode" == "remote" ]; then
     echo "Starting with remote datastore"
@@ -121,7 +118,6 @@ dev_appserver.py \
     --host=0.0.0.0 \
     --runtime="python37" \
     --application="$application" \
-    "${datastore_args[@]}" \
     "${tasks_args[@]}" \
     "${env[@]}" \
     --env_var TBA_LOG_LEVEL="$tba_log_level" \

--- a/ops/dev/vagrant/run_datastore_emulator.sh
+++ b/ops/dev/vagrant/run_datastore_emulator.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+set -e
+
+# We start the emulator regardless of whether we use the local or remote datastore
+# It's just easier that way
+
+# The project/port should match what's configured in the dev_appserver invocation
+project="test"
+emulator_port=8089
+datastore_path="/datastore/tba.db"
+
+gcloud beta emulators datastore start --project="$project" --data-dir="$datastore_path" --host-port="0.0.0.0:$emulator_port"

--- a/ops/dev/vagrant/start-devserver.sh
+++ b/ops/dev/vagrant/start-devserver.sh
@@ -19,10 +19,11 @@ fi
 echo "Starting devserver in new tmux session..."
 tmux new-session -d -s $session
 tmux new-window -t "$session:1" -n gae "./ops/dev/vagrant/dev_appserver.sh 2>&1 | tee /var/log/tba.log; read"
-tmux new-window -t "$session:2" -n webpack "./ops/dev/vagrant/run_webpack.sh 2>&1 | tee /var/log/webpack.log; read"
-tmux new-window -t "$session:3" -n redis "redis-server 2>&1 | tee /var/log/redis.log; read"
-tmux new-window -t "$session:4" -n rq-worker "rq worker default cache-clearing post-update-hooks 2>&1 | tee /var/log/rq-worker.log; read"
-tmux new-window -t "$session:5" -n rq-dashboard "rq-dashboard 2>&1 | tee /var/log/rq-dashboard.log; read"
+tmux new-window -t "$session:2" -n datastore "./ops/dev/vagrant/run_datastore_emulator.sh 2>&1 | tee /var/log/datastore_emulator.log; read"
+tmux new-window -t "$session:3" -n webpack "./ops/dev/vagrant/run_webpack.sh 2>&1 | tee /var/log/webpack.log; read"
+tmux new-window -t "$session:4" -n redis "redis-server 2>&1 | tee /var/log/redis.log; read"
+tmux new-window -t "$session:5" -n rq-worker "rq worker default cache-clearing post-update-hooks 2>&1 | tee /var/log/rq-worker.log; read"
+tmux new-window -t "$session:6" -n rq-dashboard "rq-dashboard 2>&1 | tee /var/log/rq-dashboard.log; read"
 if [ -n "$instance_name" ]; then
     echo "Starting Cloud SQL proxy to connect to $instance_name"
     tmux new-window -t "$session:6" -n sql "/cloud_sql_proxy -instances=$instance_name=tcp:3306 -credential_file=$auth_path | tee /var/log/sql.log; read"

--- a/ops/shell/ipython_config.py
+++ b/ops/shell/ipython_config.py
@@ -25,15 +25,24 @@ c.InteractiveShellApp.exec_lines = [
 ]
 
 # Set up Google Application Credentials
+dev_config = {}
+if os.path.isfile("tba_dev_config.json"):
+    with open("tba_dev_config.json") as f:
+        default_config = json.load(f)
+        dev_config.update(default_config)
+
 if os.path.isfile("tba_dev_config.local.json"):
     with open("tba_dev_config.local.json") as f:
         local_config = json.load(f)
-        if "google_application_credentials" in local_config:
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = local_config[
-                "google_application_credentials"
-            ]
+        dev_config.update(local_config)
 
-        if local_config.get("datastore_mode") == "local":
-            # These match the defaults used in the dev_appserver invocation
-            os.environ["DATASTORE_EMULATOR_HOST"] = "localhost:8089"
-            os.environ["DATASTORE_DATASET"] = "test"
+
+if "google_application_credentials" in dev_config:
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = dev_config[
+        "google_application_credentials"
+    ]
+
+if dev_config.get("datastore_mode") == "local":
+    # These match the defaults used in the dev_appserver invocation
+    os.environ["DATASTORE_EMULATOR_HOST"] = "localhost:8089"
+    os.environ["DATASTORE_DATASET"] = "test"


### PR DESCRIPTION
There were two things that needed fixing:
 (1) the shell launcher needs to merge the local config file with the
default one to properly resolve when someone wants to use the local
datastore

 (2) we need to run the datastore emulator bound to 0.0.0.0, so we can
access it outside the dev container. This diff changes the dev container
to run the emulator in a separate tmux window (always) instead as part
of dev_appserver. This is because dev_appserver's emulator launcher
alwys hardcodes `localhost`, and we need to specify the host ourselves.

After this lands, people will need to `vagrant rsync; vagrant halt; vagrant up` to recreate the container to launch TBA with the updated script

Test:
```
In [1]: import os

In [2]: os.environ["DATASTORE_EMULATOR_HOST"]
Out[2]: 'localhost:8089'

In [3]: with shell_lib.connect_to_ndb():
   ...:     from backend.common.models.event import Event
   ...:     event = Event.get_by_id("2019ctwat")
   ...:     print(event.name)
   ...: 
Connecting to local datastore at localhost:8089
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-d36dc6a2163f> in <module>
      2     from backend.common.models.event import Event
      3     event = Event.get_by_id("2019ctwat")
----> 4     print(event.name)
      5 

AttributeError: 'NoneType' object has no attribute 'name'
```