### PR TITLE
Use py3 dev_appserver and drop py2 from Vagrant install

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -17,11 +17,9 @@ RUN apt-get update && apt-get install -y \
   redis-server
 
 # Setup python environmenets
-# python3 should be the default, but gcloud currently depends on python2
 RUN apt-get install -y \
     python3-pip \
     python3-venv \
-    python2 \
     python-dev
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN echo 1 | update-alternatives --config python
@@ -46,9 +44,6 @@ RUN mkdir -p $NVM_DIR  \
     && nvm install $NODE_VERSION --silent \
     && nvm alias default $NODE_VERSION \
     && nvm use default --silent
-
-# Install pip2 for gcloud dependencies
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2
 
 # Configure ssh server
 RUN mkdir /var/run/sshd

--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -5,7 +5,6 @@ set -e
 mkdir -p /datastore
 
 # The datastore emulator requires grpcio
-pip2 install grpcio==1.39.0
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r src/requirements.txt

--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -111,6 +111,7 @@ fi
 
 set -x
 dev_appserver.py \
+    --runtime_python_path=/usr/bin/python3 \
     --admin_host=0.0.0.0 \
     --host=0.0.0.0 \
     --runtime="python37" \


### PR DESCRIPTION
Use the [new Python 3 version of `dev_appserver`](https://cloud.google.com/appengine/docs/standard/python3/services/access#testing_and_deployment) locally for testing. This allows us to remove any Python 2 setup in our container.