### PR TITLE
Fix building container with no secrets file

### DIFF
--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -9,6 +9,11 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r src/requirements.txt
 
+# Create empty keys file if one does not already exist
+if [ ! -f /tba/src/backend/web/static/javascript/tba_js/tba_keys.js ]; then
+    cp /tba/src/backend/web/static/javascript/tba_js/tba_keys_template.js /tba/src/backend/web/static/javascript/tba_js/tba_keys.js
+fi
+
 # nodejs dependencies
 NVM_DIR="/nvm"
 # shellcheck source=/dev/null

--- a/ops/dev/vagrant/config.sh
+++ b/ops/dev/vagrant/config.sh
@@ -22,6 +22,6 @@ function project {
         project=$(get_project_from_key "$cred_file")
         echo "$project"
     else
-        echo "test"
+        echo "demo-test"
     fi
 }

--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -25,7 +25,7 @@ if [ "$google_application_credentials" ]; then
     application="$project"
     env+=("--env_var=GOOGLE_APPLICATION_CREDENTIALS=$cred_file")
 else
-    application="test"
+    application="demo-test"
 fi
 
 function assert_google_application_credentials {

--- a/ops/dev/vagrant/run_firebase_emulator.sh
+++ b/ops/dev/vagrant/run_firebase_emulator.sh
@@ -8,7 +8,7 @@ project=$(project)
 firebase emulators:start --project="$project" &
 
 # Give the emualtor a second to boot before inserting users
-sleep 10
+sleep 500
 
 python ops/dev/vagrant/create_auth_emulator_accounts.py --project="$project"
 

--- a/src/backend/web/static/javascript/tba_js/tba_keys_template.js
+++ b/src/backend/web/static/javascript/tba_js/tba_keys_template.js
@@ -1,8 +1,8 @@
 // Fill this out and rename to tba_keys.js
-var firebaseApiKey = "";
+var firebaseApiKey = "fake-api-key";
 var firebaseAuthDomain = "";
 var firebaseDatabaseURL = "";
-var firebaseProjectId = "";
+var firebaseProjectId = "demo-test";
 var firebaseStorageBucket = "";
 var firebaseMessagingSenderId = "";
 var firebaseAppId = "";


### PR DESCRIPTION
If we attempt to build the container with no secrets file, the JS fails to build, and people cannot use any of the Firebase JS. This PR adds a default secrets file to the container to make sure we can compile the JS at least once.