### PR TITLE
Add flake plugin to ban some builtin GAE libraries

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,9 @@ exclude =
 
 application_import_names = backend
 import-order-style = edited
+banned-modules =
+    google.appengine.api.datastore = Use google.cloud.datastore
+    google.appengine.ext.ndb = Use google.cloud.ndb
 
 [flake8:local-plugins]
 extension =

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.10.0
 black==21.11b1
 flake8==4.0.1
 flake8-import-order
+flake8-tidy-imports
 blinker==1.4
 fakeredis
 freezegun==1.1.0


### PR DESCRIPTION
Now that we can depend on some aspects of the legacy GAE runtime, we should ban importing `ndb` and `datastore` by default since we would prefer to use the google cloud libraries.

```
(venv) [phil@fedora-x1think the-blue-alliance-py3]$ git diff
diff --git a/src/backend/common/redis.py b/src/backend/common/redis.py
index 3a839b59..4208fa1e 100644
--- a/src/backend/common/redis.py
+++ b/src/backend/common/redis.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import redis
+from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.environment import Environment
(venv) [phil@fedora-x1think the-blue-alliance-py3]$ ./ops/lint_py3.sh 
All done! ✨ 🍰 ✨
517 files would be left unchanged.
./src/backend/common/redis.py:4:1: F401 'google.appengine.ext.ndb' imported but unused
./src/backend/common/redis.py:4:1: I251 Banned import 'google.appengine.ext.ndb' used - Use google.cloud.ndb.
```