### PR TITLE
Add support for /_ah/queue/deferred route

### DIFF
--- a/src/backend/common/deferred/handlers/defer_handler.py
+++ b/src/backend/common/deferred/handlers/defer_handler.py
@@ -49,7 +49,7 @@ def install_defer_routes(app: Flask) -> None:
         install_regex_url_converter(app)
 
     app.add_url_rule(
-        '/_ah/queue/<regex("deferred.*"):path>',
+        '/_ah/queue/<regex("deferred.*?"):path>',
         view_func=handle_defer,
         methods=["POST"],
     )

--- a/src/backend/common/deferred/handlers/tests/defer_handler_test.py
+++ b/src/backend/common/deferred/handlers/tests/defer_handler_test.py
@@ -17,7 +17,7 @@ from backend.common.url_converters import install_regex_url_converter
 
 
 def test_install_defer_routes():
-    route = '/_ah/queue/<regex("deferred.*"):path>'
+    route = '/_ah/queue/<regex("deferred.*?"):path>'
     app = Flask(__name__)
     rules = [r for r in app.url_map.iter_rules() if str(r) == route]
     assert len(rules) == 0


### PR DESCRIPTION
The regex for the deferred route was problematic, since it wasn't using a `?` for the wildcard match, which meant the `/_ah/queue/deferred` route wouldn't work. This PR allows support for just a `/_ah/queue/deferred` route.