### PR TITLE
Flix plurals, closes #2779

### DIFF
--- a/src/backend/web/templates/event_list.html
+++ b/src/backend/web/templates/event_list.html
@@ -31,7 +31,7 @@
           </ul>
         </div>
 
-        <h1 class="visible-xs end_header">{% if explicit_year %}{{selected_year}} {% endif %}<em>FIRST</em> Robotics Competition Events{% if state_prov %} in {{state_prov}}{% endif %}{% if events|length > == 1 %} <small>{{ events|length }} Event</small>{% endif %}{% if events|length > 1 %} <small>{{ events|length }} Events</small>{% endif %}</h1>
+        <h1 class="visible-xs end_header">{% if explicit_year %}{{selected_year}} {% endif %}<em>FIRST</em> Robotics Competition Events{% if state_prov %} in {{state_prov}}{% endif %}{% if events|length == 1 %} <small>{{ events|length }} Event</small>{% endif %}{% if events|length > 1 %} <small>{{ events|length }} Events</small>{% endif %}</h1>
 
         {% if districts %}
         <div class="btn-group">

--- a/src/backend/web/templates/event_list.html
+++ b/src/backend/web/templates/event_list.html
@@ -31,7 +31,7 @@
           </ul>
         </div>
 
-        <h1 class="visible-xs end_header">{% if explicit_year %}{{selected_year}} {% endif %}<em>FIRST</em> Robotics Competition Events{% if state_prov %} in {{state_prov}}{% endif %}{% if events|length > 0 %} <small>{{ events|length }} Events</small>{% endif %}</h1>
+        <h1 class="visible-xs end_header">{% if explicit_year %}{{selected_year}} {% endif %}<em>FIRST</em> Robotics Competition Events{% if state_prov %} in {{state_prov}}{% endif %}{% if events|length > == 1 %} <small>{{ events|length }} Event</small>{% endif %}{% if events|length > 1 %} <small>{{ events|length }} Events</small>{% endif %}</h1>
 
         {% if districts %}
         <div class="btn-group">
@@ -69,7 +69,7 @@
       </div>
     </div>
     <div class="col-xs-12 col-sm-9 col-lg-10">
-      <h1 class="hidden-xs end_header">{% if explicit_year %}{{selected_year}} {% endif %}<em>FIRST</em> Robotics Competition Events{% if state_prov %} in {{state_prov}}{% endif %}{% if events|length > 0 %} <small>{{ events|length }} Events</small>{% endif %}</h1>
+      <h1 class="hidden-xs end_header">{% if explicit_year %}{{selected_year}} {% endif %}<em>FIRST</em> Robotics Competition Events{% if state_prov %} in {{state_prov}}{% endif %}{% if events|length == 1 %} <small>{{ events|length }} Event</small>{% endif %}{% if events|length > 1 %} <small>{{ events|length }} Events</small>{% endif %}</h1>
 
       <a class="btn btn-default pull-right" href="/nearby?search_type=events"><span class="glyphicon glyphicon-search"></span> Search Nearby</a>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When there is one event in a category, say "1 Event" instead of "1 Events"

## Motivation and Context
I guess this has been bothering me for a while, because I found this old issue #2779

## How Has This Been Tested?
It hasn't, and I probably did it wrong, but only time will tell!

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22439365/154782653-ac4a866f-8667-4bbc-ab39-c0a25d9c6b40.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
