### PR TITLE
Add TBA api key field to /admin/authkeys

### DIFF
--- a/src/backend/web/handlers/admin/authkeys.py
+++ b/src/backend/web/handlers/admin/authkeys.py
@@ -1,6 +1,7 @@
 from flask import redirect, request, url_for
 from werkzeug.wrappers import Response
 
+from backend.common.sitevars.apiv3_key import Apiv3Key
 from backend.common.sitevars.firebase_secrets import FirebaseSecrets
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
 from backend.common.sitevars.gcm_server_key import GcmServerKey
@@ -23,6 +24,7 @@ def authkeys_get() -> str:
     instagram_secrets = InstagramApiSecret.get()
 
     template_values = {
+        "apiv3_key": Apiv3Key.api_key(),
         "google_secret": google_secrets.get("api_key", ""),
         "firebase_secret": firebase_secrets.get("FIREBASE_SECRET", ""),
         "fmsapi_user": fmsapi_keys.get("username", ""),
@@ -51,6 +53,7 @@ def authkeys_post() -> Response:
     twitch_client_id = request.form.get("twitch_secret", "")
     livestream_key = request.form.get("livestream_secret", "")
     instagram_key = request.form.get("instagram_secret", "")
+    apiv3_key = request.form.get("apiv3_key", "")
 
     GoogleApiSecret.put({"api_key": google_key})
     InstagramApiSecret.put({"api_key": instagram_key})
@@ -64,6 +67,7 @@ def authkeys_post() -> Response:
         }
     )
     GcmServerKey.put({"gcm_key": gcm_key})
+    Apiv3Key.put({"apiv3_key": apiv3_key})
 
     twitch_secrets = TwitchSecrets.get()
     twitch_secrets["client_id"] = twitch_client_id

--- a/src/backend/web/templates/admin/authkeys.html
+++ b/src/backend/web/templates/admin/authkeys.html
@@ -10,6 +10,9 @@
 <form method="post">
 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 <table class="table table-striped">
+  <tr><th>TBA API</th></tr>
+  <tr><td>API v3 Key</td><td><input name="apiv3_key" value="{{apiv3_key}}" class="form-control"/></td></tr>
+
   <tr><th>Google</th></tr>
   <tr><td>API Key</td><td><input name="google_secret" value="{{google_secret}}" class="form-control"/></td></tr>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously the local bootstrap page would direct you to `/admin/authkeys` to save your api key, but there was no field for the TBA key. 

## Motivation and Context
Make development process easier. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="1004" alt="Screen Shot 2023-02-25 at 10 19 15 PM" src="https://user-images.githubusercontent.com/6137845/221395682-d2089d68-32a2-4a72-9659-5853288091e7.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
