### PR TITLE
Stop using @before_first_request

### DIFF
--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 from firebase_admin import auth
 from flask import session
+from google.auth import exceptions
 
 from backend.common.firebase import app
 from backend.common.models.user import User
@@ -37,7 +38,7 @@ def _decoded_claims() -> Optional[Dict[str, Any]]:
     # if the user's Firebase session was revoked, user deleted/disabled, etc.
     try:
         return auth.verify_session_cookie(session_cookie, check_revoked=True, app=app())
-    except auth.InvalidSessionCookieError:
+    except (auth.InvalidSessionCookieError, exceptions.DefaultCredentialsError):
         # Session cookie is invalid, expired or revoked. Force user to login.
         return None
 

--- a/src/backend/common/middleware.py
+++ b/src/backend/common/middleware.py
@@ -48,9 +48,9 @@ class AfterResponseMiddleware:
 
 
 def install_middleware(app: Flask, configure_secret_key: bool = True) -> None:
-    @app.before_first_request
+    @app.before_request
     def _app_before():
-        if configure_secret_key:
+        if configure_secret_key and not app.secret_key:
             _set_secret_key(app)
 
     # The middlewares get added in order of this last, and each wraps the previous

--- a/src/backend/common/tests/middleware_test.py
+++ b/src/backend/common/tests/middleware_test.py
@@ -92,9 +92,10 @@ def test_install_middleware(app: Flask) -> None:
         backend.common.middleware, "_set_secret_key"
     ) as mock_set_secret_key:
         install_middleware(app)
-        assert len(app.before_first_request_funcs) > 0
-        app.try_trigger_before_first_request_functions()
-    mock_set_secret_key.assert_called_with(app)
+        assert len(app.before_request_funcs) > 0
+        for func in app.before_request_funcs[None]:
+            func()
+    mock_set_secret_key.assert_called_once_with(app)
     assert type(app.wsgi_app) is TraceRequestMiddleware
 
 

--- a/src/backend/web/tests/main_test.py
+++ b/src/backend/web/tests/main_test.py
@@ -16,10 +16,12 @@ def test_app_secret_key(ndb_stub) -> None:
     assert main.app.secret_key is None
 
     # Setting up the secret key will run before the first request
-    assert len(main.app.before_first_request_funcs) > 0
+    assert len(main.app.before_request_funcs) > 0
 
     # Force run the before-first-request functions
-    main.app.try_trigger_before_first_request_functions()
+    with main.app.test_request_context():
+        for func in main.app.before_request_funcs[None]:
+            func()
 
     # Make sure they set the secret key
     assert main.app.secret_key == FlaskSecrets.DEFAULT_SECRET_KEY


### PR DESCRIPTION
`@before_first_request` was deprecated in Flask 2.2.0, and this is blocking a dependency update.

https://flask.palletsprojects.com/en/2.2.x/changes/#version-2-2-0

It's also pretty flaky. This just switches it to use `@before_request` which is hopefully better?

Although really we probably shouldn't use this pattern at all, but since we need to load the secret key from a sitevar, that requires an ndb context, which really can only come through a request

Maybe we should pull this from an env variable or tease out the right configuration to load an ndb context during the app configuration time, so we can make the query