### PR TITLE
Validate zebra json

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_zebra_motionworks_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_zebra_motionworks_parser.py
@@ -41,6 +41,12 @@ class JSONZebraMotionWorksParser:
 
         parsed_data: List[ZebraData] = []
         for zebra_data in data:
+            # Check that 'zebra_data' is a dict
+            if not isinstance(zebra_data, dict):
+                raise ParserInputException(
+                    f"Zebra MotionWorks data must be a dict: {zebra_data}"
+                )
+
             # Check 'times' is an array of floats
             times = zebra_data.get("times", [])
             if not isinstance(times, list):

--- a/src/backend/api/api_trusted_parsers/tests/test_json_zebra_motion_parser.py
+++ b/src/backend/api/api_trusted_parsers/tests/test_json_zebra_motion_parser.py
@@ -63,6 +63,10 @@ class TestJSONZebraMotionWorksParser(unittest.TestCase):
         parsed = JSONZebraMotionWorksParser.parse(json.dumps(self.data))
         self.assertEqual(parsed, self.data)
 
+    def testNotListOfDicts(self):
+        with self.assertRaises(ParserInputException):
+            JSONZebraMotionWorksParser.parse("""["some", "bad", "input"]""")
+
     def testMissingTimes(self):
         del self.data[0]["times"]
         with self.assertRaises(ParserInputException):


### PR DESCRIPTION
## Description
Respond with a more useful error message instead of returning 500 for malformatted data.

Ran into unhelpful 500 errors due to 

```
  File "/workspace/backend/api/handlers/trusted.py", line 343, in add_match_zebra_motionworks_info
    for zebra_data in JSONZebraMotionWorksParser.parse(request.data):
  File "/workspace/backend/api/api_trusted_parsers/json_zebra_motionworks_parser.py", line 45, in parse
    times = zebra_data.get("times", [])
AttributeError: 'str' object has no attribute 'get'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
