### PR TITLE
Cache flask responses using query strings

### DIFF
--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -19,6 +19,7 @@ def cached_public(func: Optional[Callable] = None, ttl: Union[int, timedelta] = 
             cached = current_app.cache.cached(
                 timeout=timeout,
                 response_filter=lambda resp: make_response(resp).status_code == 200,
+                query_string=True,
             )
             resp = make_response(cached(func)(*args, **kwargs))
         else:


### PR DESCRIPTION
Worked in dev, should work in prod? I think this is dumb because it actually creates a cache depending on the *order* of the query strings, which isn't great. But let's see if it fixes our cache problem upstream and then write tests and figure out how to make it suck less later.