### PR TITLE
Dispatch fmsapi_awards endpoints to py3

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -34,6 +34,13 @@ dispatch:
 - url: "*/clientapi/*"
   service: clientapi
 
+# Mirgated py3 tasks
+- url: "*/tasks/tasks/enqueue/fmsapi_awards/*"
+  service: py3-tasks-io
+
+- url: "*/tasks/tasks/get/fmsapi_awards/*"
+  service: py3-tasks-io
+
 # Handles latency-insensive tasks
 - url: "*/tasks/*"
   service: tasks

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -35,10 +35,10 @@ dispatch:
   service: clientapi
 
 # Mirgated py3 tasks
-- url: "*/tasks/tasks/enqueue/fmsapi_awards/*"
+- url: "*/tasks/enqueue/fmsapi_awards/*"
   service: py3-tasks-io
 
-- url: "*/tasks/tasks/get/fmsapi_awards/*"
+- url: "*/tasks/get/fmsapi_awards/*"
   service: py3-tasks-io
 
 # Handles latency-insensive tasks


### PR DESCRIPTION
Requires https://github.com/the-blue-alliance/the-blue-alliance/pull/3520 to land - but will allow us to fetch awards in py3