### PR TITLE
Create double elimination bracket renderer

### DIFF
--- a/src/backend/web/handlers/tests/event_detail_test.py
+++ b/src/backend/web/handlers/tests/event_detail_test.py
@@ -110,3 +110,6 @@ def test_render_double_elim(web_client: Client, test_data_importer) -> None:
     elim_match_table = soup.find(id="elim-match-table")
     elim_matches = elim_match_table.find("tbody").find_all("tr")
     assert len(elim_matches) > 1
+
+    double_elim_bracket = soup.find(id="double-elim-bracket-table")
+    assert double_elim_bracket is not None

--- a/src/backend/web/static/css/less_css/less/tba/tba_double_elim_bracket_table.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_double_elim_bracket_table.less
@@ -1,0 +1,75 @@
+#double-elim-bracket-wrapper {
+  overflow-x: auto;
+
+  /* Make sure tooltips aren't truncated by overflow */
+  margin-left: -20px;
+  width: calc(100% + 20px);
+}
+
+#double-elim-bracket-table {
+  margin-left: 20px;
+  width: calc(100% - 20px);
+
+  tr {
+    height: 31px;
+  }
+
+  td {
+    min-width: 10px;
+    position: relative;
+  }
+
+  .match {
+    min-width: 120px;
+    width: 140px;
+  }
+
+  .team-placeholder {
+    background-color: #f0f0f0;
+  }
+
+  .inner {
+    position: absolute;
+    top: 0%;
+    height: 100%;
+    width: 100%;
+  }
+
+  .inner.merger {
+    border: 2px solid black;
+    border-left: 0px;
+  }
+
+  .inner.snake {
+    top: -1px;
+    height: calc(100% + 1px);
+
+    border: 2px solid black;
+    border-left: 0px;
+    border-top: 0px;
+  }
+
+  .inner.top {
+    border-top: 2px solid black;
+  }
+
+  .dash {
+    border-bottom: 2px solid black;
+  }
+
+  .match-label {
+    position: absolute;
+    top: -22px;
+    left: 5px;
+    color: #777;
+    font-style: italic;
+  }
+
+  .match-table {
+    margin-bottom: 0px;
+  }
+
+  .gap-row {
+    height: 40px;
+  }
+}

--- a/src/backend/web/static/css/less_css/tba_style.main.less
+++ b/src/backend/web/static/css/less_css/tba_style.main.less
@@ -16,6 +16,7 @@
 @import "less/tba/tba_about.less";
 @import "less/tba/tba_blue_banners.less";
 @import "less/tba/tba_bracket_table.less";
+@import "less/tba/tba_double_elim_bracket_table.less";
 @import "less/tba/tba_event_page.less";
 @import "less/tba/tba_event_table.less";
 @import "less/tba/tba_facebook.less";

--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -1,0 +1,226 @@
+{% macro bracket_match(match, red_alliance_placeholder, blue_alliance_placeholder) %}
+  <table class="match-table">
+    {% if match %}
+      <tr>
+        <td>
+          <span rel="tooltip" data-placement="top" title="{{ match.red_alliance|join(', ') }}">
+            {{ match.red_name if match.red_name else 'Unknown' }}
+          </span>
+        </td>
+        <td class="redScore {% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_record.wins }}</td>
+      </tr>
+      <tr>
+        <td>
+          <span rel="tooltip" data-placement="bottom" title="{{ match.blue_alliance|join(', ') }}">
+            {{ match.blue_name if match.blue_name else 'Unknown' }}
+          </span>
+        </td>
+        <td class="blueScore {% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_record.wins }}</td>
+      </tr>
+    {% else %}
+      <tr>
+        <td class="team-placeholder">{{ red_alliance_placeholder }}</td>
+      </tr>
+      <tr>
+        <td class="team-placeholder">{{ blue_alliance_placeholder }}</td>
+      </tr>
+    {% endif %}
+  </table>
+{% endmacro %}
+
+<div id="double-elim-bracket-wrapper">
+  <table id="double-elim-bracket-table">
+    <tr class="gap-row"></tr>
+
+    <!--    Upper Bracket -->
+    <tr>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 1</span>
+        {{ bracket_match(bracket_table.ef.get('ef1'), 'Alliance 1', 'Alliance 8') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td rowspan="4" class="">
+        <div class="merger inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td></td>
+      <td class="dash"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 7</span>
+        {{ bracket_match(bracket_table.qf.get('qf1'), 'Winner of M1', 'Winner of M2') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="3"></td>
+      <td rowspan="8" colspan="3">
+        <div class="merger inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 2</span>
+        {{ bracket_match(bracket_table.ef.get('ef2'), 'Alliance 4', 'Alliance 5') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="16"></td>
+    </tr>
+
+    <tr>
+      <td colspan="4"></td>
+      <td class="dash" colspan="2"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 12</span>
+        {{ bracket_match(bracket_table.sf.get('sf2'), 'Winner of M7', 'Winner of M8') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="9"></td>
+      <td class="" colspan="3">
+        <div class="top inner"></div>
+      </td>
+      <td class="" rowspan="9">
+        <div class="merger inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 3</span>
+        {{ bracket_match(bracket_table.ef.get('ef3'), 'Alliance 3', 'Alliance 6') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td rowspan="4">
+        <div class="merger inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td></td>
+      <td class="dash"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 8</span>
+        {{ bracket_match(bracket_table.qf.get('qf2'), 'Winner of M3', 'Winner of M4') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="3"></td>
+      <td colspan="10"></td>
+      <td class="dash" colspan="1"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Finals</span>
+        {{ bracket_match(bracket_table.f.get('f2'), 'Winner of M12', 'Winner of M13') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 4</span>
+        {{ bracket_match(bracket_table.ef.get('ef4'), 'Alliance 2', 'Alliance 7') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td></td>
+    </tr>
+
+    <!--    Lower Bracket -->
+    <tr>
+      <td colspan="16"></td>
+    </tr>
+
+    <tr>
+      <td colspan="11"></td>
+      <td class="dash"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 13</span>
+        {{ bracket_match(bracket_table.f.get('f1'), 'Loser of M12', 'Winner of M11') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="5"></td>
+      <td class="dash" colspan="1"></td>
+
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 10</span>
+        {{ bracket_match(bracket_table.qf.get('qf4'), 'Loser of M8', 'Winner of M5') }}
+      </td>
+      <td colspan="3"></td>
+      <td rowspan="3">
+        <div class="snake inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="4"></td>
+      <td rowspan="2">
+        <div class="snake inner"></div>
+      </td>
+      <td colspan="1"></td>
+      <td rowspan="4" class="">
+        <div class="merger inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="3"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 5</span>
+        {{ bracket_match(bracket_table.ef.get('ef5'), 'Loser of M1', 'Winner of M2') }}
+      </td>
+      <td colspan="3"></td>
+      <td class="dash"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 11</span>
+        {{ bracket_match(bracket_table.sf.get('sf1'), 'Loser of M10', 'Winner of M9') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="1"></td>
+    </tr>
+
+    <tr>
+      <td colspan="5"></td>
+      <td class="dash" colspan="1"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 9</span>
+        {{ bracket_match(bracket_table.qf.get('qf3'), 'Loser of M7', 'Winner of M6') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="4"></td>
+      <td rowspan="2" class="path">
+        <div class="snake inner"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="3"></td>
+      <td rowspan="2" class="match">
+        <span class="match-label">Match 6</span>
+        {{ bracket_match(bracket_table.ef.get('ef6'), 'Loser of M3', 'Winner of M4') }}
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="1"></td>
+    </tr>
+
+    <tr class="gap-row"></tr>
+
+  </table>
+</div>

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -211,6 +211,15 @@
           {% endif %}
         </div>
         {% endif %}
+
+        <!-- Double Elim Bracket -->
+        {% if event.playoff_type == 10 and (matches.ef or matches.qf or matches.sf or matches.f) %}
+          <div class="col-sm-12">
+            <h3>Playoff Bracket</h3>
+            {% include "bracket_partials/double_elim_bracket_table.html" %}
+          </div>
+        {% endif %}
+
       </div>
       <div class="row">
         <div class="col-sm-12">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for displaying double elimination brackets on the event page. 

- Layout is done through HTML tables
- I created the `.inner` class since the behavior for drawing borders directly on `td`s was inconsistent between different browsers
- I put the team names in the tooltip, to prevent the bracket from being too wide

Feedback is welcome!

<img width="1492" alt="Screen Shot 2022-09-14 at 11 53 33 PM" src="https://user-images.githubusercontent.com/6137845/190337513-d6682ab8-9057-480c-aecc-b7e13ccab948.png">
<hr/>
<img width="1158" alt="Screen Shot 2022-09-14 at 11 55 02 PM" src="https://user-images.githubusercontent.com/6137845/190337518-c1556413-7c76-4ee4-9ae2-56d2e0c65923.png">

## Motivation and Context
#4716 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
