### PR TITLE
Support android notifications with legacy data format

### DIFF
--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -19,6 +19,10 @@ FCM_CLIENTS: Set[ClientType] = {
     ClientType.WEB,
 }
 
+FCM_LEGACY_CLIENTS: Set[ClientType] = {
+    ClientType.OS_ANDROID,
+}
+
 
 NAMES: Dict[ClientType, str] = {
     ClientType.OS_ANDROID: "Android",

--- a/src/backend/common/models/tests/match_test.py
+++ b/src/backend/common/models/tests/match_test.py
@@ -55,7 +55,9 @@ def test_valid_key_names(key: str) -> None:
     assert Match.validate_key_name(key) is True
 
 
-@pytest.mark.parametrize("key", ["frc177", "2010ct_qm1m1", "2010ctf1m1", "2010ct_f1", "2022on_306_qm15"])
+@pytest.mark.parametrize(
+    "key", ["frc177", "2010ct_qm1m1", "2010ctf1m1", "2010ct_f1", "2022on_306_qm15"]
+)
 def test_invalid_key_names(key: str) -> None:
     assert Match.validate_key_name(key) is False
 


### PR DESCRIPTION
Android phones expect the webhook formatted payloads

Fixes https://github.com/the-blue-alliance/the-blue-alliance/issues/4303