### PR TITLE
Fix webpage render_time always being UTC

### DIFF
--- a/src/backend/web/context_processors.py
+++ b/src/backend/web/context_processors.py
@@ -1,8 +1,8 @@
-import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional
 
 
-def render_time_context_processor() -> Dict[str, Optional[datetime.datetime]]:
+def render_time_context_processor() -> Dict[str, Optional[datetime]]:
     return dict(
-        render_time=datetime.datetime.now().replace(second=0, microsecond=0)
+        render_time=datetime.now(timezone.utc).astimezone().replace(second=0, microsecond=0)
     )  # Prevent ETag from changing too quickly

--- a/src/backend/web/tests/context_processors_test.py
+++ b/src/backend/web/tests/context_processors_test.py
@@ -1,8 +1,10 @@
-import datetime
+from datetime import datetime, timezone
 
 from backend.web.context_processors import render_time_context_processor
 
 
 def test_render_time_context_processor() -> None:
     render_time_context = render_time_context_processor()
-    assert type(render_time_context["render_time"]) is datetime.datetime
+    render_time = render_time_context["render_time"]
+    assert type(render_time) is datetime
+    assert render_time.tzinfo == timezone.utc


### PR DESCRIPTION
The [JS code to convert from a UTC date to a local date](https://github.com/the-blue-alliance/the-blue-alliance/blob/b52f8bffb113bf22bf6023318a5d4d4ec2038427/src/backend/web/static/javascript/tba_js/tba.js#L133) to show the render time of the webpage in the user's local time does not currently work since the `render_time` coming from the server isn't timezone-aware, and the `Date` constructor will assume a timezone-less date is in the user's local time already.

This PR modifies the `render_time` datetime to be a timezone-aware (UTC specifically) datetime object. This allows for proper parsing by the JS `Date` class.