### PR TITLE
Change the webhook test form to use form CSRF instead of Javascript headers

### DIFF
--- a/src/backend/web/templates/apidocs_partials/apidocs_webhooks_test.html
+++ b/src/backend/web/templates/apidocs_partials/apidocs_webhooks_test.html
@@ -1,6 +1,7 @@
 {% if type in enabled %}
 <h4>Test Notification</h4>
     <form method="POST" action="/apidocs/webhooks/test/{{ type.value }}" class="form-horizontal" role="form" onsubmit="event.preventDefault()">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <div class="row">
             {% if event_key %}
             <div class="form-group">

--- a/src/backend/web/templates/apidocs_webhooks.html
+++ b/src/backend/web/templates/apidocs_webhooks.html
@@ -623,15 +623,6 @@ $( document ).ready(function() {
         $(this).html(stringified);
     });
 
-    var csrf_token = "{{ csrf_token() }}";
-    $.ajaxSetup({
-        beforeSend: function(xhr, settings) {
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader("X-CSRFToken", csrf_token);
-            }
-        }
-    });
-
     $('.webhook-send-btn').click(function(e){
         e.preventDefault();
         $(this).attr('disabled', true);


### PR DESCRIPTION
For some reason the webhook test page is getting 400s with missing CSRF tokens. This PR just changes the form to hold the CSRF token, which seemed to work more reliably in my local instance. Should be an easy revert if it doesn't fix the issue.