### PR TITLE
Remove forked appengine-python-standard Dependency

### DIFF
--- a/src/backend/common/manipulators/tests/base_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/base_manipulator_test.py
@@ -323,8 +323,7 @@ def test_cache_clearing(ndb_context, taskqueue_stub) -> None:
     assert len(tasks) == 1
 
     # This lets us ensure that the devserver can run our task
-    # See https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45
-    six.ensure_text(tasks[0].payload)
+    six.ensure_binary(tasks[0].payload)
 
     # Run cache clearing manually
     deferred.run(tasks[0].payload)

--- a/src/backend/common/manipulators/tests/event_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/event_manipulator_test.py
@@ -124,7 +124,7 @@ class TestEventManipulator(unittest.TestCase):
         for task in tasks:
             # This lets us ensure that the devserver can run our task
             # See https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45
-            six.ensure_text(task.payload)
+            six.ensure_binary(task.payload)
             deferred.run(task.payload)
 
         assert none_throws(Event.get_by_id("2011ct")).timezone_id is not None

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,4 +15,4 @@ pyre-extensions==0.0.29
 requests==2.28.1
 typing-extensions==4.3.0
 Werkzeug==2.2.2
-appengine-python-standard-tbafork==0.4.0dev2
+appengine-python-standard==1.0.0


### PR DESCRIPTION
The issue that caused us to fork the library in the first place seems to
have been addressed in the `dev_appserver` implementation.

So I think that renders our fork unnecessary, so let's remove it and
bump ourselves to the latest version

https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45#issuecomment-1229537695