### PR TITLE
Add supercharged node count

### DIFF
--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -57,6 +57,7 @@ MANUAL_COMPONENTS = {
     2023: {
         "Total Game Piece Count": lambda match, color: (
             match.score_breakdown[color].get("teleopGamePieceCount", 0)
+            + match.score_breakdown[color].get("extraGamePieceCount", 0)
         ),
         "Total Game Piece Points": lambda match, color: (
             match.score_breakdown[color].get("autoGamePiecePoints", 0)

--- a/src/backend/common/helpers/score_breakdown_keys.py
+++ b/src/backend/common/helpers/score_breakdown_keys.py
@@ -329,6 +329,7 @@ VALID_BREAKDOWNS: Dict[Year, Set[str]] = {
             "autoGamePiecePoints",
             "autoChargeStationPoints",
             "teleopGamePieceCount",
+            "extraGamePieceCount",
             "teleopPoints",
             "teleopGamePiecePoints",
             "endGameChargeStationPoints",

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -6928,6 +6928,9 @@
           "endGameParkPoints": {
             "type": "integer"
           },
+          "extraGamePieceCount": {
+            "type": "integer"
+          },
           "foulCount": {
             "type": "integer"
           },

--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2023.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2023.html
@@ -212,6 +212,17 @@
         </td>
     </tr>
     {% endif %}
+    {% if "extraGamePieceCount" in match.score_breakdown.red %}
+    <tr>
+      <td class="red" colspan="2">
+        {{match.score_breakdown.red.extraGamePieceCount}}
+      </td>
+      <td>Supercharged Node Count</td>
+      <td class="blue" colspan="2">
+        {{match.score_breakdown.blue.extraGamePieceCount}}
+      </td>
+    </tr>
+    {% endif %}
     <!-- Game Piece Points -->
     {% if "teleopGamePiecePoints" in match.score_breakdown.red %}
     <tr class="key">


### PR DESCRIPTION
`extraGamePieceCount` is separate from `teleopGamePieceCount` but `teleopGamePiecePoints` includes points for both

![image](https://user-images.githubusercontent.com/1421884/232937199-88766e1c-ff55-4b6d-a9ed-0697d3820a9c.png)
