### PR TITLE
Port website blocklist to py3

### DIFF
--- a/src/backend/tasks_io/handlers/tasks.py
+++ b/src/backend/tasks_io/handlers/tasks.py
@@ -1,0 +1,27 @@
+from flask import Blueprint, escape, make_response, redirect
+from werkzeug.wrappers import Response
+
+from backend.common.manipulators.team_manipulator import TeamManipulator
+from backend.common.models.keys import TeamKey
+from backend.common.models.team import Team
+from backend.common.sitevars.website_blacklist import WebsiteBlacklist
+
+
+blueprint = Blueprint("tasks", __name__)
+
+
+@blueprint.route("/backend-tasks/do/team_blacklist_website/<team_key>")
+def blacklist_website(team_key: TeamKey) -> Response:
+    if not Team.validate_key_name(team_key):
+        return make_response(f"Bad team key: {escape(team_key)}", 400)
+
+    team = Team.get_by_id(team_key)
+
+    if team and team.website:
+        # Blacklist website
+        WebsiteBlacklist.blacklist(team.website)
+        # Clear existing website
+        team.website = ""
+        TeamManipulator.createOrUpdate(team)
+
+    return redirect(f"/backend-tasks/get/team_details/{team_key}")

--- a/src/backend/tasks_io/handlers/tests/tasks_test.py
+++ b/src/backend/tasks_io/handlers/tests/tasks_test.py
@@ -1,0 +1,43 @@
+import urllib.parse
+from unittest.mock import patch
+
+from werkzeug.test import Client
+
+from backend.common.manipulators.team_manipulator import TeamManipulator
+from backend.common.models.team import Team
+from backend.common.sitevars.website_blacklist import WebsiteBlacklist
+
+
+def test_blacklist_website_invalid_key(tasks_client: Client):
+    resp = tasks_client.get("/backend-tasks/do/team_blacklist_website/1")
+    assert resp.status_code == 400
+    assert resp.data == b"Bad team key: 1"
+
+
+def test_blacklist_website_no_team(tasks_client: Client):
+    resp = tasks_client.get("/backend-tasks/do/team_blacklist_website/frc7332")
+    assert resp.status_code == 302
+
+    redirect_url = urllib.parse.urlparse(resp.location)
+    assert redirect_url.path == "/backend-tasks/get/team_details/frc7332"
+
+
+def test_blacklist_website_team(tasks_client: Client):
+    website = "https://www.thebluealliance.com"
+
+    team = Team(id="frc7332", team_number=7332, website=website)
+    team.put()
+
+    assert team.website == website
+
+    with patch.object(WebsiteBlacklist, "blacklist") as mock_blacklist, patch.object(TeamManipulator, "createOrUpdate") as mock_update:
+        resp = tasks_client.get("/backend-tasks/do/team_blacklist_website/frc7332")
+
+    assert resp.status_code == 302
+    assert mock_blacklist.called_with(website)
+    assert mock_update.called_with(team)
+
+    redirect_url = urllib.parse.urlparse(resp.location)
+    assert redirect_url.path == "/backend-tasks/get/team_details/frc7332"
+
+    assert not team.website

--- a/src/backend/tasks_io/main.py
+++ b/src/backend/tasks_io/main.py
@@ -6,6 +6,7 @@ from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
 from backend.tasks_io.handlers.cron_misc import blueprint as cron_misc_blueprint
 from backend.tasks_io.handlers.frc_api import blueprint as frc_api_blueprint
+from backend.tasks_io.handlers.tasks import blueprint as tasks_blueprint
 
 
 configure_logging()
@@ -17,3 +18,4 @@ install_defer_routes(app)
 
 app.register_blueprint(cron_misc_blueprint)
 app.register_blueprint(frc_api_blueprint)
+app.register_blueprint(tasks_blueprint)


### PR DESCRIPTION
The big difference here between the previous website blocklist is that we clear the team's website *before* doing a refetch. This allows us to handle the current situation where the FRC API is returning empty responses for websites