### PR TITLE
Strip whitespace from team names

### DIFF
--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_team_details_parser.py
@@ -42,8 +42,8 @@ class FMSAPITeamDetailsParser(
             team = Team(
                 id="frc{}".format(teamData["teamNumber"]),
                 team_number=teamData["teamNumber"],
-                name=teamData["nameFull"],
-                nickname=teamData["nameShort"],
+                name=teamData["nameFull"].strip(),
+                nickname=teamData["nameShort"].strip(),
                 school_name=teamData.get("schoolName"),
                 home_cmp=teamData.get("homeCMP").lower()
                 if teamData.get("homeCMP")


### PR DESCRIPTION
Whitespace bad

Local fetch doesn't include trailing whitespace

![image](https://user-images.githubusercontent.com/2754863/159594930-dfc5af9a-c986-43e7-a624-743c3f727ced.png)


Fixes https://github.com/the-blue-alliance/the-blue-alliance/issues/4331