### PR TITLE
fail pytest on warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,13 +2,15 @@
 markers =
     no_auto_ndb_context
 filterwarnings =
-    ignore::DeprecationWarning:flask_caching
-    ignore::DeprecationWarning:google.appengine
-    ignore::DeprecationWarning:google.api
-    ignore::DeprecationWarning:google.cloud
-    ignore::DeprecationWarning:google.iam
-    ignore::DeprecationWarning:google.rpc
-    ignore::DeprecationWarning:google.type
+    error
+
+    ignore::DeprecationWarning:dateutil
+    ignore::DeprecationWarning:flask*
+    ignore::DeprecationWarning:google*
     ignore::DeprecationWarning:urllib3
+    ignore:Deprecated call to `pkg_resources.declare_namespace\('google'\)
+    ignore:'cgi' is deprecated
+
+    ignore::PendingDeprecationWarning:google*
 
     ignore::UserWarning:flask_caching

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -95,7 +95,7 @@ install_middleware(app)
 install_url_converters(app)
 configure_flask_cache(app)
 
-app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True
+app.json.compact = False  # pyre-ignore[16]
 app.url_map.converters["simple_model_type"] = SimpleModelTypeConverter
 app.url_map.converters["model_type"] = ModelTypeConverter
 app.url_map.converters["event_detail_type"] = EventDetailTypeConverter

--- a/src/backend/common/environment/environment.py
+++ b/src/backend/common/environment/environment.py
@@ -1,7 +1,6 @@
 import enum
 import os
 import tempfile
-from distutils.util import strtobool
 from pathlib import Path
 from typing import Optional
 
@@ -15,6 +14,12 @@ class EnvironmentMode(enum.Enum):
 # Mostly GAE env variables
 # See https://cloud.google.com/appengine/docs/standard/python3/runtime#environment_variables
 class Environment:
+    @staticmethod
+    def _strtobool(value: str) -> bool:
+        if not value:
+            return False
+        return str(value).lower() in ("y", "yes", "t", "true", "on", "1")
+
     @staticmethod
     def is_unit_test() -> bool:
         return os.environ.get("TBA_UNIT_TEST") == "true"
@@ -44,13 +49,17 @@ class Environment:
     def ndb_log_level() -> Optional[str]:
         return os.environ.get("NDB_LOG_LEVEL")
 
-    @staticmethod
-    def flask_response_cache_enabled() -> bool:
-        return bool(strtobool(os.environ.get("FLASK_RESPONSE_CACHE_ENABLED", "true")))
+    @classmethod
+    def flask_response_cache_enabled(cls) -> bool:
+        return bool(
+            cls._strtobool(os.environ.get("FLASK_RESPONSE_CACHE_ENABLED", "true"))
+        )
 
-    @staticmethod
-    def cache_control_header_enabled() -> bool:
-        return bool(strtobool(os.environ.get("CACHE_CONTROL_HEADER_ENABLED", "true")))
+    @classmethod
+    def cache_control_header_enabled(cls) -> bool:
+        return bool(
+            cls._strtobool(os.environ.get("CACHE_CONTROL_HEADER_ENABLED", "true"))
+        )
 
     @staticmethod
     def storage_mode() -> EnvironmentMode:

--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -411,7 +411,9 @@ class TBANSHelper:
         # Cancel any previously-scheduled `match_upcoming` notifications for this match
         queue.delete_tasks(taskqueue.Task(name=task_name))
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc).replace(  # pyre-ignore[16]
+            tzinfo=None
+        )
         # If we know when our match is starting, schedule to send Xmins before start of match.
         # Otherwise, send immediately.
         if match.time is None or match.time + MATCH_UPCOMING_MINUTES <= now:

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -1,6 +1,6 @@
-import datetime
 import json
 import unittest
+from datetime import datetime, timedelta, timezone
 
 import mock
 import pytest
@@ -883,7 +883,9 @@ class TestTBANSHelper(unittest.TestCase):
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 0
 
-        self.match.time = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        self.match.time = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+            hours=1
+        )
         # Make sure after calling our schedule_upcoming_match we defer the task
         TBANSHelper.schedule_upcoming_match(self.match)
 
@@ -900,7 +902,9 @@ class TestTBANSHelper(unittest.TestCase):
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 0
 
-        self.match.time = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        self.match.time = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+            hours=1
+        )
         # Make sure after calling our schedule_upcoming_match we defer the task
         TBANSHelper.schedule_upcoming_match(self.match, "user_id")
 

--- a/src/backend/common/middleware.py
+++ b/src/backend/common/middleware.py
@@ -7,7 +7,7 @@ from werkzeug.wsgi import ClosingIterator
 
 from backend.common.environment import Environment
 from backend.common.profiler import send_traces, Span, trace_context
-from backend.common.run_after_response import execute_callbacks, local_context
+from backend.common.run_after_response import execute_callbacks
 
 
 class TraceRequestMiddleware:
@@ -37,7 +37,6 @@ class AfterResponseMiddleware:
 
     @ndb.toplevel
     def __call__(self, environ: Any, start_response: Any):
-        local_context.request = Request(environ)
         return ClosingIterator(self.app(environ, start_response), self._run_after)
 
     def _run_after(self):

--- a/src/backend/common/run_after_response.py
+++ b/src/backend/common/run_after_response.py
@@ -1,10 +1,7 @@
 import logging
 from typing import Callable
 
-from werkzeug.local import Local
-
-
-local_context = Local()
+from flask import g
 
 
 def run_after_response(callback: Callable[[], None]) -> None:
@@ -22,16 +19,16 @@ def run_after_response(callback: Callable[[], None]) -> None:
     def function_to_run():
         ...
     """
-    if not hasattr(local_context.request, "callbacks"):
-        local_context.request.callbacks = []
-    local_context.request.callbacks.append(callback)
+    if "after_response_callbacks" not in g:
+        g.after_response_callbacks = []
+    g.after_response_callbacks.append(callback)
 
 
 def execute_callbacks() -> None:
-    if not hasattr(local_context.request, "callbacks"):
+    if not g or "after_response_callbacks" not in g:
         return
 
-    for callback in local_context.request.callbacks:
+    for callback in g.after_response_callbacks:
         logging.info(
             f"Running callback after response: {callback.__name__ if hasattr(callback, '__name__') else None}"
         )

--- a/src/backend/common/tests/fixture_loader.py
+++ b/src/backend/common/tests/fixture_loader.py
@@ -110,7 +110,8 @@ def load_fixture(filename, kind, post_processor=None):
 
         return loaded
 
-    tree = json.load(open(filename))
+    with open(filename) as f:
+        tree = json.load(f)
 
     loaded = []
 

--- a/src/backend/common/tests/google_analytics_test.py
+++ b/src/backend/common/tests/google_analytics_test.py
@@ -1,7 +1,9 @@
 import itertools
+from typing import Generator
 from unittest.mock import patch
 
 import pytest
+from flask import Flask
 
 from backend.common.google_analytics import GoogleAnalytics
 from backend.common.run_after_response import execute_callbacks
@@ -10,6 +12,12 @@ from backend.common.run_after_response import execute_callbacks
 @pytest.fixture(autouse=True)
 def auto_add_ndb_stub(ndb_stub) -> None:
     pass
+
+
+@pytest.fixture(autouse=True)
+def run_with_werkzeug_context(app: Flask) -> Generator:
+    with app.test_request_context("/"):
+        yield
 
 
 def test_GoogleAnalytics_track_event_missing_sitevar() -> None:

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -1,9 +1,10 @@
+from concurrent import futures
 from typing import Generator
 
 import pytest
 from freezegun import api as freezegun_api
+from google.appengine.api import apiproxy_rpc
 from google.appengine.api import datastore_types
-from google.appengine.api.apiproxy_rpc import _THREAD_POOL
 from google.appengine.ext import ndb, testbed
 
 from backend.common.context_cache import context_cache
@@ -11,14 +12,21 @@ from backend.common.models.cached_query_result import CachedQueryResult
 from backend.tests.json_data_importer import JsonDataImporter
 
 
-@pytest.fixture(autouse=True, scope="session")
-def drain_gae_rpc_thread_pool() -> Generator:
+@pytest.fixture(autouse=True)
+def drain_gae_rpc_thread_pool(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Generator:
+    max_concurrent = apiproxy_rpc._MAX_CONCURRENT_API_CALLS  # pyre-ignore[16]
+    thread_pool = futures.ThreadPoolExecutor(
+        max_concurrent, thread_name_prefix=f"ApiProxyThreadPool:{request.node.name}"
+    )
+    monkeypatch.setattr(apiproxy_rpc, "_THREAD_POOL", thread_pool)
     yield
 
     # This thread pool can leave work dangling after the test session
     # is done, which can cause pytest to hang.
     # So we add this fixture to manually shut it down
-    _THREAD_POOL.shutdown()
+    thread_pool.shutdown()
 
 
 @pytest.fixture(autouse=True)

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -228,7 +228,7 @@ class FMSAPIHybridScheduleParser(
                 and existing_match.actual_time != actual_time
                 and not self.is_blank_match(existing_match)
             ):
-                logging.warning("Match {} is tied!".format(existing_match.key.id()))
+                logging.info("Match {} is tied!".format(existing_match.key.id()))
 
                 # TODO: Only query within set if set_number ever gets indexed
                 match_count = 0
@@ -266,7 +266,7 @@ class FMSAPIHybridScheduleParser(
                 existing_match.tiebreak_match_key = ndb.Key(Match, key_name)
                 parsed_matches.append(existing_match)
 
-                logging.warning("Creating new match: {}".format(key_name))
+                logging.info("Creating new match: {}".format(key_name))
             elif existing_match:
                 remapped_matches[key_name] = existing_match.key.id()
                 key_name = existing_match.key.id()

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/test_fms_api_match_tiebreaker.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/test_fms_api_match_tiebreaker.py
@@ -20,6 +20,9 @@ from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
 from backend.common.storage.clients.gcloud_client import GCloudStorageClient
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
+# these are coming from within the NDB library
+pytestmark = pytest.mark.filterwarnings("ignore::ResourceWarning")
+
 
 @pytest.fixture(autouse=True)
 def fms_api_secrets(ndb_stub) -> None:

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
@@ -11,6 +11,7 @@ from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_match_parser import (
     FMSAPIHybridScheduleParser,
+    FMSAPIMatchDetailsParser,
 )
 from backend.tasks_io.datafeeds.parsers.fms_api.simple_json_parser import (
     FMSAPISimpleJsonParser,
@@ -33,18 +34,26 @@ def test_get_event_matches() -> None:
     ) as mock_schedule_api, patch.object(
         FRCAPI, "matches", return_value=response
     ) as mock_matches_api, patch.object(
+        FRCAPI, "match_scores", return_value=response
+    ) as mock_match_scores_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
     ) as mock_schedule_parse, patch.object(
+        FMSAPIMatchDetailsParser, "parse"
+    ) as mock_match_detail_parser, patch.object(
         FMSAPISimpleJsonParser, "parse"
     ) as mock_json_parse:
         mock_schedule_parse.side_effect = ([], [])
         mock_json_parse.return_value = {"Schedule": [], "Matches": []}
+        mock_match_detail_parser.return_value = {}
         df.get_event_matches("2020miket")
 
     mock_schedule_api.assert_has_calls(
         [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
     )
     mock_matches_api.assert_has_calls(
+        [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
+    )
+    mock_match_scores_api.assert_has_calls(
         [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
     )
     mock_schedule_parse.assert_has_calls(
@@ -63,18 +72,26 @@ def test_get_event_matches_cmp() -> None:
     ) as mock_schedule_api, patch.object(
         FRCAPI, "matches", return_value=response
     ) as mock_matches_api, patch.object(
+        FRCAPI, "match_scores", return_value=response
+    ) as mock_match_scores_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
     ) as mock_schedule_parse, patch.object(
+        FMSAPIMatchDetailsParser, "parse"
+    ) as mock_match_detail_parser, patch.object(
         FMSAPISimpleJsonParser, "parse"
     ) as mock_json_parse:
         mock_schedule_parse.side_effect = ([], [])
         mock_json_parse.return_value = {"Schedule": [], "Matches": []}
+        mock_match_detail_parser.return_value = {}
         df.get_event_matches("2014gal")
 
     mock_schedule_api.assert_has_calls(
         [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
     )
     mock_matches_api.assert_has_calls(
+        [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
+    )
+    mock_match_scores_api.assert_has_calls(
         [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
     )
     mock_schedule_parse.assert_has_calls(

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_details_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_details_test.py
@@ -82,9 +82,16 @@ def test_get_bad_key(tasks_client: Client) -> None:
     assert resp.status_code == 400
 
 
+@mock.patch.object(DatafeedFMSAPI, "get_event_team_avatars")
+@mock.patch.object(DatafeedFMSAPI, "get_event_teams")
 @mock.patch.object(DatafeedFMSAPI, "get_event_details")
-def test_get_event_details(event_mock, tasks_client: Client) -> None:
+def test_get_event_details(
+    event_mock, teams_mock, avatars_mock, tasks_client: Client
+) -> None:
     event_mock.return_value = ([create_event()], [create_district()])
+    teams_mock.return_value = []
+    avatars_mock.return_value = ([], [])
+
     resp = tasks_client.get("/backend-tasks/get/event_details/2019casj")
     assert resp.status_code == 200
     assert len(resp.data) > 0
@@ -126,12 +133,14 @@ def test_get_event_details_writes_teams(
 
 
 @mock.patch.object(SeasonHelper, "get_max_year", return_value=2019)
+@mock.patch.object(DatafeedFMSAPI, "get_event_team_avatars")
 @mock.patch.object(DatafeedFMSAPI, "get_event_teams")
 @mock.patch.object(DatafeedFMSAPI, "get_event_details")
 def test_get_event_details_clears_eventteams(
-    event_mock, teams_mock, max_year_mock, tasks_client: Client
+    event_mock, teams_mock, avatars_mock, max_year_mock, tasks_client: Client
 ) -> None:
     event_mock.return_value = ([create_event()], [create_district()])
+    avatars_mock.return_value = ([], [])
     teams_mock.return_value = [
         (
             Team(id="frc254", team_number=254),
@@ -205,11 +214,16 @@ def test_get_event_details_skip_eventteams(
     assert tasks[0].url == "/tasks/math/do/eventteam_update/2019casj?allow_deletes=True"
 
 
+@mock.patch.object(DatafeedFMSAPI, "get_event_team_avatars")
+@mock.patch.object(DatafeedFMSAPI, "get_event_teams")
 @mock.patch.object(DatafeedFMSAPI, "get_event_details")
 def test_get_event_details_no_output_in_taskqueue(
-    event_mock, tasks_client: Client
+    event_mock, teams_mock, avatars_mock, tasks_client: Client
 ) -> None:
     event_mock.return_value = ([create_event()], [])
+    teams_mock.return_value = []
+    avatars_mock.return_value = ([], [])
+
     resp = tasks_client.get(
         "/backend-tasks/get/event_details/2019casj",
         headers={"X-Appengine-Taskname": "test"},

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_list_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_list_test.py
@@ -80,20 +80,26 @@ def test_get_bad_year(tasks_client: Client) -> None:
     assert resp.status_code == 404
 
 
+@mock.patch.object(DatafeedFMSAPI, "get_district_list")
 @mock.patch.object(DatafeedFMSAPI, "get_event_list")
-def test_get_no_events(event_list_mock, tasks_client: Client) -> None:
+def test_get_no_events(
+    event_list_mock, district_list_mock, tasks_client: Client
+) -> None:
     event_list_mock.return_value = ([], [])
+    district_list_mock.return_value = []
 
     resp = tasks_client.get("/backend-tasks/get/event_list/2020")
     assert resp.status_code == 200
     assert len(resp.data) > 0
 
 
+@mock.patch.object(DatafeedFMSAPI, "get_district_list")
 @mock.patch.object(DatafeedFMSAPI, "get_event_list")
 def test_get_no_events_no_output_in_taskqueue(
-    event_list_mock, tasks_client: Client
+    event_list_mock, district_list_mock, tasks_client: Client
 ) -> None:
     event_list_mock.return_value = ([], [])
+    district_list_mock.return_value = []
 
     resp = tasks_client.get(
         "/backend-tasks/get/event_list/2020",

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
@@ -3,6 +3,7 @@ import json
 from typing import Dict, Optional
 from unittest import mock
 
+import pytest
 from freezegun import freeze_time
 from google.appengine.ext import ndb, testbed
 from werkzeug.test import Client
@@ -106,6 +107,7 @@ def test_get_bad_key(tasks_client: Client) -> None:
     assert resp.status_code == 404
 
 
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
 def test_get_no_event(tasks_client: Client) -> None:
     resp = tasks_client.get("/tasks/get/fmsapi_matches/2020nyny")
     assert resp.status_code == 404
@@ -164,6 +166,7 @@ def test_get(
     assert Match.get_by_id("2020nyny_qm1") is not None
 
 
+@pytest.mark.filterwarnings("ignore:divide by zero")
 @mock.patch.object(DatafeedFMSAPI, "get_event_matches")
 def test_get_remap_teams(
     fmsapi_matches_mock,

--- a/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
@@ -13,9 +13,14 @@ from backend.common.models.team import Team
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
 
+@mock.patch.object(DatafeedFMSAPI, "get_team_details")
 def test_enqueue_rolling(
-    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+    team_details_mock,
+    tasks_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
 ) -> None:
+    team_details_mock.return_value = (None, None, None)
+
     # Create 10 teams
     [
         Team(


### PR DESCRIPTION
Keeping warnings clean in tests is a good thing. Unfortunately, most of them come from third party libraries so they need to be suppressed, but there's at least a few things we should have fixed in our code.