### PR TITLE
Add page to show regional events in a year

### DIFF
--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -63,6 +63,22 @@ class DistrictEventsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
         return events
 
 
+class RegionalEventsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "regional_events_{year}"
+    DICT_CONVERTER = EventConverter
+
+    def __init__(self, year: Year) -> None:
+        super().__init__(year=year)
+
+    @typed_tasklet
+    def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
+        events = yield Event.query(
+            Event.event_type_enum == EventType.REGIONAL, Event.year == year
+        ).fetch_async()
+        return events
+
+
 class DistrictChampsInYearQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
     CACHE_VERSION = 0
     CACHE_KEY_FORMAT = "district_list_{year}"

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -11,6 +11,7 @@ from werkzeug.wrappers import Response
 from backend.common.consts import comp_level, playoff_type
 from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.comp_level import COMP_LEVELS, CompLevel
+from backend.common.consts.event_type import EventType
 from backend.common.decorators import cached_public
 from backend.common.flask_cache import make_cached_response
 from backend.common.helpers.award_helper import AwardHelper
@@ -60,6 +61,10 @@ def event_list(year: Optional[Year] = None) -> Response:
     for district in districts_future.get_result():
         districts.append((district.abbreviation, district.display_name))
     districts = sorted(districts, key=lambda d: d[1])
+
+    # Special case to display a list of regionals
+    if any(map(lambda e: e.event_type_enum == EventType.REGIONAL, events)):
+        districts.insert(0, ("regional", "Regional Events"))
 
     valid_state_provs = set()
     for event in all_events_future.get_result():

--- a/src/backend/web/handlers/tests/district_detail_test.py
+++ b/src/backend/web/handlers/tests/district_detail_test.py
@@ -66,7 +66,7 @@ def test_valid_districts_dropdown(ndb_stub, web_client: Client) -> None:
     )
     assert district_dropdown is not None
 
-    expected_districts = ["All Events", "FIM", "MAR"]
+    expected_districts = ["All Events", "Regional Events", "FIM", "MAR"]
     assert [
         y.string for y in district_dropdown.contents if y != "\n"
     ] == expected_districts

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -151,6 +151,38 @@ def preseed_district(district_key: DistrictKey) -> Generator:
 
 
 @ndb.synctasklet
+def preseed_regional(event_key: EventKey) -> Generator:
+    year = int(event_key[:4])
+    yield ndb.put_multi_async(
+        [
+            Event(
+                id=f"{event_key}{i}",
+                event_short=f"{event_key[4:]}{i}",
+                year=year,
+                name=f"Event {i}",
+                district_key=None,
+                event_type_enum=EventType.REGIONAL,
+                official=True,
+                start_date=datetime(year, 3, 1) + timedelta(days=7 * i),
+                end_date=datetime(year, 3, 3) + timedelta(days=7 * i),
+            )
+            for i in range(1, 6)
+        ]
+    )
+    yield ndb.put_multi_async(
+        [
+            Team(
+                id=f"frc{i}",
+                team_number=i,
+                nickname=f"The {i} Team",
+                city=f"City {i}",
+            )
+            for i in range(1, 6)
+        ]
+    )
+
+
+@ndb.synctasklet
 def preseed_event_for_team(team_number: TeamNumber, event_key: EventKey) -> Generator:
     yield Event(
         id=event_key,

--- a/src/backend/web/handlers/tests/regional_detail_test.py
+++ b/src/backend/web/handlers/tests/regional_detail_test.py
@@ -1,0 +1,57 @@
+import datetime
+
+from bs4 import BeautifulSoup
+from werkzeug.test import Client
+
+from backend.web.handlers.tests import helpers
+
+
+def test_get_bad_year(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_regional("2020nyc")
+    resp = web_client.get("/events/regional/2022")
+    assert resp.status_code == 404
+
+
+def test_render_regionals(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_regional("2020nyc")
+    resp = web_client.get("/events/regional/2020")
+    assert resp.status_code == 200
+    assert "max-age=86400" in resp.headers["Cache-Control"]
+
+    soup = BeautifulSoup(resp.data, "html.parser")
+
+    regional_header = soup.find(id="regional-header")
+    assert "".join(regional_header.strings) == "2020 Regional Events 5 Events"
+
+
+def test_valid_years_dropdown(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_regional("2020nyc")
+
+    resp = web_client.get("/events/regional/2020")
+    assert resp.status_code == 200
+
+    year_dropdown = BeautifulSoup(resp.data, "html.parser").find(id="valid-years")
+    assert year_dropdown is not None
+
+    expected_years = list(reversed(range(1992, datetime.datetime.now().year + 1)))
+    assert [
+        int(y.string) for y in year_dropdown.contents if y != "\n"
+    ] == expected_years
+
+
+def test_valid_districts_dropdown(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_regional("2020nyc")
+    [helpers.preseed_district(f"2020{district}") for district in ["ne", "fim", "mar"]]
+
+    resp = web_client.get("/events/regional/2020")
+    assert resp.status_code == 200
+
+    district_dropdown = BeautifulSoup(resp.data, "html.parser").find(
+        id="valid-districts"
+    )
+    assert district_dropdown is not None
+
+    expected_districts = ["All Events", "FIM", "MAR", "NE"]
+    assert [
+        y.string for y in district_dropdown.contents if y != "\n"
+    ] == expected_districts

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -17,7 +17,7 @@ from backend.web.handlers.ajax import (
     typeahead_handler,
 )
 from backend.web.handlers.apidocs import blueprint as apidocs_blueprint
-from backend.web.handlers.district import district_detail
+from backend.web.handlers.district import district_detail, regional_detail
 from backend.web.handlers.embed import instagram_oembed
 from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.event import (
@@ -85,6 +85,12 @@ app.add_url_rule("/event/<event_key>", view_func=event_detail)
 app.add_url_rule("/event/<event_key>/feed", view_func=event_rss)
 app.add_url_rule("/event/<event_key>/insights", view_func=event_insights)
 app.add_url_rule("/events/<int:year>", view_func=event_list)
+app.add_url_rule(
+    "/events/regional",
+    view_func=regional_detail,
+    defaults={"year": None},
+)
+app.add_url_rule("/events/regional/<int:year>", view_func=regional_detail)
 app.add_url_rule(
     '/events/<regex("[a-z]+"):district_abbrev>',
     view_func=district_detail,

--- a/src/backend/web/templates/regional_details.html
+++ b/src/backend/web/templates/regional_details.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}{% if explicit_year %}{{year}} {% endif %}FIRST Robotics Regional Events - The Blue Alliance{% endblock %}
+
+{% block meta_description %}Regional Events for the FIRST Robotics Competition{% if explicit_year %} from {{year}}{% endif %}.{% endblock %}
+
+{% block events_active %}active{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-sm-3 col-lg-2">
+      <div class="tba-sidenav-affixed">
+        <div class="btn-group-vertical">
+          <div class="btn-group">
+          <a class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" href="#">
+            {{year}}
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu tba-dropdown-menu-limited" id="valid-years">
+            {% for valid_year in valid_years|reverse %}
+              <li><a href="/events/{{district_abbrev}}/{{valid_year}}">{{valid_year}}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+
+        <h1 class="visible-xs end_header" id="regional-header">{% if explicit_year %}{{year}} {% endif %}Regional Events{% if events|length > 0 %}<small> {{ events|length }} Events</small>{% endif %}</h1>
+
+        <div class="btn-group">
+          <a class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" style="white-space:normal; word-wrap: break-word; word-break: normal;" href="#">
+            Regional Events
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu tba-dropdown-menu-limited" id="valid-districts">
+            <li><a href="/events{% if explicit_year %}/{{year}}{% endif %}">All Events</a></li>
+            {% for valid_district in valid_districts %}
+              {% if district_name != valid_district.0 %}
+              <li><a href="/events/{{valid_district.1}}{% if explicit_year %}/{{year}}{% endif %}">{{valid_district.0}}</a></li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        </div>
+	</div>
+
+        <div class="tba-sidebar">
+          <ul class="nav tba-sidenav">
+          {% for label, events in week_events.items() %}
+            <li><a class="smooth-scroll" href="#{{label|slugify}}">{{label}}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-9 col-lg-10">
+      <h1 class="hidden-xs end_header">{% if explicit_year %}{{year}} {% endif %}Regional Events{% if events|length > 0 %}<small> {{ events|length }} Events</small>{% endif %}</h1>
+
+      <div class="tab-content">
+        <div class="tab-pane active" id="events">
+          {% for label, events in week_events.items() %}
+            <div id="event_label_container_{{label|slugify}}">
+              <h2 id="{{label|slugify}}">{{ label }} <small>{{events|length}} Events</small></h2>
+              {% include "event_partials/event_table.html" %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Similar to the district detail endpoint, show a page of regional events too.

This basically reserves the `regional` code to never be used as a district. Which ... why would it