### PR TITLE
Add Dynamic View Cache TTLs

### DIFF
--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -1,5 +1,6 @@
+from datetime import timedelta
 from functools import partial, wraps
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from flask import current_app, has_request_context, make_response, request, Response
 from flask_caching import CachedResponse
@@ -7,9 +8,10 @@ from flask_caching import CachedResponse
 from backend.common.environment import Environment
 
 
-def cached_public(func: Optional[Callable] = None, timeout: int = 61):
+def cached_public(func: Optional[Callable] = None, ttl: Union[int, timedelta] = 61):
+    timeout = ttl if isinstance(ttl, int) else ttl.total_seconds()
     if func is None:  # Handle no-argument decorator
-        return partial(cached_public, timeout=timeout)
+        return partial(cached_public, ttl=ttl)
 
     @wraps(func)
     def decorated_function(*args, **kwargs):

--- a/src/backend/common/flask_cache.py
+++ b/src/backend/common/flask_cache.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from typing import Any, Dict
 
 from flask import Flask, make_response, Response
@@ -22,6 +23,6 @@ def configure_flask_cache(app: Flask) -> None:
     app.cache = cache
 
 
-def make_cached_response(*args: Any, timeout: int) -> Response:
+def make_cached_response(*args: Any, ttl: timedelta) -> Response:
     resp = make_response(*args)
-    return CachedResponse(response=resp, timeout=timeout)
+    return CachedResponse(response=resp, timeout=int(ttl.total_seconds()))

--- a/src/backend/common/flask_cache.py
+++ b/src/backend/common/flask_cache.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Dict
+from typing import Any, Dict
 
-from flask import Flask
-from flask_caching import BaseCache, Cache
+from flask import Flask, make_response, Response
+from flask_caching import BaseCache, Cache, CachedResponse
 from google.appengine.api import memcache
 
 from backend.common.cache.flask_response_cache import MemcacheFlaskResponseCache
@@ -20,3 +20,8 @@ def configure_flask_cache(app: Flask) -> None:
     cache = Cache(config=config)
     cache.init_app(app)
     app.cache = cache
+
+
+def make_cached_response(*args: Any, timeout: int) -> Response:
+    resp = make_response(*args)
+    return CachedResponse(response=resp, timeout=timeout)

--- a/src/backend/common/tests/decorator_test.py
+++ b/src/backend/common/tests/decorator_test.py
@@ -41,7 +41,7 @@ def test_cached_public_default(app: Flask) -> None:
 
 def test_cached_public_timeout(app: Flask) -> None:
     @app.route("/")
-    @cached_public(timeout=3600)
+    @cached_public(ttl=3600)
     def view():
         return "Hello!"
 
@@ -51,7 +51,7 @@ def test_cached_public_timeout(app: Flask) -> None:
 
 def test_cached_public_timeout_dynamic(app: Flask) -> None:
     @app.route("/")
-    @cached_public(timeout=3600)
+    @cached_public(ttl=3600)
     def view():
         # This should take precedence over the static timeout
         return CachedResponse(make_response("Hello!"), 600)
@@ -102,7 +102,7 @@ def test_flask_cache_with_memcache_static_timeout(app: Flask, memcache_stub) -> 
     configure_flask_cache(app)
 
     @app.route("/")
-    @cached_public(timeout=1)
+    @cached_public(ttl=1)
     def view():
         return "Hello!"
 
@@ -122,7 +122,7 @@ def test_flask_cache_with_memcache_dynamic_timeout(app: Flask, memcache_stub) ->
     configure_flask_cache(app)
 
     @app.route("/")
-    @cached_public(timeout=1)
+    @cached_public(ttl=1)
     def view():
         return CachedResponse(make_response("Hello!"), 2)
 

--- a/src/backend/web/handlers/apidocs.py
+++ b/src/backend/web/handlers/apidocs.py
@@ -1,8 +1,10 @@
+from datetime import timedelta
+
 from backend.common.decorators import cached_public
 from backend.web.profiled_render import render_template
 
 
-@cached_public(timeout=int(60 * 60 * 24 * 7))
+@cached_public(ttl=timedelta(weeks=1))
 def apidocs_trusted_v1() -> str:
     template_values = {
         "title": "Trusted APIv1",
@@ -11,7 +13,7 @@ def apidocs_trusted_v1() -> str:
     return render_template("apidocs_swagger.html", template_values)
 
 
-@cached_public(timeout=int(60 * 60 * 24 * 7))
+@cached_public(ttl=timedelta(weeks=1))
 def apidocs_v3() -> str:
     template_values = {
         "title": "APIv3",

--- a/src/backend/web/handlers/district.py
+++ b/src/backend/web/handlers/district.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from datetime import timedelta
 from operator import itemgetter
 from typing import List, Optional, Tuple
 
@@ -8,6 +9,7 @@ from google.appengine.ext import ndb
 from werkzeug.wrappers import Response
 
 from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.event_team_status_helper import EventTeamStatusHelper
 from backend.common.helpers.season_helper import SeasonHelper
@@ -24,7 +26,7 @@ from backend.common.queries.team_query import DistrictTeamsQuery, EventTeamsQuer
 from backend.web.profiled_render import render_template
 
 
-@cached_public(timeout=60 * 15)
+@cached_public
 def district_detail(
     district_abbrev: DistrictAbbreviation, year: Optional[Year]
 ) -> Response:
@@ -55,7 +57,9 @@ def district_detail(
     live_events = []
     live_eventteams_futures = []
 
+    current_year = False
     if year == datetime.datetime.now().year:  # Only show active teams for current year
+        current_year = True
         live_events = EventHelper.week_events()
     for event in live_events:
         live_eventteams_futures.append(EventTeamsQuery(event.key_name).fetch_async())
@@ -155,4 +159,7 @@ def district_detail(
         "live_events_with_teams": live_events_with_teams,
     }
 
-    return render_template("district_details.html", template_values)
+    return make_cached_response(
+        render_template("district_details.html", template_values),
+        ttl=timedelta(minutes=15) if current_year else timedelta(days=1),
+    )

--- a/src/backend/web/handlers/district.py
+++ b/src/backend/web/handlers/district.py
@@ -24,7 +24,7 @@ from backend.common.queries.team_query import DistrictTeamsQuery, EventTeamsQuer
 from backend.web.profiled_render import render_template
 
 
-@cached_public
+@cached_public(timeout=60 * 15)
 def district_detail(
     district_abbrev: DistrictAbbreviation, year: Optional[Year]
 ) -> Response:

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -1,5 +1,5 @@
 import collections
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 from flask import abort, redirect, request
@@ -75,7 +75,7 @@ def event_list(year: Optional[Year] = None) -> Response:
     }
     return make_cached_response(
         render_template("event_list.html", template_values),
-        timeout=60 * 5 if year == datetime.now().year else 60 * 60 * 24,
+        ttl=timedelta(minutes=5) if year == datetime.now().year else timedelta(days=1),
     )
 
 
@@ -244,5 +244,5 @@ def event_detail(event_key: EventKey) -> Response:
 
     return make_cached_response(
         render_template("event_details.html", template_values),
-        timeout=61 if event.within_a_day else 60 * 60 * 24,
+        ttl=timedelta(seconds=61) if event.within_a_day else timedelta(days=1),
     )

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -1,4 +1,5 @@
 import collections
+from datetime import datetime
 from typing import Optional
 
 from flask import abort, redirect, request
@@ -8,6 +9,7 @@ from werkzeug.wrappers import Response
 
 from backend.common.consts import comp_level, playoff_type
 from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
 from backend.common.helpers.award_helper import AwardHelper
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.match_helper import MatchHelper
@@ -71,17 +73,19 @@ def event_list(year: Optional[Year] = None) -> Response:
         "state_prov": state_prov,
         "valid_state_provs": valid_state_provs,
     }
-    return render_template("event_list.html", template_values)
+    return make_cached_response(
+        render_template("event_list.html", template_values),
+        timeout=60 * 5 if year == datetime.now().year else 60 * 60 * 24,
+    )
 
 
 @cached_public
 def event_detail(event_key: EventKey) -> Response:
-    event = event_query.EventQuery(event_key).fetch()
+    event: Optional[Event] = event_query.EventQuery(event_key).fetch()
 
     if not event:
         abort(404)
 
-    event = none_throws(event)  # for pyre
     event.prep_awards_matches_teams()
     event.prep_details()
     medias_future = media_query.EventTeamsPreferredMediasQuery(event_key).fetch_async()
@@ -110,7 +114,7 @@ def event_detail(event_key: EventKey) -> Response:
     cleaned_matches = event.matches
     # MatchHelper.delete_invalid_matches(event.matches, event)
     match_count, matches = MatchHelper.organized_matches(cleaned_matches)
-    teams = TeamHelper.sort_teams(event.teams)
+    teams = TeamHelper.sort_teams(event.teams)  # pyre-ignore[6]
 
     # Organize medias by team
     image_medias = MediaHelper.get_images(
@@ -238,4 +242,7 @@ def event_detail(event_key: EventKey) -> Response:
         "elim_playlist": elim_playlist,
     }
 
-    return render_template("event_details.html", template_values)
+    return make_cached_response(
+        render_template("event_details.html", template_values),
+        timeout=61 if event.within_a_day else 60 * 60 * 24,
+    )

--- a/src/backend/web/handlers/gameday.py
+++ b/src/backend/web/handlers/gameday.py
@@ -3,6 +3,6 @@ from flask import render_template
 from backend.common.decorators import cached_public
 
 
-@cached_public
+@cached_public(timeout=61)
 def gameday() -> str:
     return render_template("gameday2.html", webcasts_json={}, default_chat=None)

--- a/src/backend/web/handlers/gameday.py
+++ b/src/backend/web/handlers/gameday.py
@@ -1,8 +1,10 @@
+from datetime import timedelta
+
 from flask import render_template
 
 from backend.common.decorators import cached_public
 
 
-@cached_public(timeout=61)
+@cached_public(ttl=timedelta(seconds=61))
 def gameday() -> str:
     return render_template("gameday2.html", webcasts_json={}, default_chat=None)

--- a/src/backend/web/handlers/match.py
+++ b/src/backend/web/handlers/match.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from typing import Optional
 
 from flask import abort
@@ -51,5 +52,5 @@ def match_detail(match_key: MatchKey) -> Response:
 
     return make_cached_response(
         render_template("match_details.html", template_values),
-        timeout=61 if event.within_a_day else 60 * 60 * 24,
+        ttl=timedelta(seconds=61) if event.within_a_day else timedelta(days=1),
     )

--- a/src/backend/web/handlers/team.py
+++ b/src/backend/web/handlers/team.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timedelta
 
 from flask import abort, Response
 
@@ -45,7 +46,7 @@ def team_detail(
         abort(404)
     return make_cached_response(
         render_template("team_details.html", template_values),
-        timeout=61 if short_cache else 60 * 60 * 24,
+        ttl=timedelta(seconds=61) if short_cache else timedelta(days=1),
     )
 
 
@@ -62,7 +63,7 @@ def team_history(team_number: TeamNumber, is_canonical: bool = False) -> Respons
     template_values, short_cache = TeamRenderer.render_team_history(team, is_canonical)
     return make_cached_response(
         render_template("team_history.html", template_values),
-        timeout=60 * 5 if short_cache else 60 * 60 * 24,
+        ttl=timedelta(minutes=5) if short_cache else timedelta(days=1),
     )
 
 
@@ -84,7 +85,7 @@ def team_canonical(team_number: TeamNumber) -> Response:
     return team_detail(team_number, current_year, is_canonical=True)
 
 
-@cached_public(timeout=60 * 60 * 24 * 7)
+@cached_public(ttl=timedelta(days=7))
 def team_list(page: int) -> str:
     page_labels = []
     cur_page_label = ""

--- a/src/backend/web/handlers/team.py
+++ b/src/backend/web/handlers/team.py
@@ -1,8 +1,9 @@
 import datetime
 
-from flask import abort
+from flask import abort, Response
 
 from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.keys import TeamNumber, Year
 from backend.common.models.team import Team
@@ -24,7 +25,9 @@ VALID_PAGES = range(
 
 
 @cached_public
-def team_detail(team_number: TeamNumber, year: Year, is_canonical: bool = False) -> str:
+def team_detail(
+    team_number: TeamNumber, year: Year, is_canonical: bool = False
+) -> Response:
     team_key = f"frc{team_number}"
     if not Team.validate_key_name(team_key):
         abort(404)
@@ -35,14 +38,19 @@ def team_detail(team_number: TeamNumber, year: Year, is_canonical: bool = False)
     if not team:
         abort(404)
 
-    template_values = TeamRenderer.render_team_details(team, year, is_canonical)
+    template_values, short_cache = TeamRenderer.render_team_details(
+        team, year, is_canonical
+    )
     if template_values is None:
         abort(404)
-    return render_template("team_details.html", template_values)
+    return make_cached_response(
+        render_template("team_details.html", template_values),
+        timeout=61 if short_cache else 60 * 60 * 24,
+    )
 
 
 @cached_public
-def team_history(team_number: TeamNumber, is_canonical: bool = False) -> str:
+def team_history(team_number: TeamNumber, is_canonical: bool = False) -> Response:
     team_key = f"frc{team_number}"
     if not Team.validate_key_name(team_key):
         abort(404)
@@ -51,12 +59,15 @@ def team_history(team_number: TeamNumber, is_canonical: bool = False) -> str:
     if not team:
         abort(404)
 
-    template_values = TeamRenderer.render_team_history(team, is_canonical)
-    return render_template("team_history.html", template_values)
+    template_values, short_cache = TeamRenderer.render_team_history(team, is_canonical)
+    return make_cached_response(
+        render_template("team_history.html", template_values),
+        timeout=60 * 5 if short_cache else 60 * 60 * 24,
+    )
 
 
 @cached_public
-def team_canonical(team_number: TeamNumber) -> str:
+def team_canonical(team_number: TeamNumber) -> Response:
     team_future = TeamQuery(team_key=f"frc{team_number}").fetch_async()
     team = team_future.get_result()
     if not team:
@@ -73,7 +84,7 @@ def team_canonical(team_number: TeamNumber) -> str:
     return team_detail(team_number, current_year, is_canonical=True)
 
 
-@cached_public
+@cached_public(timeout=60 * 60 * 24 * 7)
 def team_list(page: int) -> str:
     page_labels = []
     cur_page_label = ""

--- a/src/backend/web/handlers/tests/event_detail_test.py
+++ b/src/backend/web/handlers/tests/event_detail_test.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from freezegun import freeze_time
 from werkzeug.test import Client
 
 from backend.web.handlers.tests import helpers
@@ -14,11 +15,21 @@ def test_render_event(ndb_stub, web_client: Client) -> None:
 
     resp = web_client.get("/event/2020nyny")
     assert resp.status_code == 200
+    assert "max-age=86400" in resp.headers["Cache-Control"]
 
     soup = BeautifulSoup(resp.data, "html.parser")
     assert soup.find(id="event-name").string == "Test Event 2020"
     assert soup.find(itemprop="startDate").string == "March 1"
     assert soup.find(itemprop="endDate").string == "March 5, 2020"
+
+
+@freeze_time("2020-03-02")
+def test_render_short_cache(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_event("2020nyny")
+
+    resp = web_client.get("/event/2020nyny")
+    assert resp.status_code == 200
+    assert "max-age=61" in resp.headers["Cache-Control"]
 
 
 def test_render_full_regional(web_client: Client, setup_full_event) -> None:

--- a/src/backend/web/handlers/tests/match_detail_test.py
+++ b/src/backend/web/handlers/tests/match_detail_test.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from freezegun import freeze_time
 from werkzeug.test import Client
 
 
@@ -17,6 +18,7 @@ def test_render_match(web_client: Client, setup_full_match) -> None:
 
     resp = web_client.get("/match/2019nyny_qm1")
     assert resp.status_code == 200
+    assert "max-age=86400" in resp.headers["Cache-Control"]
 
     soup = BeautifulSoup(resp.data, "html.parser")
     assert (
@@ -26,3 +28,12 @@ def test_render_match(web_client: Client, setup_full_match) -> None:
     assert soup.find(id="match-table-2019nyny_qm1") is not None
     assert soup.find(id="match-breakdown") is not None
     assert soup.find(id="youtube_ooI6fkKfzLc") is not None
+
+
+@freeze_time("2019-04-04")
+def test_render_match_short_cache(web_client: Client, setup_full_match) -> None:
+    setup_full_match("2019nyny_qm1")
+
+    resp = web_client.get("/match/2019nyny_qm1")
+    assert resp.status_code == 200
+    assert "max-age=61" in resp.headers["Cache-Control"]

--- a/src/backend/web/handlers/tests/team_canonical_test.py
+++ b/src/backend/web/handlers/tests/team_canonical_test.py
@@ -17,8 +17,8 @@ def test_team_not_found(web_client: Client) -> None:
 def test_team_found_no_events(web_client: Client, ndb_stub) -> None:
     helpers.preseed_team(254)
     resp = web_client.get("/team/254")
-    # This should render team history, but it's not implemented yet
     assert resp.status_code == 200
+    assert "max-age=86400" in resp.headers["Cache-Control"]
     assert (
         helpers.get_page_title(resp.data)
         == "The 254 Team - Team 254 (History) - The Blue Alliance"
@@ -51,3 +51,17 @@ def test_team_info(web_client: Client, ndb_stub) -> None:
     assert team_info.location == "New York, NY, USA"
     assert team_info.full_name == "The Blue Alliance / Some High School"
     assert team_info.rookie_year == "Rookie Year: 2008"
+
+
+@freeze_time("2020-03-01")
+def test_short_cache_live_event(web_client: Client, ndb_stub) -> None:
+    helpers.preseed_team(254)
+    # We need an event to not render the history page
+    helpers.preseed_event_for_team(254, "2020test")
+    resp = web_client.get("/team/254")
+    assert resp.status_code == 200
+    assert "max-age=61" in resp.headers["Cache-Control"]
+    assert (
+        helpers.get_page_title(resp.data)
+        == "The 254 Team - Team 254 - The Blue Alliance"
+    )

--- a/src/backend/web/handlers/tests/team_detail_test.py
+++ b/src/backend/web/handlers/tests/team_detail_test.py
@@ -31,6 +31,7 @@ def test_page_title(web_client: Client, ndb_stub) -> None:
     helpers.preseed_event_for_team(254, "2020test")
     resp = web_client.get("/team/254/2020")
     assert resp.status_code == 200
+    assert "max-age=86400" in resp.headers["Cache-Control"]
     assert (
         helpers.get_page_title(resp.data)
         == "The 254 Team - Team 254 (2020) - The Blue Alliance"
@@ -70,6 +71,7 @@ def test_team_info_live_event_no_upcoming_matches(
 ) -> None:
     resp = web_client.get("/team/148/2019")
     assert resp.status_code == 200
+    assert "max-age=61" in resp.headers["Cache-Control"]
 
     team_info = helpers.get_team_info(resp.data)
     assert team_info.header == "Team 148 - Robowranglers"

--- a/src/backend/web/handlers/tests/team_history_test.py
+++ b/src/backend/web/handlers/tests/team_history_test.py
@@ -1,3 +1,4 @@
+from freezegun.api import freeze_time
 from werkzeug.test import Client
 
 from backend.web.handlers.tests import helpers
@@ -18,10 +19,20 @@ def test_page_title(web_client: Client, ndb_stub) -> None:
     helpers.preseed_event_for_team(254, "2020test")
     resp = web_client.get("/team/254/history")
     assert resp.status_code == 200
+    assert "max-age=86400" in resp.headers["Cache-Control"]
     assert (
         helpers.get_page_title(resp.data)
         == "The 254 Team - Team 254 (History) - The Blue Alliance"
     )
+
+
+@freeze_time("2020-03-01")
+def test_short_cache_live_event(web_client: Client, ndb_stub) -> None:
+    helpers.preseed_team(254)
+    helpers.preseed_event_for_team(254, "2020test")
+    resp = web_client.get("/team/254/history")
+    assert resp.status_code == 200
+    assert "max-age=300" in resp.headers["Cache-Control"]
 
 
 def test_team_info(web_client: Client, setup_full_team) -> None:

--- a/src/backend/web/handlers/tests/team_list_test.py
+++ b/src/backend/web/handlers/tests/team_list_test.py
@@ -38,6 +38,7 @@ def test_bad_page(web_client: Client) -> None:
 def test_team_list_empty_no_page(web_client: Client) -> None:
     resp = web_client.get("/teams")
     assert resp.status_code == 200
+    assert "max-age=604800" in resp.headers["Cache-Control"]
 
     assert len(get_all_teams(resp.data)) == 0
 


### PR DESCRIPTION
We can cache data that isn't associated with an active event for longer.

This relies on using our forked version of `flask-caching`, but will maintain functionality from the old site. Timeouts were taken from the legacy controllers