### PR TITLE
Update home page links

### DIFF
--- a/src/backend/web/templates/index/index_offseason.html
+++ b/src/backend/web/templates/index/index_offseason.html
@@ -16,8 +16,7 @@
       </div>
       <div>
         <a class="btn btn-default" href="https://www.firstinspires.org/covid-19" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> COVID-19 Resources</a>
-        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2021 Game and Season Resources</a>
-        <a class="btn btn-default" href="https://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/game-and-season-info/competition-manual/2021/2021-frc-season-details.pdf" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2021 Season Details</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2023 Game and Season Resources</a>
       </div>
 
       {% include "media_partials/live_special_webcast_partial.html" %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

Change 2021 game and season resources to 2023 game and season resources and remove the 2021 season details button


## Motivation and Context
The years are wrong and the updated version is now consistent with the other index page templates
## How Has This Been Tested?

## Screenshots (if appropriate):

Current home page
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/43558768/744cd099-bac7-49ae-8bce-50d3b51dd7bc)

Updated home page
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/43558768/4136310d-9421-40dd-a7d8-a3d0f7e95b09)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
