### PR TITLE
Add Hall of Fame page

### DIFF
--- a/src/backend/web/handlers/conftest.py
+++ b/src/backend/web/handlers/conftest.py
@@ -205,3 +205,14 @@ def setup_full_match(test_data_importer):
 @pytest.fixture
 def setup_full_year_events(test_data_importer) -> None:
     test_data_importer.import_event_list(__file__, "tests/data/all_events_2019.json")
+
+
+@pytest.fixture
+def setup_hof_awards(test_data_importer) -> None:
+    def import_event(event_key) -> None:
+        test_data_importer.import_event(__file__, f"tests/data/{event_key}.json")
+        test_data_importer.import_award_list(
+            __file__, f"tests/data/{event_key}_awards.json"
+        )
+
+    return import_event

--- a/src/backend/web/handlers/conftest.py
+++ b/src/backend/web/handlers/conftest.py
@@ -209,7 +209,10 @@ def setup_full_year_events(test_data_importer) -> None:
 
 @pytest.fixture
 def setup_hof_awards(test_data_importer) -> None:
-    def import_event(event_key) -> None:
+    def import_event(event_key, team_keys) -> None:
+        for team_key in team_keys:
+            test_data_importer.import_team(__file__, f"tests/data/{team_key}.json")
+
         test_data_importer.import_event(__file__, f"tests/data/{event_key}.json")
         test_data_importer.import_award_list(
             __file__, f"tests/data/{event_key}_awards.json"

--- a/src/backend/web/handlers/hall_of_fame.py
+++ b/src/backend/web/handlers/hall_of_fame.py
@@ -1,0 +1,54 @@
+from collections import defaultdict
+from datetime import timedelta
+
+from werkzeug.wrappers import Response
+
+from backend.common.consts.award_type import AwardType
+from backend.common.consts.event_type import EventType
+from backend.common.consts.media_tag import MediaTag
+from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
+from backend.common.models.award import Award
+from backend.common.queries.media_query import TeamTagMediasQuery
+from backend.web.profiled_render import render_template
+
+
+@cached_public
+def hall_of_fame_overview() -> Response:
+    awards_future = Award.query(
+        Award.award_type_enum == AwardType.CHAIRMANS,
+        Award.event_type_enum == EventType.CMP_FINALS,
+    ).fetch_async()
+
+    teams_by_year = defaultdict(list)
+    for award in awards_future.get_result():
+        for team_key in award.team_list:
+            teams_by_year[award.year].append(
+                (
+                    team_key.get_async(),
+                    award.event.get_async(),
+                    award,
+                    TeamTagMediasQuery(
+                        team_key.id(), MediaTag.CHAIRMANS_VIDEO
+                    ).fetch_async(),
+                    TeamTagMediasQuery(
+                        team_key.id(), MediaTag.CHAIRMANS_PRESENTATION
+                    ).fetch_async(),
+                    TeamTagMediasQuery(
+                        team_key.id(), MediaTag.CHAIRMANS_ESSAY
+                    ).fetch_async(),
+                )
+            )
+
+    teams_by_year = sorted(teams_by_year.items(), key=lambda k: -k)
+    for _, team in teams_by_year:
+        team.sort(key=lambda x: x[1].get_result().start_date)
+
+    template_values = {
+        "teams_by_year": teams_by_year,
+    }
+
+    return make_cached_response(
+        render_template("hof.html", template_values),
+        ttl=timedelta(weeks=1),
+    )

--- a/src/backend/web/handlers/hall_of_fame.py
+++ b/src/backend/web/handlers/hall_of_fame.py
@@ -40,7 +40,8 @@ def hall_of_fame_overview() -> Response:
                 )
             )
 
-    teams_by_year = sorted(teams_by_year.items(), key=lambda k: -k)
+    teams_by_year = sorted(teams_by_year.items(), key=lambda k_v: -k_v[0])
+
     for _, team in teams_by_year:
         team.sort(key=lambda x: x[1].get_result().start_date)
 

--- a/src/backend/web/handlers/tests/data/2021cmpaw.json
+++ b/src/backend/web/handlers/tests/data/2021cmpaw.json
@@ -1,0 +1,36 @@
+{
+  "address": "1132, 200 Bedford St #101, Manchester, NH 03101, USA",
+  "city": "Manchester",
+  "country": "USA",
+  "district": null,
+  "division_keys": [
+
+  ],
+  "end_date": "2021-06-30",
+  "event_code": "cmpaw",
+  "event_type": 4,
+  "event_type_string": "Championship Finals",
+  "first_event_code": "CMPAW",
+  "first_event_id": null,
+  "gmaps_place_id": "ChIJAUrtOChP4okRGKESFx2fpLk",
+  "gmaps_url": "https://maps.google.com/?cid=13376991740487180568",
+  "key": "2021cmpaw",
+  "lat": 42.9896383,
+  "lng": -71.467803,
+  "location_name": "FIRST",
+  "name": "FIRST Robotics Competition Championship Level Awards Only Event",
+  "parent_event_key": null,
+  "playoff_type": 0,
+  "playoff_type_string": null,
+  "postal_code": "03101",
+  "short_name": "FIRST Robotics Competition Championship Level Awards Only",
+  "start_date": "2021-06-30",
+  "state_prov": "NH",
+  "timezone": "America/New_York",
+  "webcasts": [
+
+  ],
+  "website": "http://None",
+  "week": null,
+  "year": 2021
+}

--- a/src/backend/web/handlers/tests/data/2021cmpaw_awards.json
+++ b/src/backend/web/handlers/tests/data/2021cmpaw_awards.json
@@ -1,0 +1,118 @@
+[
+  {
+    "award_type": 0,
+    "event_key": "2021cmpaw",
+    "name": "Chairman's Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc503"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4613"
+      }
+    ],
+    "year": 2021
+  },
+  {
+    "award_type": 3,
+    "event_key": "2021cmpaw",
+    "name": "Woodie Flowers Award",
+    "recipient_list": [
+      {
+        "awardee": "Matt Fagen",
+        "team_key": "frc4253"
+      }
+    ],
+    "year": 2021
+  },
+  {
+    "award_type": 4,
+    "event_key": "2021cmpaw",
+    "name": "FIRST Dean's List Award",
+    "recipient_list": [
+      {
+        "awardee": "Obike Anwisye",
+        "team_key": "frc931"
+      },
+      {
+        "awardee": "Megan Enriquez",
+        "team_key": "frc3932"
+      },
+      {
+        "awardee": "Ignacio Fernandez",
+        "team_key": "frc7717"
+      },
+      {
+        "awardee": "Arseniy Ilinich",
+        "team_key": "frc503"
+      },
+      {
+        "awardee": "Mim Macdonell",
+        "team_key": "frc6035"
+      },
+      {
+        "awardee": "Kathleen O'Sullivan",
+        "team_key": "frc8603"
+      },
+      {
+        "awardee": "Fikir Teklemedhin",
+        "team_key": "frc3006"
+      },
+      {
+        "awardee": "Claudius Tewari",
+        "team_key": "frc604"
+      },
+      {
+        "awardee": "Tatiana Vassiliev",
+        "team_key": "frc118"
+      },
+      {
+        "awardee": "Eric Zhou",
+        "team_key": "frc7461"
+      }
+    ],
+    "year": 2021
+  },
+  {
+    "award_type": 5,
+    "event_key": "2021cmpaw",
+    "name": "Volunteer of the Year",
+    "recipient_list": [
+      {
+        "awardee": "David Greenley",
+        "team_key": null
+      },
+      {
+        "awardee": "Peter Johnson",
+        "team_key": null
+      }
+    ],
+    "year": 2021
+  },
+  {
+    "award_type": 69,
+    "event_key": "2021cmpaw",
+    "name": "Chairman's Award Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1156"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3284"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3504"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6024"
+      }
+    ],
+    "year": 2021
+  }
+]

--- a/src/backend/web/handlers/tests/data/2022cmptx.json
+++ b/src/backend/web/handlers/tests/data/2022cmptx.json
@@ -1,0 +1,44 @@
+{
+  "address": "1001 Avenida De Las Americas, Houston, TX 77010, USA",
+  "city": "Houston",
+  "country": "USA",
+  "district": null,
+  "division_keys": [
+    "2022carv",
+    "2022gal",
+    "2022hop",
+    "2022new",
+    "2022roe",
+    "2022tur"
+  ],
+  "end_date": "2022-04-23",
+  "event_code": "cmptx",
+  "event_type": 4,
+  "event_type_string": "Championship Finals",
+  "first_event_code": "CMPTX",
+  "first_event_id": null,
+  "gmaps_place_id": "ChIJgw3vTiK_QIYRsMwBp668_Lo",
+  "gmaps_url": "https://maps.google.com/?q=1001+Avenida+De+Las+Americas,+Houston,+TX+77010,+USA&ftid=0x8640bf224eef0d83:0xbafcbcaea701ccb0",
+  "key": "2022cmptx",
+  "lat": 29.7520006,
+  "lng": -95.3576434,
+  "location_name": "1001 Avenida De Las Americas",
+  "name": "Einstein Field",
+  "parent_event_key": null,
+  "playoff_type": 4,
+  "playoff_type_string": "Round Robin (6 Alliances)",
+  "postal_code": "77010",
+  "short_name": "Einstein",
+  "start_date": "2022-04-23",
+  "state_prov": "TX",
+  "timezone": "America/Chicago",
+  "webcasts": [
+    {
+      "channel": "firstinspires",
+      "type": "twitch"
+    }
+  ],
+  "website": "https://www.firstchampionship.org",
+  "week": null,
+  "year": 2022
+}

--- a/src/backend/web/handlers/tests/data/2022cmptx_awards.json
+++ b/src/backend/web/handlers/tests/data/2022cmptx_awards.json
@@ -1,0 +1,166 @@
+[
+  {
+    "award_type": 0,
+    "event_key": "2022cmptx",
+    "name": "Chairman's Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1629"
+      }
+    ],
+    "year": 2022
+  },
+  {
+    "award_type": 1,
+    "event_key": "2022cmptx",
+    "name": "Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1619"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc254"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3175"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6672"
+      }
+    ],
+    "year": 2022
+  },
+  {
+    "award_type": 2,
+    "event_key": "2022cmptx",
+    "name": "Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1577"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4414"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2539"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4099"
+      }
+    ],
+    "year": 2022
+  },
+  {
+    "award_type": 3,
+    "event_key": "2022cmptx",
+    "name": "Woodie Flowers Award",
+    "recipient_list": [
+      {
+        "awardee": "Christine Sapio",
+        "team_key": "frc2486"
+      }
+    ],
+    "year": 2022
+  },
+  {
+    "award_type": 4,
+    "event_key": "2022cmptx",
+    "name": "FIRST Dean's List Award",
+    "recipient_list": [
+      {
+        "awardee": "Alicia Ramirez",
+        "team_key": "frc2383"
+      },
+      {
+        "awardee": "Ethan Brown",
+        "team_key": "frc5338"
+      },
+      {
+        "awardee": "Leslie Kim",
+        "team_key": "frc3928"
+      },
+      {
+        "awardee": "Nate King",
+        "team_key": "frc2129"
+      },
+      {
+        "awardee": "Nazlı Eren",
+        "team_key": "frc2905"
+      },
+      {
+        "awardee": "Thomas Gormley",
+        "team_key": "frc2834"
+      },
+      {
+        "awardee": "Arvind Seshan",
+        "team_key": "frc8027"
+      },
+      {
+        "awardee": "Christopher Palazzo",
+        "team_key": "frc871"
+      },
+      {
+        "awardee": "Trevor Langley",
+        "team_key": "frc5188"
+      },
+      {
+        "awardee": "Joyce Yang",
+        "team_key": "frc1967"
+      }
+    ],
+    "year": 2022
+  },
+  {
+    "award_type": 5,
+    "event_key": "2022cmptx",
+    "name": "Volunteer of the Year",
+    "recipient_list": [
+      {
+        "awardee": "Chuck Dickerson",
+        "team_key": null
+      }
+    ],
+    "year": 2022
+  },
+  {
+    "award_type": 69,
+    "event_key": "2022cmptx",
+    "name": "Chairman's Award Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1511"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1629"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2438"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2468"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6652"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6429"
+      }
+    ],
+    "year": 2022
+  }
+]

--- a/src/backend/web/handlers/tests/data/frc1629.json
+++ b/src/backend/web/handlers/tests/data/frc1629.json
@@ -1,0 +1,20 @@
+{
+  "address": null,
+  "city": "Accident",
+  "country": "USA",
+  "gmaps_place_id": null,
+  "gmaps_url": null,
+  "key": "frc1629",
+  "lat": null,
+  "lng": null,
+  "location_name": null,
+  "motto": null,
+  "name": "Garrett County Public Schools / Pillar Innovations / Beitzel Corporation / Wilson Supply & Northern Garrett High School & Southern Garrett High School",
+  "nickname": "Garrett Coalition (GaCo)",
+  "postal_code": "21520",
+  "rookie_year": 2005,
+  "school_name": "Northern Garrett High School & Southern Garrett High School",
+  "state_prov": "Maryland",
+  "team_number": 1629,
+  "website": "http://www.garrettcountyschools.org/frc1629"
+}

--- a/src/backend/web/handlers/tests/data/frc4613.json
+++ b/src/backend/web/handlers/tests/data/frc4613.json
@@ -1,0 +1,20 @@
+{
+  "address": null,
+  "city": "Sydney",
+  "country": "Australia",
+  "gmaps_place_id": null,
+  "gmaps_url": null,
+  "key": "frc4613",
+  "lat": null,
+  "lng": null,
+  "location_name": null,
+  "motto": null,
+  "name": "AARNet/Innovation First International/BirdDog&Barker College",
+  "nickname": "Barker Redbacks",
+  "postal_code": "2077",
+  "rookie_year": 2013,
+  "school_name": "Barker College",
+  "state_prov": "New South Wales",
+  "team_number": 4613,
+  "website": "http://team4613.org/"
+}

--- a/src/backend/web/handlers/tests/data/frc503.json
+++ b/src/backend/web/handlers/tests/data/frc503.json
@@ -1,0 +1,20 @@
+{
+  "address": null,
+  "city": "Novi",
+  "country": "USA",
+  "gmaps_place_id": null,
+  "gmaps_url": null,
+  "key": "frc503",
+  "lat": null,
+  "lng": null,
+  "location_name": null,
+  "motto": null,
+  "name": "Magna Seating Systems (Primary Sponsor) / Denso / The Nissan Foundation / Tata Technologies / Ford Motor Company / Novi Community School District / NGK Sparkplugs / ASCO Numatics Inc. / Autodesk / Michigan Department of Education & Novi High School",
+  "nickname": "Frog Force",
+  "postal_code": "48375",
+  "rookie_year": 2001,
+  "school_name": "Novi High School",
+  "state_prov": "Michigan",
+  "team_number": 503,
+  "website": "http://www.frogforce503.org"
+}

--- a/src/backend/web/handlers/tests/hall_of_fame_test.py
+++ b/src/backend/web/handlers/tests/hall_of_fame_test.py
@@ -9,56 +9,23 @@ def test_hof_page_loads(web_client: Client) -> None:
 
 
 def test_2022_hof_info(web_client: Client, setup_hof_awards) -> None:
-    # helpers.import_team()
     setup_hof_awards("2021cmpaw", ["frc503", "frc4613"])
     setup_hof_awards("2022cmptx", ["frc1629"])
 
     resp = web_client.get("/hall-of-fame")
+
     assert resp.status_code == 200
-
-    # print(resp.data)
-
     assert helpers.get_page_title(resp.data) == "FIRST Hall of Fame - The Blue Alliance"
 
     hof_awards = helpers.get_HOF_awards(resp.data)
-
-    print(hof_awards)
-
-    # assert team_history == [
-    #     helpers.TeamEventHistory(year=2019, event="The Remix", awards=[]),
-    #     helpers.TeamEventHistory(
-    #         year=2019, event="Texas Robotics Invitational", awards=[]
-    #     ),
-    #     helpers.TeamEventHistory(
-    #         year=2019, event="Einstein Field (Houston)", awards=[]
-    #     ),
-    #     helpers.TeamEventHistory(
-    #         year=2019,
-    #         event="Roebling Division",
-    #         awards=[
-    #             "Championship Subdivision Winner",
-    #             "Quality Award sponsored by Motorola Solutions Foundation",
-    #         ],
-    #     ),
-    #     helpers.TeamEventHistory(
-    #         year=2019,
-    #         event="FIRST In Texas District Championship",
-    #         awards=["District Championship Winner"],
-    #     ),
-    #     helpers.TeamEventHistory(
-    #         year=2019,
-    #         event="FIT District Dallas Event",
-    #         awards=[
-    #             "District Event Winner",
-    #             "Industrial Design Award sponsored by General Motors",
-    #         ],
-    #     ),
-    #     helpers.TeamEventHistory(
-    #         year=2019,
-    #         event="FIT District Amarillo Event",
-    #         awards=[
-    #             "District Event Winner",
-    #             "Quality Award sponsored by Motorola Solutions Foundation",
-    #         ],
-    #     ),
-    # ]
+    assert hof_awards == [
+        helpers.TeamHOFInfo(
+            team_number=1629, year="2022", event="2022 Houston Championship"
+        ),
+        helpers.TeamHOFInfo(
+            team_number=503, year="2021", event="2021 Manchester Championship"
+        ),
+        helpers.TeamHOFInfo(
+            team_number=4613, year="2021", event="2021 Manchester Championship"
+        ),
+    ]

--- a/src/backend/web/handlers/tests/hall_of_fame_test.py
+++ b/src/backend/web/handlers/tests/hall_of_fame_test.py
@@ -1,0 +1,60 @@
+from werkzeug.test import Client
+
+from backend.web.handlers.tests import helpers
+
+
+def test_hof_page_loads(web_client: Client) -> None:
+    resp = web_client.get("/hall-of-fame")
+    assert resp.status_code == 200
+
+
+def test_2022_hof_info(web_client: Client, setup_hof_awards) -> None:
+    setup_hof_awards("2021cmpaw")
+    setup_hof_awards("2022cmptx")
+
+    resp = web_client.get("/hall-of-fame")
+    assert resp.status_code == 200
+
+    print(resp.data)
+
+    assert helpers.get_page_title(resp.data) == "FIRST Hall of Fame - The Blue Alliance"
+
+    # team_history = helpers.get_team_history(resp.data)
+    # assert team_history == [
+    #     helpers.TeamEventHistory(year=2019, event="The Remix", awards=[]),
+    #     helpers.TeamEventHistory(
+    #         year=2019, event="Texas Robotics Invitational", awards=[]
+    #     ),
+    #     helpers.TeamEventHistory(
+    #         year=2019, event="Einstein Field (Houston)", awards=[]
+    #     ),
+    #     helpers.TeamEventHistory(
+    #         year=2019,
+    #         event="Roebling Division",
+    #         awards=[
+    #             "Championship Subdivision Winner",
+    #             "Quality Award sponsored by Motorola Solutions Foundation",
+    #         ],
+    #     ),
+    #     helpers.TeamEventHistory(
+    #         year=2019,
+    #         event="FIRST In Texas District Championship",
+    #         awards=["District Championship Winner"],
+    #     ),
+    #     helpers.TeamEventHistory(
+    #         year=2019,
+    #         event="FIT District Dallas Event",
+    #         awards=[
+    #             "District Event Winner",
+    #             "Industrial Design Award sponsored by General Motors",
+    #         ],
+    #     ),
+    #     helpers.TeamEventHistory(
+    #         year=2019,
+    #         event="FIT District Amarillo Event",
+    #         awards=[
+    #             "District Event Winner",
+    #             "Quality Award sponsored by Motorola Solutions Foundation",
+    #         ],
+    #     ),
+    # ]

--- a/src/backend/web/handlers/tests/hall_of_fame_test.py
+++ b/src/backend/web/handlers/tests/hall_of_fame_test.py
@@ -9,17 +9,21 @@ def test_hof_page_loads(web_client: Client) -> None:
 
 
 def test_2022_hof_info(web_client: Client, setup_hof_awards) -> None:
-    setup_hof_awards("2021cmpaw")
-    setup_hof_awards("2022cmptx")
+    # helpers.import_team()
+    setup_hof_awards("2021cmpaw", ["frc503", "frc4613"])
+    setup_hof_awards("2022cmptx", ["frc1629"])
 
     resp = web_client.get("/hall-of-fame")
     assert resp.status_code == 200
 
-    print(resp.data)
+    # print(resp.data)
 
     assert helpers.get_page_title(resp.data) == "FIRST Hall of Fame - The Blue Alliance"
 
-    # team_history = helpers.get_team_history(resp.data)
+    hof_awards = helpers.get_HOF_awards(resp.data)
+
+    print(hof_awards)
+
     # assert team_history == [
     #     helpers.TeamEventHistory(year=2019, event="The Remix", awards=[]),
     #     helpers.TeamEventHistory(

--- a/src/backend/web/handlers/tests/hall_of_fame_test.py
+++ b/src/backend/web/handlers/tests/hall_of_fame_test.py
@@ -20,12 +20,12 @@ def test_2022_hof_info(web_client: Client, setup_hof_awards) -> None:
     hof_awards = helpers.get_HOF_awards(resp.data)
     assert hof_awards == [
         helpers.TeamHOFInfo(
-            team_number=1629, year="2022", event="2022 Houston Championship"
+            team_number=1629, year=2022, event="2022 Houston Championship"
         ),
         helpers.TeamHOFInfo(
-            team_number=503, year="2021", event="2021 Manchester Championship"
+            team_number=503, year=2021, event="2021 Manchester Championship"
         ),
         helpers.TeamHOFInfo(
-            team_number=4613, year="2021", event="2021 Manchester Championship"
+            team_number=4613, year=2021, event="2021 Manchester Championship"
         ),
     ]

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -338,9 +338,12 @@ def get_HOF_awards(resp_data: str) -> Optional[List[TeamHOFInfo]]:
     return [
         TeamHOFInfo(
             team_number=int(re.match(r"\/team\/(\d+)", b.find("a")["href"])[1]),
-            year=re.match(
-                r"(\d+)", b.find("div", {"class": "award-event"}).find("span").string
-            )[1],
+            year=int(
+                re.match(
+                    r"(\d+)",
+                    b.find("div", {"class": "award-event"}).find("span").string,
+                )[1]
+            ),
             event=b.find("div", {"class": "award-event"}).find("span").string,
         )
         for b in banners

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -335,19 +335,13 @@ def get_HOF_awards(resp_data: str) -> Optional[List[TeamHOFInfo]]:
     soup = bs4.BeautifulSoup(resp_data, "html.parser")
     banners = soup.find_all("div", class_="panel-default")
 
-    # print(banners)
-
-    # for b in banners:
-    #     print(b)
-    #     print("---------------")
-    #     team_number = re.match(r"\/team\/(\d+)", b.find("a")["href"])[1]
-    #     print("---------------")
-
     return [
         TeamHOFInfo(
             team_number=int(re.match(r"\/team\/(\d+)", b.find("a")["href"])[1]),
-            year=2022,  # .join(e.find_all("td")[1].stripped_strings),
-            event="",  # list(e.find_all("td")[2].stripped_strings),
+            year=re.match(
+                r"(\d+)", b.find("div", {"class": "award-event"}).find("span").string
+            )[1],
+            event=b.find("div", {"class": "award-event"}).find("span").string,
         )
         for b in banners
     ]

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -50,6 +50,12 @@ class TeamEventHistory(NamedTuple):
     awards: List[str]
 
 
+class TeamHOFInfo(NamedTuple):
+    team_number: int
+    year: int
+    event: str
+
+
 class ParsedTeam(NamedTuple):
     team_number: TeamNumber
     team_number_link: Optional[str]
@@ -323,3 +329,25 @@ def get_all_teams(resp_data: str) -> List[ParsedTeam]:
         return []
     assert len(tables) == 2
     return get_teams_from_table(tables[0]) + get_teams_from_table(tables[1])
+
+
+def get_HOF_awards(resp_data: str) -> Optional[List[TeamHOFInfo]]:
+    soup = bs4.BeautifulSoup(resp_data, "html.parser")
+    banners = soup.find_all("div", class_="panel-default")
+
+    # print(banners)
+
+    # for b in banners:
+    #     print(b)
+    #     print("---------------")
+    #     team_number = re.match(r"\/team\/(\d+)", b.find("a")["href"])[1]
+    #     print("---------------")
+
+    return [
+        TeamHOFInfo(
+            team_number=int(re.match(r"\/team\/(\d+)", b.find("a")["href"])[1]),
+            year=2022,  # .join(e.find_all("td")[1].stripped_strings),
+            event="",  # list(e.find_all("td")[2].stripped_strings),
+        )
+        for b in banners
+    ]

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -5,6 +5,7 @@ from typing import Generator, List, NamedTuple, Optional, Tuple
 
 import bs4
 from google.appengine.ext import ndb
+from pyre_extensions import none_throws
 
 from backend.common.consts.event_type import EventType
 from backend.common.models.district import District
@@ -337,11 +338,15 @@ def get_HOF_awards(resp_data: str) -> Optional[List[TeamHOFInfo]]:
 
     return [
         TeamHOFInfo(
-            team_number=int(re.match(r"\/team\/(\d+)", b.find("a")["href"])[1]),
+            team_number=int(
+                none_throws(re.match(r"\/team\/(\d+)", b.find("a")["href"]))[1]
+            ),
             year=int(
-                re.match(
-                    r"(\d+)",
-                    b.find("div", {"class": "award-event"}).find("span").string,
+                none_throws(
+                    re.match(
+                        r"(\d+)",
+                        b.find("div", {"class": "award-event"}).find("span").string,
+                    )
                 )[1]
             ),
             event=b.find("div", {"class": "award-event"}).find("span").string,

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -16,6 +16,7 @@ from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.event import event_detail, event_insights, event_list
 from backend.web.handlers.eventwizard import eventwizard
 from backend.web.handlers.gameday import gameday, gameday_redirect
+from backend.web.handlers.hall_of_fame import hall_of_fame_overview
 from backend.web.handlers.index import about, avatar_list, index
 from backend.web.handlers.insights import insights_detail, insights_overview
 from backend.web.handlers.match import match_detail
@@ -91,6 +92,8 @@ app.add_url_rule("/avatars/<int:year>", view_func=avatar_list)
 
 app.add_url_rule("/insights", view_func=insights_overview)
 app.add_url_rule("/insights/<int:year>", view_func=insights_detail)
+
+app.add_url_rule("/hall-of-fame", view_func=hall_of_fame_overview)
 
 # Static pages
 app.add_url_rule("/add-data", view_func=add_data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `/hall-of-fame` url, handler, and tests

## Motivation and Context
More `py3`

## How Has This Been Tested?
Locally.
Added HOF tests (WIP)
Added test data for `2022cmptx`, `2022cmptx_awards`, `2021cmpaw`, and `2021cmpaw_awards`, which is enough data to make sure that the page correctly renders:
  1) Years in the correct order (most recent first)
  2) Single-winner years
  3) Two champ years 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1204591/182538580-1d8119ca-3bc6-4a93-8721-9145f83dd6fa.png)
Note: I have no data locally, which is what the tests are for  🙂 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
