### PR TITLE
Ensure we use x86 Ubuntu image for Docker image

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM --platform=linux/x86_64 ubuntu:latest
 MAINTAINER The Blue Alliance
 
 # Set debconf to run non-interactively


### PR DESCRIPTION
New M1 machines will use the native ARM image instead of the emulated x86 image of Ubuntu. This makes sure we always use the x86 version of Ubuntu (tooling will fail to install in weird ways if we use the ARM image)