### PR TITLE
Pin grpcio version for py2 bootstrap

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get install -y \
     python3-pip \
     python3-venv \
-    python2
+    python2 \
+    python-dev
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN echo 1 | update-alternatives --config python
 

--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -5,7 +5,7 @@ set -e
 mkdir -p /datastore
 
 # The datastore emulator requires grpcio
-pip2 install grpcio
+pip2 install grpcio==1.39.0
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r src/requirements.txt


### PR DESCRIPTION
The latest version of `grpcio` dropped the Python 2.7 binary wheel generations, which was causing our bootstrap [bootstrap-dev-container script](https://github.com/the-blue-alliance/the-blue-alliance/blob/37f9ea386bb876d032423f0fdf84ec107759f921/ops/dev/vagrant/bootstrap-dev-container.sh#L8) to fail when starting the development container.

This PR pins the `grpcio` version to the last known good version that supports py2