### PR TITLE
Support granting trustedapi auth to all offiical events

### DIFF
--- a/src/backend/api/handlers/tests/trustedapi_auth_test.py
+++ b/src/backend/api/handlers/tests/trustedapi_auth_test.py
@@ -24,12 +24,14 @@ from backend.common.models.keys import EventKey
 
 def setup_event(
     event_type: EventType = EventType.OFFSEASON,
+    official: bool = False,
 ) -> None:
     Event(
         id="2019nyny",
         year=2019,
         event_short="nyny",
         event_type_enum=event_type,
+        official=official,
     ).put()
 
 
@@ -52,18 +54,20 @@ def setup_user(
 
 
 def setup_api_auth(
-    event_key: EventKey,
+    event_key: Optional[EventKey],
     auth_types: List[AuthType] = [],
     expiration: Optional[datetime.datetime] = None,
     owner: Optional[ndb.Key] = None,
+    all_official_events: bool = False,
 ) -> Tuple[str, str]:
     auth = ApiAuthAccess(
         id="".join(random.choices(string.ascii_letters + string.digits, k=10)),
         secret="".join(random.choices(string.ascii_letters + string.digits, k=10)),
-        event_list=[ndb.Key(Event, event_key)],
+        event_list=[ndb.Key(Event, event_key)] if event_key else [],
         auth_types_enum=auth_types,
         expiration=expiration,
         owner=owner,
+        all_official_events=all_official_events,
     )
     auth.put()
 
@@ -502,6 +506,41 @@ def test_explicit_auth_not_expired(
         "2019nyny",
         auth_types=[AuthType.EVENT_TEAMS],
         expiration=datetime.datetime(2019, 7, 1),
+    )
+
+    with api_client.application.test_request_context():  # pyre-ignore[16]
+        request_data = json.dumps([])
+        request_path = "/api/trusted/v1/event/2019nyny/team_list/update"
+        resp = api_client.post(
+            request_path,
+            headers={
+                "X-TBA-Auth-Id": auth_id,
+                "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                    auth_secret, request_path, request_data
+                ),
+            },
+            data=request_data,
+        )
+
+    assert resp.status_code == 200, resp.data
+    assert "Success" in resp.json
+
+
+@freeze_time("2019-06-01")
+def test_explicit_auth_all_official_events(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """
+    If a user is logged in, we can automatically pull their linked auth, provided it is unexpired
+    Here, we can allow all "official" events to pass the key, a technique we use with FIRST HQ
+    """
+    setup_event(event_type=EventType.OFFSEASON, official=True)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        None,
+        auth_types=[AuthType.EVENT_TEAMS],
+        expiration=None,
+        all_official_events=True,
     )
 
     with api_client.application.test_request_context():  # pyre-ignore[16]

--- a/src/backend/api/trusted_api_auth_helper.py
+++ b/src/backend/api/trusted_api_auth_helper.py
@@ -58,7 +58,7 @@ class TrustedApiAuthHelper:
         # that are valid for this event
         if user:
             user_has_auth = any(
-                cls._validate_auth(auth, event_key, required_auth_types) is None
+                cls._validate_auth(auth, event, required_auth_types) is None
                 for auth in user.api_write_keys
             )
             if user_has_auth:
@@ -106,7 +106,7 @@ class TrustedApiAuthHelper:
             )
 
         # Checks event key is valid, correct auth types, and expiration
-        error = cls._validate_auth(auth, event_key, required_auth_types)
+        error = cls._validate_auth(auth, event, required_auth_types)
         if error:
             abort(make_response(profiled_jsonify({"Error": error}), 401))
 
@@ -114,11 +114,13 @@ class TrustedApiAuthHelper:
     def _validate_auth(
         cls,
         auth: ApiAuthAccess,
-        event_key: EventKey,
+        event: Event,
         required_auth_types: Set[AuthType],
     ) -> Optional[str]:
         allowed_event_keys = [none_throws(ekey.string_id()) for ekey in auth.event_list]
-        if event_key not in allowed_event_keys:
+        if event.key_name not in allowed_event_keys and not (
+            auth.all_official_events and event.official
+        ):
             return "Only allowed to edit events: {}".format(
                 ", ".join(allowed_event_keys)
             )

--- a/src/backend/common/models/api_auth_access.py
+++ b/src/backend/common/models/api_auth_access.py
@@ -34,6 +34,8 @@ class ApiAuthAccess(ndb.Model):
     event_list: List[ndb.Key] = ndb.KeyProperty(  # pyre-ignore[8]
         kind=Event, repeated=True
     )  # events for which auth is granted
+    # Allow access for all events marked official
+    all_official_events: bool = ndb.BooleanProperty()
     expiration: Optional[datetime.datetime] = ndb.DateTimeProperty()
 
     def put(self, *args, **kwargs):


### PR DESCRIPTION
This'll make it easier for us to support FIRST HQ's match video system, where we can easily grant them access to write videos to all events with official sync enabled