### PR TITLE
Awards elim district points as matches are won

### DIFF
--- a/src/backend/common/consts/district_point_values.py
+++ b/src/backend/common/consts/district_point_values.py
@@ -47,10 +47,8 @@ class DistrictPointValues:
     F_WIN = {2015: 5.0}
 
     # Double elimination bracket points (2023 onwards)
-    DE_SF_12_LOSS = 7
-    DE_SF_13_LOSS = 13
-    DE_F_LOSS = 20
-    DE_F_WIN = 30
+    DE_SF_WIN = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 13, 8: 13, 9: 7, 10: 7, 11: 7, 12: 6, 13: 7}
+    DE_F_WIN = 10
 
     # Chairman's Award
     CHAIRMANS_DEFAULT = 10

--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -377,7 +377,6 @@ class DistrictHelper:
             lambda: defaultdict(int)
         )
 
-
         elim_alliance_pts: DefaultDict[int, int] = defaultdict(int)
         elim_alliance_wins: DefaultDict[int, int] = defaultdict(int)
         elim_team_wins: DefaultDict[TeamKey, int] = defaultdict(int)
@@ -403,22 +402,29 @@ class DistrictHelper:
             elim_alliance_wins[winning_alliance_number] += 1
 
             for team in match.alliances[winning_alliance]["teams"]:
-                elim_alliances[team] = winning_alliance
+                elim_alliances[team] = winning_alliance_number
                 elim_team_wins[team] += 1
 
             if match.comp_level == CompLevel.SF:
-                elim_alliance_pts[winning_alliance_number] += DistrictPointValues.DE_SF_WIN[match.set_number]
-            elif match.comp_level == CompLevel.F and elim_num_wins[match_set_key][winning_alliance] >= 2:
-                elim_alliance_pts[winning_alliance_number] += DistrictPointValues.DE_F_WIN
+                elim_alliance_pts[
+                    winning_alliance_number
+                ] += DistrictPointValues.DE_SF_WIN[match.set_number]
+            elif (
+                match.comp_level == CompLevel.F
+                and elim_num_wins[match_set_key][winning_alliance] >= 2
+            ):
+                elim_alliance_pts[
+                    winning_alliance_number
+                ] += DistrictPointValues.DE_F_WIN
 
         for team in elim_alliances:
             alliance = elim_alliances[team]
             multiplier = (
-                POINTS_MULTIPLIER
-                * elim_team_wins[team]
-                / elim_alliance_wins[alliance]
+                POINTS_MULTIPLIER * elim_team_wins[team] / elim_alliance_wins[alliance]
             )
-            district_points["points"][team]["elim_points"] = math.ceil(elim_alliance_pts[alliance] * multiplier)
+            district_points["points"][team]["elim_points"] = math.ceil(
+                elim_alliance_pts[alliance] * multiplier
+            )
 
     @classmethod
     def _calc_elim_match_points_pre_2023(

--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -419,11 +419,9 @@ class DistrictHelper:
 
         for team in elim_alliances:
             alliance = elim_alliances[team]
-            multiplier = (
-                POINTS_MULTIPLIER * elim_team_wins[team] / elim_alliance_wins[alliance]
-            )
-            district_points["points"][team]["elim_points"] = math.ceil(
-                elim_alliance_pts[alliance] * multiplier
+            multiplier = elim_team_wins[team] / elim_alliance_wins[alliance]
+            district_points["points"][team]["elim_points"] = (
+                math.ceil(elim_alliance_pts[alliance] * multiplier) * POINTS_MULTIPLIER
             )
 
     @classmethod

--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -377,8 +377,11 @@ class DistrictHelper:
             lambda: defaultdict(int)
         )
 
+
+        elim_alliance_pts: DefaultDict[int, int] = defaultdict(int)
         elim_alliance_wins: DefaultDict[int, int] = defaultdict(int)
         elim_team_wins: DefaultDict[TeamKey, int] = defaultdict(int)
+        elim_alliances: DefaultDict[TeamKey, int] = defaultdict(int)
 
         for match in matches:
             if not match.has_been_played or match.winning_alliance == "":
@@ -389,7 +392,6 @@ class DistrictHelper:
                 match.event_key_name, match.comp_level, match.set_number
             )
             winning_alliance = cast(AllianceColor, match.winning_alliance)
-            losing_allaince = cast(AllianceColor, match.losing_alliance)
             elim_num_wins[match_set_key][winning_alliance] += 1
 
             # Get alliance numbers
@@ -397,65 +399,26 @@ class DistrictHelper:
                 alliance_selections,
                 match.alliances[winning_alliance]["teams"],
             )
-            losing_alliance_number = cls._get_alliance_number_from_teams(
-                alliance_selections,
-                match.alliances[losing_allaince]["teams"],
-            )
 
             elim_alliance_wins[winning_alliance_number] += 1
 
             for team in match.alliances[winning_alliance]["teams"]:
+                elim_alliances[team] = winning_alliance
                 elim_team_wins[team] += 1
 
-            # Loser of match 12 receives 7 points
-            if match.comp_level == CompLevel.SF and match.set_number == 12:
-                for team in alliance_selections[losing_alliance_number]["picks"]:
-                    multiplier = (
-                        POINTS_MULTIPLIER
-                        * elim_team_wins[team]
-                        / elim_alliance_wins[losing_alliance_number]
-                    )
-                    district_points["points"][team]["elim_points"] += math.ceil(
-                        DistrictPointValues.DE_SF_12_LOSS * multiplier
-                    )
+            if match.comp_level == CompLevel.SF:
+                elim_alliance_pts[winning_alliance_number] += DistrictPointValues.DE_SF_WIN[match.set_number]
+            elif match.comp_level == CompLevel.F and elim_num_wins[match_set_key][winning_alliance] >= 2:
+                elim_alliance_pts[winning_alliance_number] += DistrictPointValues.DE_F_WIN
 
-            # Loser of match 13 receives 13 points
-            elif match.comp_level == CompLevel.SF and match.set_number == 13:
-                for team in alliance_selections[losing_alliance_number]["picks"]:
-                    multiplier = (
-                        POINTS_MULTIPLIER
-                        * elim_team_wins[team]
-                        / elim_alliance_wins[losing_alliance_number]
-                    )
-                    district_points["points"][team]["elim_points"] += math.ceil(
-                        DistrictPointValues.DE_SF_13_LOSS * multiplier
-                    )
-
-            elif (
-                match.comp_level == CompLevel.F
-                and elim_num_wins[match_set_key][winning_alliance] >= 2
-            ):
-                # Winner of finals receives 30 points
-                for team in alliance_selections[winning_alliance_number]["picks"]:
-                    multiplier = (
-                        POINTS_MULTIPLIER
-                        * elim_team_wins[team]
-                        / elim_alliance_wins[winning_alliance_number]
-                    )
-                    district_points["points"][team]["elim_points"] += math.ceil(
-                        DistrictPointValues.DE_F_WIN * multiplier
-                    )
-
-                # Loser of finals receives 20 points
-                for team in alliance_selections[losing_alliance_number]["picks"]:
-                    multiplier = (
-                        POINTS_MULTIPLIER
-                        * elim_team_wins[team]
-                        / elim_alliance_wins[losing_alliance_number]
-                    )
-                    district_points["points"][team]["elim_points"] += math.ceil(
-                        DistrictPointValues.DE_F_LOSS * multiplier
-                    )
+        for team in elim_alliances:
+            alliance = elim_alliances[team]
+            multiplier = (
+                POINTS_MULTIPLIER
+                * elim_team_wins[team]
+                / elim_alliance_wins[alliance]
+            )
+            district_points["points"][team]["elim_points"] = math.ceil(elim_alliance_pts[alliance] * multiplier)
 
     @classmethod
     def _calc_elim_match_points_pre_2023(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of awarding points to the loser of a match, we can award points to the winner of the previous match. This lets us award district points earlier, while an event is ongoing.

## Motivation and Context
A website I help run, frclocks.com, uses the blue alliance for district points. That website tracks when a team clinches a spot to the district championship or to the world championship. We would like to mark when a team clinches a spot as soon as possible - while an event is ongoing. This change would allow frclocks to do that while still using the blue alliance api, rather than implementing our own points tracking system. It will also give TBA users accurate district points as an event is ongoing.

## How Has This Been Tested?
I've been having difficulties getting vagrant to run on my machine, so I have not been able to test this as well as I would like. I would appreciate it if others could verify this. I would also appreciate help in setting up vagrant 😅 .

## Screenshots (if appropriate):
<img width="326" alt="Screen Shot 2023-03-17 at 10 17 26 AM" src="https://user-images.githubusercontent.com/11708940/225930618-ad730e69-10d9-4032-963b-b021d473c0b7.png">

This is the calculation for how points are awarded by match. No matter which route through the bracket an alliance takes it should end up in the 30/20/13/7/0/0/0/0 split.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
