### PR TITLE
Add 5m countdown to all district points calculations to allow cache clear jobs to run first

### DIFF
--- a/src/backend/common/manipulators/event_details_manipulator.py
+++ b/src/backend/common/manipulators/event_details_manipulator.py
@@ -47,6 +47,7 @@ def event_details_post_update_hook(
                 method="GET",
                 target="py3-tasks-io",
                 queue_name="default",
+                countdown=300,  # Wait ~5m so cache clearing can run before we attempt to recalculate district points
             )
         except Exception:
             logging.exception(f"Error enqueuing district_points_calc for {event_key}")

--- a/src/backend/common/manipulators/match_manipulator.py
+++ b/src/backend/common/manipulators/match_manipulator.py
@@ -171,6 +171,7 @@ class MatchPostUpdateHooks:
                 method="GET",
                 target="py3-tasks-io",
                 queue_name="default",
+                countdown=300,  # Wait ~5m so cache clearing can run before we attempt to recalculate district points
             )
         except Exception:
             logging.exception(f"Error enqueuing district_points_calc for {event_key}")

--- a/src/backend/common/manipulators/tests/event_details_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/event_details_manipulator_test.py
@@ -131,8 +131,8 @@ class TestEventDetailsManipulator(unittest.TestCase):
         )
         assert len(tasks) == 2
 
-        assert tasks[0].url == "/tasks/math/do/district_points_calc/2011ct"
-        assert tasks[1].url == "/tasks/math/do/event_team_status/2011ct"
+        assert tasks[0].url == "/tasks/math/do/event_team_status/2011ct"
+        assert tasks[1].url == "/tasks/math/do/district_points_calc/2011ct"
 
     def test_postUpdateHook_notifications(self):
         import datetime


### PR DESCRIPTION
This attempts to fix https://github.com/the-blue-alliance/the-blue-alliance/issues/4401 (and mirrors https://github.com/the-blue-alliance/the-blue-alliance/pull/4354) by waiting for the cache clear jobs to run before running our district point calculations