### PR TITLE
Port Typeahead Ajax Endpoint

### DIFF
--- a/old_py2/controllers/ajax_controller.py
+++ b/old_py2/controllers/ajax_controller.py
@@ -168,38 +168,6 @@ class LiveEventHandler(CacheableHandler):
         return json.dumps(event_dict)
 
 
-class TypeaheadHandler(CacheableHandler):
-    """
-    Currently just returns a list of all teams and events
-    Needs to be optimized at some point.
-    Tried a trie but the datastructure was too big to
-    fit into memcache efficiently
-    """
-    CACHE_VERSION = 2
-    CACHE_KEY_FORMAT = "typeahead_entries:{}"  # (search_key)
-    CACHE_HEADER_LENGTH = 60 * 60 * 24
-
-    def __init__(self, *args, **kw):
-        super(TypeaheadHandler, self).__init__(*args, **kw)
-        self._cache_expiration = self.CACHE_HEADER_LENGTH
-
-    def get(self, search_key):
-        import urllib2
-        search_key = urllib2.unquote(search_key)
-        self._partial_cache_key = self.CACHE_KEY_FORMAT.format(search_key)
-        super(TypeaheadHandler, self).get(search_key)
-
-    def _render(self, search_key):
-        self.response.headers['content-type'] = 'application/json; charset="utf-8"'
-
-        entry = TypeaheadEntry.get_by_id(search_key)
-        if entry is None:
-            return '[]'
-        else:
-            self._last_modified = entry.updated
-            return entry.data_json
-
-
 class EventRemapTeamsHandler(CacheableHandler):
     """
     Returns the current team remapping for an event

--- a/old_py2/main.py
+++ b/old_py2/main.py
@@ -10,7 +10,7 @@ MyTBAMatchController, MyTBATeamController
 from controllers.advanced_search_controller import AdvancedSearchController
 from controllers.ajax_controller import AccountInfoHandler, AccountRegisterFCMToken, AccountFavoritesHandler, AccountFavoritesAddHandler, AccountFavoritesDeleteHandler, \
       YouTubePlaylistHandler, AllowedApiWriteEventsHandler, PlayoffTypeGetHandler
-from controllers.ajax_controller import LiveEventHandler, TypeaheadHandler, EventRemapTeamsHandler, WebcastHandler
+from controllers.ajax_controller import LiveEventHandler, EventRemapTeamsHandler, WebcastHandler
 from controllers.apiai_controller import APIAIHandler
 from controllers.apidocs_controller import AddDataHandler, WebhookDocumentationHandler
 from controllers.event_controller import EventList, EventDetail, EventRss, \
@@ -150,7 +150,6 @@ app = webapp2.WSGIApplication([
       RedirectRoute(r'/_/api_ai', APIAIHandler, 'api-ai', strict_slash=True),
       RedirectRoute(r'/_/nightbot/nextmatch/<arg_str:(.*)>', NightbotTeamNextmatchHandler, 'nightbot-team-nextmatch', strict_slash=True),
       RedirectRoute(r'/_/nightbot/status/<team_number:[0-9]+>', NightbotTeamStatuskHandler, 'nightbot-team-status', strict_slash=True),
-      RedirectRoute(r'/_/typeahead/<search_key>', TypeaheadHandler, 'ajax-typeahead', strict_slash=True),
       RedirectRoute(r'/_/remap_teams/<event_key>', EventRemapTeamsHandler, 'ajax-remap-teams', strict_slash=True),
       RedirectRoute(r'/_/webcast/<event_key>/<webcast_number>', WebcastHandler, 'ajax-webcast', strict_slash=True),
       RedirectRoute(r'/_/yt/playlist/videos', YouTubePlaylistHandler, 'ajex-yt-playlist', strict_slash=True),

--- a/src/backend/common/models/typeahead_entry.py
+++ b/src/backend/common/models/typeahead_entry.py
@@ -7,10 +7,11 @@ class TypeaheadEntry(ndb.Model):
     TypeaheadEntry.id (set in cron_controller.TypeaheadCalcDo) is the key and
     TypeaheadEntry.data_json is the value.
     """
-    ALL_TEAMS_KEY = 'teams-all'
-    ALL_EVENTS_KEY = 'events-all'
-    ALL_DISTRICTS_KEY = 'districts-all'
-    YEAR_EVENTS_KEY = 'events-{}'
+
+    ALL_TEAMS_KEY = "teams-all"
+    ALL_EVENTS_KEY = "events-all"
+    ALL_DISTRICTS_KEY = "districts-all"
+    YEAR_EVENTS_KEY = "events-{}"
 
     data_json = ndb.TextProperty(required=True, indexed=False)
 

--- a/src/backend/web/handlers/ajax.py
+++ b/src/backend/web/handlers/ajax.py
@@ -1,0 +1,16 @@
+from flask import jsonify, make_response, Response
+
+from backend.common.decorators import cached_public
+from backend.common.models.typeahead_entry import TypeaheadEntry
+
+
+@cached_public
+def typeahead_handler(search_key: str) -> Response:
+    entry = TypeaheadEntry.get_by_id(search_key)
+    if entry is None:
+        return jsonify([])
+
+    response = make_response(entry.data_json)
+    response.content_type = 'application/json; charset="utf-8"'
+    response.last_modified = entry.updated
+    return response

--- a/src/backend/web/handlers/tests/ajax_test.py
+++ b/src/backend/web/handlers/tests/ajax_test.py
@@ -1,0 +1,43 @@
+import json
+
+from werkzeug.test import Client
+
+from backend.common.models.typeahead_entry import TypeaheadEntry
+
+
+def test_typeahead_empty(web_client: Client) -> None:
+    resp = web_client.get("/_/typeahead/teams-all")
+    assert resp.status_code == 200
+    assert resp.json == []
+
+
+def test_typeahead_empty_cached(web_client: Client) -> None:
+    resp = web_client.get("/_/typeahead/teams-all")
+    assert resp.status_code == 200
+    assert resp.json == []
+
+
+def test_typeahead_content(web_client: Client) -> None:
+    data = ["254 | The Cheesy Poofs"]
+    entry = TypeaheadEntry(id=TypeaheadEntry.ALL_TEAMS_KEY, data_json=json.dumps(data))
+    entry.put()
+
+    resp = web_client.get("/_/typeahead/teams-all")
+    assert resp.status_code == 200
+    assert resp.json == data
+
+
+def test_typeahead_content_cached(web_client: Client) -> None:
+    data = ["254 | The Cheesy Poofs"]
+    entry = TypeaheadEntry(id=TypeaheadEntry.ALL_TEAMS_KEY, data_json=json.dumps(data))
+    entry.put()
+
+    resp = web_client.get("/_/typeahead/teams-all")
+    assert resp.status_code == 200
+    assert resp.json == data
+
+    resp2 = web_client.get(
+        "/_/typeahead/teams-all",
+        headers={"If-Modified-Since": resp.headers["Last-Modified"]},
+    )
+    assert resp2.status_code == 304

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -10,6 +10,7 @@ from backend.common.url_converters import install_url_converters
 from backend.web.context_processors import render_time_context_processor
 from backend.web.handlers.account import blueprint as account_blueprint
 from backend.web.handlers.admin.blueprint import admin_routes as admin_blueprint
+from backend.web.handlers.ajax import typeahead_handler
 from backend.web.handlers.apidocs import blueprint as apidocs_blueprint
 from backend.web.handlers.district import district_detail
 from backend.web.handlers.error import handle_404, handle_500
@@ -108,6 +109,9 @@ app.add_url_rule("/privacy", view_func=privacy)
 # Off-site redirects
 app.add_url_rule("/bigquery", view_func=bigquery)
 app.add_url_rule("/swag", view_func=swag)
+
+# Ajax/Helper endpoints
+app.add_url_rule("/_/typeahead/<search_key>", view_func=typeahead_handler)
 
 app.register_blueprint(apidocs_blueprint)
 app.register_blueprint(admin_blueprint)


### PR DESCRIPTION
This still 404s on every page load :stuck_out_tongue: so it's probably time to port it

(also it's one of the few things that'll loudly fail if we swap the default routing to py3)