### PR TITLE
Filter avatars with empty references

### DIFF
--- a/src/backend/web/handlers/index.py
+++ b/src/backend/web/handlers/index.py
@@ -219,8 +219,10 @@ def avatar_list(year: Optional[Year] = None) -> Response:
         avatars_future = Media.query(
             Media.media_type_enum == MediaType.AVATAR, Media.year == year
         ).fetch_async()
+        avatars = avatars_future.get_result()
+        avatars = filter(lambda a: len(a.references) > 0, avatars)
         avatars = sorted(
-            avatars_future.get_result(), key=lambda a: int(a.references[0].id()[3:])
+            avatars, key=lambda a: int(a.references[0].id()[3:])
         )
 
         shards = {}


### PR DESCRIPTION
Fixes #4988

References can be empty if an avatar is deleted from a team (we don't delete the actual object, just remove the reference).