### PR TITLE
Disable sending push notifications to Android

### DIFF
--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -15,7 +15,6 @@ class ClientType(enum.IntEnum):
 
 
 FCM_CLIENTS: Set[ClientType] = {
-    ClientType.OS_ANDROID,
     ClientType.OS_IOS,
     ClientType.WEB,
 }


### PR DESCRIPTION
Going to disable sending notifications to Android until we can confirm Android is getting the proper payloads to not crash