### PR TITLE
Hide Covid information for events outside 2022

### DIFF
--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -87,7 +87,7 @@
         {% endif %}
         {% if event.website %}<br><span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank" rel="noopener noreferrer">{{ event.website }}</a>{% endif %}
         {% if event.first_eid or event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="{% if event.first_eid %}https://www.firstinspires.org/team-event-search/event?id={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank" rel="noopener noreferrer">firstinspires.org</a>{% endif %}
-        {% if event.year > 2021 %}{% if event.official %}<br><span class="glyphicon glyphicon-plus"></span> <a href="https://www.firstinspires.org/sites/default/files/uploads/frc/{{event.year}}-events/{{event.year}}_{{event.first_api_code}}_SiteInfo.pdf" target="_blank" rel="noopener noreferrer">COVID-19 Site Information</a>{% endif %}{% endif %}
+        {% if event.year == 2022 %}{% if event.official %}<br><span class="glyphicon glyphicon-plus"></span> <a href="https://www.firstinspires.org/sites/default/files/uploads/frc/{{event.year}}-events/{{event.year}}_{{event.first_api_code}}_SiteInfo.pdf" target="_blank" rel="noopener noreferrer">COVID-19 Site Information</a>{% endif %}{% endif %}
         {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank" rel="noopener noreferrer">RSVP on Facebook</a><br>{% endif %}
       </p>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Shows Covid-19 Site Information only if year = 2022.

## Motivation and Context
Currently, site information populates for years > 2021, which includes 2023 and will include subsequent years. However, there are no Covid-19 site info summaries for events outside of 2022. Current links error on the FIRST website.

## How Has This Been Tested?
Hasn't

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
