### PR TITLE
Makes Einstein bracket look better on mobile

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_double_elim_bracket_table.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_double_elim_bracket_table.less
@@ -20,7 +20,7 @@
   }
 
   .match {
-    min-width: 140px;
+    min-width: 160px;
   }
 
   .team-placeholder {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change makes Einstein look better on mobile. The three character codes instead of the one character alliance number makes the boxes overlap each other. This stretches out the boxes by 20 pixels. This slightly affects non-Einstein double-elim brackets as well, but not by much.

I'm not very familiar with frontend changes. There might be a better way to implement this. One option I can think of would be to keep the width the same for non-Einstein brackets, and change the width only for Einstein.

## Motivation and Context
The Einstein bracket does not look good on small mobile screens.

## How Has This Been Tested?
This has been run locally. It's only a cosmetic change.

## Screenshots (if appropriate):

These screenshots are on a standard-size (not XL) iPhone 13.


**Before:**

![IMG_3618](https://user-images.githubusercontent.com/11708940/234453239-0cac641f-b4d5-4388-a3fd-7d62ad213fa7.png)


**After:**

![IMG_3620](https://user-images.githubusercontent.com/11708940/234453252-6d3f5da7-e05b-422b-b42f-43baba21a6f9.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
