### PR TITLE
Revert "Ensure we use x86 Ubuntu image for Docker image (#3851)"

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 ubuntu:latest
+FROM ubuntu:latest
 MAINTAINER The Blue Alliance
 
 # Set debconf to run non-interactively


### PR DESCRIPTION
This reverts commit 55026199b13cece8d9b8fd6fd2a33b95f8c48d64.

Reverting this change, since this DRAMATICALLY slows down the container on M1 machines. The tooling I'm running in to issues running has alternatives (like versions that can be installed via `npm`), which I'll try instead