### PR TITLE
Fix quintet opportunities

### DIFF
--- a/src/backend/common/helpers/event_insights_helper.py
+++ b/src/backend/common/helpers/event_insights_helper.py
@@ -223,8 +223,8 @@ class EventInsightsHelper:
             / opportunities_1x,
             "quintet_count": [
                 quintet_count,
-                opportunities_3x,
-                100.0 * float(quintet_count) / opportunities_3x,
+                opportunities_1x,
+                100.0 * float(quintet_count) / opportunities_1x,
             ],
             "average_cargo_points_auto": float(cargo_points_auto) / opportunities_1x,
             "average_points_auto": float(points_auto) / opportunities_1x,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I noticed that the quintet success rates seemed suspiciously low at 2022orsal, but didn't question it too much. Looks like @arimb found the reason in #4366! This changes the quintet opportunities to use `opportunities_1x` (per-alliance) rather than `opportunities_3x` (per-robot).

## Motivation and Context

Closes https://github.com/the-blue-alliance/the-blue-alliance/issues/4366

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It's been a while since my last contribution so I don't have the testing environment fully setup, but this change seems to be relatively straight-forward. We may want to re-run the event stat calculation tasks for all completed 2022 events to update them, but probably not too big of a deal if that's a tedious job. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
