### PR TITLE
Improve double elim bracket layout

### DIFF
--- a/src/backend/common/helpers/playoff_advancement_helper.py
+++ b/src/backend/common/helpers/playoff_advancement_helper.py
@@ -290,6 +290,10 @@ class PlayoffAdvancementHelper(object):
                                 f"{color}_alliance"
                             ] += cls.ordered_alliance(alliance, alliance_selections)
 
+                # Skip if match hasn't been played
+                if not match.has_been_played:
+                    continue
+
                 winner = match.winning_alliance
                 if not winner or winner == "":
                     # if the match is a tie

--- a/src/backend/web/static/css/less_css/less/tba/tba_double_elim_bracket_table.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_double_elim_bracket_table.less
@@ -11,7 +11,7 @@
   width: calc(100% - 20px);
 
   tr {
-    height: 31px;
+    height: 35px;
   }
 
   td {
@@ -20,8 +20,7 @@
   }
 
   .match {
-    min-width: 120px;
-    width: 140px;
+    min-width: 140px;
   }
 
   .team-placeholder {
@@ -67,14 +66,18 @@
 
   .match-table {
     margin-bottom: 0px;
+  }
 
-    .alliance-name {
-      border-bottom: 1px dotted #777
-    }
+  .match-table-wrapper {
+    position: absolute;
+    width: 100%;
 
-    .tooltip-inner {
-      width: 140px
-    }
+    top: -20px;
+    bottom: -20px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 
   .gap-row {

--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -1,39 +1,61 @@
-{% macro bracket_match(match, red_alliance_placeholder, blue_alliance_placeholder) %}
-  <table class="match-table">
-    {% if match %}
-      <tr>
-        {% if match.red_name %}
-        <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name[-1] }}</td>
+{% macro bracket_match(match_name, match, red_alliance_placeholder, blue_alliance_placeholder) %}
+  <div class="match-table-wrapper">
+    <div style="position: relative;">
+      <span class="match-label">{{ match_name }}</span>
+      <table class="match-table">
+        {% if match %}
+          {% if match.red_alliance and ('0' not in match.red_alliance) %}
+            <tr>
+              {% if match.red_name %}
+                <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name[-1] }}</td>
+              {% endif %}
+              <td>
+                <span class="alliance-name {% if match.winning_alliance == 'red' %}winner{% endif %}">
+                  {% set delim = joiner("-") %}
+                  {% for team in match.red_alliance %}{{ delim() }}<wbr><a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
+                </span>
+              </td>
+              {% if match.red_record.wins + match.red_record.losses + match.red_record.ties > 0 %}
+                <td class="redScore {% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_record.wins }}</td>
+              {% endif %}
+            </tr>
+          {% else %}
+            <tr>
+              <td class="team-placeholder" colspan="2">{{ red_alliance_placeholder }}</td>
+            </tr>
+          {% endif %}
+
+          {% if match.blue_alliance and ('0' not in match.blue_alliance) %}
+            <tr>
+              {% if match.blue_name %}
+                <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name[-1] }}</td>
+              {% endif %}
+              <td>
+                <span class="alliance-name {% if match.winning_alliance == 'blue' %}winner{% endif %}">
+                  {% set delim = joiner("-") %}
+                  {% for team in match.blue_alliance %}{{ delim() }}<wbr><a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
+                </span>
+              </td>
+              {% if match.blue_record.wins + match.blue_record.losses + match.blue_record.ties > 0 %}
+                <td class="blueScore {% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_record.wins }}</td>
+              {% endif %}
+            </tr>
+          {% else %}
+            <tr>
+              <td class="team-placeholder" colspan="2">{{ blue_alliance_placeholder }}</td>
+            </tr>
+          {% endif %}
+        {% else %}
+          <tr>
+            <td class="team-placeholder">{{ red_alliance_placeholder }}</td>
+          </tr>
+          <tr>
+            <td class="team-placeholder">{{ blue_alliance_placeholder }}</td>
+          </tr>
         {% endif %}
-        <td>
-          <span class="alliance-name {% if match.winning_alliance == 'red' %}winner{% endif %}" rel="tooltip" data-placement="top" title="{{ match.red_name if match.red_name else 'Unknown' }}">
-            {% set delim = joiner("-") %}
-            {% for team in match.red_alliance %}{{ delim() }}{% if match.red_alliance|length > 3 %}<wbr>{% endif %}<a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
-          </span>
-        </td>
-        <td class="redScore {% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_record.wins }}</td>
-      </tr>
-      <tr>
-        {% if match.blue_name %}
-        <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name[-1] }}</td>
-        {% endif %}
-        <td>
-          <span class="alliance-name {% if match.winning_alliance == 'blue' %}winner{% endif %}" rel="tooltip" data-placement="bottom" title="{{ match.blue_name if match.blue_name else 'Unknown' }}">
-            {% set delim = joiner("-") %}
-            {% for team in match.blue_alliance %}{{ delim() }}{% if match.blue_alliance|length > 3 %}<wbr>{% endif %}<a href="/team/{{ team }}">{{ team }}</a>{% endfor %}
-          </span>
-        </td>
-        <td class="blueScore {% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_record.wins }}</td>
-      </tr>
-    {% else %}
-      <tr>
-        <td class="team-placeholder">{{ red_alliance_placeholder }}</td>
-      </tr>
-      <tr>
-        <td class="team-placeholder">{{ blue_alliance_placeholder }}</td>
-      </tr>
-    {% endif %}
-  </table>
+      </table>
+    </div>
+  </div>
 {% endmacro %}
 
 <div id="double-elim-bracket-wrapper">
@@ -43,8 +65,7 @@
     <!-- Upper Bracket -->
     <tr>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 1</span>
-        {{ bracket_match(bracket_table.sf.get('sf1'), 'Alliance 1', 'Alliance 8') }}
+        {{ bracket_match('Match 1', bracket_table.sf.get('sf1'), 'Alliance 1', 'Alliance 8') }}
       </td>
     </tr>
 
@@ -58,8 +79,7 @@
       <td></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 7</span>
-        {{ bracket_match(bracket_table.sf.get('sf7'), 'Winner of M1', 'Winner of M2') }}
+        {{ bracket_match('Match 7', bracket_table.sf.get('sf7'), 'Winner of M1', 'Winner of M2') }}
       </td>
     </tr>
 
@@ -72,8 +92,7 @@
 
     <tr>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 2</span>
-        {{ bracket_match(bracket_table.sf.get('sf2'), 'Alliance 4', 'Alliance 5') }}
+        {{ bracket_match('Match 2', bracket_table.sf.get('sf2'), 'Alliance 4', 'Alliance 5') }}
       </td>
     </tr>
 
@@ -85,13 +104,7 @@
       <td colspan="4"></td>
       <td class="dash" colspan="2"></td>
       <td rowspan="2" class="match">
-        {% if event.year >= 2023 %}
-        <span class="match-label">Match 11</span>
-        {{ bracket_match(bracket_table.sf.get('sf11'), 'Winner of M10', 'Winner of M9') }}
-        {% else %}
-        <span class="match-label">Match 12</span>
-        {{ bracket_match(bracket_table.sf.get('sf12'), 'Winner of M7', 'Winner of M8') }}
-        {% endif %}
+        {{ bracket_match('Match 11', bracket_table.sf.get('sf11'), 'Winner of M7', 'Winner of M8') }}
       </td>
     </tr>
 
@@ -107,8 +120,7 @@
 
     <tr>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 3</span>
-        {{ bracket_match(bracket_table.sf.get('sf3'), 'Alliance 3', 'Alliance 6') }}
+        {{ bracket_match('Match 3', bracket_table.sf.get('sf3'), 'Alliance 3', 'Alliance 6') }}
       </td>
     </tr>
 
@@ -122,8 +134,7 @@
       <td></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 8</span>
-        {{ bracket_match(bracket_table.sf.get('sf8'), 'Winner of M3', 'Winner of M4') }}
+        {{ bracket_match('Match 8', bracket_table.sf.get('sf8'), 'Winner of M3', 'Winner of M4') }}
       </td>
     </tr>
 
@@ -132,15 +143,13 @@
       <td colspan="10"></td>
       <td class="dash" colspan="1"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Finals</span>
-        {{ bracket_match(bracket_table.f.get('f1'), 'Winner of M12', 'Winner of M13') }}
+        {{ bracket_match('Finals', bracket_table.f.get('f1'), 'Winner of M12', 'Winner of M13') }}
       </td>
     </tr>
 
     <tr>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 4</span>
-        {{ bracket_match(bracket_table.sf.get('sf4'), 'Alliance 2', 'Alliance 7') }}
+        {{ bracket_match('Match 4', bracket_table.sf.get('sf4'), 'Alliance 2', 'Alliance 7') }}
       </td>
     </tr>
 
@@ -157,8 +166,7 @@
       <td colspan="11"></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 13</span>
-        {{ bracket_match(bracket_table.sf.get('sf13'), 'Loser of M12', 'Winner of M11') }}
+        {{ bracket_match('Match 13', bracket_table.sf.get('sf13'), 'Loser of M11', 'Winner of M12') }}
       </td>
     </tr>
 
@@ -167,8 +175,7 @@
       <td class="dash" colspan="1"></td>
 
       <td rowspan="2" class="match">
-        <span class="match-label">Match 10</span>
-        {{ bracket_match(bracket_table.sf.get('sf10'), 'Loser of M8', 'Winner of M5') }}
+        {{ bracket_match('Match 10', bracket_table.sf.get('sf10'), 'Loser of M8', 'Winner of M5') }}
       </td>
       <td colspan="3"></td>
       <td rowspan="3">
@@ -190,19 +197,12 @@
     <tr>
       <td colspan="3"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 5</span>
-        {{ bracket_match(bracket_table.sf.get('sf5'), 'Loser of M1', 'Loser of M2') }}
+        {{ bracket_match('Match 5', bracket_table.sf.get('sf5'), 'Loser of M1', 'Loser of M2') }}
       </td>
       <td colspan="3"></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        {% if event.year >= 2023 %}
-        <span class="match-label">Match 12</span>
-        {{ bracket_match(bracket_table.sf.get('sf12'), 'Winner of M7', 'Winner of M8') }}
-        {% else %}
-        <span class="match-label">Match 11</span>
-        {{ bracket_match(bracket_table.sf.get('sf11'), 'Winner of M10', 'Winner of M9') }}
-        {% endif %}
+        {{ bracket_match('Match 12', bracket_table.sf.get('sf12'), 'Winner of M10', 'Winner of M9') }}
       </td>
     </tr>
 
@@ -214,8 +214,7 @@
       <td colspan="5"></td>
       <td class="dash" colspan="1"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 9</span>
-        {{ bracket_match(bracket_table.sf.get('sf9'), 'Loser of M7', 'Winner of M6') }}
+        {{ bracket_match('Match 9', bracket_table.sf.get('sf9'), 'Loser of M7', 'Winner of M6') }}
       </td>
     </tr>
 
@@ -229,8 +228,7 @@
     <tr>
       <td colspan="3"></td>
       <td rowspan="2" class="match">
-        <span class="match-label">Match 6</span>
-        {{ bracket_match(bracket_table.sf.get('sf6'), 'Loser of M3', 'Loser of M4') }}
+        {{ bracket_match( 'Match 6', bracket_table.sf.get('sf6'), 'Loser of M3', 'Loser of M4') }}
       </td>
     </tr>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Make bracket layout more compact
- In the match tables:
    - Fix display of placeholder teams ("Winner of M1")
    - Only show the score column if the match has been played 
    - Remove the alliance name tooltips since we already display them in front of the team numbers

## Motivation and Context
Fix bugs/improve the readability of the bracket

## How Has This Been Tested?
Checked locally

## Screenshots (if appropriate):
### Before
<img width="1046" alt="Screen Shot 2023-03-05 at 11 42 40 AM" src="https://user-images.githubusercontent.com/6137845/222982497-39a05dfd-01ff-4ecc-a37c-b978e4516647.png">

### After
<img width="939" alt="Screen Shot 2023-03-05 at 11 43 06 AM" src="https://user-images.githubusercontent.com/6137845/222982502-17b95cb3-c857-4c71-abbb-6b4a7b6e83aa.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
