### PR TITLE
Add back in `render_time` to templates

### DIFF
--- a/src/backend/web/context_processors.py
+++ b/src/backend/web/context_processors.py
@@ -1,0 +1,8 @@
+import datetime
+from typing import Dict, Optional
+
+
+def render_time_context_processor() -> Dict[str, Optional[datetime.datetime]]:
+    return dict(
+        render_time=datetime.datetime.now().replace(second=0, microsecond=0)
+    )  # Prevent ETag from changing too quickly

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -7,6 +7,7 @@ from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
 from backend.common.url_converters import install_url_converters
+from backend.web.context_processors import render_time_context_processor
 from backend.web.handlers.account import blueprint as account_blueprint
 from backend.web.handlers.admin.blueprint import admin_routes as admin_blueprint
 from backend.web.handlers.apidocs import apidocs_trusted_v1, apidocs_v3
@@ -86,6 +87,7 @@ app.register_error_handler(404, handle_404)
 app.register_error_handler(500, handle_500)
 
 app.context_processor(_user_context_processor)
+app.context_processor(render_time_context_processor)
 
 register_template_filters(app)
 maybe_install_local_routes(app, csrf)

--- a/src/backend/web/tests/context_processors_test.py
+++ b/src/backend/web/tests/context_processors_test.py
@@ -1,0 +1,8 @@
+import datetime
+
+from backend.web.context_processors import render_time_context_processor
+
+
+def test_render_time_context_processor() -> None:
+    render_time_context = render_time_context_processor()
+    assert type(render_time_context["render_time"]) is datetime.datetime


### PR DESCRIPTION
We support the `render_time` in the base templates, but we don't add the render time to the template. This PR adds the render time to web's template variables. This should make debugging caching easier.