### PR TITLE
Port clientapi ping to py3

### DIFF
--- a/old_py2/mobile_main.py
+++ b/old_py2/mobile_main.py
@@ -138,30 +138,6 @@ class MobileAPI(remote.Service):
             ndb.delete_multi(query)
             return BaseResponse(code=200, message="User deleted")
 
-    @endpoints.method(PingRequest, BaseResponse,
-                      path='ping', http_method='POST',
-                      name='ping')
-    def ping_client(self, request):
-        current_user = endpoints.get_current_user()
-        if current_user is None:
-            return BaseResponse(code=401, message="Unauthorized to ping client")
-
-        user_id = PushHelper.user_email_to_id(current_user.email())
-        gcm_id = request.mobile_id
-
-        # Find a Client for the current user with the passed GCM ID
-        clients = MobileClient.query(MobileClient.messaging_id == gcm_id, ancestor=ndb.Key(Account, user_id)).fetch(1)
-        if len(clients) == 0:
-            # No Client for user with that push token - bailing
-            return BaseResponse(code=404, message="Invalid push token for user")
-        else:
-            client = clients[0]
-            from helpers.tbans_helper import TBANSHelper
-            success = TBANSHelper.ping(client)
-            if success:
-                return BaseResponse(code=200, message="Ping sent")
-            else:
-                return BaseResponse(code=500, message="Failed to ping client")
 
     @endpoints.method(message_types.VoidMessage, FavoriteCollection,
                       path='favorites/list', http_method='POST',

--- a/ops/test_ops.sh
+++ b/ops/test_ops.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-npm run testops
+npm run testops -- --runInBand --testTimeout=10000 --silent=false
 ret=$?
 
 if [ -n "$CI" ]; then

--- a/ops/tests/client_api_fullstack.test.js
+++ b/ops/tests/client_api_fullstack.test.js
@@ -1,4 +1,5 @@
 const fetch = require("node-fetch");
+const http = require("http");
 
 async function postToAuthEmulator(endpoint, body) {
   const url =
@@ -74,12 +75,11 @@ describe("Mobile device registration", () => {
 
   it("should return the newly registered device", async () => {
     const listRes = await postToClientAPI("list_clients", idToken, {});
-    expect(listRes.status).toEqual(200);
-    expect(await listRes.json()).toEqual({
-      code: 200,
-      message: "",
-      devices: [device],
-    });
+    expect([200, 304]).toContainEqual(listRes.status);
+
+    const respBody = await listRes.json();
+    expect(respBody.code).toEqual(200);
+    expect(respBody.devices).toContainEqual(device);
   });
 
   it("should unregister successfully", async () => {
@@ -94,10 +94,53 @@ describe("Mobile device registration", () => {
   it("should should no longer return the device", async () => {
     const listRes = await postToClientAPI("list_clients", idToken, {});
     expect(listRes.status).toEqual(200);
-    expect(await listRes.json()).toEqual({
+
+    const respBody = await listRes.json();
+    expect(respBody.code).toEqual(200);
+    expect(respBody.devices).not.toContainEqual(device);
+  });
+});
+
+describe("webhook ping", () => {
+  let idToken = null;
+  it("can fetch an auth token", async () => {
+    idToken = await getIdToken();
+  });
+
+  const device = {
+    name: "Test Device",
+    operating_system: "webhook",
+    mobile_id: "http://localhost:8080/local/webhooks",
+    device_uuid: "test",
+  };
+  it("should register successfully", async () => {
+    const regRes = await postToClientAPI("register", idToken, device);
+    expect(regRes.status).toEqual(200);
+
+    const respBody = await regRes.json();
+    expect([200, 304]).toContainEqual(respBody.code);
+  });
+  it("can ping the device", async () => {
+    const pingRes = await postToClientAPI("ping", idToken, device);
+    expect(pingRes.status).toEqual(200);
+    expect(await pingRes.json()).toEqual({
       code: 200,
-      message: "",
-      devices: [],
+      message: "Ping sent",
+    });
+  });
+  it("can receive webhook message", async () => {
+    const fetchResp = await fetch("http://localhost:8080/local/webhooks", {
+      method: "GET",
+    });
+    expect(fetchResp.status).toEqual(200);
+
+    const respBody = await fetchResp.json();
+    expect(respBody).toEqual({
+      message_type: "ping",
+      message_data: {
+        title: "Test Notification",
+        desc: "This is a test message ensuring your device can recieve push messages from The Blue Alliance.",
+      },
     });
   });
 });

--- a/src/backend/api/client_api_types.py
+++ b/src/backend/api/client_api_types.py
@@ -29,3 +29,7 @@ class RegisteredMobileClient(TypedDict):
 
 class ListDevicesResponse(BaseResponse):
     devices: List[RegisteredMobileClient]
+
+
+class PingRequest(TypedDict):
+    mobile_id: str

--- a/src/backend/api/handlers/tests/client_api_ping_test.py
+++ b/src/backend/api/handlers/tests/client_api_ping_test.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+from werkzeug.test import Client
+
+from backend.api.client_api_types import (
+    PingRequest,
+)
+from backend.api.handlers.tests.clientapi_test_helper import make_clientapi_request
+from backend.common.consts.client_type import ClientType
+from backend.common.helpers.tbans_helper import TBANSHelper
+from backend.common.models.mobile_client import MobileClient
+from backend.common.models.user import User
+
+
+def test_ping_no_auth(api_client: Client) -> None:
+    req = PingRequest(
+        mobile_id="abc123",
+    )
+    resp = make_clientapi_request(api_client, "/ping", req)
+    assert resp["code"] == 401
+
+
+def test_ping_no_device(api_client: Client, mock_clientapi_auth: User) -> None:
+    req = PingRequest(
+        mobile_id="abc123",
+    )
+    resp = make_clientapi_request(api_client, "/ping", req)
+    assert resp["code"] == 404
+
+
+def test_ping_clinet(api_client: Client, mock_clientapi_auth: User, ndb_stub) -> None:
+    MobileClient(
+        parent=mock_clientapi_auth.account_key,
+        user_id=str(mock_clientapi_auth.uid),
+        messaging_id="abc123",
+        client_type=ClientType.TEST,
+        device_uuid="asdf",
+        display_name="Test Device",
+    ).put()
+
+    with patch.object(TBANSHelper, "ping") as mock_ping:
+        mock_ping.return_value = True
+        req = PingRequest(
+            mobile_id="abc123",
+        )
+        resp = make_clientapi_request(api_client, "/ping", req)
+
+    assert resp["code"] == 200
+
+
+def test_ping_clinet_fails(
+    api_client: Client, mock_clientapi_auth: User, ndb_stub
+) -> None:
+    MobileClient(
+        parent=mock_clientapi_auth.account_key,
+        user_id=str(mock_clientapi_auth.uid),
+        messaging_id="abc123",
+        client_type=ClientType.TEST,
+        device_uuid="asdf",
+        display_name="Test Device",
+    ).put()
+
+    with patch.object(TBANSHelper, "ping") as mock_ping:
+        mock_ping.return_value = False
+        req = PingRequest(
+            mobile_id="abc123",
+        )
+        resp = make_clientapi_request(api_client, "/ping", req)
+
+    assert resp["code"] == 500

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -7,6 +7,7 @@ from werkzeug.routing import BaseConverter
 
 from backend.api.handlers.client_api import (
     list_mobile_clients,
+    ping_mobile_client,
     register_mobile_client,
     unregister_mobile_client,
 )
@@ -349,6 +350,11 @@ client_api.add_url_rule(
     "/list_clients",
     methods=["POST"],
     view_func=list_mobile_clients,
+)
+client_api.add_url_rule(
+    "/ping",
+    methods=["POST"],
+    view_func=ping_mobile_client,
 )
 client_api.add_url_rule(
     "/unregister",

--- a/src/backend/web/local/blueprint.py
+++ b/src/backend/web/local/blueprint.py
@@ -1,8 +1,12 @@
-from flask import abort, Blueprint, Flask, redirect, request, url_for
+import json
+import logging
+
+from flask import abort, Blueprint, Flask, jsonify, redirect, request, url_for
 from flask_wtf.csrf import CSRFProtect
 from werkzeug.wrappers import Response
 
 from backend.common.environment import Environment
+from backend.common.memcache import MemcacheClient
 from backend.common.sitevars.apiv3_key import Apiv3Key
 from backend.web.local.bootstrap import LocalDataBootstrap
 from backend.web.profiled_render import render_template
@@ -55,6 +59,25 @@ def bootstrap_post() -> Response:
 def sdk_version() -> str:
     with open("/usr/lib/google-cloud-sdk/VERSION", "r") as version_file:
         return version_file.read()
+
+
+@local_routes.route("/webhooks", methods=["POST"])
+def webhook_server_post() -> str:
+    incoming_webhook = request.json
+    logging.info(f"got webhook: {incoming_webhook}")
+
+    cache = MemcacheClient.get()
+    cache.set(b"test_webhooks_received", json.dumps(incoming_webhook))
+
+    return ""
+
+
+@local_routes.route("/webhooks", methods=["GET"])
+def webhook_server_get() -> Response:
+    cache = MemcacheClient.get()
+    webhooks = cache.get(b"test_webhooks_received") or "{}"
+    cache.delete(b"test_webhooks_received")
+    return jsonify(json.loads(webhooks))
 
 
 def maybe_register(app: Flask, csrf: CSRFProtect) -> None:


### PR DESCRIPTION
This ports `ping` functionality in a way that we can test using the fullstack test framework. A few things:
 - change the existing test to be a bit more idempotent to simplify local development
 - add some jest arguments to run tests serially, so we can avoid tests conflicting state on the local devserver and bump the timeout 
 - implement a basic webhook receiver on a the `local` blueprint, so we can fetch and validate the notifications we receive.