### PR TITLE
Bump google-api-core from 1.34.0 to 2.11.0 and protobuf from 3.20.2 to 4.22.3

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ Flask==2.3.2
 Flask-Caching==2.0.2
 Flask-Cors==3.0.10
 Flask-WTF==1.1.1
-google-api-core==1.34.0
+google-api-core==2.11.0
 google-api-python-client==2.86.0
 google-cloud-storage==2.8.0
 grpcio==1.54.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,7 +12,7 @@ Jinja2==3.1.2
 MarkupSafe==2.1.2
 numpy==1.24.3
 oauth2client==4.1.3
-protobuf==3.20.2
+protobuf==4.22.3
 pyre-extensions==0.0.30
 requests==2.29.0
 typing-extensions==4.5.0


### PR DESCRIPTION
Replaces #5210 and #5179