### PR TITLE
Remove unnecessary url_prefix set from account_blueprint in web

### DIFF
--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -69,7 +69,7 @@ app.add_url_rule("/team/<int:team_number>/history", view_func=team_history)
 app.add_url_rule("/teams/<int:page>", view_func=team_list)
 app.add_url_rule("/teams", view_func=team_list, defaults={"page": 1})
 
-app.register_blueprint(account_blueprint, url_prefix="/account")
+app.register_blueprint(account_blueprint)
 app.register_blueprint(suggestion_blueprint)
 app.register_blueprint(suggestion_review_blueprint)
 


### PR DESCRIPTION
We already set this up in the blueprint itself https://github.com/the-blue-alliance/the-blue-alliance/blob/8c49c185312db1d5dace186c970dc48e8dd91394/src/backend/web/handlers/account.py#L35