### PR TITLE
Add event_key logging for EventDetails manipulator

### DIFF
--- a/src/backend/common/manipulators/event_details_manipulator.py
+++ b/src/backend/common/manipulators/event_details_manipulator.py
@@ -63,6 +63,7 @@ def event_details_post_update_hook(
         except Exception:
             logging.exception(f"Error enqueuing event_team_status for {event_key}")
 
+        print(event_key)
         print(updated_model.updated_attrs)
 
         event = Event.get_by_id(event_key)


### PR DESCRIPTION
Sorry for the additional logging but - adding one piece of information for myself to attempt to troubleshoot multiple alliance selection push notification sends. I've run out of breadcrumbs to follow locally...