### PR TITLE
Improve setup for Apple Silicon mac

### DIFF
--- a/docs/Setup/Setup-Guide.md
+++ b/docs/Setup/Setup-Guide.md
@@ -16,6 +16,8 @@ Before starting the container, ensure that Vagrant and Docker are both up and ru
 $ vagrant up
 ```
 
+**Note:** If you're setting up an Apple Silicon Mac, you'll likely want to [use the local dockerfile](https://github.com/the-blue-alliance/the-blue-alliance/wiki/Development-Runbook#using-the-local-dockerfile) for better performance. 
+
 After a little bit of installation and setup, a local instance of The Blue Alliance will be accessible at [localhost:8080](http://localhost:8080). The Google App Engine admin panel for the local instance can be access at [localhost:8000](http://localhost:8000).
 
 ## Working in the Container

--- a/ops/dev/vagrant/bootstrap-dev-container.sh
+++ b/ops/dev/vagrant/bootstrap-dev-container.sh
@@ -22,6 +22,10 @@ NVM_DIR="/nvm"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm use default
+# skip puppeteer chromium install on aarch64
+if [ "$(uname -m)" = "aarch64" ]; then
+    export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+fi
 npm install
 
 # Install the Firebase tools for the Firebase emulator


### PR DESCRIPTION
- Add note about TBA_LOCAL_DOCKERFILE
- Add flag for puppeteer install to avoid this error: 
```
The chromium binary is not available for arm64.
If you are on Ubuntu, you can install with: 

 sudo apt install chromium


 sudo apt install chromium-browser

ERROR: Failed to set up Chromium r1095492! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
Error
    at handleArm64 (/tba/node_modules/puppeteer-core/lib/cjs/puppeteer/node/BrowserFetcher.js:137:11)
    at BrowserFetcher.download (/tba/node_modules/puppeteer-core/lib/cjs/puppeteer/node/BrowserFetcher.js:284:13)
    at fetchBinary (/tba/node_modules/puppeteer/lib/cjs/puppeteer/node/install.js:112:14)
    at downloadBrowser (/tba/node_modules/puppeteer/lib/cjs/puppeteer/node/install.js:61:11)
    at Object.<anonymous> (/tba/node_modules/puppeteer/install.js:40:1)
    at Module._compile (internal/modules/cjs/loader.js:1114:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1143:10)
    at Module.load (internal/modules/cjs/loader.js:979:32)
    at Function.Module._load (internal/modules/cjs/loader.js:819:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12)
```
