### PR TITLE
Validate requirements as a pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@ repos:
 - repo: local
   hooks:
     # These run on the default stages (pre-commit)
+    - id: py3-deps
+      name: "[py3] venv Dependencies"
+      always_run: true
+      language: script
+      entry: ./ops/check_venv_deps.sh
+      stages: [commit]
     - id: py3-type
       name: "[py3] Type Checking"
       types: [file, python]

--- a/ops/check_venv_deps.py
+++ b/ops/check_venv_deps.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pkg_resources
+
+REQUIREMENTS_FILES = [
+    Path(__file__).parent.parent / "requirements.txt",
+    Path(__file__).parent.parent / "src/requirements.txt",
+]
+
+
+def test_requirements():
+    missing_requirements = []
+    for requirement_file in REQUIREMENTS_FILES:
+        requirements = pkg_resources.parse_requirements(
+            requirement_file.read_text()
+        )
+        for requirement in requirements:
+            requirement = str(requirement)
+            try:
+                pkg_resources.require(requirement)
+            except pkg_resources.DistributionNotFound:
+                missing_requirements.append(requirement)
+
+    if missing_requirements:
+        print(f"Missing requirements! {missing_requirements}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    test_requirements()

--- a/ops/check_venv_deps.sh
+++ b/ops/check_venv_deps.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+function help_on_error() {
+    echo "You have mismatched dependencies!"
+    echo "Try running using a venv: https://github.com/the-blue-alliance/the-blue-alliance/wiki/Repo-Setup#virtualenv-install"
+    echo "And make sure everything is up to date by running: pip install -r requirements.txt && pip install -r src/requirements.txt"
+}
+
+set -eE
+trap 'help_on_error' ERR
+
+if [[ -z "$VIRTUAL_ENV" ]]; then
+    echo "No venv detected, exiting..."
+    exit 0
+fi
+
+python3 ops/check_venv_deps.py


### PR DESCRIPTION
This will make it easier for people to catch when they have stale dependencies in their local checkout, and to make sure we run tests/lints/etc hermetically against what's in the repo

Example failure
```
(venv) [phil@fedora-x1think the-blue-alliance-py3]$ pre-commit run py3-deps
[py3] venv Dependencies..................................................Failed
- hook id: py3-deps
- exit code: 1

Missing requirements! ['black==22.6.0']
You have mismatched dependencies!
Try running using a venv: https://github.com/the-blue-alliance/the-blue-alliance/wiki/Repo-Setup#virtualenv-install
And make sure everything is up to date by running: pip install -r requirements.txt && pip install -r src/requirements.txt
```