### PR TITLE
Corrects alliance names in brackets on Einstein/MSC

### DIFF
--- a/src/backend/web/templates/bracket_partials/double_elim_4_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_4_bracket_table.html
@@ -7,7 +7,7 @@
             {% if match.red_alliance and ('0' not in match.red_alliance) %}
             <tr>
                 {% if match.red_name %}
-                <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name[-1] }}</td>
+                <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name.replace("Alliance", "") }}</td>
                 {% endif %}
                 <td>
                     <span class="alliance-name {% if match.winning_alliance == 'red' %}winner{% endif %}">
@@ -30,7 +30,7 @@
             {% if match.blue_alliance and ('0' not in match.blue_alliance) %}
             <tr>
                 {% if match.blue_name %}
-                <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name[-1] }}</td>
+                <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name.replace("Alliance", "") }}</td>
                 {% endif %}
                 <td>
                     <span class="alliance-name {% if match.winning_alliance == 'blue' %}winner{% endif %}">

--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -7,7 +7,7 @@
           {% if match.red_alliance and ('0' not in match.red_alliance) %}
             <tr>
               {% if match.red_name %}
-                <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name[-1] }}</td>
+                <td class="{% if match.winning_alliance == 'red' %}winner{% endif %}">{{ match.red_name.replace("Alliance", "")[0:3] }}</td>
               {% endif %}
               <td>
                 <span class="alliance-name {% if match.winning_alliance == 'red' %}winner{% endif %}">
@@ -28,7 +28,7 @@
           {% if match.blue_alliance and ('0' not in match.blue_alliance) %}
             <tr>
               {% if match.blue_name %}
-                <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name[-1] }}</td>
+                <td class="{% if match.winning_alliance == 'blue' %}winner{% endif %}">{{ match.blue_name.replace("Alliance", "")[0:3] }}</td>
               {% endif %}
               <td>
                 <span class="alliance-name {% if match.winning_alliance == 'blue' %}winner{% endif %}">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Alliance names in the bracket in production currently show the last letter of the division name. This changes it to show the first 3 characters of the division name on Einstein, and the full name in Michigan.

There are definitely other ways to format this and I'm not tied to any format in particular!

Existing brackets at normal events are unchanged.

## Motivation and Context
The existing bracket looks confusing! There's weird letters instead of showing which alliance is what.
![Screen Shot 2023-04-23 at 6 19 23 PM](https://user-images.githubusercontent.com/11708940/233870220-df5f4a81-f5b7-4141-b2a9-73ba68230ec0.png)


## How Has This Been Tested?
I have ran this locally.

## Screenshots (if appropriate):
Einstein:
![Screen Shot 2023-04-23 at 6 33 40 PM](https://user-images.githubusercontent.com/11708940/233870242-28b5dadb-1dc6-4a1f-98ed-d14c0a426bba.png)

Michigan:
![Screen Shot 2023-04-23 at 6 35 56 PM](https://user-images.githubusercontent.com/11708940/233870249-1be234a0-cb22-40b7-b08e-e4c94f2189f6.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
