### PR TITLE
Add website editing to admin page

### DIFF
--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -13,6 +13,7 @@ from backend.web.handlers.admin.team import (
     team_detail,
     team_list,
     team_robot_name_update,
+    team_website_update,
 )
 from backend.web.profiled_render import render_template
 
@@ -56,6 +57,8 @@ admin_routes.add_url_rule("/teams", view_func=team_list)
 admin_routes.add_url_rule("/teams/<int:page_num>", view_func=team_list)
 admin_routes.add_url_rule("/team/<int:team_number>", view_func=team_detail)
 admin_routes.add_url_rule(
+    "/team/website", view_func=team_website_update, methods=["POST"]
+)
+admin_routes.add_url_rule(
     "/team/set_robot_name", view_func=team_robot_name_update, methods=["POST"]
 )
-# admin_routes.add_url_rule("/team/<int:team_number>", view_func=team_detail)

--- a/src/backend/web/templates/admin/team_details.html
+++ b/src/backend/web/templates/admin/team_details.html
@@ -110,6 +110,19 @@
 
 <div class="tab-pane" id="media">
 <div class="row">
+<h2>Website</h2>
+<form action="/admin/team/website" method="post">
+    <table class="table table-striped table-hover table-condensed">
+        <tr>
+            <td>URL</td>
+            <td><input class="form-control" name="website" value="{{ team.website if team.website }}" type="text" placeholder="https://thebluealliance.com/"></td>
+        </tr>
+    </table>
+    <input type="hidden" name="team_key" value="{{ team.key_name }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <button class="btn btn-primary" type="submit"><span class="glyphicon glyphicon-thumbs-up"></span> Update Website</button>
+</form>
+
 <h2>Add Media</h2>
 <form action="/admin/media/add_media" method="post">
     <table class="table table-striped table-hover table-condensed">


### PR DESCRIPTION
Since FIRST no longer supports serving websites, we need a custom way to modify/add team websites if we get an email about this.

We should look to add this sort of stuff in the team mod dashboard to allow teams to update their websites themselves probably.

https://user-images.githubusercontent.com/516458/150724043-1025e44e-c2bd-4b4e-9aea-0ed8b6491cfd.mov

