### PR TITLE
Copr fix

### DIFF
--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -203,7 +203,7 @@ class MatchstatsHelper(object):
         ].items():
             try:
                 float(value)
-            except ValueError:
+            except ValueError | TypeError:
                 pass
             else:
                 coprs[component] = cls.calc_stat(

--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -203,7 +203,7 @@ class MatchstatsHelper(object):
         ].items():
             try:
                 float(value)
-            except (ValueError, TypeError) as _:
+            except (ValueError, TypeError):
                 pass
             else:
                 coprs[component] = cls.calc_stat(

--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -203,7 +203,7 @@ class MatchstatsHelper(object):
         ].items():
             try:
                 float(value)
-            except ValueError | TypeError:
+            except (ValueError, TypeError) as _:
                 pass
             else:
                 coprs[component] = cls.calc_stat(


### PR DESCRIPTION
This is the first score breakdown with nested data, so previously trying to parse an invalid data type as a float would be a `ValueError`. However, now that a dict is there, we also need to catch `TypeError`.

![image](https://user-images.githubusercontent.com/7595639/219971136-238a9862-bd1f-42cb-a759-14ee77726e1d.png)
