### PR TITLE
Update swagger documentation for the 2023 season

### DIFF
--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -6762,6 +6762,272 @@
           }
         }
       },
+      "Match_Score_Breakdown_2023": {
+        "type": "object",
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2023_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2023_Alliance"
+          }
+        },
+        "description": "See the 2023 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
+      },
+      "Match_Score_Breakdown_2023_Alliance": {
+        "type": "object",
+        "properties": {
+          "activationBonusAchieved": {
+            "type": "boolean"
+          },
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "autoBridgeState": {
+            "type": "string",
+            "enum": [
+              "NotLevel",
+              "Level"
+            ]
+          },
+          "autoChargeStationPoints": {
+            "type": "integer"
+          },
+          "autoChargeStationRobot1": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Docked"
+            ]
+          },
+          "autoChargeStationRobot2": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Docked"
+            ]
+          },
+          "autoChargeStationRobot3": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Docked"
+            ]
+          },
+          "autoDocked": {
+            "type": "boolean"
+          },
+          "autoCommunity": {
+            "type": "object",
+            "properties": {
+              "B": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "M": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "T": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              }
+            }
+          },
+          "autoGamePieceCount": {
+            "type": "integer"
+          },
+          "autoGamePiecePoints": {
+            "type": "integer"
+          },
+          "autoMobilityPoints": {
+            "type": "integer"
+          },
+          "mobilityRobot1": {
+            "type": "string",
+            "enum": [
+              "Yes",
+              "No"
+            ]
+          },
+          "mobilityRobot2": {
+            "type": "string",
+            "enum": [
+              "Yes",
+              "No"
+            ]
+          },
+          "mobilityRobot3": {
+            "type": "string",
+            "enum": [
+              "Yes",
+              "No"
+            ]
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "coopGamePieceCount": {
+            "type": "integer"
+          },
+          "coopertitionCriteriaMet": {
+            "type": "boolean"
+          },
+          "endGameBridgeState": {
+            "type": "string",
+            "enum": [
+              "NotLevel",
+              "Level"
+            ]
+          },
+          "endGameChargeStationPoints": {
+            "type": "integer"
+          },
+          "endGameChargeStationRobot1": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Docked"
+            ]
+          },
+          "endGameChargeStationRobot2": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Docked"
+            ]
+          },
+          "endGameChargeStationRobot3": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Docked"
+            ]
+          },
+          "endGameParkPoints": {
+            "type": "integer"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "linkPoints": {
+            "type": "integer"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "nodes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "None",
+                      "Cone",
+                      "Cube"
+                    ]
+                  }
+                },
+                "row": {
+                  "type": "string",
+                  "enum": [
+                    "Bottom",
+                    "Mid",
+                    "Top"
+                  ]
+                }
+              }
+            }
+          },
+          "sustainabilityBonusAchieved": {
+            "type": "boolean"
+          },
+          "teleopCommunity": {
+            "type": "object",
+            "properties": {
+              "B": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "M": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "T": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              }
+            }
+          },
+          "teleopGamePieceCount": {
+            "type": "integer"
+          },
+          "teleopGamePiecePoints": {
+            "type": "integer"
+          },
+          "totalChargeStationPoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          }
+        }
+      },
       "Media": {
         "required": [
           "type",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the Match_Score_Breakdown_2023 and Match_Score_Breakdown_2023_Alliance models.

Breakdown information is pulled from week 1 event information from the api.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Documentation isn't updated for the new season.

Also autogenerated client apis that rely on the swagger docs don't get the type information they need for this year.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run swagger build and made sure everything looked correct.

## Screenshots (if appropriate):

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/6081500/223165996-65ab9c2b-8ce9-487b-acb2-fb30865b2929.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
