### PR TITLE
Show all OPRs by default

### DIFF
--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -32,7 +32,7 @@ from backend.web.profiled_render import render_template
 
 
 def sort_and_limit_stats(
-    stats_dict: TeamStatMap, num_matchstats: int = 15
+    stats_dict: TeamStatMap, num_matchstats: Optional[int] = None
 ) -> List[Tuple[TeamKey, float]]:
     return sorted(stats_dict.items(), key=lambda t: -t[1])[:num_matchstats]
 

--- a/src/backend/web/templates/event_partials/event_copr_table.html
+++ b/src/backend/web/templates/event_partials/event_copr_table.html
@@ -1,5 +1,5 @@
 {% if has_coprs %}
-<h3><abbr title="Component Offensive Power Ratings">COPRs</abbr> - Top 15 (<a href="/opr">?</a>)</h3>
+<h3><abbr title="Component Offensive Power Ratings">COPRs</abbr> (<a href="/opr">?</a>)</h3>
 <div class="btn-group">
   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false">

--- a/src/backend/web/templates/event_partials/event_opr_table.html
+++ b/src/backend/web/templates/event_partials/event_opr_table.html
@@ -1,5 +1,5 @@
 {% if oprs|length > 0 %}
-<h3><abbr title="Offensive Power Ratings">OPRs</abbr> - Top 15 (<a href="/opr">?</a>)</h3>
+<h3><abbr title="Offensive Power Ratings">OPRs</abbr> (<a href="/opr">?</a>)</h3>
   <table class="table table-condensed table-striped table-center">
     <thead>
       <tr>

--- a/src/backend/web/templates/opr.html
+++ b/src/backend/web/templates/opr.html
@@ -10,7 +10,6 @@
     <div class="col-xs-8 col-sm-offset-2 col-lg-offset-2">
       <h1 class="end_header">What is OPR?</h1>
       <p>OPR stands for <strong>Offensive Power Rating</strong>, which is a system to attempt to deduce the average point contribution of a team to an alliance. It is based on <a href="https://en.wikipedia.org/wiki/Sports_rating_system">sports rating systems</a> used in other sports. OPRs are an interesting way to slice the data for teams at particular events, but aren't a perfect system for assessing a team's performance or contribution.</p>
-      <p>The Blue Alliance opts to show the top 15 OPRs for each competition.</p>
       </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
Shows all OPRs by default on event insights tab.

## Motivation and Context
The community has been asking (a lot) to show more than just the top 15 OPRs. These are available in the API anyhow.

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7595639/220424860-13446628-5a1e-4fc0-9a02-17e0898cc9d9.png)
![image](https://user-images.githubusercontent.com/7595639/220424918-83720ee2-cd71-46d7-a69c-33ce701a4c8c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
