### PR TITLE
Improve double elim bracket styling

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_match_table.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_match_table.less
@@ -61,6 +61,10 @@ table.match-table .winner {
   font-weight: bold;
 }
 
+tr:has(td.winner) {
+  font-weight: bold;
+}
+
 table.match-table td.current-team {
   text-decoration: underline;
 }

--- a/src/backend/web/static/css/less_css/less/tba/tba_match_table.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_match_table.less
@@ -61,7 +61,7 @@ table.match-table .winner {
   font-weight: bold;
 }
 
-tr:has(td.winner) {
+#double-elim-bracket-table > tr:has(td.winner) {
   font-weight: bold;
 }
 

--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -2,19 +2,25 @@
   <table class="match-table">
     {% if match %}
       <tr>
+        {% if match.red_name %}
+        <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name[-1] }}</td>
+        {% endif %}
         <td>
-          <span class="alliance-name" rel="tooltip" data-placement="top" title="{{ match.red_name if match.red_name else 'Unknown' }}">
-            {% set delim = joiner(" - ") %}
-            {% for team in match.red_alliance %}{{ delim() }}<a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
+          <span class="alliance-name {% if match.winning_alliance == 'red' %}winner{% endif %}" rel="tooltip" data-placement="top" title="{{ match.red_name if match.red_name else 'Unknown' }}">
+            {% set delim = joiner("-") %}
+            {% for team in match.red_alliance %}{{ delim() }}<wbr><a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
           </span>
         </td>
         <td class="redScore {% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_record.wins }}</td>
       </tr>
       <tr>
+        {% if match.blue_name %}
+        <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name[-1] }}</td>
+        {% endif %}
         <td>
-          <span class="alliance-name" rel="tooltip" data-placement="bottom" title="{{ match.blue_name if match.blue_name else 'Unknown' }}">
-            {% set delim = joiner(" - ") %}
-            {% for team in match.blue_alliance %}{{ delim() }}<a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
+          <span class="alliance-name {% if match.winning_alliance == 'blue' %}winner{% endif %}" rel="tooltip" data-placement="bottom" title="{{ match.blue_name if match.blue_name else 'Unknown' }}">
+            {% set delim = joiner("-") %}
+            {% for team in match.blue_alliance %}{{ delim() }}<wbr><a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
           </span>
         </td>
         <td class="blueScore {% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_record.wins }}</td>


### PR DESCRIPTION
## Description
Adds some changed styling to double elim bracket to improve readability at a glance.

- Removes spaces in alliance member delimiters
- Inserts `<wbr>` between teams on 4-team alliances to suggest to the browser to wrap text after the hyphens
- Bolds the entire winning alliance, rather than their winning set score
- Adds column for alliance seed next to each alliance (if alliance names exist)

## Motivation and Context
The bracket as is can be a little difficult to follow at a quick glance.

## How Has This Been Tested?
Locally. **This will be ugly if any double elimination brackets have named alliances, such as Einstein**, so an improvement to this would be appreciated. This is because it uses `alliance_name[-1]` to get the alliance seed.

## Screenshots (if appropriate):

2022cc before: 
![image](https://user-images.githubusercontent.com/7595639/219973496-c5cf92fa-cc0a-4c4e-b09f-d41485cd078c.png)

2022cc after: 
![image](https://user-images.githubusercontent.com/7595639/219973676-740f13d3-fc40-4f80-97c4-68689bd9843b.png)


2023week0 before: 
![image](https://user-images.githubusercontent.com/7595639/219973533-1e837cea-779f-433e-8c25-9c25f9738960.png)

2023week0 after: 
![image](https://user-images.githubusercontent.com/7595639/219973692-7c206cf9-44ea-4f0b-bc0d-d14417ad1803.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
