### PR TITLE
Re-add deferred catchall routing

### DIFF
--- a/src/backend/common/deferred/__init__.py
+++ b/src/backend/common/deferred/__init__.py
@@ -1,0 +1,1 @@
+from .defer_handler import install_defer_routes  # noqa: F401

--- a/src/backend/common/deferred/defer_handler.py
+++ b/src/backend/common/deferred/defer_handler.py
@@ -1,0 +1,23 @@
+from flask import Flask, request, Response
+from google.appengine.ext import deferred
+
+from backend.common.url_converters import (
+    has_regex_url_converter,
+    install_regex_url_converter,
+)
+
+
+def handle_defer(path: str) -> Response:
+    return deferred.application.post(request.environ)
+
+
+def install_defer_routes(app: Flask) -> None:
+    # Requires regex URL converter
+    if not has_regex_url_converter(app):
+        install_regex_url_converter(app)
+
+    app.add_url_rule(
+        '/_ah/queue/<regex("deferred.*?"):path>',
+        view_func=handle_defer,
+        methods=["POST"],
+    )

--- a/src/backend/common/deferred/tests/defer_handler_test.py
+++ b/src/backend/common/deferred/tests/defer_handler_test.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+from flask import Flask
+
+from backend.common.deferred.defer_handler import handle_defer, install_defer_routes
+from backend.common.url_converters import install_regex_url_converter
+
+
+def test_install_defer_routes():
+    route = '/_ah/queue/<regex("deferred.*?"):path>'
+    app = Flask(__name__)
+    rules = [r for r in app.url_map.iter_rules() if str(r) == route]
+    assert len(rules) == 0
+    install_defer_routes(app)
+    rules = [r for r in app.url_map.iter_rules() if str(r) == route]
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule.methods == {"OPTIONS", "POST"}
+    assert rule.endpoint == "handle_defer"
+
+
+def test_install_defer_routes_regex():
+    app = Flask(__name__)
+
+    with patch(
+        "backend.common.deferred.defer_handler.install_regex_url_converter",
+        wraps=install_regex_url_converter,
+    ) as mock_install_regex_url_converter:
+        install_defer_routes(app)
+
+    mock_install_regex_url_converter.assert_called()
+
+
+def test_install_defer_routes_regex_already_installed():
+    app = Flask(__name__)
+
+    install_regex_url_converter(app)
+
+    with patch(
+        "backend.common.deferred.defer_handler.has_regex_url_converter",
+        return_value=True,
+    ), patch(
+        "backend.common.deferred.defer_handler.install_regex_url_converter",
+        wraps=install_regex_url_converter,
+    ) as mock_install_regex_url_converter:
+        install_defer_routes(app)
+
+    mock_install_regex_url_converter.assert_not_called()
+
+
+def test_handle_defer():
+    app = Flask(__name__)
+    with app.test_request_context() as request_context, patch(
+        "google.appengine.ext.deferred.application.post"
+    ) as mock_post:
+        environ = request_context.request.environ
+        handle_defer("/some/path")
+
+    assert mock_post.called_with(environ)

--- a/src/backend/tasks_io/main.py
+++ b/src/backend/tasks_io/main.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from google.appengine.api import wrap_wsgi_app
 
+from backend.common.deferred import install_defer_routes
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
 
@@ -10,3 +11,4 @@ configure_logging()
 app = Flask(__name__)
 app.wsgi_app = wrap_wsgi_app(app.wsgi_app, use_deferred=True)
 install_middleware(app)
+install_defer_routes(app)


### PR DESCRIPTION
The catch-all `/_ah/queue/deferred.*` routing was removed in #3999 - however, we still depend on it in production. This PR re-adds the catch-all routing using our old `install_deferred_routes` method.