### PR TITLE
Switch alliance name and alliance teams in double elim bracket display

### DIFF
--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -3,16 +3,18 @@
     {% if match %}
       <tr>
         <td>
-          <span class="alliance-name" rel="tooltip" data-placement="top" title="{{ match.red_alliance|join(', ') }}">
-            {{ match.red_name if match.red_name else 'Unknown' }}
+          <span class="alliance-name" rel="tooltip" data-placement="top" title="{{ match.red_name if match.red_name else 'Unknown' }}">
+            {% set delim = joiner(" - ") %}
+            {% for team in match.red_alliance %}{{ delim() }}<a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
           </span>
         </td>
         <td class="redScore {% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_record.wins }}</td>
       </tr>
       <tr>
         <td>
-          <span class="alliance-name" rel="tooltip" data-placement="bottom" title="{{ match.blue_alliance|join(', ') }}">
-            {{ match.blue_name if match.blue_name else 'Unknown' }}
+          <span class="alliance-name" rel="tooltip" data-placement="bottom" title="{{ match.blue_name if match.blue_name else 'Unknown' }}">
+            {% set delim = joiner(" - ") %}
+            {% for team in match.blue_alliance %}{{ delim() }}<a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
           </span>
         </td>
         <td class="blueScore {% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_record.wins }}</td>


### PR DESCRIPTION
## Description

Changes the double elim bracket display to display team numbers by default and alliance names on hover. There are several team number separators shown in screenshots. The PR (when opened) uses the ` - ` as a separator, but I'm not particularly attached to any single one.

## Motivation and Context
Since alliance names are typically not on the same screen as the bracket display (due to page layout), it's difficult to remember which teams are on which alliance when looking at the bracket. Moving the mouse around to hover on each alliance in each match is frustrating. If alliance names are not set, the entire bracket shows as "Unknown", making it unreadable.

## How Has This Been Tested?
UI change only, ran locally.

## Screenshots (if appropriate):

https://i.imgur.com/xfNifAG.png
https://i.imgur.com/ZGjcUdl.png
https://i.imgur.com/CeSgKBq.png
https://i.imgur.com/DCWkl54.png

(the full bracket css wasn't loading for whatever reason, but it didn't have to do with the change, it was like that prior to any changes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
