### PR TITLE
Wrap text on district selector

### DIFF
--- a/src/backend/web/templates/district_details.html
+++ b/src/backend/web/templates/district_details.html
@@ -27,7 +27,7 @@
         <h1 class="visible-xs end_header" id="district-name">{% if explicit_year %}{{year}} {% endif %}{{district_name}} District{% if events|length > 0 %}<small> {{ events|length }} Events</small>{% endif %}</h1>
 
         <div class="btn-group">
-          <a class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" href="#">
+          <a class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" style="white-space:normal; word-wrap: break-word; word-break: normal;" href="#">
             {{district_name}}
             <span class="caret"></span>
           </a>


### PR DESCRIPTION
## Description
On the events page, wrap text on the District dropdown  menu.

## Motivation and Context
Currently, when selecting a long district name (e.g. FIRST Indiana Robotics), the button expands, overlapping with other text on the page. The change will keep the width of the button fixed, and wrap text when it exceeds the space allotted.

## How Has This Been Tested?
Inspect Element 🙃 

## Screenshots (if appropriate):
#### Current
![image](https://user-images.githubusercontent.com/22439365/154607900-eb85e849-09c4-40be-93eb-7d1733e286a7.png)
#### Changes
![image](https://user-images.githubusercontent.com/22439365/154607953-3a850a45-439f-43cf-8661-b9126e8808ed.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
