### PR TITLE
Allow 2 digit semifinal set number in match validation

### DIFF
--- a/src/backend/common/models/match.py
+++ b/src/backend/common/models/match.py
@@ -495,7 +495,7 @@ class Match(CachedModel):
     @classmethod
     def validate_key_name(cls, match_key: str) -> bool:
         key_name_regex = re.compile(
-            r"^[1-9]\d{3}[a-z]+[0-9]*\_(?:qm|ef\dm|qf\dm|sf\dm|f\dm)\d+$"
+            r"^[1-9]\d{3}[a-z]+[0-9]*\_(?:qm|ef\dm|qf\dm|sf\d{1,2}m|f\dm)\d+$"
         )
         match = re.match(key_name_regex, match_key)
         return True if match else False

--- a/src/backend/common/models/tests/match_test.py
+++ b/src/backend/common/models/tests/match_test.py
@@ -50,13 +50,13 @@ def get_base_qual_match(**kwargs) -> Match:
     )
 
 
-@pytest.mark.parametrize("key", ["2019nyny_qm1", "2010ct_sf1m3", "2022on306_qm15"])
+@pytest.mark.parametrize("key", ["2019nyny_qm1", "2010ct_sf1m3", "2022on306_qm15", "2023week0_sf13m1"])
 def test_valid_key_names(key: str) -> None:
     assert Match.validate_key_name(key) is True
 
 
 @pytest.mark.parametrize(
-    "key", ["frc177", "2010ct_qm1m1", "2010ctf1m1", "2010ct_f1", "2022on_306_qm15"]
+    "key", ["frc177", "2010ct_qm1m1", "2010ctf1m1", "2010ct_f1", "2022on_306_qm15", "2023week0_sf130m1"]
 )
 def test_invalid_key_names(key: str) -> None:
     assert Match.validate_key_name(key) is False


### PR DESCRIPTION
SF set number can go up to 13 now in double elims.