### PR TITLE
Fix Tiebreaker Match Generation For Double Elim Events

### DIFF
--- a/src/backend/common/models/match.py
+++ b/src/backend/common/models/match.py
@@ -338,18 +338,26 @@ class Match(CachedModel):
 
         event = self.event.get()
         if (
-            self.comp_level != "qm"
+            self.comp_level != CompLevel.QM
             and event
             and event.playoff_type == PlayoffType.DOUBLE_ELIM_8_TEAM
         ):
-            if self.comp_level == "f":
+            if self.comp_level == CompLevel.F:
                 return f"Finals {self.match_number}"
+
+            # hard-code the match number to 1 for non-finals,
+            # so we can render this correctly for replays
             match_num = DOUBLE_ELIM_MAPPING_INVERSE.get(
-                (self.comp_level, self.set_number, self.match_number)
+                (self.comp_level, self.set_number, 1)
             )
             if match_num is None:
                 match_num = "?"
-            return f"Match {match_num}"
+
+            replay_suffix = ""
+            if self.match_number > 1:
+                replay_suffix = f" (Play {self.match_number})"
+            return f"Match {match_num}{replay_suffix}"
+
         elif (
             self.comp_level != "qm"
             and event

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -9,6 +9,7 @@ from pyre_extensions import none_throws
 from backend.common.consts.alliance_color import ALLIANCE_COLORS, AllianceColor
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.media_type import MediaType
+from backend.common.consts.playoff_type import DOUBLE_ELIM_TYPES
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.playoff_advancement_helper import PlayoffAdvancementHelper
 from backend.common.helpers.playoff_type_helper import PlayoffTypeHelper
@@ -238,8 +239,15 @@ class FMSAPIHybridScheduleParser(
                     if match_key.startswith("{}{}".format(comp_level, set_number)):
                         match_count += 1
 
-                # Sanity check: Tiebreakers must be played after at least 3 matches if not finals
-                if match_count < 3 and comp_level != "f":
+                # Sanity check:
+                # In a classic bracket, tiebreakers must be played after at least 3 matches
+                # if not finals
+                # But in a double elim bracket, we can play them immediately
+                if (
+                    event.playoff_type not in DOUBLE_ELIM_TYPES
+                    and match_count < 3
+                    and comp_level != CompLevel.F
+                ):
                     logging.warning(
                         "Match supposedly tied, but existing count is {}! Skipping match.".format(
                             match_count


### PR DESCRIPTION
Reported because https://www.thebluealliance.com/match/2023ncash_sf12m1 shows the tie, but we never got the next match imported.

The bug was from an assumption about best-of-three, where we'd only replay third+ matches.

Added test coverage for the double elim case