### PR TITLE
Add /webcasts to py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage.xml
 venv/
 .testmondata
 .vscode
+.idea
 
 # Compiled/Intermediate Files #
 ###############################

--- a/src/backend/web/handlers/tests/webcast_list_test.py
+++ b/src/backend/web/handlers/tests/webcast_list_test.py
@@ -1,0 +1,27 @@
+import json
+
+from bs4 import BeautifulSoup
+from freezegun import freeze_time
+from werkzeug.test import Client
+
+from backend.web.handlers.tests import helpers
+
+
+@freeze_time("2020-04-02")
+def test_render_webcast_list(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_event("2020nyny")
+
+    resp = web_client.get("/webcasts")
+    assert resp.status_code == 200
+
+    table = BeautifulSoup(resp.data, "html.parser").find("table")
+    rows = table.find("tbody").find_all("tr")
+
+    assert len(rows) == 1
+    event_row = rows[0]
+
+    assert "".join(event_row.find_all("td")[0].stripped_strings) == "Test Event"
+    assert json.loads("".join(event_row.find_all("td")[3].strings)) == [
+        {"type": "twitch", "channel": "robosportsnetwork"},
+        {"type": "twitch", "channel": "firstinspires"},
+    ]

--- a/src/backend/web/handlers/webcasts.py
+++ b/src/backend/web/handlers/webcasts.py
@@ -1,20 +1,23 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from werkzeug.wrappers import Response
 
 from backend.common.decorators import cached_public
 from backend.common.flask_cache import make_cached_response
-from backend.common.models.event import Event
+from backend.common.helpers.event_helper import EventHelper
+from backend.common.helpers.season_helper import SeasonHelper
+from backend.common.queries.event_query import EventListQuery
 from backend.web.profiled_render import render_template
 
 
 @cached_public
 def webcast_list() -> Response:
-    year = datetime.now().year
-    events = Event.query(Event.year == year).order(Event.start_date).fetch(500)
+    year = SeasonHelper.get_current_season()
+    events = EventListQuery(year).fetch()
+    sorted_events = EventHelper.sorted_events(events)
 
     template_values = {
-        "events": events,
+        "events": sorted_events,
         "year": year,
     }
 

--- a/src/backend/web/handlers/webcasts.py
+++ b/src/backend/web/handlers/webcasts.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+
+from werkzeug.wrappers import Response
+
+from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
+from backend.common.models.event import Event
+from backend.web.profiled_render import render_template
+
+
+@cached_public
+def webcast_list() -> Response:
+    year = datetime.now().year
+    events = Event.query(Event.year == year).order(Event.start_date)
+
+    template_values = {
+        "events": events,
+        "year": year,
+    }
+
+    return make_cached_response(
+        render_template("webcasts.html", template_values),
+        ttl=timedelta(weeks=1),
+    )

--- a/src/backend/web/handlers/webcasts.py
+++ b/src/backend/web/handlers/webcasts.py
@@ -11,7 +11,7 @@ from backend.web.profiled_render import render_template
 @cached_public
 def webcast_list() -> Response:
     year = datetime.now().year
-    events = Event.query(Event.year == year).order(Event.start_date)
+    events = Event.query(Event.year == year).order(Event.start_date).fetch(500)
 
     template_values = {
         "events": events,

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -41,6 +41,7 @@ from backend.web.handlers.team import (
     team_history,
     team_list,
 )
+from backend.web.handlers.webcasts import webcast_list
 from backend.web.jinja2_filters import register_template_filters
 from backend.web.local.blueprint import maybe_register as maybe_install_local_routes
 
@@ -94,6 +95,8 @@ app.add_url_rule("/insights", view_func=insights_overview)
 app.add_url_rule("/insights/<int:year>", view_func=insights_detail)
 
 app.add_url_rule("/hall-of-fame", view_func=hall_of_fame_overview)
+
+app.add_url_rule("/webcasts", view_func=webcast_list)
 
 # Static pages
 app.add_url_rule("/add-data", view_func=add_data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `/webcasts` url, handler, and tests

Old handler: https://github.com/the-blue-alliance/the-blue-alliance/blob/py3/old_py2/controllers/main_controller.py#L210

## Motivation and Context
Port to py3

## How Has This Been Tested?
Added a basic test

## Screenshots (if appropriate):

<img width="1094" alt="Screen Shot 2022-08-29 at 9 34 29 PM" src="https://user-images.githubusercontent.com/6137845/187350061-053b08f3-21ee-4e3d-8662-3b0f2c7ab2df.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
