### PR TITLE
Fix mistyped notification method returns

### DIFF
--- a/src/backend/common/models/notifications/alliance_selection.py
+++ b/src/backend/common/models/notifications/alliance_selection.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -64,7 +64,7 @@ class AllianceSelectionNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         payload = {"event_key": self.event.key_name}
 
         if self.team:
@@ -78,7 +78,7 @@ class AllianceSelectionNotification(Notification):
             EventConverter,
         )
 
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         payload["event_name"] = self.event.name
         payload["event"] = EventConverter.eventConverter_v3(self.event)
         return payload

--- a/src/backend/common/models/notifications/awards.py
+++ b/src/backend/common/models/notifications/awards.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -56,7 +56,7 @@ class AwardsNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         payload = {"event_key": self.event.key_name}
 
         if self.team:
@@ -66,7 +66,7 @@ class AwardsNotification(Notification):
 
     @property
     def webhook_message_data(self) -> Optional[Dict[str, Any]]:
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         payload["event_name"] = self.event.name
 
         from backend.common.helpers.award_helper import AwardHelper

--- a/src/backend/common/models/notifications/broadcast.py
+++ b/src/backend/common/models/notifications/broadcast.py
@@ -28,7 +28,7 @@ class BroadcastNotification(Notification):
         return messaging.Notification(title=self.title, body=self.message)
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         payload = {}
 
         if self.url:

--- a/src/backend/common/models/notifications/district_points.py
+++ b/src/backend/common/models/notifications/district_points.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -29,11 +29,11 @@ class DistrictPointsNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         return {"district_key": self.district.key_name}
 
     @property
     def webhook_message_data(self) -> Optional[Dict[str, Any]]:
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         payload["district_name"] = self.district.display_name
         return payload

--- a/src/backend/common/models/notifications/event_level.py
+++ b/src/backend/common/models/notifications/event_level.py
@@ -1,6 +1,6 @@
 import calendar
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -49,12 +49,12 @@ class EventLevelNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         return {"comp_level": self.match.comp_level, "event_key": self.event.key_name}
 
     @property
     def webhook_message_data(self) -> Optional[Dict[str, Any]]:
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         payload["event_name"] = self.event.name
         if self.match.time:
             payload["scheduled_time"] = calendar.timegm(self.match.time.utctimetuple())

--- a/src/backend/common/models/notifications/event_schedule.py
+++ b/src/backend/common/models/notifications/event_schedule.py
@@ -1,6 +1,6 @@
 import calendar
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -53,12 +53,12 @@ class EventScheduleNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         return {"event_key": self.event.key_name}
 
     @property
     def webhook_message_data(self) -> Optional[Dict[str, Any]]:
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         if self.next_match and self.next_match.time:
             payload["first_match_time"] = calendar.timegm(
                 self.next_match.time.utctimetuple()

--- a/src/backend/common/models/notifications/match_score.py
+++ b/src/backend/common/models/notifications/match_score.py
@@ -64,7 +64,7 @@ class MatchScoreNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         payload = {"event_key": self.event.key_name, "match_key": self.match.key_name}
 
         if self.team:
@@ -78,7 +78,7 @@ class MatchScoreNotification(Notification):
             MatchConverter,
         )
 
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         # Remove the FCM-only keys
         del payload["match_key"]
 

--- a/src/backend/common/models/notifications/match_upcoming.py
+++ b/src/backend/common/models/notifications/match_upcoming.py
@@ -1,5 +1,5 @@
 import calendar
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -57,7 +57,7 @@ class MatchUpcomingNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         payload = {
             "event_key": self.event.key_name,
             "match_key": self.match.key_name,
@@ -70,7 +70,7 @@ class MatchUpcomingNotification(Notification):
 
     @property
     def webhook_message_data(self) -> Optional[Dict[str, Any]]:
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         payload["event_name"] = self.event.name
         payload["team_keys"] = self.match.team_key_names
 

--- a/src/backend/common/models/notifications/match_video.py
+++ b/src/backend/common/models/notifications/match_video.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, cast, Dict, Optional
 
 from pyre_extensions import none_throws
 
@@ -42,7 +42,7 @@ class MatchVideoNotification(Notification):
         )
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         payload = {"event_key": self.event.key_name, "match_key": self.match.key_name}
 
         if self.team:
@@ -56,7 +56,7 @@ class MatchVideoNotification(Notification):
             MatchConverter,
         )
 
-        payload = none_throws(self.data_payload)
+        payload = cast(Dict[str, Any], none_throws(self.data_payload))
         # Remove the FCM-only keys
         del payload["match_key"]
 

--- a/src/backend/common/models/notifications/notification.py
+++ b/src/backend/common/models/notifications/notification.py
@@ -57,7 +57,7 @@ class Notification(object):
         return None
 
     @property
-    def data_payload(self) -> Optional[Dict[str, Any]]:
+    def data_payload(self) -> Optional[Dict[str, str]]:
         """Arbitrary key/value payload.
 
         Returns:
@@ -117,6 +117,6 @@ class Notification(object):
         """
         return self.data_payload
 
-    def _additional_logging_values(self) -> List[Tuple[str, Any]]:
+    def _additional_logging_values(self) -> List[Tuple[str, str]]:
         """Return a list of value (or None)/name tuples to be adding to str for logging"""
         return []

--- a/src/backend/common/models/notifications/verification.py
+++ b/src/backend/common/models/notifications/verification.py
@@ -43,5 +43,5 @@ class VerificationNotification(Notification):
     def webhook_message_data(self) -> Optional[Dict[str, Any]]:
         return {"verification_key": self.verification_key}
 
-    def _additional_logging_values(self) -> List[Tuple[str, Any]]:
+    def _additional_logging_values(self) -> List[Tuple[str, str]]:
         return [(self.verification_key, "verification_key")]


### PR DESCRIPTION
FCM requires a str/str key/value for payloads. We should make that clear in the typing for the notification models.