### PR TITLE
Rename Legacy Double Elim Playoff Type

### DIFF
--- a/src/backend/common/consts/playoff_type.py
+++ b/src/backend/common/consts/playoff_type.py
@@ -27,7 +27,9 @@ class PlayoffType(enum.IntEnum):
     ROUND_ROBIN_6_TEAM = 4
 
     # Double Elimination Bracket
-    DOUBLE_ELIM_8_TEAM = 5
+    # The legacy style is just a basic internet bracket
+    # https://www.printyourbrackets.com/fillable-brackets/8-seeded-double-fillable.pdf
+    LEGACY_DOUBLE_ELIM_8_TEAM = 5
 
     # Festival of Champions
     BO5_FINALS = 6
@@ -46,7 +48,7 @@ BRACKET_TYPES: Set[PlayoffType] = {
 
 
 DOUBLE_ELIM_TYPES: Set[PlayoffType] = {
-    PlayoffType.DOUBLE_ELIM_8_TEAM,
+    PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM,
 }
 
 
@@ -58,7 +60,7 @@ TYPE_NAMES: Dict[PlayoffType, str] = {
     PlayoffType.BRACKET_2_TEAM: "Elimination Bracket (2 Alliances)",
     PlayoffType.AVG_SCORE_8_TEAM: "Average Score (8 Alliances)",
     PlayoffType.ROUND_ROBIN_6_TEAM: "Round Robin (6 Alliances)",
-    PlayoffType.DOUBLE_ELIM_8_TEAM: "Double Elimination Bracket (8 Alliances)",
+    PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM: "Legacy Double Elimination Bracket (8 Alliances)",
     PlayoffType.BO3_FINALS: "Best of 3 Finals",
     PlayoffType.BO5_FINALS: "Best of 5 Finals",
     PlayoffType.CUSTOM: "Custom",
@@ -151,7 +153,7 @@ BRACKET_OCTO_ELIM_MAPPING: Dict[int, Tuple[int, int]] = {
 # Map match number -> set/match for a 8 alliance double elim bracket
 # Based off: https://www.printyourbrackets.com/fillable-brackets/8-seeded-double-fillable.pdf
 # Matches 1-6 are ef, 7-10 are qf, 11/12 are sf, 13 is f1, and 14/15 are f2
-DOUBLE_ELIM_MAPPING: Dict[int, Tuple[CompLevel, int, int]] = {
+LEGACY_DOUBLE_ELIM_MAPPING: Dict[int, Tuple[CompLevel, int, int]] = {
     # octofinals (winners bracket)
     1: (CompLevel.EF, 1, 1),
     2: (CompLevel.EF, 2, 1),

--- a/src/backend/common/helpers/match_helper.py
+++ b/src/backend/common/helpers/match_helper.py
@@ -77,7 +77,7 @@ class MatchHelper(object):
 
     # Assumed that organized_matches is called first
     @classmethod
-    def organized_double_elim_matches(
+    def organized_legacy_double_elim_matches(
         cls, organized_matches: TOrganizedMatches
     ) -> TOrganizedDoubleElimMatches:
         matches = collections.defaultdict(lambda: collections.defaultdict(list))

--- a/src/backend/common/helpers/playoff_advancement_helper.py
+++ b/src/backend/common/helpers/playoff_advancement_helper.py
@@ -122,8 +122,10 @@ class PlayoffAdvancementHelper(object):
         cls, event: Event, matches: TOrganizedMatches
     ) -> Optional[TOrganizedDoubleElimMatches]:
         double_elim_matches = None
-        if event.playoff_type == PlayoffType.DOUBLE_ELIM_8_TEAM:
-            double_elim_matches = MatchHelper.organized_double_elim_matches(matches)
+        if event.playoff_type == PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM:
+            double_elim_matches = MatchHelper.organized_legacy_double_elim_matches(
+                matches
+            )
         return double_elim_matches
 
     @classmethod

--- a/src/backend/common/helpers/playoff_type_helper.py
+++ b/src/backend/common/helpers/playoff_type_helper.py
@@ -4,8 +4,8 @@ from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.playoff_type import (
     BRACKET_ELIM_MAPPING,
     BRACKET_OCTO_ELIM_MAPPING,
-    DOUBLE_ELIM_MAPPING,
     DoubleElimBracket,
+    LEGACY_DOUBLE_ELIM_MAPPING,
     PlayoffType,
 )
 
@@ -28,8 +28,8 @@ class PlayoffTypeHelper:
             elif playoff_type == PlayoffType.ROUND_ROBIN_6_TEAM:
                 # Einstein 2017 for example. 15 round robin matches, then finals
                 return CompLevel.SF if match_number <= 15 else CompLevel.F
-            elif playoff_type == PlayoffType.DOUBLE_ELIM_8_TEAM:
-                level, _, _ = DOUBLE_ELIM_MAPPING[match_number]
+            elif playoff_type == PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM:
+                level, _, _ = LEGACY_DOUBLE_ELIM_MAPPING[match_number]
                 return level
             elif (
                 playoff_type == PlayoffType.BO3_FINALS
@@ -86,8 +86,8 @@ class PlayoffTypeHelper:
                 return 1, match_number
             else:
                 return 1, match_number
-        elif playoff_type == PlayoffType.DOUBLE_ELIM_8_TEAM:
-            level, set, match = DOUBLE_ELIM_MAPPING[match_number]
+        elif playoff_type == PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM:
+            _, set, match = LEGACY_DOUBLE_ELIM_MAPPING[match_number]
             return set, match
         elif (
             playoff_type == PlayoffType.BO3_FINALS

--- a/src/backend/common/helpers/tests/match_helper_test.py
+++ b/src/backend/common/helpers/tests/match_helper_test.py
@@ -75,13 +75,15 @@ def test_organized_matches_sorted(test_data_importer) -> None:
     )
 
 
-def test_organized_double_elim_matches(test_data_importer) -> None:
+def test_organized_legacy_double_elim_matches(test_data_importer) -> None:
     matches = test_data_importer.parse_match_list(
         __file__, "data/2017wiwi_matches.json"
     )
 
     _, organized_matches = MatchHelper.organized_matches(matches)
-    double_elim_matches = MatchHelper.organized_double_elim_matches(organized_matches)
+    double_elim_matches = MatchHelper.organized_legacy_double_elim_matches(
+        organized_matches
+    )
 
     assert DoubleElimBracket.WINNER in double_elim_matches
     assert DoubleElimBracket.LOSER in double_elim_matches


### PR DESCRIPTION
Towards https://github.com/the-blue-alliance/the-blue-alliance/issues/4716

Since there are some actual changes we need to make to match ordering and bracket rendering (plus some existing data in the DB), I think we'll want to just keep separate playoff types in the code to separate old/new. This diff renames the existing double elim playoff type to `LEGACY` so the new style can be the "real" one