### PR TITLE
Update to node 18

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -140,7 +140,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -174,7 +174,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -140,7 +140,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -174,7 +174,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Cache node modules
         uses: actions/cache@v3.3.1
         with:

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN echo 1 | update-alternatives --config python2
 
 # Set up nvm and nodejs
 ENV NVM_DIR /nvm
-ENV NODE_VERSION 16
+ENV NODE_VERSION 18
 RUN mkdir -p $NVM_DIR  \
     && wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash \
     && . $NVM_DIR/nvm.sh \

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN echo 1 | update-alternatives --config python2
 
 # Set up nvm and nodejs
 ENV NVM_DIR /nvm
-ENV NODE_VERSION 14
+ENV NODE_VERSION 16
 RUN mkdir -p $NVM_DIR  \
     && wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash \
     && . $NVM_DIR/nvm.sh \

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tba-react",
   "version": "0.0.0",
   "engines": {
-    "node": "^14"
+    "node": "^16"
   },
   "dependencies": {
     "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tba-react",
   "version": "0.0.0",
   "engines": {
-    "node": "^16"
+    "node": "^18"
   },
   "dependencies": {
     "classnames": "^2.3.2",


### PR DESCRIPTION
This seems like the better way to fix the current build failures: https://github.com/firebase/firebase-tools/issues/5041.

Especially since node 14 has been EOL (and I wish dependabot could manage this for us)