### PR TITLE
Fix inverted techFoulCount tiebreaker for 2023

### DIFF
--- a/src/backend/common/helpers/match_tiebreakers.py
+++ b/src/backend/common/helpers/match_tiebreakers.py
@@ -84,7 +84,7 @@ class MatchTiebreakers(object):
         # Since tech foul points are not provided, we use the count instead.
         if "techFoulCount" in red_breakdown and "techFoulCount" in blue_breakdown:
             tiebreakers.append(
-                (red_breakdown["techFoulCount"], blue_breakdown["techFoulCount"])
+                (blue_breakdown["techFoulCount"], red_breakdown["techFoulCount"])
             )
         else:
             tiebreakers.append(None)

--- a/src/backend/common/helpers/tests/data/2023cmptx_sf12m1.json
+++ b/src/backend/common/helpers/tests/data/2023cmptx_sf12m1.json
@@ -1,0 +1,400 @@
+{
+  "actual_time": 1682200769,
+  "alliances": {
+    "blue": {
+      "dq_team_keys": [],
+      "score": 201,
+      "surrogate_team_keys": [],
+      "team_keys": [
+        "frc973",
+        "frc2075",
+        "frc9312"
+      ]
+    },
+    "red": {
+      "dq_team_keys": [],
+      "score": 201,
+      "surrogate_team_keys": [],
+      "team_keys": [
+        "frc125",
+        "frc5460",
+        "frc870"
+      ]
+    }
+  },
+  "comp_level": "sf",
+  "event_key": "2023cmptx",
+  "key": "2023cmptx_sf12m1",
+  "match_number": 1,
+  "post_result_time": 1682201011,
+  "predicted_time": 1682200802,
+  "score_breakdown": {
+    "blue": {
+      "activationBonusAchieved": false,
+      "adjustPoints": 0,
+      "autoBridgeState": "Level",
+      "autoChargeStationPoints": 12,
+      "autoChargeStationRobot1": "None",
+      "autoChargeStationRobot2": "None",
+      "autoChargeStationRobot3": "Docked",
+      "autoCommunity": {
+        "B": [
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "Cube",
+          "None",
+          "None"
+        ],
+        "M": [
+          "Cone",
+          "Cube",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None"
+        ],
+        "T": [
+          "None",
+          "None",
+          "None",
+          "Cone",
+          "None",
+          "None",
+          "None",
+          "Cube",
+          "Cone"
+        ]
+      },
+      "autoDocked": true,
+      "autoGamePieceCount": 6,
+      "autoGamePiecePoints": 29,
+      "autoMobilityPoints": 9,
+      "autoPoints": 50,
+      "coopGamePieceCount": 9,
+      "coopertitionCriteriaMet": false,
+      "endGameBridgeState": "Level",
+      "endGameChargeStationPoints": 20,
+      "endGameChargeStationRobot1": "Park",
+      "endGameChargeStationRobot2": "Docked",
+      "endGameChargeStationRobot3": "Docked",
+      "endGameParkPoints": 2,
+      "extraGamePieceCount": 4,
+      "foulCount": 1,
+      "foulPoints": 5,
+      "g405Penalty": false,
+      "h111Penalty": false,
+      "linkPoints": 45,
+      "links": [
+        {
+          "nodes": [
+            0,
+            1,
+            2
+          ],
+          "row": "Bottom"
+        },
+        {
+          "nodes": [
+            3,
+            4,
+            5
+          ],
+          "row": "Bottom"
+        },
+        {
+          "nodes": [
+            6,
+            7,
+            8
+          ],
+          "row": "Bottom"
+        },
+        {
+          "nodes": [
+            0,
+            1,
+            2
+          ],
+          "row": "Mid"
+        },
+        {
+          "nodes": [
+            3,
+            4,
+            5
+          ],
+          "row": "Mid"
+        },
+        {
+          "nodes": [
+            6,
+            7,
+            8
+          ],
+          "row": "Mid"
+        },
+        {
+          "nodes": [
+            0,
+            1,
+            2
+          ],
+          "row": "Top"
+        },
+        {
+          "nodes": [
+            3,
+            4,
+            5
+          ],
+          "row": "Top"
+        },
+        {
+          "nodes": [
+            6,
+            7,
+            8
+          ],
+          "row": "Top"
+        }
+      ],
+      "mobilityRobot1": "Yes",
+      "mobilityRobot2": "Yes",
+      "mobilityRobot3": "Yes",
+      "rp": 0,
+      "sustainabilityBonusAchieved": false,
+      "techFoulCount": 1,
+      "teleopCommunity": {
+        "B": [
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cube",
+          "Cone",
+          "Cube",
+          "Cube",
+          "Cube",
+          "Cube"
+        ],
+        "M": [
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone"
+        ],
+        "T": [
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone"
+        ]
+      },
+      "teleopGamePieceCount": 27,
+      "teleopGamePiecePoints": 79,
+      "teleopPoints": 101,
+      "totalChargeStationPoints": 32,
+      "totalPoints": 201
+    },
+    "red": {
+      "activationBonusAchieved": false,
+      "adjustPoints": 0,
+      "autoBridgeState": "Level",
+      "autoChargeStationPoints": 12,
+      "autoChargeStationRobot1": "Docked",
+      "autoChargeStationRobot2": "None",
+      "autoChargeStationRobot3": "None",
+      "autoCommunity": {
+        "B": [
+          "None",
+          "Cube",
+          "None",
+          "Cone",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None"
+        ],
+        "M": [
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None",
+          "None"
+        ],
+        "T": [
+          "Cone",
+          "None",
+          "None",
+          "None",
+          "Cube",
+          "None",
+          "None",
+          "Cube",
+          "Cone"
+        ]
+      },
+      "autoDocked": true,
+      "autoGamePieceCount": 6,
+      "autoGamePiecePoints": 27,
+      "autoMobilityPoints": 9,
+      "autoPoints": 48,
+      "coopGamePieceCount": 9,
+      "coopertitionCriteriaMet": false,
+      "endGameBridgeState": "Level",
+      "endGameChargeStationPoints": 30,
+      "endGameChargeStationRobot1": "Docked",
+      "endGameChargeStationRobot2": "Docked",
+      "endGameChargeStationRobot3": "Docked",
+      "endGameParkPoints": 0,
+      "extraGamePieceCount": 6,
+      "foulCount": 1,
+      "foulPoints": 17,
+      "g405Penalty": false,
+      "h111Penalty": false,
+      "linkPoints": 40,
+      "links": [
+        {
+          "nodes": [
+            2,
+            3,
+            4
+          ],
+          "row": "Bottom"
+        },
+        {
+          "nodes": [
+            5,
+            6,
+            7
+          ],
+          "row": "Bottom"
+        },
+        {
+          "nodes": [
+            0,
+            1,
+            2
+          ],
+          "row": "Mid"
+        },
+        {
+          "nodes": [
+            3,
+            4,
+            5
+          ],
+          "row": "Mid"
+        },
+        {
+          "nodes": [
+            6,
+            7,
+            8
+          ],
+          "row": "Mid"
+        },
+        {
+          "nodes": [
+            0,
+            1,
+            2
+          ],
+          "row": "Top"
+        },
+        {
+          "nodes": [
+            3,
+            4,
+            5
+          ],
+          "row": "Top"
+        },
+        {
+          "nodes": [
+            6,
+            7,
+            8
+          ],
+          "row": "Top"
+        }
+      ],
+      "mobilityRobot1": "Yes",
+      "mobilityRobot2": "Yes",
+      "mobilityRobot3": "Yes",
+      "rp": 0,
+      "sustainabilityBonusAchieved": false,
+      "techFoulCount": 0,
+      "teleopCommunity": {
+        "B": [
+          "Cube",
+          "None",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone"
+        ],
+        "M": [
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone"
+        ],
+        "T": [
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone",
+          "Cone",
+          "Cube",
+          "Cone"
+        ]
+      },
+      "teleopGamePieceCount": 26,
+      "teleopGamePiecePoints": 66,
+      "teleopPoints": 96,
+      "totalChargeStationPoints": 42,
+      "totalPoints": 201
+    }
+  },
+  "set_number": 12,
+  "time": 1682197500,
+  "videos": [
+    {
+      "key": "QVhS2DD6M6s",
+      "type": "youtube"
+    }
+  ],
+  "winning_alliance": "blue"
+}

--- a/src/backend/common/helpers/tests/match_tiebreaker_test.py
+++ b/src/backend/common/helpers/tests/match_tiebreaker_test.py
@@ -74,3 +74,9 @@ def test_2022_tiebreakers(test_data_importer) -> None:
     test_data_importer.import_match(__file__, "data/2022wasam_qf2m2.json")
     match: Match = none_throws(Match.get_by_id("2022wasam_qf2m2"))
     assert match.winning_alliance == AllianceColor.BLUE
+
+
+def test_2023_tiebreakers(test_data_importer) -> None:
+    test_data_importer.import_match(__file__, "data/2023cmptx_sf12m1.json")
+    match: Match = none_throws(Match.get_by_id("2023cmptx_sf12m1"))
+    assert match.winning_alliance == AllianceColor.RED


### PR DESCRIPTION
## Description
This should fix the logic used to determine the winner of 2023 matches where the "tech foul" tiebreaker was used.

## Motivation and Context
https://www.thebluealliance.com/match/2023cmptx_sf12m1 currently has the wrong winner assigned (blue, should be red) because the tiebreaker logic is awarding the win to the alliance with the larger `techFoulCount` (the number of tech fouls committed by the alliance, which award points to the opposing alliance).

This was probably overlooked when copying tiebreaker logic from 2022, where `foulPoints` (points earned from fouls committed by the opposing alliance) was the first tiebreaker.

Followup to #5005/#5007

## How Has This Been Tested?
Unit test added and appears to pass in CI.

I also verified that all existing ties broken by `techFoulCount` are showing the wrong winner on TBA (this was only the 4th "normal" match of the season affected!):

* [2023txfor_sf6m1](https://www.thebluealliance.com/match/2023txfor_sf6m1): indicated as a red win by TBA. Audience display is not visible in the video, but the bracket has blue advancing despite indicating a red win.
<details>

![image](https://user-images.githubusercontent.com/3719547/233819906-ea932b4b-5cfe-4b7a-bfa0-9eec6bffaf8e.png)

</details>

* [2023mose_sf3m1](https://www.thebluealliance.com/match/2023mose_sf3m1): indicated as a blue win by TBA. Audience display and bracket show red winning/advancing.
<details>

![image](https://user-images.githubusercontent.com/3719547/233819931-4bf388ef-a95f-469b-8f81-02565242292b.png)
![image](https://user-images.githubusercontent.com/3719547/233819967-47ecee55-eb97-4670-9ca3-9bfb9c96aba7.png)

</details>

* [2023ilpe_sf8m1](https://www.thebluealliance.com/match/2023ilpe_sf8m1): indicated as a red win by TBA. Audience display and bracket show blue winning/advancing.

<details>

![image](https://user-images.githubusercontent.com/3719547/233820077-8014b0a8-f5cc-4c51-81ec-a71b0d4b3977.png)
![image](https://user-images.githubusercontent.com/3719547/233820112-a98c024a-4b72-45e8-9683-f86831df00ab.png)

</details>

* [2023week0_f1m2](https://www.thebluealliance.com/match/2023week0_f1m2) would also have been affected, but is a finals match where tiebreakers are not used.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3719547/233818968-9ed80e0c-e43d-4b74-a221-4948ad31aa4f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
