### PR TITLE
Update build season template for 2022. Remove commented out bits from kickoff page

### DIFF
--- a/src/backend/web/templates/index/index_buildseason.html
+++ b/src/backend/web/templates/index/index_buildseason.html
@@ -31,8 +31,7 @@
 
       <div>
         <a class="btn btn-default" href="https://www.firstinspires.org/covid-19" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> COVID-19 Resources</a>
-        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2021 Game and Season Resources</a>
-        <a class="btn btn-default" href="https://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/game-and-season-info/competition-manual/2021/2021-frc-season-details.pdf" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2021 Season Details</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2022 Game and Season Resources</a>
       </div>
 
       {% if build_handler_show_ri3d %}

--- a/src/backend/web/templates/index/index_kickoff.html
+++ b/src/backend/web/templates/index/index_kickoff.html
@@ -41,37 +41,13 @@
       <div>
         <a class="btn btn-default" href="https://www.firstinspires.org/covid-19" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> COVID-19 Resources</a>
         <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2022 Game and Season Resources</a>
-        <!--<span class="glyphicon glyphicon-globe"></span> <a href="http://www.firstinspires.org/2018-frc-teaser" target="_blank" rel="noopener noreferrer" title="FIRST Kickoff Page"><em>FIRST</em> Kickoff Page</a><br> -->
-        <!-- <a class="hashtag-link hashtag-cd" href="https://www.chiefdelphi.com/forums/showthread.php?threadid=138575" target="_blank" rel="noopener noreferrer" title="Chief Delphi Discussion Thread">Chief Delphi Game Hint Thread</a><br> -->
-        <!--<span class="glyphicon glyphicon-info-sign"></span> <a href="#" target="_blank" rel="noopener noreferrer">Download {{kickoff_datetime_est|strftime("%Y")}} Game Manual</a><br />-->
+        <!-- <span class="glyphicon glyphicon-globe"></span> <a href="https://www.firstinspires.org/robotics/frc/kickoff" target="_blank" rel="noopener noreferrer" title="FIRST Kickoff Page"><em>FIRST</em> Kickoff Page</a><br> -->
         <br>
         <div class="fitvids">
           <iframe width="420" height="315" src="https://www.youtube.com/embed/{{game_teaser_youtube_id}}" frameborder="0" allowfullscreen></iframe>
         </div>
       </div>
     </div>
-    <!-- <div class="col-sm-4">
-      <h2>{{kickoff_datetime_est|strftime("%Y")}} Game Info</h2>
-      <p><em>More coming soon!</em></p>
-      <p><a class="btn btn-default disabled" href="#"><span class="glyphicon glyphicon-film"></span> {{kickoff_datetime_est|strftime("%Y")}} Game Video</a></p>
-      <h4>{{kickoff_datetime_est|strftime("%Y")}} Game Manual</h4>
-      <div class="btn-group-vertical game-manual">
-        <a class="btn btn-default" href="http://frc-manual.usfirst.org/" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-file"></span> PDF Version</a>
-        <a class="btn btn-default" href="https://itunes.apple.com/us/app/frc-manual/id488793605" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-download"></span> iPhone App</a>
-        <a class="btn btn-default" href="https://play.google.com/store/apps/details?id=org.usfirst.manual.frc" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-download"></span> Android App</a>
-      </div>
-    </div> -->
   </div>
-  <!--TODO: Make these real CSS classes instead of inline styles -gregmarra 11/27/12
-  <div class="row">
-    <div class="col-xs-12">
-      <h2>#omgrobots <small><a href="http://searchinstagram.com/omgrobots" title="Instagram Search">Instagram</a> + <a href="https://twitter.com/search/realtime?q=%23omgrobots" target="_blank" rel="noopener noreferrer">Twitter</a></small></h2>
-      <img alt="#omgrobots" src="" style="float: left; margin: 14px; background-color: grey; margin: 6px; height: 148px; width: 222px;" />
-      <img alt="#omgrobots" src="" style="float: left; margin: 14px; background-color: grey; margin: 6px; height: 148px; width: 222px;" />
-      <img alt="#omgrobots" src="" style="float: left; margin: 14px; background-color: grey; margin: 6px; height: 148px; width: 222px;" />
-      <img alt="#omgrobots" src="" style="float: left; margin: 14px; background-color: grey; margin: 6px; height: 148px; width: 222px;" />
-      <img alt="#omgrobots" src="" style="float: left; margin: 14px; background-color: grey; margin: 6px; height: 148px; width: 222px;" />
-    </div>
-  </div>-->
 </div>
 {% endblock %}


### PR DESCRIPTION
Build season page -
<img width="1213" alt="Screen Shot 2022-01-08 at 2 31 18 AM" src="https://user-images.githubusercontent.com/516458/148636039-4b1ac7e7-4f93-4d5b-9738-eca3d3f29c94.png">

The bits being removed from the kickoff page are mostly like, dead links for things that don't exist anymore