### PR TITLE
Fix broken Firebase emulator by updating JRE to 11 in Docker container

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -41,6 +41,9 @@ RUN apt-get update && apt-get install -y \
     google-cloud-sdk-datastore-emulator \
     google-cloud-sdk-pubsub-emulator
 
+# Install JDK 11 for firebase-tools
+RUN apt-get install default-jre -y
+
 # dev_appserver expects `python2` to exist
 RUN update-alternatives --install /usr/bin/python2 python2 /usr/bin/python2.7 1
 RUN echo 1 | update-alternatives --config python2


### PR DESCRIPTION
From discussion in Slack - the Firebase emulator is currently broken, complaining about a bad Java version

<img width="1512" alt="Screen Shot 2022-05-21 at 1 59 44 PM" src="https://user-images.githubusercontent.com/516458/169665631-b66e4c4a-0295-4502-a6d2-6706189f9662.png">

Updating the JRE to the latest (11) seems to fix.

Will build a new version of the Docker container once this lands.