### PR TITLE
Fix firstinspires.org links for CMP divs

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -747,14 +747,12 @@ class Event(CachedModel):
     def first_api_code(self) -> str:
         if self.first_code is None:
             return self.compute_first_api_code(self.year, self.event_short)
-
         return self.first_code
 
     @classmethod
     def compute_first_api_code(cls, year: int, event_short: str) -> str:
         if year == 2023:
             return cls.EVENT_SHORT_EXCEPTIONS_2023.get(event_short, event_short)
-
         return cls.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)
 
     @property

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -746,16 +746,16 @@ class Event(CachedModel):
     @property
     def first_api_code(self) -> str:
         if self.first_code is None:
-            if self.year == 2023:
-                return self.EVENT_SHORT_EXCEPTIONS_2023.get(
-                    self.event_short, self.event_short
-                ).upper()
+            return self.compute_first_api_code(self.year, self.event_short)
 
-            return self.EVENT_SHORT_EXCEPTIONS.get(
-                self.event_short, self.event_short
-            ).upper()
+        return self.first_code
 
-        return self.first_code.upper()
+    @classmethod
+    def compute_first_api_code(cls, year: int, event_short: str) -> str:
+        if year == 2023:
+            return cls.EVENT_SHORT_EXCEPTIONS_2023.get(event_short, event_short)
+
+        return cls.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)
 
     @property
     def is_in_season(self) -> bool:

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -36,6 +36,32 @@ class Event(CachedModel):
     key_name is like '2010ct'
     """
 
+    EVENT_SHORT_EXCEPTIONS = {
+        "arc": "archimedes",
+        "cars": "carson",
+        "carv": "carver",
+        "cur": "curie",
+        "dal": "daly",
+        "dar": "darwin",
+        "gal": "galileo",
+        "hop": "hopper",
+        "new": "newton",
+        "roe": "roebling",
+        "tes": "tesla",
+        "tur": "turing",
+    }
+
+    EVENT_SHORT_EXCEPTIONS_2023 = {
+        "arc": "arpky",
+        "cur": "cpra",
+        "dal": "dcmp",
+        "gal": "gcmp",
+        "hop": "hcmp",
+        "joh": "jcmp",
+        "mil": "mpcia",
+        "new": "npfcmp",
+    }
+
     name = ndb.StringProperty()
     event_type_enum = ndb.IntegerProperty(required=True, choices=list(EventType))
 
@@ -720,7 +746,15 @@ class Event(CachedModel):
     @property
     def first_api_code(self) -> str:
         if self.first_code is None:
-            return self.event_short.upper()
+            if self.year == 2023:
+                return self.EVENT_SHORT_EXCEPTIONS_2023.get(
+                    self.event_short, self.event_short
+                ).upper()
+
+            return self.EVENT_SHORT_EXCEPTIONS.get(
+                self.event_short, self.event_short
+            ).upper()
+
         return self.first_code.upper()
 
     @property

--- a/src/backend/common/models/tests/event_test.py
+++ b/src/backend/common/models/tests/event_test.py
@@ -367,6 +367,24 @@ def test_details() -> None:
     assert event.details == d
 
 
+def test_first_api_code() -> None:
+    # Pre-2023 regular event
+    event = Event(id="2019ingre", year=2019, event_short="ingre")
+    assert event.first_api_code == "INGRE"
+
+    # 2023 regular event
+    event = Event(id="2023ingre", year=2023, event_short="ingre")
+    assert event.first_api_code == "INGRE"
+
+    # Pre-2023 championship div
+    event = Event(id="2022hop", year=2022, event_short="hop")
+    assert event.first_api_code == "HOPPER"
+
+    # 2023 championship div
+    event = Event(id="2023hop", year=2023, event_short="hop")
+    assert event.first_api_code == "HCMP"
+
+
 def test_get_alliances() -> None:
     event = Event(id="2019ct", year=2019, event_short="ct")
     assert event.alliance_selections is None

--- a/src/backend/common/models/tests/event_test.py
+++ b/src/backend/common/models/tests/event_test.py
@@ -370,19 +370,19 @@ def test_details() -> None:
 def test_first_api_code() -> None:
     # Pre-2023 regular event
     event = Event(id="2019ingre", year=2019, event_short="ingre")
-    assert event.first_api_code == "INGRE"
+    assert event.first_api_code == "ingre"
 
     # 2023 regular event
     event = Event(id="2023ingre", year=2023, event_short="ingre")
-    assert event.first_api_code == "INGRE"
+    assert event.first_api_code == "ingre"
 
     # Pre-2023 championship div
     event = Event(id="2022hop", year=2022, event_short="hop")
-    assert event.first_api_code == "HOPPER"
+    assert event.first_api_code == "hopper"
 
     # 2023 championship div
     event = Event(id="2023hop", year=2023, event_short="hop")
-    assert event.first_api_code == "HCMP"
+    assert event.first_api_code == "hcmp"
 
 
 def test_get_alliances() -> None:

--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -383,16 +383,9 @@ class DatafeedFMSAPI:
 
     @classmethod
     def _get_event_short(self, event_short: str, event: Optional[Event]) -> str:
-        # First, check if we've manually set the FRC API key
-        if event and event.first_code:
-            return event.first_code
-
-        # Second, use the first_api_code if the event exists
-        if event and event.first_api_code:
+        if event:
             return event.first_api_code
-
-        # Otherwise, check hard-coded exceptions
-        return Event.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)
+        return event_short
 
     def _parse(
         self, response: requests.Response, parser: ParserBase[TParsedResponse]

--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -63,32 +63,6 @@ from backend.tasks_io.datafeeds.parsers.parser_base import ParserBase, TParsedRe
 
 
 class DatafeedFMSAPI:
-    EVENT_SHORT_EXCEPTIONS = {
-        "arc": "archimedes",
-        "cars": "carson",
-        "carv": "carver",
-        "cur": "curie",
-        "dal": "daly",
-        "dar": "darwin",
-        "gal": "galileo",
-        "hop": "hopper",
-        "new": "newton",
-        "roe": "roebling",
-        "tes": "tesla",
-        "tur": "turing",
-    }
-
-    EVENT_SHORT_EXCEPTIONS_2023 = {
-        "arc": "arpky",
-        "cur": "cpra",
-        "dal": "dcmp",
-        "gal": "gcmp",
-        "hop": "hcmp",
-        "joh": "jcmp",
-        "mil": "mpcia",
-        "new": "npfcmp",
-    }
-
     SUBDIV_TO_DIV = {  # 2015, 2016
         "arc": "arte",
         "cars": "gaca",
@@ -415,12 +389,12 @@ class DatafeedFMSAPI:
 
         # Second, check if it is a new 2023 division event code
         if event and event.year == 2023:
-            return DatafeedFMSAPI.EVENT_SHORT_EXCEPTIONS_2023.get(
+            return Event.EVENT_SHORT_EXCEPTIONS_2023.get(
                 event_short, event_short
             )
 
         # Otherwise, check hard-coded exceptions
-        return DatafeedFMSAPI.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)
+        return Event.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)
 
     def _parse(
         self, response: requests.Response, parser: ParserBase[TParsedResponse]

--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -140,7 +140,7 @@ class DatafeedFMSAPI:
         event_short = event_key[4:]
 
         event = Event.get_by_id(event_key)
-        api_event_short = self._get_event_short(event_short, event)
+        api_event_short = self._get_event_short(year, event_short, event)
         event_info_response = self.api.event_info(year, api_event_short)
         result = self._parse(
             event_info_response, FMSAPIEventListParser(year, short=event_short)
@@ -154,7 +154,7 @@ class DatafeedFMSAPI:
         year = int(event_key[:4])
         event_short = event_key[4:]
         event = Event.get_by_id(event_key)
-        event_code = self._get_event_short(event_short, event)
+        event_code = self._get_event_short(year, event_short, event)
 
         parser = FMSAPITeamDetailsParser(year)
         models: List[Tuple[Team, Optional[DistrictTeam], Optional[Robot]]] = []
@@ -178,8 +178,12 @@ class DatafeedFMSAPI:
     def get_awards(self, event: Event) -> List[Award]:
         awards = []
 
-        # 8 subdivisions from 2015+ have awards listed under 4 divisions
-        if event.event_type_enum == EventType.CMP_DIVISION and event.year >= 2015:
+        # 8 subdivisions from 2015-2021 have awards listed under 4 divisions
+        if (
+            event.event_type_enum == EventType.CMP_DIVISION
+            and event.year >= 2015
+            and event.year < 2022
+        ):
             event_team_keys = EventTeam.query(EventTeam.event == event.key).fetch(
                 keys_only=True
             )
@@ -192,9 +196,7 @@ class DatafeedFMSAPI:
             else:
                 division = self.SUBDIV_TO_DIV[event.event_short]
 
-            api_awards_response = self.api.awards(
-                event.year, event_code=DatafeedFMSAPI._get_event_short(division, event)
-            )
+            api_awards_response = self.api.awards(event.year, event_code=division)
             awards += (
                 self._parse(
                     api_awards_response, FMSAPIAwardsParser(event, valid_team_nums)
@@ -204,7 +206,9 @@ class DatafeedFMSAPI:
 
         api_awards_response = self.api.awards(
             event.year,
-            event_code=DatafeedFMSAPI._get_event_short(event.event_short, event),
+            event_code=DatafeedFMSAPI._get_event_short(
+                event.year, event.event_short, event
+            ),
         )
         awards += self._parse(api_awards_response, FMSAPIAwardsParser(event)) or []
 
@@ -215,7 +219,7 @@ class DatafeedFMSAPI:
         event_short = event_key[4:]
 
         event = Event.get_by_id(event_key)
-        api_event_short = self._get_event_short(event_short, event)
+        api_event_short = self._get_event_short(year, event_short, event)
         api_response = self.api.alliances(year, api_event_short)
         alliances = self._parse(api_response, FMSAPIEventAlliancesParser())
         return alliances or []
@@ -225,7 +229,7 @@ class DatafeedFMSAPI:
         event_short = event_key[4:]
 
         event = Event.get_by_id(event_key)
-        api_event_short = self._get_event_short(event_short, event)
+        api_event_short = self._get_event_short(year, event_short, event)
         api_response = self.api.rankings(year, api_event_short)
         result = self._parse(api_response, FMSAPIEventRankingsParser(year))
         return result or []
@@ -239,7 +243,7 @@ class DatafeedFMSAPI:
         hs_parser = FMSAPIHybridScheduleParser(year, event_short)
         detail_parser = FMSAPIMatchDetailsParser(year, event_short)
 
-        api_event_short = DatafeedFMSAPI._get_event_short(event_short, event)
+        api_event_short = DatafeedFMSAPI._get_event_short(year, event_short, event)
 
         # TODO do we make all these sequentually, or go back to GAE urlfetch
         # we can run in parallel?
@@ -332,7 +336,7 @@ class DatafeedFMSAPI:
 
         event = Event.get_by_id(event_key)
         parser = FMSAPITeamAvatarParser(year)
-        api_event_short = DatafeedFMSAPI._get_event_short(event_short, event)
+        api_event_short = DatafeedFMSAPI._get_event_short(year, event_short, event)
         avatars: List[Media] = []
         keys_to_delete: Set[ndb.Key] = set()
 
@@ -382,10 +386,12 @@ class DatafeedFMSAPI:
         return advancement
 
     @classmethod
-    def _get_event_short(self, event_short: str, event: Optional[Event]) -> str:
+    def _get_event_short(
+        self, year: int, event_short: str, event: Optional[Event]
+    ) -> str:
         if event:
             return event.first_api_code
-        return event_short
+        return Event.compute_first_api_code(year, event_short)
 
     def _parse(
         self, response: requests.Response, parser: ParserBase[TParsedResponse]

--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -387,11 +387,9 @@ class DatafeedFMSAPI:
         if event and event.first_code:
             return event.first_code
 
-        # Second, check if it is a new 2023 division event code
-        if event and event.year == 2023:
-            return Event.EVENT_SHORT_EXCEPTIONS_2023.get(
-                event_short, event_short
-            )
+        # Second, use the first_api_code if the event exists
+        if event and event.first_api_code:
+            return event.first_api_code
 
         # Otherwise, check hard-coded exceptions
         return Event.EVENT_SHORT_EXCEPTIONS.get(event_short, event_short)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_awards_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_awards_test.py
@@ -25,11 +25,12 @@ def fms_api_secrets(ndb_stub):
 
 @pytest.mark.parametrize("first_code, event_short", [("miket", None), (None, "miket")])
 def test_get_awards_event(first_code, event_short):
-    event = Mock(spec=Event)
-    event.event_type_enum = EventType.DISTRICT
-    event.first_code = first_code
-    event.event_short = event_short
-    event.year = 2020
+    event = Event(
+        event_type_enum=EventType.DISTRICT,
+        first_code=first_code,
+        event_short=event_short,
+        year=2020,
+    )
 
     response = Mock(spec=Response)
     response.status_code = 200
@@ -52,11 +53,12 @@ def test_get_awards_event(first_code, event_short):
 
 @pytest.mark.parametrize("first_code, event_short", [("galileo", None), (None, "gal")])
 def test_get_awards_event_cmp(first_code, event_short):
-    event = Mock(spec=Event)
-    event.event_type_enum = EventType.CMP_DIVISION
-    event.first_code = first_code
-    event.event_short = event_short
-    event.year = 2014
+    event = Event(
+        event_type_enum=EventType.CMP_DIVISION,
+        first_code=first_code,
+        event_short=event_short,
+        year=2014,
+    )
 
     response = Mock(spec=Response)
     response.status_code = 200

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -38,15 +38,34 @@ def test_init(ndb_stub):
     list(Event.EVENT_SHORT_EXCEPTIONS.items()) + [("miket", "miket")],
 )
 def test_get_event_short_event_first_code_none(event_code, expected):
-    event = Mock(spec=Event)
-    event.first_code = None
-    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected
+    event = Event(
+        year=2022,
+        event_short=event_code,
+    )
+    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected.upper()
+
+
+@pytest.mark.parametrize(
+    "event_code, expected",
+    list(Event.EVENT_SHORT_EXCEPTIONS_2023.items()),
+)
+def test_get_event_short_2023_event_first_code_none(event_code, expected):
+    event = Event(
+        year=2023,
+        event_short=event_code,
+    )
+    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected.upper()
 
 
 def test_get_event_short_event_first_code():
-    event = Mock(spec=Event)
-    event.first_code = "MIKET"
-    assert DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_code
+    event = Event(
+        year=2020,
+        event_short="2020miket",
+        first_code="MIKET",
+    )
+    assert (
+        DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_code.upper()
+    )
 
 
 def test_get_event_short_event_cmp():

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -40,13 +40,13 @@ def test_init(ndb_stub):
 def test_get_event_short_event_first_code_none(event_code, expected):
     event = Mock(spec=Event)
     event.first_code = None
-    assert DatafeedFMSAPI._get_event_short(event_code, event) == event.first_api_code
+    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected
 
 
 def test_get_event_short_event_first_code():
     event = Mock(spec=Event)
     event.first_code = "MIKET"
-    assert DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_api_code
+    assert DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_code
 
 
 def test_get_event_short_event_cmp():

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -40,17 +40,17 @@ def test_init(ndb_stub):
 def test_get_event_short_event_first_code_none(event_code, expected):
     event = Mock(spec=Event)
     event.first_code = None
-    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected
+    assert DatafeedFMSAPI._get_event_short(event_code, event) == event.first_api_code
 
 
 def test_get_event_short_event_first_code():
     event = Mock(spec=Event)
     event.first_code = "MIKET"
-    assert DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_code
+    assert DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_api_code
 
 
 def test_get_event_short_event_cmp():
-    assert DatafeedFMSAPI._get_event_short("arc", None) == "archimedes"
+    assert DatafeedFMSAPI._get_event_short("arc", None) == "arc"
 
 
 def test_get_root(fms_api_secrets):

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -35,7 +35,7 @@ def test_init(ndb_stub):
 
 @pytest.mark.parametrize(
     "event_code, expected",
-    list(DatafeedFMSAPI.EVENT_SHORT_EXCEPTIONS.items()) + [("miket", "miket")],
+    list(Event.EVENT_SHORT_EXCEPTIONS.items()) + [("miket", "miket")],
 )
 def test_get_event_short_event_first_code_none(event_code, expected):
     event = Mock(spec=Event)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -42,7 +42,7 @@ def test_get_event_short_event_first_code_none(event_code, expected):
         year=2022,
         event_short=event_code,
     )
-    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected.upper()
+    assert DatafeedFMSAPI._get_event_short(event.year, event_code, event) == expected
 
 
 @pytest.mark.parametrize(
@@ -54,26 +54,28 @@ def test_get_event_short_2023_event_first_code_none(event_code, expected):
         year=2023,
         event_short=event_code,
     )
-    assert DatafeedFMSAPI._get_event_short(event_code, event) == expected.upper()
+    assert DatafeedFMSAPI._get_event_short(event.year, event_code, event) == expected
 
 
 def test_get_event_short_event_first_code():
     event = Event(
         year=2020,
         event_short="miket",
-        first_code="MIKET",
+        first_code="miket",
     )
-    assert DatafeedFMSAPI._get_event_short("miket", event) == event.first_code.upper()
+    assert (
+        DatafeedFMSAPI._get_event_short(event.year, "miket", event) == event.first_code
+    )
 
 
 def test_get_event_short_event_cmp():
     event = Event(year=2022, event_short="arc")
-    assert DatafeedFMSAPI._get_event_short("arc", event) == "ARCHIMEDES"
+    assert DatafeedFMSAPI._get_event_short(event.year, "arc", event) == "archimedes"
 
 
 def test_get_event_short_event_cmp_2023():
     event = Event(year=2023, event_short="arc")
-    assert DatafeedFMSAPI._get_event_short("arc", event) == "ARPKY"
+    assert DatafeedFMSAPI._get_event_short(event.year, "arc", event) == "arpky"
 
 
 def test_get_root(fms_api_secrets):

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -60,16 +60,20 @@ def test_get_event_short_2023_event_first_code_none(event_code, expected):
 def test_get_event_short_event_first_code():
     event = Event(
         year=2020,
-        event_short="2020miket",
+        event_short="miket",
         first_code="MIKET",
     )
-    assert (
-        DatafeedFMSAPI._get_event_short("2020miket", event) == event.first_code.upper()
-    )
+    assert DatafeedFMSAPI._get_event_short("miket", event) == event.first_code.upper()
 
 
 def test_get_event_short_event_cmp():
-    assert DatafeedFMSAPI._get_event_short("arc", None) == "arc"
+    event = Event(year=2022, event_short="arc")
+    assert DatafeedFMSAPI._get_event_short("arc", event) == "ARCHIMEDES"
+
+
+def test_get_event_short_event_cmp_2023():
+    event = Event(year=2023, event_short="arc")
+    assert DatafeedFMSAPI._get_event_short("arc", event) == "ARPKY"
 
 
 def test_get_root(fms_api_secrets):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix firstinspires.org links for CMP divs.

## Motivation and Context
Closes #5181
In addition, I moved the `EVENT_SHORT_EXCEPTIONS` and `EVENT_SHORT_EXCEPTIONS_2023` into the `Event` model, as that seemed like a better location as the "source of truth", if you will.

I'd like to move/unify the `FMSAPIEventListParser.EVENT_CODE_EXCEPTIONS` into this as well, but that will likely be a different PR with more refactoring.

## How Has This Been Tested?
Locally, as well as additional testing.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1204591/232143579-72819fdc-96a3-4ef6-8711-e38ce9aaa3af.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
