### PR TITLE
Disable FIRST Sync Code input box for 2021 season.

### DIFF
--- a/src/backend/web/templates/suggestions/suggest_offseason_event.html
+++ b/src/backend/web/templates/suggestions/suggest_offseason_event.html
@@ -135,7 +135,7 @@
                                 <tr>
                                     <td>FIRST Sync Code</td>
                                     <td>
-                                      <input class="form-control" type="text" name="first_code" placeholder="IRI"{% if first_code %} value="{{first_code}}"{% endif %}/>
+                                      <input class="form-control" type="text" disabled="disabled" name="first_code" placeholder="Like 'IRI'.  Disabled for 2021 season."{% if first_code %} value="{{first_code}}"{% endif %}/>
                                     </td>
                                 </tr>
                             </table>


### PR DESCRIPTION
FIRST is not issuing sync codes for the 2021 season.  This disables the form input so teams don't input it.


## Motivation and Context
This mitigates teams submitting incorrect FIRST Sync codes for 2021 events.

## How Has This Been Tested?
This has only been tested via inspect element; the HTML is valid and renders correctly.  However we may encounter issues with form parsing, as I presently have no way to verify that in a dev environment.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6531081/128734719-5a1ac1d8-b213-451c-9d69-0ef4eae62db5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
