### PR TITLE
Port Basic Mobile API Registration Methods

### DIFF
--- a/ops/dev/pull-gae-logs.sh
+++ b/ops/dev/pull-gae-logs.sh
@@ -13,4 +13,4 @@ host=$(echo -e "${config}" | grep HostName | cut -d " " -f 4)
 port=$(echo -e "${config}" | grep Port | cut -d " " -f 4)
 keyfile=$(echo -e "${config}" | grep IdentityFile | cut -d " " -f 4)
 
-scp -v -P "$port" -i "$keyfile" -oStrictHostKeyChecking=no "root@$host:/var/log/tba.log" "/tmp/tba.log"
+scp -P "$port" -i "$keyfile" -oStrictHostKeyChecking=no "root@$host:/var/log/tba.log" "/tmp/tba.log"

--- a/ops/dev/pull-gae-logs.sh
+++ b/ops/dev/pull-gae-logs.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+if vagrant status default | grep -q 'running'; then
+    echo "Found running container to $1 datastore"
+else
+    echo "Vagrant container not running, skipping..."
+    exit 0
+fi
+
+config=$(vagrant ssh-config)
+
+host=$(echo -e "${config}" | grep HostName | cut -d " " -f 4)
+port=$(echo -e "${config}" | grep Port | cut -d " " -f 4)
+keyfile=$(echo -e "${config}" | grep IdentityFile | cut -d " " -f 4)
+
+scp -v -P "$port" -i "$keyfile" -oStrictHostKeyChecking=no "root@$host:/var/log/tba.log" "/tmp/tba.log"

--- a/ops/test_ops.sh
+++ b/ops/test_ops.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
 npm run testops
+ret=$?
+
+if [ -n "$CI" ]; then
+    ./ops/dev/pull-gae-logs.sh
+    cat /tmp/tba.log
+fi
+
+exit $ret

--- a/ops/tests/client_api_fullstack.test.js
+++ b/ops/tests/client_api_fullstack.test.js
@@ -1,0 +1,103 @@
+const fetch = require("node-fetch");
+
+async function postToAuthEmulator(endpoint, body) {
+  const url =
+    "http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:" +
+    endpoint +
+    "?key=testing_key";
+  return await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function postToClientAPI(endpoint, idToken, body) {
+  return await fetch(
+    "http://localhost:8080/clientapi/tbaClient/v9/" + endpoint,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + idToken,
+      },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+async function getIdToken() {
+  // When running against a local instance, the user might already exist
+  // So we can handle that case
+  const body = {
+    email: "integration_test@thebluealliance.com",
+    password: "this_is_only_a_test",
+  };
+  const registerResp = await postToAuthEmulator("signUp", body);
+
+  const registerRespBody = await registerResp.json();
+  if (
+    registerResp.status == 400 &&
+    registerRespBody.error.errors[0].message == "EMAIL_EXISTS"
+  ) {
+    const tokenResp = await postToAuthEmulator("signInWithPassword", body);
+    expect(tokenResp.status).toEqual(200);
+    return (await tokenResp.json()).idToken;
+  } else {
+    return registerRespBody.idToken;
+  }
+}
+
+describe("Mobile device registration", () => {
+  let idToken = null;
+  it("can fetch an auth token", async () => {
+    idToken = await getIdToken();
+  });
+
+  const device = {
+    name: "Test Device",
+    operating_system: "test",
+    mobile_id: "abc123",
+    device_uuid: "test",
+  };
+
+  it("should register successfully", async () => {
+    const regRes = await postToClientAPI("register", idToken, device);
+    expect(regRes.status).toEqual(200);
+    expect(await regRes.json()).toEqual({
+      code: 200,
+      message: "Registration successful",
+    });
+  });
+
+  it("should return the newly registered device", async () => {
+    const listRes = await postToClientAPI("list_clients", idToken, {});
+    expect(listRes.status).toEqual(200);
+    expect(await listRes.json()).toEqual({
+      code: 200,
+      message: "",
+      devices: [device],
+    });
+  });
+
+  it("should unregister successfully", async () => {
+    const unregReq = await postToClientAPI("unregister", idToken, device);
+    expect(unregReq.status).toEqual(200);
+    expect(await unregReq.json()).toEqual({
+      code: 200,
+      message: "User deleted",
+    });
+  });
+
+  it("should should no longer return the device", async () => {
+    const listRes = await postToClientAPI("list_clients", idToken, {});
+    expect(listRes.status).toEqual(200);
+    expect(await listRes.json()).toEqual({
+      code: 200,
+      message: "",
+      devices: [],
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8103,11 +8103,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
       }
     },
     "end-of-stream": {
@@ -9640,11 +9640,11 @@
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "icss-utils": {
@@ -10044,7 +10044,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
     },
     "is-string": {
       "version": "1.0.7",
@@ -10129,6 +10129,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "istanbul-lib-coverage": {
@@ -12392,12 +12403,11 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "whatwg-url": "^5.0.0"
       }
     },
     "node-int64": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "less": "4.1.3",
     "md5": "^2.3.0",
     "mini-css-extract-plugin": "^2.7.5",
+    "node-fetch": "^2.6.9",
     "process": "^0.11.10",
     "puppeteer": "^20.1.0",
     "style-loader": "^3.3.2",

--- a/src/backend/api/client_api_auth_helper.py
+++ b/src/backend/api/client_api_auth_helper.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from flask import request
+
+from backend.common.auth import verify_id_token
+from backend.common.models.user import User
+
+
+class ClientApiAuthHelper:
+    @staticmethod
+    def get_current_user() -> Optional[User]:
+        auth_header = request.headers.get("Authorization")
+        bearer_token_prefix = "Bearer "
+        if not auth_header or not auth_header.startswith(bearer_token_prefix):
+            return None
+
+        id_token = auth_header[len(bearer_token_prefix) :]
+        decoded_token = verify_id_token(id_token)
+        return User(decoded_token) if decoded_token is not None else None

--- a/src/backend/api/client_api_types.py
+++ b/src/backend/api/client_api_types.py
@@ -1,4 +1,8 @@
-from typing import TypedDict
+from typing import List, TypedDict
+
+
+class VoidRequest(TypedDict):
+    pass
 
 
 class BaseResponse(TypedDict):
@@ -14,3 +18,14 @@ class RegistrationRequest(_RegistrationRequestNotRequired):
     operating_system: str
     mobile_id: str
     device_uuid: str
+
+
+class RegisteredMobileClient(TypedDict):
+    name: str
+    operating_system: str
+    mobile_id: str
+    device_uuid: str
+
+
+class ListDevicesResponse(BaseResponse):
+    devices: List[RegisteredMobileClient]

--- a/src/backend/api/client_api_types.py
+++ b/src/backend/api/client_api_types.py
@@ -1,0 +1,16 @@
+from typing import TypedDict
+
+
+class BaseResponse(TypedDict):
+    code: int
+    message: str
+
+
+class _RegistrationRequestNotRequired(TypedDict, total=False):
+    name: str
+
+
+class RegistrationRequest(_RegistrationRequestNotRequired):
+    operating_system: str
+    mobile_id: str
+    device_uuid: str

--- a/src/backend/api/handlers/client_api.py
+++ b/src/backend/api/handlers/client_api.py
@@ -1,0 +1,71 @@
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+
+from backend.api.client_api_auth_helper import ClientApiAuthHelper
+from backend.api.client_api_types import BaseResponse, RegistrationRequest
+from backend.api.handlers.decorators import client_api_method
+from backend.common.consts.client_type import ENUMS as CLIENT_TYPE_MAP
+from backend.common.models.mobile_client import MobileClient
+
+
+@client_api_method(RegistrationRequest, BaseResponse)
+def register_mobile_client(req: RegistrationRequest) -> BaseResponse:
+    current_user = ClientApiAuthHelper.get_current_user()
+    if current_user is None:
+        return BaseResponse(code=401, message="Unauthorized to register")
+
+    # TODO should this be stringified?
+    account_key = none_throws(current_user.account_key)
+    user_id = str(account_key.id())
+
+    gcm_id = req["mobile_id"]
+    os = CLIENT_TYPE_MAP[req["operating_system"]]
+    name = req.get("name", "Unnamed Device")
+    uuid = req["device_uuid"]
+
+    query = MobileClient.query(
+        MobileClient.user_id == user_id,
+        MobileClient.device_uuid == uuid,
+        MobileClient.client_type == os,
+    )
+
+    # trying to figure out an elusive dupe bug
+    if query.count() == 0:
+        # Record doesn't exist yet, so add it
+        MobileClient(
+            parent=account_key,
+            user_id=user_id,
+            messaging_id=gcm_id,
+            client_type=os,
+            device_uuid=uuid,
+            display_name=name,
+        ).put()
+        return BaseResponse(code=200, message="Registration successful")
+    else:
+        # Record already exists, update it
+        client = query.fetch(1)[0]
+        client.messaging_id = gcm_id
+        client.display_name = name
+        client.put()
+        return BaseResponse(code=304, message="Client already exists")
+
+
+@client_api_method(RegistrationRequest, BaseResponse)
+def unregister_mobile_client(req: RegistrationRequest) -> BaseResponse:
+    current_user = ClientApiAuthHelper.get_current_user()
+    if current_user is None:
+        return BaseResponse(code=401, message="Unauthorized to unregister")
+
+    account_key = none_throws(current_user.account_key)
+
+    gcm_id = req["mobile_id"]
+    query = MobileClient.query(
+        MobileClient.messaging_id == gcm_id,
+        ancestor=account_key,
+    ).fetch(keys_only=True)
+    if len(query) == 0:
+        # Record doesn't exist, so we can't remove it
+        return BaseResponse(code=404, message="User doesn't exist. Can't remove it")
+    else:
+        ndb.delete_multi(query)
+        return BaseResponse(code=200, message="User deleted")

--- a/src/backend/api/handlers/tests/client_api_registration_test.py
+++ b/src/backend/api/handlers/tests/client_api_registration_test.py
@@ -1,7 +1,11 @@
 from pyre_extensions import none_throws
 from werkzeug.test import Client
 
-from backend.api.client_api_types import RegistrationRequest
+from backend.api.client_api_types import (
+    ListDevicesResponse,
+    RegisteredMobileClient,
+    RegistrationRequest,
+)
 from backend.api.handlers.tests.clientapi_test_helper import make_clientapi_request
 from backend.common.consts.client_type import ClientType
 from backend.common.models.mobile_client import MobileClient
@@ -74,6 +78,33 @@ def test_register_existing_client(
     assert client.client_type == ClientType.WEB
     assert client.device_uuid == "asdf"
     assert client.display_name == "Test Device"
+
+
+def test_list_clients_no_auth(api_client: Client) -> None:
+    resp = make_clientapi_request(api_client, "/list_clients", {}, ListDevicesResponse)
+    assert resp["code"] == 401
+
+
+def test_list_clients(api_client: Client, mock_clientapi_auth: User) -> None:
+    MobileClient(
+        parent=mock_clientapi_auth.account_key,
+        user_id=str(none_throws(mock_clientapi_auth.account_key).id()),
+        messaging_id="abc123",
+        client_type=ClientType.WEB,
+        device_uuid="asdf",
+        display_name="Test Device",
+    ).put()
+
+    resp = make_clientapi_request(api_client, "/list_clients", {}, ListDevicesResponse)
+    assert resp["code"] == 200
+    assert resp["devices"] == [
+        RegisteredMobileClient(
+            name="Test Device",
+            operating_system="web",
+            mobile_id="abc123",
+            device_uuid="asdf",
+        )
+    ]
 
 
 def test_unregister_no_auth(api_client: Client) -> None:

--- a/src/backend/api/handlers/tests/client_api_registration_test.py
+++ b/src/backend/api/handlers/tests/client_api_registration_test.py
@@ -1,0 +1,130 @@
+from pyre_extensions import none_throws
+from werkzeug.test import Client
+
+from backend.api.client_api_types import RegistrationRequest
+from backend.api.handlers.tests.clientapi_test_helper import make_clientapi_request
+from backend.common.consts.client_type import ClientType
+from backend.common.models.mobile_client import MobileClient
+from backend.common.models.user import User
+
+
+def test_register_no_auth(api_client: Client) -> None:
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/register", req)
+    assert resp["code"] == 401
+
+
+def test_register_new_client(api_client: Client, mock_clientapi_auth: User) -> None:
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/register", req)
+    assert resp["code"] == 200
+
+    user_clients = MobileClient.query(
+        MobileClient.user_id == str(none_throws(mock_clientapi_auth.account_key).id())
+    ).fetch()
+    assert len(user_clients) == 1
+
+    client = user_clients[0]
+    assert client.user_id == "1"
+    assert client.messaging_id == "abc123"
+    assert client.client_type == ClientType.WEB
+    assert client.device_uuid == "asdf"
+    assert client.display_name == "Test Device"
+
+
+def test_register_existing_client(
+    api_client: Client, mock_clientapi_auth: User
+) -> None:
+    MobileClient(
+        parent=mock_clientapi_auth.account_key,
+        user_id=str(none_throws(mock_clientapi_auth.account_key).id()),
+        messaging_id="abc123",
+        client_type=ClientType.WEB,
+        device_uuid="asdf",
+        display_name="Test Device",
+    ).put()
+
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/register", req)
+    assert resp["code"] == 304
+
+    user_clients = MobileClient.query(
+        MobileClient.user_id == str(none_throws(mock_clientapi_auth.account_key).id())
+    ).fetch()
+    assert len(user_clients) == 1
+
+    client = user_clients[0]
+    assert client.user_id == "1"
+    assert client.messaging_id == "abc123"
+    assert client.client_type == ClientType.WEB
+    assert client.device_uuid == "asdf"
+    assert client.display_name == "Test Device"
+
+
+def test_unregister_no_auth(api_client: Client) -> None:
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/unregister", req)
+    assert resp["code"] == 401
+
+
+def test_unregister_existing_client(
+    api_client: Client, mock_clientapi_auth: User
+) -> None:
+    MobileClient(
+        parent=mock_clientapi_auth.account_key,
+        user_id=str(none_throws(mock_clientapi_auth.account_key).id()),
+        messaging_id="abc123",
+        client_type=ClientType.WEB,
+        device_uuid="asdf",
+        display_name="Test Device",
+    ).put()
+
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/unregister", req)
+    assert resp["code"] == 200
+
+    user_clients = MobileClient.query(
+        MobileClient.user_id == str(none_throws(mock_clientapi_auth.account_key).id())
+    ).fetch()
+    assert len(user_clients) == 0
+
+
+def test_unregister_no_client(api_client: Client, mock_clientapi_auth: User) -> None:
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/unregister", req)
+    assert resp["code"] == 404
+
+    user_clients = MobileClient.query(
+        MobileClient.user_id == str(none_throws(mock_clientapi_auth.account_key).id())
+    ).fetch()
+    assert len(user_clients) == 0

--- a/src/backend/api/handlers/tests/clientapi_auth_test.py
+++ b/src/backend/api/handlers/tests/clientapi_auth_test.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from werkzeug.test import Client
+
+from backend.api.client_api_auth_helper import ClientApiAuthHelper
+from backend.common import auth
+
+
+def test_no_headers(api_client: Client) -> None:
+    with api_client.application.test_request_context(headers=None):  # pyre-ignore[16]
+        user = ClientApiAuthHelper.get_current_user()
+        assert user is None
+
+
+def test_malformed_header(api_client: Client) -> None:
+    with api_client.application.test_request_context(  # pyre-ignore[16]
+        headers={"Authorization": "badly_formatted"}
+    ):
+        user = ClientApiAuthHelper.get_current_user()
+        assert user is None
+
+
+def test_valid_header(api_client: Client) -> None:
+    with api_client.application.test_request_context(  # pyre-ignore[16]
+        headers={"Authorization": "Bearer abc123"}
+    ), patch.object(auth, "_verify_id_token") as mock_verify_id_token:
+        mock_verify_id_token.return_value = {}
+        user = ClientApiAuthHelper.get_current_user()
+        assert user is not None
+        assert user._session_claims == {}
+
+
+def test_invalid_header(api_client: Client) -> None:
+    with api_client.application.test_request_context(  # pyre-ignore[16]
+        headers={"Authorization": "Bearer abc123"}
+    ), patch.object(auth, "_verify_id_token") as mock_verify_id_token:
+        mock_verify_id_token.return_value = None
+        user = ClientApiAuthHelper.get_current_user()
+        assert user is None

--- a/src/backend/api/handlers/tests/clientapi_test_helper.py
+++ b/src/backend/api/handlers/tests/clientapi_test_helper.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Type, TypeVar
 
 from pyre_extensions import safe_json
 from werkzeug.test import Client
@@ -7,8 +7,13 @@ from werkzeug.test import Client
 from backend.api.client_api_types import BaseResponse
 
 
-def make_clientapi_request(api_client: Client, endpoint: str, req: Any) -> BaseResponse:
+T = TypeVar("T", bound=BaseResponse)
+
+
+def make_clientapi_request(
+    api_client: Client, endpoint: str, req: Any, resp_type: Type[T] = BaseResponse
+) -> T:
     req_body = json.dumps(req)
     resp = api_client.post("/clientapi/tbaClient/v9" + endpoint, data=req_body)
     assert resp.status_code == 200
-    return safe_json.loads(resp.data, BaseResponse)
+    return safe_json.loads(resp.data, resp_type)

--- a/src/backend/api/handlers/tests/clientapi_test_helper.py
+++ b/src/backend/api/handlers/tests/clientapi_test_helper.py
@@ -1,0 +1,14 @@
+import json
+from typing import Any
+
+from pyre_extensions import safe_json
+from werkzeug.test import Client
+
+from backend.api.client_api_types import BaseResponse
+
+
+def make_clientapi_request(api_client: Client, endpoint: str, req: Any) -> BaseResponse:
+    req_body = json.dumps(req)
+    resp = api_client.post("/clientapi/tbaClient/v9" + endpoint, data=req_body)
+    assert resp.status_code == 200
+    return safe_json.loads(resp.data, BaseResponse)

--- a/src/backend/api/handlers/tests/conftest.py
+++ b/src/backend/api/handlers/tests/conftest.py
@@ -1,5 +1,11 @@
+from unittest.mock import Mock
+
 import pytest
 from werkzeug.test import Client
+
+from backend.api.client_api_auth_helper import ClientApiAuthHelper
+from backend.common.models.account import Account
+from backend.common.models.user import User
 
 
 @pytest.fixture
@@ -7,3 +13,28 @@ def api_client(gae_testbed, ndb_stub, memcache_stub, taskqueue_stub) -> Client:
     from backend.api.main import app
 
     return app.test_client()
+
+
+@pytest.fixture
+def mock_clientapi_auth(ndb_stub, monkeypatch: pytest.MonkeyPatch) -> User:
+    account = Account(
+        email="test@tba.com",
+        registered=True,
+    )
+    account_key = account.put()
+
+    mock_user = Mock(spec=User)
+    mock_user.is_registered = True
+    mock_user.is_admin = False
+    mock_user.api_read_keys = []
+    mock_user.api_write_keys = []
+    mock_user.mobile_clients = []
+    mock_user.permissions = []
+    mock_user.account_key = account_key
+    mock_user.uid = account_key.id()
+
+    def mock_current_user():
+        return mock_user
+
+    monkeypatch.setattr(ClientApiAuthHelper, "get_current_user", mock_current_user)
+    return mock_user

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -5,6 +5,10 @@ from flask_cors import CORS
 from google.appengine.api import wrap_wsgi_app
 from werkzeug.routing import BaseConverter
 
+from backend.api.handlers.client_api import (
+    register_mobile_client,
+    unregister_mobile_client,
+)
 from backend.api.handlers.district import (
     district_events,
     district_list_year,
@@ -327,6 +331,27 @@ def handle_bad_input(e: Exception) -> Response:
     return make_response(profiled_jsonify({"Error": f"{e}"}), 400)
 
 
+# This is a port of the cloud endpoints API service, used by mobile apps
+client_api = Blueprint("client_api", __name__, url_prefix="/clientapi/tbaClient/v9/")
+CORS(
+    client_api,
+    origins="*",
+    methods=["OPTIONS", "POST"],
+    allow_headers=["Content-Type", "Authorization"],
+)
+client_api.add_url_rule(
+    "/register",
+    methods=["POST"],
+    view_func=register_mobile_client,
+)
+client_api.add_url_rule(
+    "/unregister",
+    methods=["POST"],
+    view_func=unregister_mobile_client,
+)
+
+
 app.register_blueprint(api_v3)
 app.register_blueprint(trusted_api)
+app.register_blueprint(client_api)
 app.register_error_handler(404, handle_404)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -6,6 +6,7 @@ from google.appengine.api import wrap_wsgi_app
 from werkzeug.routing import BaseConverter
 
 from backend.api.handlers.client_api import (
+    list_mobile_clients,
     register_mobile_client,
     unregister_mobile_client,
 )
@@ -343,6 +344,11 @@ client_api.add_url_rule(
     "/register",
     methods=["POST"],
     view_func=register_mobile_client,
+)
+client_api.add_url_rule(
+    "/list_clients",
+    methods=["POST"],
+    view_func=list_mobile_clients,
 )
 client_api.add_url_rule(
     "/unregister",

--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import Any, Dict, Optional
 
 from firebase_admin import auth
@@ -13,6 +14,18 @@ _SESSION_KEY = "session"
 
 
 # Code from https://firebase.google.com/docs/auth/admin/manage-cookies
+
+
+def _verify_id_token(id_token: str) -> Optional[dict]:
+    try:
+        return auth.verify_id_token(id_token, check_revoked=True, app=app())
+    except (exceptions.DefaultCredentialsError, auth.ExpiredIdTokenError):
+        logging.warning("Error validing clientapi token", exc_info=True)
+        return None
+
+
+def verify_id_token(id_token: str) -> Optional[dict]:
+    return _verify_id_token(id_token)
 
 
 def create_session_cookie(id_token: str, expires_in: datetime.timedelta) -> None:

--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -11,6 +11,7 @@ class ClientType(enum.IntEnum):
     OS_IOS = 1
     WEBHOOK = 2
     WEB = 3
+    TEST = 4
 
 
 FCM_CLIENTS: Set[ClientType] = {
@@ -28,6 +29,7 @@ NAMES: Dict[ClientType, str] = {
     ClientType.OS_IOS: "iOS",
     ClientType.WEBHOOK: "Webhook",
     ClientType.WEB: "Web",
+    ClientType.TEST: "Test",
 }
 
 ENUMS: Dict[str, ClientType] = {
@@ -35,4 +37,5 @@ ENUMS: Dict[str, ClientType] = {
     "ios": ClientType.OS_IOS,
     "webhook": ClientType.WEBHOOK,
     "web": ClientType.WEB,
+    "test": ClientType.TEST,
 }

--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -29,3 +29,10 @@ NAMES: Dict[ClientType, str] = {
     ClientType.WEBHOOK: "Webhook",
     ClientType.WEB: "Web",
 }
+
+ENUMS: Dict[str, ClientType] = {
+    "android": ClientType.OS_ANDROID,
+    "ios": ClientType.OS_IOS,
+    "webhook": ClientType.WEBHOOK,
+    "web": ClientType.WEB,
+}

--- a/src/backend/common/firebase.py
+++ b/src/backend/common/firebase.py
@@ -1,8 +1,11 @@
 import firebase_admin
 
+from backend.common.environment import Environment
+
 
 def app() -> firebase_admin.App:
     try:
         return firebase_admin.get_app()
     except Exception:
-        return firebase_admin.initialize_app()
+        project = Environment.project()
+        return firebase_admin.initialize_app(options={"projectId": project})

--- a/src/backend/common/tests/auth_test.py
+++ b/src/backend/common/tests/auth_test.py
@@ -11,8 +11,25 @@ from backend.common.auth import (
     create_session_cookie,
     current_user,
     revoke_session_cookie,
+    verify_id_token,
 )
 from backend.common.models.user import User
+
+
+def test_validate_id_token() -> None:
+    with patch.object(auth, "verify_id_token") as mock_verify_id_token:
+        mock_verify_id_token.return_value = {}
+        decoded_token = verify_id_token("abc123")
+        assert decoded_token == {}
+
+
+def test_expired_id_token() -> None:
+    with patch.object(auth, "verify_id_token") as mock_verify_id_token:
+        mock_verify_id_token.side_effect = auth.ExpiredIdTokenError(
+            "expired token", None
+        )
+        decoded_token = verify_id_token("abc123")
+        assert decoded_token is None
 
 
 def test_create_session_cookie(secret_app: Flask) -> None:

--- a/src/dispatch.yaml
+++ b/src/dispatch.yaml
@@ -1,6 +1,9 @@
 dispatch:
   - url: "*/api/*"
     service: py3-api
+  
+  - url: "*/clientapi/*"
+    service: py3-api
 
   - url: "*/tasks/*"
     service: py3-tasks-io


### PR DESCRIPTION
Okay I think this is essentially what we'll need.

If I grab a id_token for my user, and put it over curl, then I can successfully register a client

```
[phil@fedora-x1think the-blue-alliance-py3]$ curl -H "Authorization: Bearer <snip>" -H "Content-Type: application/json" --data '{"name": "test device", "operating_system": "android", "mobile_id": "abc123", "device_uuid": "test"}' http://localhost:8080/clientapi/tbaClient/v9/register

{"code":200,"message":"Registration successful"}
```

![image](https://user-images.githubusercontent.com/2754863/235564564-46c60718-d422-4d6a-bd52-32fc0faeff9b.png)


This is how we get tokens in the android app, so I think this should be good:

https://github.com/the-blue-alliance/the-blue-alliance-android/blob/4313501d57594089ff01de2705bdc544a3d19eb9/android/src/main/java/com/thebluealliance/androidclient/auth/firebase/FirebaseAuthProvider.java#L64-L76


This PR also adds a fullstack test to verify that the endpoints work end-to-end. Highlights:
 - the test container will run using the auth emulator
 - [This API](https://github.com/firebase/firebase-admin-python/blob/f0865f7493a2c642d2e551efdf19da1e53c1a8c3/firebase_admin/__init__.py#L258-L261) can throw a `SessionNotFoundException`, so we need to specifically plumb through the project ID using thje environment variables we set at startup (the value will be [`demo-test`](https://github.com/the-blue-alliance/the-blue-alliance/blob/504b2de197ebb9cee3a570808e3ff535f0cf9578/ops/dev/vagrant/dev_appserver.sh#L27-L29))
 - The test use the firebase auth [REST API](https://firebase.google.com/docs/reference/rest/auth) to create a user on the emulator, and log in with its credentials to get an id token, which we can then pass in the `Authorization` header
 - Also pull the GAE `dev_appserver` logs off the container and print them into the github actions logfile, for easier debugging