### PR TITLE
Removes (Houston) from 2023 Champs to match 2022 Champs

### DIFF
--- a/src/backend/common/helpers/event_helper.py
+++ b/src/backend/common/helpers/event_helper.py
@@ -79,10 +79,7 @@ class EventHelper(object):
                 EventType.CMP_DIVISION,
                 EventType.CMP_FINALS,
             }:
-                if event.year == 2021:
-                    # 2021 had a remote CMP - so only a single CMP
-                    champs_label = CHAMPIONSHIP_EVENTS_LABEL
-                elif event.year >= 2017 and event.year != 2022:
+                if event.year >= 2017 and event.year <= 2020:
                     champs_label = TWO_CHAMPS_LABEL.format(event.city)
                 else:
                     champs_label = CHAMPIONSHIP_EVENTS_LABEL

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -88,8 +88,8 @@ class FMSAPIEventListParser(ParserJSON[Tuple[List[Event], List[District]]]):
         self.event_short = short
 
     def get_code_and_short_name(self, season, code):
-        # Even though 2022 Einstein is listed as "cmptx", we don't want it to say "(Houston)".
-        if season == 2022 and code == "cmptx":
+        # Even though 2022/2023 Einstein is listed as "cmptx", we don't want it to say "(Houston)".
+        if season >= 2022 and code == "cmptx":
             return (code, "{}")
         return self.EVENT_CODE_EXCEPTIONS[code]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is special logic to make the two champs names correct that applied for 2023 when I believe it should not have. This makes 2023 look the same way as 2022.

## Motivation and Context
Champs for 2023 is called `Einstein Field (Houston)` when last year it was called just `Einstein Field`.

## How Has This Been Tested?
I have only run the automated tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
