### PR TITLE
Update runtime to python 3.11

### DIFF
--- a/.github/workflows/comment_screenshots_on_pr.yml
+++ b/.github/workflows/comment_screenshots_on_pr.yml
@@ -13,10 +13,10 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -125,10 +125,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -153,10 +153,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
@@ -182,10 +182,10 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -130,10 +130,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip
         uses: actions/cache@v3.3.1
         with:
@@ -158,10 +158,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Set up Node
         uses: actions/setup-node@v3.6.0
         with:
@@ -197,10 +197,10 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/Setup/Repo-Setup.md
+++ b/docs/Setup/Repo-Setup.md
@@ -3,7 +3,7 @@ A small amount of repo configuration can be done in order to streamline developm
 ## Install Dependencies
 This optional tooling requires [Python 3](https://www.python.org/downloads/) and [`pip`](https://pip.pypa.io/en/stable/installing/) to install.
 
-1. Install [Python 3](https://www.python.org/downloads/) (3.10+)
+1. Install [Python 3](https://www.python.org/downloads/) (3.11+)
 2. Install [`pip`](https://pip.pypa.io/en/stable/installing/)
 3. *(optionally)* Install [watchman](https://facebook.github.io/watchman/)
 4. *(optionally)* Install [shfmt](https://github.com/mvdan/sh)

--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -15,13 +15,13 @@ RUN apt-get update && apt-get install -y \
     vim \
     openssh-server
 
-# Needed for Python 3.10
+# Needed for Python 3.11
 RUN apt-get install software-properties-common -y
 RUN add-apt-repository ppa:deadsnakes/ppa -y
 RUN apt-get update
 
 # Setup python environment
-ENV PYTHON_VERSION python3.10
+ENV PYTHON_VERSION python3.11
 RUN apt-get install -y \
     "$PYTHON_VERSION" \
     "$PYTHON_VERSION-venv" \

--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -89,7 +89,7 @@ fi
 
 # The CLI doesn't recognize python310 as a valid runtime yet
 # but it'll still happy run things using the underlying 3.10 binary
-runtime_version="python39"
+runtime_version="python311"
 
 set -x
 dev_appserver.py \

--- a/src/api.yaml
+++ b/src/api.yaml
@@ -1,5 +1,5 @@
 service: py3-api
-runtime: python310
+runtime: python311
 entrypoint: gunicorn -b :$PORT backend.api.main:app
 app_engine_apis: true
 

--- a/src/default.yaml
+++ b/src/default.yaml
@@ -1,4 +1,4 @@
-runtime: python310
+runtime: python311
 entrypoint: gunicorn -b :$PORT backend.default.main:app
 
 instance_class: F1

--- a/src/tasks_io.yaml
+++ b/src/tasks_io.yaml
@@ -1,5 +1,5 @@
 service: py3-tasks-io
-runtime: python310
+runtime: python311
 entrypoint: gunicorn -b :$PORT backend.tasks_io.main:app
 app_engine_apis: true
 

--- a/src/web.yaml
+++ b/src/web.yaml
@@ -1,5 +1,5 @@
 service: py3-web
-runtime: python310
+runtime: python311
 entrypoint: gunicorn -b :$PORT backend.web.main:app
 app_engine_apis: true
 


### PR DESCRIPTION
python3.11 is GA, as of Feb 27.

App Engine changelog: https://cloud.google.com/appengine/docs/standard/python3/release-notes#February_27_2023

python3.11 changelog: https://docs.python.org/3/whatsnew/3.11.html

Notably, marking individual `TypedDict` items as required or not ([PEP 655](https://docs.python.org/3/whatsnew/3.11.html#whatsnew311-pep655))