### PR TITLE
Slow down push-notifications queue in an attempt to fix retried push notification tasks

### DIFF
--- a/src/queue.yaml
+++ b/src/queue.yaml
@@ -24,7 +24,7 @@ queue:
   rate: 5/s
 
 - name: push-notifications
-  rate: 100/s
+  rate: 10/s
   retry_parameters:
     task_age_limit: 3m
     min_backoff_seconds: 10


### PR DESCRIPTION
I'm seeing a lot of 502s coming from the `/_ah/queue/deferred_notification_send` endpoint - which might be the cause of our multiple push notification sends. I'm going to bump down the speed on our push notification sends to try to not overwhelm the instance to see if we can get more 200s here and then monitor if we're still seeing duplicate sends.
 
<img width="1018" alt="Screen Shot 2022-09-18 at 10 22 31 AM" src="https://user-images.githubusercontent.com/516458/190912621-744ad07a-108e-4325-93dc-648ce331e6aa.png">
