### PR TITLE
Update to python 3.9

### DIFF
--- a/.github/workflows/comment_screenshots_on_pr.yml
+++ b/.github/workflows/comment_screenshots_on_pr.yml
@@ -13,10 +13,10 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -125,10 +125,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -153,10 +153,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Set up Node
         uses: actions/setup-node@v2.5.1
         with:
@@ -182,10 +182,10 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.0
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -130,10 +130,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2.1.7
         with:
@@ -158,10 +158,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Set up Node
         uses: actions/setup-node@v2.5.1
         with:
@@ -197,10 +197,10 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.0
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -260,10 +260,10 @@ jobs:
     if: contains(github.event.commits[0].message, '[nodeploy]') == false
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
@@ -282,10 +282,10 @@ jobs:
     if: contains(github.event.commits[0].message, '[nodeploy]') == false
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Download production artifacts
         uses: actions/download-artifact@v2
         with:
@@ -309,10 +309,10 @@ jobs:
     if: contains(github.event.commits[0].message, '[nodeploy]') == false
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
@@ -331,10 +331,10 @@ jobs:
     if: contains(github.event.commits[0].message, '[nodeploy]') == false
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:

--- a/docs/Setup/Repo-Setup.md
+++ b/docs/Setup/Repo-Setup.md
@@ -3,7 +3,7 @@ A small amount of repo configuration can be done in order to streamline developm
 ## Install Dependencies
 This optional tooling requires [Python 3](https://www.python.org/downloads/) and [`pip`](https://pip.pypa.io/en/stable/installing/) to install.
 
-1. Install [Python 3](https://www.python.org/downloads/) (3.8+)
+1. Install [Python 3](https://www.python.org/downloads/) (3.9+)
 2. Install [`pip`](https://pip.pypa.io/en/stable/installing/)
 3. *(optionally)* Install [watchman](https://facebook.github.io/watchman/)
 4. *(optionally)* Install [shfmt](https://github.com/mvdan/sh)

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:rolling
 MAINTAINER The Blue Alliance
 
 # Set debconf to run non-interactively
@@ -15,12 +15,14 @@ RUN apt-get update && apt-get install -y \
   vim \
   openssh-server
 
-# Setup python environmenets
+# Setup python environmenet
+ENV PYTHON_VERSION python3.9
 RUN apt-get install -y \
-    python3-pip \
-    python3-venv \
-    python-dev
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    "$PYTHON_VERSION" \
+    "$PYTHON_VERSION-venv" \
+    "$PYTHON_VERSION-dev" \
+    python3-pip
+RUN update-alternatives --install /usr/bin/python python "/usr/bin/$PYTHON_VERSION" 1
 RUN echo 1 | update-alternatives --config python
 
 # Add gcloud repository and Cloud SDK dependencies
@@ -33,6 +35,10 @@ RUN apt-get update && apt-get install -y \
     google-cloud-sdk-app-engine-python-extras \
     google-cloud-sdk-datastore-emulator \
     google-cloud-sdk-pubsub-emulator
+
+# dev_appserver expects `python2` to exist
+RUN update-alternatives --install /usr/bin/python2 python2 /usr/bin/python2.7 1
+RUN echo 1 | update-alternatives --config python2
 
 # Set up nvm and nodejs
 ENV NVM_DIR /nvm

--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -92,7 +92,7 @@ dev_appserver.py \
     --runtime_python_path=/usr/bin/python3 \
     --admin_host=0.0.0.0 \
     --host=0.0.0.0 \
-    --runtime="python37" \
+    --runtime="python39" \
     --application="$application" \
     "${env[@]}" \
     --env_var TBA_LOG_LEVEL="$tba_log_level" \

--- a/src/api.yaml
+++ b/src/api.yaml
@@ -1,5 +1,5 @@
 service: py3-api
-runtime: python38
+runtime: python39
 entrypoint: gunicorn -b :$PORT backend.api.main:app
 app_engine_apis: true
 

--- a/src/default.yaml
+++ b/src/default.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python39
 entrypoint: gunicorn -b :$PORT backend.default.main:app
 
 instance_class: F1

--- a/src/tasks_io.yaml
+++ b/src/tasks_io.yaml
@@ -1,5 +1,5 @@
 service: py3-tasks-io
-runtime: python38
+runtime: python39
 entrypoint: gunicorn -b :$PORT backend.tasks_io.main:app
 app_engine_apis: true
 

--- a/src/web.yaml
+++ b/src/web.yaml
@@ -1,5 +1,5 @@
 service: py3-web
-runtime: python38
+runtime: python39
 entrypoint: gunicorn -b :$PORT backend.web.main:app
 app_engine_apis: true
 


### PR DESCRIPTION
Base changelog: https://docs.python.org/3/whatsnew/3.9.html

This also changes the dev container to use `ubuntu:rolling`, which is the newest version, instead of the LTS. This means we have access to newer python versions sooner, so it's a benefit 