### PR TITLE
Update media instructions for 2023.

### DIFF
--- a/src/backend/web/templates/suggestions/suggest_team_media.html
+++ b/src/backend/web/templates/suggestions/suggest_team_media.html
@@ -56,8 +56,8 @@
 
           <p><strong>Currently supported formats are:</strong></p>
           <ul>
-            <li><strong>Chief Delphi images</strong>, like <code>https://www.chiefdelphi.com/media/photos/36646</code></li>
-            <li><strong>Imgur images</strong>, like <code>http://imgur.com/aF8T5ZE</code></li>
+            <!--<li><strong>Chief Delphi images</strong>, like <code>https://www.chiefdelphi.com/media/photos/36646</code></li>-->
+            <li><strong>Imgur images</strong>, like <code>http://imgur.com/aF8T5ZE</code>, but NOT albums with <code>/a/</code> in their URL (<a href="https://www.chiefdelphi.com/t/getting-imgur-photo-link-from-an-imgur-album-link/429809">see album instructions</a>)</li>
             <li><strong>Instagram photos and videos</strong>, like <code>https://www.instagram.com/p/BUnZiriBYre</code></li>
             <li><strong>YouTube videos</strong>, like <code>https://www.youtube.com/watch?v=DojyJ9bZ4fk</code></li>
             <li><strong>GrabCAD files</strong>, like <code>https://grabcad.com/library/cad-stuff</code></li>


### PR DESCRIPTION
Remove Chief Delphi from instructions, add instructions about imgur.

## Motivation and Context
Lots of confused emails when this doesn't work.

## How Has This Been Tested?
It hasn't, I don't have local auth working so can't load this page.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
