### PR TITLE
Pin NDB Library So Deferred Works on `dev_appserver`

### DIFF
--- a/src/backend/common/manipulators/tests/base_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/base_manipulator_test.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, Generator, List, Optional, Set
 
 import pytest
+import six
 from google.appengine.ext import deferred
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
@@ -320,6 +321,10 @@ def test_cache_clearing(ndb_context, taskqueue_stub) -> None:
     # Ensure we've enqueued the cache clearing task to be run
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="cache-clearing")
     assert len(tasks) == 1
+
+    # This lets us ensure that the devserver can run our task
+    # See https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45
+    six.ensure_text(tasks[0].payload)
 
     # Run cache clearing manually
     deferred.run(tasks[0].payload)

--- a/src/backend/common/manipulators/tests/event_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/event_manipulator_test.py
@@ -5,6 +5,7 @@ from typing import Optional
 from unittest.mock import patch
 
 import pytest
+import six
 from google.appengine.ext import deferred
 from google.appengine.ext import testbed
 from pyre_extensions import none_throws
@@ -121,6 +122,9 @@ class TestEventManipulator(unittest.TestCase):
         )
         assert len(tasks) == 1
         for task in tasks:
+            # This lets us ensure that the devserver can run our task
+            # See https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45
+            six.ensure_text(task.payload)
             deferred.run(task.payload)
 
         assert none_throws(Event.get_by_id("2011ct")).timezone_id is not None

--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -136,7 +136,7 @@ class DatafeedFMSAPI:
                 break
 
             partial_models, more_pages = result
-            models.extend(partial_models)
+            models.extend(partial_models or [])
 
             page = page + 1
 
@@ -198,7 +198,8 @@ class DatafeedFMSAPI:
             if result is None:
                 break
 
-            (partial_avatars, partial_keys_to_delete), more_pages = result
+            parser_result, more_pages = result
+            (partial_avatars, partial_keys_to_delete) = parser_result or ([], {})
             avatars.extend(partial_avatars)
             keys_to_delete = keys_to_delete.union(partial_keys_to_delete)
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,4 +14,4 @@ pyre-extensions==0.0.27
 requests==2.26.0
 typing-extensions==4.0.1
 Werkzeug==2.0.2
-appengine-python-standard==0.3.1
+appengine-python-standard-tbafork==0.4.0dev2


### PR DESCRIPTION
This pins us to a forked version of the GAE library, as a way to work around https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45

This package is running the changes from https://github.com/GoogleCloudPlatform/appengine-python-standard/pull/46 so we can base64 encode all the deferred payload before attempting to execute them.

This one was fun to track down...