### PR TITLE
Fix broken links on review pending suggestions page

### DIFF
--- a/src/backend/web/static/javascript/tba_js/tba.js
+++ b/src/backend/web/static/javascript/tba_js/tba.js
@@ -29,7 +29,7 @@ $(document).ready(function(){
   var hash = window.location.hash;
   hash && $('ul.nav a[href="' + hash + '"]').tab('show');
 
-  $('.nav-tabs a, .nav-pills a').click(function (e) {
+  $('.nav-tabs a, .nav-pills a').not(".nav-pills#suggestion-review-list a").click(function (e) {
     e.preventDefault();
     window.location.hash = this.hash;
   });


### PR DESCRIPTION
## Description
On the https://www.thebluealliance.com/suggest/review page the links are nav-pills and this logic seems to not be needed, I'm not sure if this code is needed for any other page or if it should just be removed.

## Motivation and Context
The links are .nav-pills but do not use hash routing so the previous version of the code resulted in links that only work when opened in a new tab.

## How Has This Been Tested?
Built and ran locally.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
