### PR TITLE
Add RSS feeds to events

### DIFF
--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -350,3 +350,28 @@ def event_insights(event_key: EventKey) -> Response:
         render_template("event_insights.html", template_values),
         ttl=timedelta(seconds=61) if event.within_a_day else timedelta(days=1),
     )
+
+
+@cached_public
+def event_rss(event_key: EventKey) -> Response:
+    event: Optional[Event] = event_query.EventQuery(event_key).fetch()
+
+    if not event:
+        return redirect("/events")
+
+    cleaned_matches = event.matches
+    _, matches = MatchHelper.organized_matches(cleaned_matches)
+
+    template_values = {
+        "event": event,
+        "matches": matches,
+        "datetime": datetime.datetime.now(),
+    }
+
+    response = make_cached_response(
+        render_template("event_rss.xml", template_values),
+        ttl=timedelta(seconds=61) if event.within_a_day else timedelta(days=1),
+    )
+    response.headers["content-type"] = "application/xml; charset=UTF-8"
+
+    return response

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -365,7 +365,7 @@ def event_rss(event_key: EventKey) -> Response:
     template_values = {
         "event": event,
         "matches": matches,
-        "datetime": datetime.datetime.now(),
+        "datetime": datetime.now(),
     }
 
     response = make_cached_response(

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -21,9 +21,9 @@ from backend.web.handlers.district import district_detail
 from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.event import (
     event_detail,
-    event_rss,
     event_insights,
     event_list,
+    event_rss,
 )
 from backend.web.handlers.eventwizard import eventwizard, eventwizard2
 from backend.web.handlers.gameday import gameday, gameday_redirect

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -19,7 +19,12 @@ from backend.web.handlers.ajax import (
 from backend.web.handlers.apidocs import blueprint as apidocs_blueprint
 from backend.web.handlers.district import district_detail
 from backend.web.handlers.error import handle_404, handle_500
-from backend.web.handlers.event import event_detail, event_insights, event_list
+from backend.web.handlers.event import (
+    event_detail,
+    event_rss,
+    event_insights,
+    event_list,
+)
 from backend.web.handlers.eventwizard import eventwizard, eventwizard2
 from backend.web.handlers.gameday import gameday, gameday_redirect
 from backend.web.handlers.hall_of_fame import hall_of_fame_overview
@@ -76,6 +81,7 @@ app.add_url_rule("/gameday/<alias>", view_func=gameday_redirect)
 app.add_url_rule("/gameday", view_func=gameday)
 
 app.add_url_rule("/event/<event_key>", view_func=event_detail)
+app.add_url_rule("/event/<event_key>/feed", view_func=event_rss)
 app.add_url_rule("/event/<event_key>/insights", view_func=event_insights)
 app.add_url_rule("/events/<int:year>", view_func=event_list)
 app.add_url_rule(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Port RSS event feeds over to `py3`

## Motivation and Context
It was mentioned in a couple issues (closes #4872, closes #4326), as well as in Slack.
I personally have used the RSS feeds in the past, and it was easy enough to port them over, so I figured why not?  🤷‍♂️ 

## How Has This Been Tested?
Tested locally, with `2022cmptx` (see below)

## Screenshots (if appropriate):
<img width="856" alt="Screen Shot 2022-11-12 at 2 33 49 PM" src="https://user-images.githubusercontent.com/1204591/201491486-6e487b3e-1d30-46ad-8557-83ad8b75321d.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
