### PR TITLE
Fix horizontal scroll issue

### DIFF
--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -275,7 +275,7 @@
 
 {% block footer_content %}
 {% if year and year >= 2015 %}
-<div class="text-left col-xs-12 col-sm-offset-3 col-lg-offset-2" style="margin-bottom: 2rem;">
+<div class="text-left col-sm-9 col-lg-10 col-sm-offset-3 col-lg-offset-2" style="margin-bottom: 2rem;">
   <span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank" rel="noopener noreferrer"><em>FIRST</em><sup>®</sup> Events API</a><br>
 </div>
 {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tried to fix the horizontal scroll issue in #4613. It was caused by this div extending too far to the right
<img width="1134" alt="Screen Shot 2022-08-22 at 11 05 08 PM" src="https://user-images.githubusercontent.com/6137845/186084792-d9c0eb7e-e2ce-442f-84ac-f3de591e9fdf.png">

## Motivation and Context


## How Has This Been Tested?

Tested manually that you can no longer horizontally scroll, and the page otherwise looks the same on different screen sizes.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
