### PR TITLE
[CI] Properly handle screenshotting and commenting in PRs from forks

### DIFF
--- a/.github/workflows/comment_screenshots_on_pr.yml
+++ b/.github/workflows/comment_screenshots_on_pr.yml
@@ -1,0 +1,52 @@
+name: Comment screenshots on PR
+
+on:
+  workflow_run:
+    workflows: ["On pull request"]
+    types:
+      - completed
+
+jobs:
+  upload_and_comment:
+    name: "Upload and Comment on PR"
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "ci_screenshots"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{ github.workspace }}/ci_screenshots.zip', Buffer.from(download.data));
+      - name: Unzip artifact
+        run: unzip ci_screenshots.zip
+      - name: Upload screenshots and generate message
+        run: |
+          ./ops/pr_screenshots/generate_screenshots_message.py ${{ secrets.GITHUB_TOKEN }}
+          MESSAGE=$(cat ci_screenshots_message.md)
+          MESSAGE="${MESSAGE//'%'/'%25'}"
+          MESSAGE="${MESSAGE//$'\n'/'%0A'}"
+          MESSAGE="${MESSAGE//$'\r'/'%0D'}"
+          echo "::set-output name=message::$MESSAGE"
+      - name: Comment screenshots message on PR
+        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        with:
+          message: ${{ steps.generate_screenshots.outputs.message }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_IDENTIFIER: "screenshots-comment-rewritable-action"

--- a/.github/workflows/comment_screenshots_on_pr.yml
+++ b/.github/workflows/comment_screenshots_on_pr.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Unzip artifact
         run: unzip ci_screenshots.zip
       - name: Upload screenshots and generate message
+        id: upload_screenshots
         run: |
           ./ops/pr_screenshots/generate_screenshots_message.py ${{ secrets.GITHUB_TOKEN }}
           MESSAGE=$(cat ci_screenshots_message.md)
@@ -47,6 +48,6 @@ jobs:
       - name: Comment screenshots message on PR
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
-          message: ${{ steps.generate_screenshots.outputs.message }}
+          message: ${{ steps.upload_screenshots.outputs.message }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_IDENTIFIER: "screenshots-comment-rewritable-action"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -208,16 +208,16 @@ jobs:
         run: |
           npm ci
           npm install -g capture-website-cli
-      # - name: Install Vagrant
-      #   run: sudo apt-get install vagrant
-      # - name: Create keys file
-      #   run: cp ./src/backend/web/static/javascript/tba_js/tba_keys_template.js ./src/backend/web/static/javascript/tba_js/tba_keys.js
-      # - name: Start Container
-      #   run: ENV='CI' vagrant up
-      # - name: Test Vagrant Startup
-      #   run: ./ops/test_vagrant_startup.py
-      # - name: Test Ops Fullstack
-      #   run: ./ops/test_ops.sh
+      - name: Install Vagrant
+        run: sudo apt-get install vagrant
+      - name: Create keys file
+        run: cp ./src/backend/web/static/javascript/tba_js/tba_keys_template.js ./src/backend/web/static/javascript/tba_js/tba_keys.js
+      - name: Start Container
+        run: ENV='CI' vagrant up
+      - name: Test Vagrant Startup
+        run: ./ops/test_vagrant_startup.py
+      - name: Test Ops Fullstack
+        run: ./ops/test_ops.sh
       - name: Capture screenshots
         run: ./ops/pr_screenshots/capture_screenshots.py
       - name: Upload screenshots artifact

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -219,17 +219,12 @@ jobs:
       # - name: Test Ops Fullstack
       #   run: ./ops/test_ops.sh
       - name: Capture screenshots
-        run: ./ops/capture_screenshots.py
-      - uses: actions/upload-artifact@v2
+        run: ./ops/pr_screenshots/capture_screenshots.py
+      - name: Upload screenshots artifact
+        uses: actions/upload-artifact@v2
         with:
           name: ci_screenshots
           path: ci_screenshots.pickle
-      # - name: Comment screenshots on PR
-      #   uses: phulsechinmay/rewritable-pr-comment@v0.2.1
-      #   with:
-      #     message: ${{ steps.generate_screenshots.outputs.message }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     COMMENT_IDENTIFIER: "screenshots-comment-rewritable-action"
 
   automerge:
     needs: [py3-type, py3-lint, py3-test, node-lint, node-test, bash-lint, build-web, ops-test]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -208,31 +208,28 @@ jobs:
         run: |
           npm ci
           npm install -g capture-website-cli
-      - name: Install Vagrant
-        run: sudo apt-get install vagrant
-      - name: Create keys file
-        run: cp ./src/backend/web/static/javascript/tba_js/tba_keys_template.js ./src/backend/web/static/javascript/tba_js/tba_keys.js
-      - name: Start Container
-        run: ENV='CI' vagrant up
-      - name: Test Vagrant Startup
-        run: ./ops/test_vagrant_startup.py
-      - name: Test Ops Fullstack
-        run: ./ops/test_ops.sh
-      - name: Generate screenshots
-        id: generate_screenshots
-        run: |
-          ./ops/generate_screenshots.py ${{ secrets.GITHUB_TOKEN }}
-          MESSAGE=$(cat ci_screenshots_message.md)
-          MESSAGE="${MESSAGE//'%'/'%25'}"
-          MESSAGE="${MESSAGE//$'\n'/'%0A'}"
-          MESSAGE="${MESSAGE//$'\r'/'%0D'}"
-          echo "::set-output name=message::$MESSAGE"
-      - name: Comment screenshots on PR
-        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+      # - name: Install Vagrant
+      #   run: sudo apt-get install vagrant
+      # - name: Create keys file
+      #   run: cp ./src/backend/web/static/javascript/tba_js/tba_keys_template.js ./src/backend/web/static/javascript/tba_js/tba_keys.js
+      # - name: Start Container
+      #   run: ENV='CI' vagrant up
+      # - name: Test Vagrant Startup
+      #   run: ./ops/test_vagrant_startup.py
+      # - name: Test Ops Fullstack
+      #   run: ./ops/test_ops.sh
+      - name: Capture screenshots
+        run: ./ops/capture_screenshots.py
+      - uses: actions/upload-artifact@v2
         with:
-          message: ${{ steps.generate_screenshots.outputs.message }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT_IDENTIFIER: "screenshots-comment-rewritable-action"
+          name: ci_screenshots
+          path: ci_screenshots.pickle
+      # - name: Comment screenshots on PR
+      #   uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+      #   with:
+      #     message: ${{ steps.generate_screenshots.outputs.message }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     COMMENT_IDENTIFIER: "screenshots-comment-rewritable-action"
 
   automerge:
     needs: [py3-type, py3-lint, py3-test, node-lint, node-test, bash-lint, build-web, ops-test]

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .pyre/
 .vagrant/
 
+ci_screenshots.pickle
 ci_screenshots_message.md
 .coverage
 coverage.xml

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -4,6 +4,7 @@
     "src"
   ],
   "search_path": [
+    "ops/pr_screenshots",
     "stubs",
     {"site-package": "fakeredis"},
     {"site-package": "flask_caching"},

--- a/ops/capture_screenshots.py
+++ b/ops/capture_screenshots.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import pickle
+import subprocess
+import time
+from typing import List, Tuple
+
+
+CAPTURE_URLS = [
+    ("Homepage", "https://www.thebluealliance.com"),
+    ("GameDay", "https://www.thebluealliance.com/gameday"),
+]  # (name, url)
+GITHUB_REF = os.environ.get("GITHUB_REF", "")
+GITHUB_PULL_REQUEST_NUMBER = (
+    int(GITHUB_REF.split("/")[2]) if "refs/pull/" in GITHUB_REF else None
+)
+OUTPUT_FILE = "ci_screenshots.pickle"
+
+
+def capture_screenshots(urls: List[Tuple[str, str]]) -> List[Tuple[str, str, str]]:
+    screenshots = []  # (name, filename, base64encode image)
+    for name, url in urls:
+        print(f"Screenshotting {name}: {url}")
+        try:
+            cmd = [
+                "capture-website",
+                url,
+                "--width",
+                "1920",
+                "--height",
+                "1080",
+            ]
+            image_data = subprocess.check_output(cmd)
+            image = base64.b64encode(image_data).decode("utf-8")
+            filename = (
+                f"pr-{GITHUB_PULL_REQUEST_NUMBER}-{url}-{int(time.time())}.png".replace(
+                    "/", "-"
+                ).replace(" ", "")
+            )
+            screenshots.append((name, filename, image))
+        except subprocess.CalledProcessError as e:
+            print(f"Error: {e}")
+    return screenshots
+
+
+if __name__ == "__main__":
+    if os.environ.get("CI"):
+        screenshots = capture_screenshots(CAPTURE_URLS)
+        pickle.dump(screenshots, open(OUTPUT_FILE, "wb"))
+    else:
+        print("Only runnable in CI.")

--- a/ops/pr_screenshots/artifact_data.py
+++ b/ops/pr_screenshots/artifact_data.py
@@ -1,0 +1,9 @@
+from typing import List, Tuple, TypedDict
+
+
+ARTIFACT_FILENAME = "ci_screenshots.pickle"
+
+
+class ArtifactData(TypedDict):
+    pr: int
+    screenshots: List[Tuple[str, str, str]]  # (name, filename, base64encode image)

--- a/ops/pr_screenshots/artifact_data.py
+++ b/ops/pr_screenshots/artifact_data.py
@@ -1,9 +1,9 @@
-from typing import List, Tuple, TypedDict
+from typing import List, Optional, Tuple, TypedDict
 
 
 ARTIFACT_FILENAME = "ci_screenshots.pickle"
 
 
 class ArtifactData(TypedDict):
-    pr: int
+    pr: Optional[int]
     screenshots: List[Tuple[str, str, str]]  # (name, filename, base64encode image)

--- a/ops/pr_screenshots/capture_screenshots.py
+++ b/ops/pr_screenshots/capture_screenshots.py
@@ -11,8 +11,8 @@ from artifact_data import ARTIFACT_FILENAME, ArtifactData
 
 
 CAPTURE_URLS = [
-    ("Homepage", "https://www.thebluealliance.com"),
-    ("GameDay", "https://www.thebluealliance.com/gameday"),
+    ("Homepage", "http://localhost:8080"),
+    ("GameDay", "http://localhost:8080/gameday"),
 ]  # (name, url)
 GITHUB_REF = os.environ.get("GITHUB_REF", "")
 GITHUB_PULL_REQUEST_NUMBER = (

--- a/ops/pr_screenshots/capture_screenshots.py
+++ b/ops/pr_screenshots/capture_screenshots.py
@@ -7,6 +7,8 @@ import subprocess
 import time
 from typing import List, Tuple
 
+from artifact_data import ARTIFACT_FILENAME, ArtifactData
+
 
 CAPTURE_URLS = [
     ("Homepage", "https://www.thebluealliance.com"),
@@ -16,7 +18,6 @@ GITHUB_REF = os.environ.get("GITHUB_REF", "")
 GITHUB_PULL_REQUEST_NUMBER = (
     int(GITHUB_REF.split("/")[2]) if "refs/pull/" in GITHUB_REF else None
 )
-OUTPUT_FILE = "ci_screenshots.pickle"
 
 
 def capture_screenshots(urls: List[Tuple[str, str]]) -> List[Tuple[str, str, str]]:
@@ -48,6 +49,9 @@ def capture_screenshots(urls: List[Tuple[str, str]]) -> List[Tuple[str, str, str
 if __name__ == "__main__":
     if os.environ.get("CI"):
         screenshots = capture_screenshots(CAPTURE_URLS)
-        pickle.dump(screenshots, open(OUTPUT_FILE, "wb"))
+        pickle.dump(
+            ArtifactData(screenshots=screenshots, pr=GITHUB_PULL_REQUEST_NUMBER),
+            open(ARTIFACT_FILENAME, "wb"),
+        )
     else:
         print("Only runnable in CI.")


### PR DESCRIPTION
Handle uploading/commenting of screenshots in a separate action to safely deal with PRs from forks. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/