### PR TITLE
[Webcast] Fix Twitch API auth & enable webcast status

### DIFF
--- a/src/backend/common/helpers/tests/webcast_online_helper_test.py
+++ b/src/backend/common/helpers/tests/webcast_online_helper_test.py
@@ -34,6 +34,12 @@ def set_youtube_secrets(ndb_stub) -> None:
     GoogleApiSecret.put({"api_key": "secret"})
 
 
+class MockTwitchAuth:
+    def __call__(self, url, payload, method, headers, request, response, **kwargs):
+        response.StatusCode = 200
+        response.Content = json.dumps({"access_token": "123testtoken"}).encode()
+
+
 class MockTwitchApi:
     def __init__(self, online=True, fail=False, throw=False) -> None:
         self.online = online
@@ -158,7 +164,8 @@ def test_add_online_status_twitch_no_secrets(
 ) -> None:
     gae_testbed.init_urlfetch_stub(
         urlmatchers=[
-            (lambda url: urlparse(url).netloc == "api.twitch.tv", MockTwitchApi())
+            (lambda url: urlparse(url).netloc == "id.twitch.tv", MockTwitchAuth()),
+            (lambda url: urlparse(url).netloc == "api.twitch.tv", MockTwitchApi()),
         ]
     )
     webcast = Webcast(
@@ -175,10 +182,11 @@ def test_add_online_status_twitch_http_failue(
 ) -> None:
     gae_testbed.init_urlfetch_stub(
         urlmatchers=[
+            (lambda url: urlparse(url).netloc == "id.twitch.tv", MockTwitchAuth()),
             (
                 lambda url: urlparse(url).netloc == "api.twitch.tv",
                 MockTwitchApi(fail=True),
-            )
+            ),
         ]
     )
     webcast = Webcast(
@@ -195,10 +203,11 @@ def test_add_online_status_twitch_http_error(
 ) -> None:
     gae_testbed.init_urlfetch_stub(
         urlmatchers=[
+            (lambda url: urlparse(url).netloc == "id.twitch.tv", MockTwitchAuth()),
             (
                 lambda url: urlparse(url).netloc == "api.twitch.tv",
                 MockTwitchApi(throw=True),
-            )
+            ),
         ]
     )
     webcast = Webcast(
@@ -215,6 +224,7 @@ def test_add_online_status_twitch(
 ) -> None:
     gae_testbed.init_urlfetch_stub(
         urlmatchers=[
+            (lambda url: urlparse(url).netloc == "id.twitch.tv", MockTwitchAuth()),
             (lambda url: urlparse(url).netloc == "api.twitch.tv", MockTwitchApi()),
         ]
     )
@@ -234,6 +244,7 @@ def test_add_online_status_twitch_offline(
 ) -> None:
     gae_testbed.init_urlfetch_stub(
         urlmatchers=[
+            (lambda url: urlparse(url).netloc == "id.twitch.tv", MockTwitchAuth()),
             (
                 lambda url: urlparse(url).netloc == "api.twitch.tv",
                 MockTwitchApi(online=False),

--- a/src/backend/common/helpers/webcast_online_helper.py
+++ b/src/backend/common/helpers/webcast_online_helper.py
@@ -57,24 +57,50 @@ class WebcastOnlineHelper:
     @ndb.tasklet
     def _add_twitch_status_async(cls, webcast: Webcast) -> Generator[Any, Any, None]:
         client_id = TwitchSecrets.client_id()
-        if client_id:
-            url = "https://api.twitch.tv/helix/streams?user_login={}".format(
+        client_secret = TwitchSecrets.client_secret()
+        if client_id and client_secret:
+            # Get auth token
+            auth_url = "https://id.twitch.tv/oauth2/token?client_id={}&client_secret={}&grant_type=client_credentials".format(
+                client_id, client_secret
+            )
+            try:
+                rpc = urlfetch.create_rpc()
+                result = yield urlfetch.make_fetch_call(rpc, auth_url, method="POST")
+            except Exception as e:
+                logging.error("URLFetch failed for: {}".format(auth_url))
+                logging.error(e)
+                raise ndb.Return(None)
+
+            if result.status_code == 200:
+                response = json.loads(result.content)
+                token = response["access_token"]
+            else:
+                logging.warning(
+                    "Twitch auth failed with status code: {}".format(result.status_code)
+                )
+                logging.warning(result.content)
+                raise ndb.Return(None)
+
+            # Get webcast status
+            status_url = "https://api.twitch.tv/helix/streams?user_login={}".format(
                 webcast["channel"]
             )
             try:
                 rpc = urlfetch.create_rpc()
                 result = yield urlfetch.make_fetch_call(
                     rpc,
-                    url,
+                    status_url,
                     headers={
+                        "Authorization": "Bearer {}".format(token),
                         "Client-ID": client_id,
                     },
                 )
-            except Exception:
-                logging.exception("URLFetch failed for: {}".format(url))
+            except Exception as e:
+                logging.exception("URLFetch failed for: {}".format(status_url))
+                logging.error(e)
                 return None
         else:
-            logging.warning("Must have Twitch Client ID")
+            logging.warning("Must have Twitch Client ID & Secret")
             return None
 
         if result.status_code == 200:

--- a/src/backend/common/helpers/webcast_online_helper.py
+++ b/src/backend/common/helpers/webcast_online_helper.py
@@ -67,7 +67,7 @@ class WebcastOnlineHelper:
                 rpc = urlfetch.create_rpc()
                 result = yield urlfetch.make_fetch_call(rpc, auth_url, method="POST")
             except Exception as e:
-                logging.error("URLFetch failed for: {}".format(auth_url))
+                logging.error("URLFetch failed when getting Twitch auth token.")
                 logging.error(e)
                 raise ndb.Return(None)
 

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -549,10 +549,9 @@ class Event(CachedModel):
                 self._webcast = None
         return self._webcast or []
 
-    """
     @property
     def webcast_status(self):
-        from helpers.webcast_online_helper import WebcastOnlineHelper
+        from backend.common.helpers.webcast_online_helper import WebcastOnlineHelper
         WebcastOnlineHelper.add_online_status(self.current_webcasts)
 
         overall_status = 'offline'
@@ -564,7 +563,6 @@ class Event(CachedModel):
             elif status == 'unknown':
                 overall_status = 'unknown'
         return overall_status
-    """
 
     @property
     def current_webcasts(self) -> List[Webcast]:

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -552,16 +552,17 @@ class Event(CachedModel):
     @property
     def webcast_status(self):
         from backend.common.helpers.webcast_online_helper import WebcastOnlineHelper
+
         WebcastOnlineHelper.add_online_status(self.current_webcasts)
 
-        overall_status = 'offline'
+        overall_status = "offline"
         for webcast in self.current_webcasts:
-            status = webcast.get('status')
-            if status == 'online':
-                overall_status = 'online'
+            status = webcast.get("status")
+            if status == "online":
+                overall_status = "online"
                 break
-            elif status == 'unknown':
-                overall_status = 'unknown'
+            elif status == "unknown":
+                overall_status = "unknown"
         return overall_status
 
     @property

--- a/src/backend/common/sitevars/twitch_secrets.py
+++ b/src/backend/common/sitevars/twitch_secrets.py
@@ -24,3 +24,7 @@ class TwitchSecrets(Sitevar[ContentType]):
     @classmethod
     def client_id(cls) -> str:
         return cls.get()["client_id"]
+
+    @classmethod
+    def client_secret(cls) -> str:
+        return cls.get()["client_secret"]


### PR DESCRIPTION
This was fixed in py2 but never got ported to py3
d9a67c174bf09653f833fc7fd63adef37129e192
4445414c1be82e7d3f1570fe8eea212bb8300417
4445414c1be82e7d3f1570fe8eea212bb8300417
4d9f267502a49dadf8aa6dee2a24890edc580841