### PR TITLE
Call FRC API v3 for Matches

### DIFF
--- a/src/backend/common/frc_api/frc_api.py
+++ b/src/backend/common/frc_api/frc_api.py
@@ -1,12 +1,16 @@
 import datetime
 import json
 import logging
+import re
 from typing import Literal, Optional
 
 import requests
 
 from backend.common.models.keys import Year
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+
+
+TCompLevel = Literal["qual", "playoff"]
 
 
 class FRCAPI:
@@ -79,17 +83,19 @@ class FRCAPI:
         endpoint = f"/{year}/rankings/{event_short}"
         return self._get(endpoint)
 
-    def matches_hybrid(
-        self, year: Year, event_short: str, level: Literal["qual", "playoff"]
-    ) -> requests.Response:
-        endpoint = f"/{year}/schedule/{event_short}/{level}/hybrid"
+    def match_schedule(self, year: Year, event_short: str, level: TCompLevel):
+        # This does not include results
+        endpoint = f"/{year}/schedule/{event_short}?tournamentLevel={level}"
+        return self._get(endpoint)
 
-        # hybrid schedule requires v2.0 because it doesn't exist in v3.0
-        # https://usfirst.collab.net/sf/go/artf6030
-        return self._get(endpoint, version="v2.0")
+    def matches(self, year: Year, event_short: str, level: TCompLevel):
+        # This includes both played/unplayed matches at the event
+        # but doesn't include full results
+        endpoint = f"/{year}/matches/{event_short}?tournamentLevel={level}"
+        return self._get(endpoint)
 
     def match_scores(
-        self, year: Year, event_short: str, level: Literal["qual", "playoff"]
+        self, year: Year, event_short: str, level: TCompLevel
     ) -> requests.Response:
         # technically "qual"/"playoff" are invalid tournament levels as per the docs,
         # but they seem to work?
@@ -155,6 +161,15 @@ class FRCAPI:
             get_files as cloud_storage_get_files,
             read as cloud_storage_read,
         )
+
+        if version == "v2.0" and "/schedule" in endpoint and "hybrid" not in endpoint:
+            # The hybrid schedule endpoint doesn't exist in newer versions,
+            # so hack the URLs to make things work with older data
+            # /2022/schedule/CADA/qual/hybrid
+            # /2022/schedule/CADA?tournamentLevel=qual
+            regex = re.search(r"/(\d+)/schedule/(\w+)\?tournamentLevel=(\w+)", endpoint)
+            if regex:
+                endpoint = f"/{regex.group(1)}/schedule/{regex.group(2)}/{regex.group(3)}/hybrid"
 
         # Get list of responses
         try:

--- a/src/backend/common/frc_api/tests/frcapi_test.py
+++ b/src/backend/common/frc_api/tests/frcapi_test.py
@@ -97,8 +97,15 @@ def test_event_rankings() -> None:
 def test_event_schedule() -> None:
     api = FRCAPI("zach")
     with patch.object(FRCAPI, "_get") as mock_get:
-        api.matches_hybrid(2020, "MIKET", "qual")
-    mock_get.assert_called_once_with("/2020/schedule/MIKET/qual/hybrid", version="v2.0")
+        api.match_schedule(2020, "MIKET", "qual")
+    mock_get.assert_called_once_with("/2020/schedule/MIKET?tournamentLevel=qual")
+
+
+def test_event_matches() -> None:
+    api = FRCAPI("zach")
+    with patch.object(FRCAPI, "_get") as mock_get:
+        api.matches(2020, "MIKET", "qual")
+    mock_get.assert_called_once_with("/2020/matches/MIKET?tournamentLevel=qual")
 
 
 def test_event_scores() -> None:

--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -1,10 +1,11 @@
 import datetime
 import json
 import logging
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import requests
 from google.appengine.ext import ndb
+from pyre_extensions import none_throws
 
 from backend.common.consts.event_type import EventType
 from backend.common.environment import Environment
@@ -54,6 +55,9 @@ from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_team_avatar_parser impor
 )
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_team_details_parser import (
     FMSAPITeamDetailsParser,
+)
+from backend.tasks_io.datafeeds.parsers.fms_api.simple_json_parser import (
+    FMSAPISimpleJsonParser,
 )
 from backend.tasks_io.datafeeds.parsers.parser_base import ParserBase, TParsedResponse
 
@@ -245,6 +249,7 @@ class DatafeedFMSAPI:
         event_short = event_key[4:]
 
         event = Event.get_by_id(event_key)
+        json_parser = FMSAPISimpleJsonParser()
         hs_parser = FMSAPIHybridScheduleParser(year, event_short)
         detail_parser = FMSAPIMatchDetailsParser(year, event_short)
 
@@ -252,25 +257,47 @@ class DatafeedFMSAPI:
 
         # TODO do we make all these sequentually, or go back to GAE urlfetch
         # we can run in parallel?
-        qual_match_result = self.api.matches_hybrid(year, api_event_short, "qual")
-        playoff_match_result = self.api.matches_hybrid(year, api_event_short, "playoff")
+        qual_schedule_result = self.api.match_schedule(year, api_event_short, "qual")
+        playoff_schedule_result = self.api.match_schedule(
+            year, api_event_short, "playoff"
+        )
+
+        qual_match_result = self.api.matches(year, api_event_short, "qual")
+        playoff_match_result = self.api.matches(year, api_event_short, "playoff")
 
         qual_scores_result = self.api.match_scores(year, api_event_short, "qual")
         playoff_scores_result = self.api.match_scores(year, api_event_short, "playoff")
 
+        qual_schedule = none_throws(self._parse(qual_schedule_result, json_parser))
+        playoff_schedule = none_throws(
+            self._parse(playoff_schedule_result, json_parser)
+        )
+
+        qual_matches = none_throws(self._parse(qual_match_result, json_parser))
+        playoff_matches = none_throws(self._parse(playoff_match_result, json_parser))
+
+        # Because the hybrid score endpoint doesn't exist in the FRC API v3
+        # we manually merge the results from the score/schedule endpoints
+        # and run it through the old hybrid schedule parser (this lets us continue
+        # to handle extra tiebreaker matches, etc)
+        qual_matches_merged = hs_parser.parse(
+            self._merge_match_schedule_and_results(qual_schedule, qual_matches)
+        )
+        playoff_matches_merged = hs_parser.parse(
+            self._merge_match_schedule_and_results(playoff_schedule, playoff_matches)
+        )
+
         # Organize matches by key
         matches_by_key = {}
-        qual_matches = self._parse(qual_match_result, hs_parser)
-        if qual_matches:
-            for match in qual_matches[0]:
+        if qual_matches_merged:
+            for match in qual_matches_merged[0]:
                 matches_by_key[match.key.id()] = match
 
-        playoff_matches = self._parse(playoff_match_result, hs_parser)
         remapped_playoff_matches = {}
-        if playoff_matches:
-            for match in playoff_matches[0]:
+        if playoff_matches_merged:
+            for match in playoff_matches_merged[0]:
                 matches_by_key[match.key.id()] = match
-            remapped_playoff_matches = playoff_matches[1]
+            remapped_playoff_matches = playoff_matches_merged[1]
 
         # Add details to matches based on key
         qual_details = self._parse(qual_scores_result, detail_parser) or {}
@@ -289,6 +316,27 @@ class DatafeedFMSAPI:
                 matches_by_key.values(),
             )
         )
+
+    def _merge_match_schedule_and_results(self, schedule: Dict, matches: Dict) -> Dict:
+        scheduled_matches = schedule["Schedule"]
+        if "Matches" not in matches:
+            matches["Matches"] = [{}] * len(scheduled_matches)
+        return {
+            "Schedule": [
+                self._merge_match(s, m)
+                for s, m in zip(scheduled_matches, matches["Matches"])
+            ]
+        }
+
+    @classmethod
+    def _merge_match(cls, scheduled: Dict, result: Dict) -> Dict:
+        for field, value in result.items():
+            if field == "teams":
+                for i, team in enumerate(value):
+                    scheduled["teams"][i].update(team)
+            else:
+                scheduled[field] = value
+        return scheduled
 
     def get_event_team_avatars(
         self, event_key: EventKey

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/simple_json_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/simple_json_parser.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from pyre_extensions import JSON
+
+from backend.tasks_io.datafeeds.parsers.json.parser_json import ParserJSON
+
+
+class FMSAPISimpleJsonParser(ParserJSON[Dict[str, JSON]]):
+    """
+    This is a parser that simply returns the raw data received from the API
+    """
+
+    def parse(self, response: Dict[str, JSON]) -> Dict[str, JSON]:
+        return response

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
@@ -12,6 +12,9 @@ from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_match_parser import (
     FMSAPIHybridScheduleParser,
 )
+from backend.tasks_io.datafeeds.parsers.fms_api.simple_json_parser import (
+    FMSAPISimpleJsonParser,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -26,17 +29,27 @@ def test_get_event_matches() -> None:
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "matches_hybrid", return_value=response
+        FRCAPI, "match_schedule", return_value=response
     ) as mock_schedule_api, patch.object(
+        FRCAPI, "matches", return_value=response
+    ) as mock_matches_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
-    ) as mock_schedule_parse:
+    ) as mock_schedule_parse, patch.object(
+        FMSAPISimpleJsonParser, "parse"
+    ) as mock_json_parse:
         mock_schedule_parse.side_effect = ([], [])
+        mock_json_parse.return_value = {"Schedule": [], "Matches": []}
         df.get_event_matches("2020miket")
 
     mock_schedule_api.assert_has_calls(
         [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
     )
-    mock_schedule_parse.assert_has_calls([call(response.json()), call(response.json())])
+    mock_matches_api.assert_has_calls(
+        [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
+    )
+    mock_schedule_parse.assert_has_calls(
+        [call({"Schedule": []}), call({"Schedule": []})]
+    )
 
 
 def test_get_event_matches_cmp() -> None:
@@ -46,14 +59,24 @@ def test_get_event_matches_cmp() -> None:
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "matches_hybrid", return_value=response
+        FRCAPI, "match_schedule", return_value=response
     ) as mock_schedule_api, patch.object(
+        FRCAPI, "matches", return_value=response
+    ) as mock_matches_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
-    ) as mock_schedule_parse:
+    ) as mock_schedule_parse, patch.object(
+        FMSAPISimpleJsonParser, "parse"
+    ) as mock_json_parse:
         mock_schedule_parse.side_effect = ([], [])
+        mock_json_parse.return_value = {"Schedule": [], "Matches": []}
         df.get_event_matches("2014gal")
 
     mock_schedule_api.assert_has_calls(
         [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
     )
-    mock_schedule_parse.assert_has_calls([call(response.json()), call(response.json())])
+    mock_matches_api.assert_has_calls(
+        [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
+    )
+    mock_schedule_parse.assert_has_calls(
+        [call({"Schedule": []}), call({"Schedule": []})]
+    )


### PR DESCRIPTION
This will let us get right data to address #4301, because the the v2 hybrid endpoint seems to have broken showing the right values after replays (it only shows the first play).

And since the hybrid schedule endpoint doesn't exist in the v3, this diff will make us call all of the schedule, matches, and scores endpoints and merge all the results together. This is done in a slightly hacky way so we can still use the old hybrid parser, so we merge the data from the schedule/scores endpoint to build objects compatible with the old hybrid endpoint (thankfully the key names are all stable)

Fields missing from the matches endpoint, which meant we couldn't just use it as a drop-in:
 - scheduled time for a match
 -  surrogate status for teams

Closes https://github.com/the-blue-alliance/the-blue-alliance/issues/4345