### PR TITLE
Add timestamp logging to debug 502s on task queue tasks

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -1,3 +1,4 @@
+import time
 import datetime
 import logging
 from typing import List, Optional
@@ -544,7 +545,9 @@ class TBANSHelper:
                 legacy_data_format=legacy_data_format,
             )
 
+            logging.info(f"Sending FCM request: {time.strftime('%X')}")
             batch_response = fcm_request.send()
+            logging.info(f"Got FCM response: {time.strftime('%X')}")
             retry_clients = []
 
             # Handle our failed sends - this might include logging/alerting, removing old clients, or retrying sends
@@ -569,8 +572,10 @@ class TBANSHelper:
             ):
                 client = subclients[index]
                 if isinstance(response.exception, UnregisteredError):
+                    logging.info(f"Deleting mobile client with ID: f{client.messaging_id}")
                     MobileClientQuery.delete_for_messaging_id(client.messaging_id)
                 elif isinstance(response.exception, SenderIdMismatchError):
+                    logging.info(f"Deleting mobile client with ID: f{client.messaging_id}")
                     MobileClientQuery.delete_for_messaging_id(client.messaging_id)
                 elif isinstance(response.exception, QuotaExceededError):
                     logging.error("Qutoa exceeded - retrying client...")

--- a/src/backend/common/models/notifications/requests/fcm_request.py
+++ b/src/backend/common/models/notifications/requests/fcm_request.py
@@ -11,14 +11,14 @@ _helpers.positional_parameters_enforcement = _helpers.POSITIONAL_IGNORE
 
 
 MAXIMUM_TOKENS = 500
-
+# https://github.com/firebase/firebase-admin-python/blob/9e5b8e383e066c319a483285df903150d5029a34/firebase_admin/_messaging_encoder.py#L78
 
 class FCMRequest(Request):
     """Represents a notification payload and a delivery option to send to FCM.
     https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages
     Attributes:
         notification (Notification): The Notification to send.
-        tokens (list, string): The FCM registration tokens (up to 100) to send a message to.
+        tokens (list, string): The FCM registration tokens (up to 500) to send a message to.
     """
 
     def __init__(self, app, notification, tokens=None, legacy_data_format=False):


### PR DESCRIPTION
Attempting to figure out what's taking so long with the FCM pushes - if it's iterating through our response objects/cleaning up tokens, or the actual sends.