### PR TITLE
Fix missing FIREBASE_APP_ID from buildweb env

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -179,6 +179,7 @@ jobs:
         env:
           GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This is causing issues in production with failing to init the Firebase stuff