### PR TITLE
[lint] Add flake8 checker for api_authenticated decorator

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,5 +22,6 @@ banned-modules =
 [flake8:local-plugins]
 extension =
   E = service_import_checker:ServiceImportChecker
+  E = api_authenticated_decorator_checker:APIAuthenticatedDecoratorCheker
 paths =
   ./flake8_plugins

--- a/flake8_plugins/api_authenticated_decorator_checker.py
+++ b/flake8_plugins/api_authenticated_decorator_checker.py
@@ -1,0 +1,24 @@
+import ast
+
+
+class APIAuthenticatedDecoratorCheker:
+    name = "api-authenticated-decorator-checker"
+    version = "0.0.1"
+    ETBA1 = "ETBA1 'api_authenticated' must be the first decorator, but is after: {}"
+
+    def __init__(self, tree, filename):
+        self.tree = tree
+        self.filename = filename
+
+    def run(self):
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.FunctionDef):
+                decorator_names = [d.id if hasattr(d, "id") else None for d in node.decorator_list]
+                for i, name in enumerate(decorator_names):
+                    if name == "api_authenticated" and i != 0:
+                        yield (
+                            node.lineno,
+                            node.col_offset,
+                            self.ETBA1.format(", ".join(decorator_names[:i])),
+                            type(self),
+                        )

--- a/flake8_plugins/api_authenticated_decorator_checker.py
+++ b/flake8_plugins/api_authenticated_decorator_checker.py
@@ -13,7 +13,9 @@ class APIAuthenticatedDecoratorCheker:
     def run(self):
         for node in ast.walk(self.tree):
             if isinstance(node, ast.FunctionDef):
-                decorator_names = [d.id if hasattr(d, "id") else None for d in node.decorator_list]
+                decorator_names = [
+                    d.id if hasattr(d, "id") else None for d in node.decorator_list
+                ]
                 for i, name in enumerate(decorator_names):
                     if name == "api_authenticated" and i != 0:
                         yield (

--- a/ops/problem_matchers/flake8_error.json
+++ b/ops/problem_matchers/flake8_error.json
@@ -5,7 +5,7 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):(\\d+):\\s+([EI]\\d+\\s+.+)$",
+                    "regexp": "^([^:]+):(\\d+):(\\d+):\\s+([EI]\\w*\\d+\\s+.+)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/ops/problem_matchers/flake8_warning.json
+++ b/ops/problem_matchers/flake8_warning.json
@@ -5,7 +5,7 @@
             "severity": "warning",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):(\\d+):\\s+([CFNW]\\d+\\s+.+)$",
+                    "regexp": "^([^:]+):(\\d+):(\\d+):\\s+([CFNW]\\w*\\d+\\s+.+)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -14,9 +14,9 @@ from backend.common.models.keys import MatchKey
 from backend.common.queries.match_query import MatchQuery
 
 
-@api_authenticated
 @validate_match_key
 @cached_public
+@api_authenticated
 def match(match_key: MatchKey, model_type: Optional[ModelType] = None) -> Response:
     """
     Returns details about one match, specified by |match_key|.

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -14,9 +14,9 @@ from backend.common.models.keys import MatchKey
 from backend.common.queries.match_query import MatchQuery
 
 
+@api_authenticated
 @validate_match_key
 @cached_public
-@api_authenticated
 def match(match_key: MatchKey, model_type: Optional[ModelType] = None) -> Response:
     """
     Returns details about one match, specified by |match_key|.


### PR DESCRIPTION
Example error:

```
Error: ./src/backend/api/handlers/match.py:20:1: ETBA1 'api_authenticated' must be the first decorator, but is after: validate_match_key, cached_public
```