### PR TITLE
Fix template bugs in event_list enqueue

### DIFF
--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -207,7 +207,7 @@ def enqueue_event_list(year: Optional[Year]) -> Response:
             method="GET",
         )
 
-    template_values = {"year": year, "event_count": year}
+    template_values = {"years": years}
 
     if (
         "X-Appengine-Taskname" not in request.headers

--- a/src/backend/tasks_io/templates/datafeeds/usfirst_events_details_enqueue.html
+++ b/src/backend/tasks_io/templates/datafeeds/usfirst_events_details_enqueue.html
@@ -1,2 +1,2 @@
-<h2>Enqueued some Events from year {{year}}</h2>
-<p>Event Gets Enqueued: {{event_count}}</p>
+<h2>Enqueued Event fetch for years:</h2>
+<p>{{ years | join(', ') }}</p>


### PR DESCRIPTION
Just fixing some weirdness with the event_list enqueue template. Modified the template to reflect the new values that we get from this endpoint (no event count - only a list of years)
<img width="1840" alt="Screen Shot 2022-01-14 at 3 00 28 PM" src="https://user-images.githubusercontent.com/516458/149578500-c519e2ce-3b16-4c78-ab5d-4de302f6e5e7.png">

