### PR TITLE
fixed double elimination bracket template

### DIFF
--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -143,7 +143,7 @@
       <td colspan="10"></td>
       <td class="dash" colspan="1"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Finals', bracket_table.f.get('f1'), 'Winner of M12', 'Winner of M13') }}
+        {{ bracket_match('Finals', bracket_table.f.get('f1'), 'Winner of M11', 'Winner of M13') }}
       </td>
     </tr>
 


### PR DESCRIPTION
Fixed a typo in the double elimination bracket which had the winner of match 12 advancing to match 13 AND the finals while the winner of match 11 didn't go anywhere.

## Description
typo fix
