### PR TITLE
Store Display Name on Match Object

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_matches_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_matches_parser.py
@@ -30,6 +30,7 @@ class MatchInput(TypedDict, total=False):
     score_breakdowns: Mapping[AllianceColor, Dict[str, Any]]
     time_string: str
     time: str
+    display_name: str
 
 
 class ParsedMatch(TypedDict):
@@ -41,6 +42,7 @@ class ParsedMatch(TypedDict):
     time_string: str
     time: datetime.datetime
     team_key_names: Sequence[TeamKey]
+    display_name: Optional[str]
 
 
 class JSONMatchesParser:
@@ -72,6 +74,7 @@ class JSONMatchesParser:
             score_breakdown = match.get("score_breakdown", None)
             time_string = match.get("time_string", None)
             time_utc = match.get("time_utc", None)
+            display_name = match.get("display_name", None)
 
             if comp_level is None:
                 raise ParserInputException("Match must have a 'comp_level'")
@@ -165,6 +168,9 @@ class JSONMatchesParser:
                         "Could not parse 'time_utc'. Check that it is in ISO 8601 format."
                     )
 
+            if display_name is not None and type(display_name) is not str:
+                raise ParserInputException("'display_name' must be a string")
+
             # validation passed. build new dicts to sanitize
             parsed_alliances: Dict[AllianceColor, MatchAlliance] = {
                 AllianceColor.RED: {
@@ -192,6 +198,7 @@ class JSONMatchesParser:
                 "time": datetime_utc,
                 "team_key_names": parsed_alliances[AllianceColor.RED]["teams"]
                 + parsed_alliances[AllianceColor.BLUE]["teams"],
+                "display_name": display_name,
             }
 
             parsed_matches.append(parsed_match)

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -224,6 +224,7 @@ def update_event_matches(event_key: EventKey) -> Response:
             score_breakdown_json=match["score_breakdown_json"],
             time_string=match["time_string"],
             time=match["time"],
+            display_name=match["display_name"],
         )
 
         if (not match.time or match.time == "") and match.time_string:

--- a/src/backend/common/models/match.py
+++ b/src/backend/common/models/match.py
@@ -109,6 +109,7 @@ class Match(CachedModel):
     tiebreak_match_key = ndb.KeyProperty(
         kind="Match"
     )  # Points to a match that was played to tiebreak this one
+    display_name: str = ndb.StringProperty()
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True)
@@ -123,6 +124,7 @@ class Match(CachedModel):
         "post_result_time",
         "push_sent",
         "tiebreak_match_key",
+        "display_name",
     }
 
     _list_attrs: Set[str] = {
@@ -325,6 +327,9 @@ class Match(CachedModel):
 
     @property
     def verbose_name(self) -> str:
+        if self.display_name:
+            return self.display_name
+
         from backend.common.helpers.event_helper import EventHelper
 
         if (

--- a/src/backend/web/handlers/admin/match.py
+++ b/src/backend/web/handlers/admin/match.py
@@ -63,6 +63,7 @@ def match_edit_post(match_key):
         if request.form.get("youtube_videos")
         else []
     )
+    display_name = request.form.get("display_name")
     team_key_names = list()
 
     for alliance in alliances:
@@ -80,6 +81,7 @@ def match_edit_post(match_key):
         tba_videos=tba_videos,
         youtube_videos=youtube_videos,
         no_auto_update=str(request.form.get("no_auto_update")).lower() == "true",
+        display_name=display_name if display_name != "None" else None,
     )
     MatchManipulator.createOrUpdate(match, auto_union=False)
 

--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -647,6 +647,11 @@
             "type": "string",
             "description": "UTC time of match in ISO 8601 format (YYYY-MM-DDTHH:MM:SS)",
             "example": "2008-01-02T10:30:00.000Z"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "The name for the match, to be shown on the event page",
+            "example": "Quals 10"
           }
         }
       }

--- a/src/backend/web/templates/admin/match_details.html
+++ b/src/backend/web/templates/admin/match_details.html
@@ -31,6 +31,10 @@
         <td>{{ match.team_key_names }}</td>
     </tr>
     <tr>
+        <td>Display Name</td>
+        <td>{{ match.display_name }}</td>
+    </tr>
+    <tr>
         <td>Alliances JSON</td>
         <td>{{ match.alliances_json }}</td>
     </tr>

--- a/src/backend/web/templates/admin/match_edit.html
+++ b/src/backend/web/templates/admin/match_edit.html
@@ -41,6 +41,10 @@
             <td><input type="checkbox" name="no_auto_update" value="True" {% if match.no_auto_update %}checked="checked"{% endif %} /></td>
         </tr>
         <tr>
+            <td>Display Name</td>
+            <td><input class="form-control" type="text" name="display_name" value="{{match.display_name}}" /></td>
+        </tr>
+        <tr>
             <td>Team Key Names (Automatically generated)</td>
             <td><textarea class="form-control" name="disabled_team_key_names" disabled="disabled">{{match.team_key_names}}</textarea></td>
         </tr>


### PR DESCRIPTION
Towards https://github.com/the-blue-alliance/the-blue-alliance/issues/4716

In the current double elim bracket rendering, it looks weird because the rounds don't exactly line up with the comp level splits.

And so, we can allow Cheesy Arena to include what the match title should be, and use that to override `match.verbose_name`

![image](https://user-images.githubusercontent.com/2754863/189484520-9dc7490e-e259-442b-a376-ed4297123f7f.png)
