### PR TITLE
Fix instagram embeds

### DIFF
--- a/src/backend/common/models/media.py
+++ b/src/backend/common/models/media.py
@@ -172,21 +172,19 @@ class Media(CachedModel):
 
     @property
     def instagram_direct_url(self) -> str:
-        return self.instagram_url_helper("l")
+        return self.instagram_url_helper(658)
 
     @property
     def instagram_direct_url_med(self) -> str:
-        return self.instagram_url_helper("m")
+        return self.instagram_url_helper(320)
 
     @property
     def instagram_direct_url_sm(self) -> str:
-        return self.instagram_url_helper("t")
+        return self.instagram_url_helper(320)
 
     def instagram_url_helper(self, size) -> str:
-        # Supported size values are t (thumbnail), m (medium), l (large)
-        # See the Instagram developer docs for more information:
-        # https://www.instagram.com/developer/embedding/#media_redirect!
-        return "{}/media/?size={}".format(self.instagram_url, size)
+        # The Oembed API supports widths between 320px and 658px
+        return f"/instagram_oembed/{self.foreign_key}?width={size}"
 
     @property
     def view_image_url(self) -> str:

--- a/src/backend/common/sitevars/instagram_api_secret.py
+++ b/src/backend/common/sitevars/instagram_api_secret.py
@@ -1,0 +1,21 @@
+from typing import TypedDict
+
+from backend.common.sitevars.sitevar import Sitevar
+
+
+class ContentType(TypedDict):
+    api_key: str
+
+
+class InstagramApiSecret(Sitevar[ContentType]):
+    @staticmethod
+    def key() -> str:
+        return "instagram.secrets"
+
+    @staticmethod
+    def description() -> str:
+        return "For Instagram embed API Calls"
+
+    @staticmethod
+    def default_value() -> ContentType:
+        return ContentType(api_key="")

--- a/src/backend/common/suggestions/media_parser.py
+++ b/src/backend/common/suggestions/media_parser.py
@@ -25,7 +25,7 @@ class MediaParser:
         MediaType.INSTAGRAM_IMAGE,
     }
 
-    OEMBED_PROVIDERS: Set[MediaType] = {MediaType.INSTAGRAM_IMAGE}
+    OEMBED_PROVIDERS: Set[MediaType] = set()
 
     # Dict that maps media types -> list of tuple of regex pattern and group # of foreign key
     FOREIGN_KEY_PATTERNS: Dict[MediaType, List[Tuple[str, int]]] = {
@@ -85,9 +85,7 @@ class MediaParser:
         "https://cad.onshape.com/api/documents/{}"  # Format w/ stripped foreign key
     )
 
-    OEMBED_DETAIL_URL: Dict[MediaType, str] = {
-        MediaType.INSTAGRAM_IMAGE: "https://api.instagram.com/oembed/?url=http://instagram.com/p/{}"
-    }
+    OEMBED_DETAIL_URL: Dict[MediaType, str] = {}
 
     @classmethod
     def partial_media_dict_from_url(cls, url: str) -> Optional[SuggestionDict]:

--- a/src/backend/web/handlers/admin/authkeys.py
+++ b/src/backend/web/handlers/admin/authkeys.py
@@ -5,6 +5,7 @@ from backend.common.sitevars.firebase_secrets import FirebaseSecrets
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
 from backend.common.sitevars.gcm_server_key import GcmServerKey
 from backend.common.sitevars.google_api_secret import GoogleApiSecret
+from backend.common.sitevars.instagram_api_secret import InstagramApiSecret
 from backend.common.sitevars.livestream_secrets import LivestreamSecrets
 from backend.common.sitevars.mobile_client_ids import MobileClientIds
 from backend.common.sitevars.twitch_secrets import TwitchSecrets
@@ -19,6 +20,7 @@ def authkeys_get() -> str:
     livestream_secrets = LivestreamSecrets.get()
     fmsapi_keys = FMSApiSecrets.get()
     clientIds = MobileClientIds.get()
+    instagram_secrets = InstagramApiSecret.get()
 
     template_values = {
         "google_secret": google_secrets.get("api_key", ""),
@@ -31,6 +33,7 @@ def authkeys_get() -> str:
         "gcm_key": gcm_serverKey.get("gcm_key", ""),
         "twitch_secret": twitch_secrets.get("client_id", ""),
         "livestream_secret": livestream_secrets.get("api_key", ""),
+        "instagram_secret": instagram_secrets.get("api_key", ""),
     }
 
     return render_template("admin/authkeys.html", template_values)
@@ -47,8 +50,10 @@ def authkeys_post() -> Response:
     gcm_key = request.form.get("gcm_key", "")
     twitch_client_id = request.form.get("twitch_secret", "")
     livestream_key = request.form.get("livestream_secret", "")
+    instagram_key = request.form.get("instagram_secret", "")
 
     GoogleApiSecret.put({"api_key": google_key})
+    InstagramApiSecret.put({"api_key": instagram_key})
     FirebaseSecrets.put({"FIREBASE_SECRET": firebase_key})
     FMSApiSecrets.put({"username": fmsapi_user, "authkey": fmsapi_secret})
     MobileClientIds.put(

--- a/src/backend/web/handlers/embed.py
+++ b/src/backend/web/handlers/embed.py
@@ -1,0 +1,50 @@
+import urllib.parse
+from datetime import timedelta
+
+import requests
+from flask import abort, redirect, request
+
+from backend.common.auth import current_user
+from backend.common.consts.account_permission import AccountPermission
+from backend.common.consts.media_type import MediaType
+from backend.common.decorators import cached_public
+from backend.common.models.media import Media
+from backend.common.sitevars.instagram_api_secret import InstagramApiSecret
+
+
+@cached_public(ttl=timedelta(hours=6), cache_redirects=True)
+def instagram_oembed(media_key: str):
+    user = current_user()
+
+    if (
+        user
+        and user.permissions
+        and (AccountPermission.REVIEW_MEDIA in user.permissions)
+    ):
+        # Skip validation for media reviewers
+        instagram_url = f"https://www.instagram.com/p/{media_key}/"
+    else:
+        if not request.referrer or ("thebluealliance.com" not in request.referrer):
+            return abort(403)
+
+        media = Media.get_by_id(
+            Media.render_key_name(MediaType.INSTAGRAM_IMAGE, media_key)
+        )
+        if not media:
+            return abort(404)
+
+        instagram_url = media.instagram_url
+
+    width = int(request.args.get("width") or 320)
+
+    response = requests.get(
+        "https://graph.facebook.com/v14.0/instagram_oembed"
+        + f"?url={urllib.parse.quote_plus(instagram_url)}"
+        + f"&maxwidth={width}"
+        + f"&access_token={InstagramApiSecret.get()['api_key']}"
+    )
+
+    if response.status_code != 200:
+        return abort(500)
+
+    return redirect(response.json()["thumbnail_url"])

--- a/src/backend/web/handlers/tests/embed_test.py
+++ b/src/backend/web/handlers/tests/embed_test.py
@@ -1,0 +1,67 @@
+import re
+from urllib.parse import urlparse
+
+from requests_mock import Mocker
+from werkzeug import Client
+
+from backend.common.consts.account_permission import AccountPermission
+from backend.common.consts.media_type import MediaType
+from backend.common.models.account import Account
+from backend.common.models.media import Media
+
+THUMBNAIL_URL = "scontent.cdninstagram.com/abc"
+
+
+def create_media() -> Media:
+    media = Media(
+        media_type_enum=MediaType.INSTAGRAM_IMAGE,
+        foreign_key="abc",
+        id=Media.render_key_name(MediaType.INSTAGRAM_IMAGE, "abc"),
+    )
+    media.put()
+    return media
+
+
+def test_instagram_no_media_key(web_client: Client):
+    resp = web_client.get("/instagram_oembed/")
+    assert resp.status_code == 404
+
+
+def test_instagram_no_referer(web_client: Client):
+    media = create_media()
+
+    resp = web_client.get(f"/instagram_oembed/{media.foreign_key}")
+    assert resp.status_code == 403
+
+
+def test_instagram_success(web_client: Client, requests_mock: Mocker):
+    media = create_media()
+
+    requests_mock.get(
+        re.compile(".*instagram_oembed.*"),
+        json={"thumbnail_url": THUMBNAIL_URL},
+    )
+
+    resp = web_client.get(
+        f"/instagram_oembed/{media.foreign_key}",
+        headers={"Referer": "thebluealliance.com"},
+    )
+
+    assert resp.status_code == 302
+    assert urlparse(resp.headers["Location"]).path == THUMBNAIL_URL
+
+
+def test_instagram_success_media_reviewer(
+    login_user: Account, requests_mock, web_client
+):
+    login_user.permissions = [AccountPermission.REVIEW_MEDIA]
+
+    requests_mock.get(
+        re.compile(".*instagram_oembed.*"),
+        json={"thumbnail_url": THUMBNAIL_URL},
+    )
+
+    resp = web_client.get("/instagram_oembed/abc")
+
+    assert resp.status_code == 302
+    assert urlparse(resp.headers["Location"]).path == THUMBNAIL_URL

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -18,6 +18,7 @@ from backend.web.handlers.ajax import (
 )
 from backend.web.handlers.apidocs import blueprint as apidocs_blueprint
 from backend.web.handlers.district import district_detail
+from backend.web.handlers.embed import instagram_oembed
 from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.event import event_detail, event_insights, event_list
 from backend.web.handlers.eventwizard import eventwizard, eventwizard2
@@ -130,6 +131,7 @@ app.add_url_rule(
 )
 app.add_url_rule("/_/playoff_types", view_func=playoff_types_handler)
 app.add_url_rule("/_/typeahead/<search_key>", view_func=typeahead_handler)
+app.add_url_rule("/instagram_oembed/<media_key>", view_func=instagram_oembed)
 
 app.register_blueprint(apidocs_blueprint)
 app.register_blueprint(admin_blueprint)

--- a/src/backend/web/templates/admin/authkeys.html
+++ b/src/backend/web/templates/admin/authkeys.html
@@ -31,6 +31,9 @@
 
   <tr><th>Livestream</th></tr>
   <tr><td>API Key</td><td><input name="livestream_secret" value="{{livestream_secret}}" class="form-control"/></td></tr>
+
+  <tr><th>Instagram</th></tr>
+  <tr><td>API Key</td><td><input name="instagram_secret" value="{{instagram_secret}}" class="form-control"/></td></tr>
 </table>
 
 <button type="submit" class="btn btn-info"><span class="glyphicon glyphicon-thumbs-up"></span> Update</button>

--- a/src/backend/web/templates/media_partials/instagram_partial.html
+++ b/src/backend/web/templates/media_partials/instagram_partial.html
@@ -1,6 +1,6 @@
 <div class="thumbnail cdphotothread-thumbnail">
   <a href="{{media.image_direct_url}}" class="gallery">
-    <span style="background:url('{{media.image_direct_url_med}}')"></span>
+    <span style="background-image:url('{{media.image_direct_url_med}}')"></span>
   </a>
   <div class="caption">
     <a href="{{media.view_image_url}}" target="_blank" rel="noopener noreferrer">Instagram Page</a>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!--- Provide a general summary of your changes in the Title above -->
Use the new facebook [oembed API](https://developers.facebook.com/docs/graph-api/reference/instagram-oembed/) to get the thumbnail embeds and suggestion submission working again. 

- Since the image links returned by the API expire, I created a helper endpoint so the frontend can dynamically fetch the image urls
- This should fix #4779 and #3489

## Motivation and Context
Slack thread: https://the-blue-alliance.slack.com/archives/C15SUFL92/p1667272352875539


## How Has This Been Tested?
Added a couple pytests

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/6137845/199652637-7a39d9cd-9f9a-4ef9-8686-16e3bc61295b.mov

<img width="1255" alt="Screen Shot 2022-11-02 at 10 01 13 PM" src="https://user-images.githubusercontent.com/6137845/199650764-0f452063-94d3-4cf2-afdf-4feabfd074b9.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
