### PR TITLE
Add Account Deletion

### DIFF
--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -67,5 +67,13 @@ def current_user() -> Optional[User]:
     return _current_user()
 
 
+def _delete_user(uid: str) -> None:
+    auth.delete_user(uid, app=app())
+
+
+def delete_user(uid: str) -> None:
+    _delete_user(uid)
+
+
 def _user_context_processor() -> Dict[str, Optional[User]]:
     return dict(user=current_user())

--- a/src/backend/common/consts/suggestion_state.py
+++ b/src/backend/common/consts/suggestion_state.py
@@ -7,3 +7,4 @@ class SuggestionState(enum.IntEnum):
     REVIEW_PENDING = 0
     REVIEW_REJECTED = -1
     REVIEW_AUTOREJECTED = -2
+    ACCOUNT_DELETED = -3

--- a/src/backend/common/helpers/account_deletion.py
+++ b/src/backend/common/helpers/account_deletion.py
@@ -1,0 +1,60 @@
+import datetime
+
+from google.appengine.ext import ndb
+
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.favorite import Favorite
+from backend.common.models.mobile_client import MobileClient
+from backend.common.models.subscription import Subscription
+from backend.common.models.suggestion import Suggestion
+
+
+class AccountDeletionHelper:
+    @classmethod
+    def delete_account(cls, account_key: ndb.Key) -> None:
+        """
+        Removes all ndb models associated with the given user
+        This will also delete the underlying account
+        """
+        user_id = str(account_key.id())
+
+        # reject pending suggestions
+        pending_suggestions_future = Suggestion.query(
+            Suggestion.author == account_key,
+            Suggestion.review_state == SuggestionState.REVIEW_PENDING,
+        ).fetch_async()
+
+        # fetch ndb models that we need to cascade-delete
+
+        mobile_clients_future = MobileClient.query(
+            MobileClient.user_id == user_id
+        ).fetch_async(keys_only=True)
+        favorites_future = Favorite.query(Favorite.user_id == user_id).fetch_async(
+            keys_only=True
+        )
+        subscriptions_future = Subscription.query(
+            Subscription.user_id == user_id
+        ).fetch_async(keys_only=True)
+        api_auth_access_future = ApiAuthAccess.query(
+            ApiAuthAccess.owner == account_key
+        ).fetch_async(keys_only=True)
+
+        keys_to_delete = [
+            account_key,
+            *mobile_clients_future.get_result(),
+            *favorites_future.get_result(),
+            *subscriptions_future.get_result(),
+            *api_auth_access_future.get_result(),
+        ]
+
+        ndb.put_multi(
+            [cls._delete_suggestion(s) for s in pending_suggestions_future.get_result()]
+        )
+        ndb.delete_multi(keys_to_delete)
+
+    @classmethod
+    def _delete_suggestion(cls, suggestion: Suggestion) -> Suggestion:
+        suggestion.review_state = SuggestionState.ACCOUNT_DELETED
+        suggestion.reviewed_at = datetime.datetime.now()
+        return suggestion

--- a/src/backend/common/helpers/tests/account_deletion_helper_test.py
+++ b/src/backend/common/helpers/tests/account_deletion_helper_test.py
@@ -1,0 +1,91 @@
+import pytest
+from google.appengine.ext import ndb
+
+from backend.common.consts.auth_type import AuthType
+from backend.common.consts.client_type import ClientType
+from backend.common.consts.model_type import ModelType
+from backend.common.consts.notification_type import NotificationType
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.helpers.account_deletion import AccountDeletionHelper
+from backend.common.models.account import Account
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.favorite import Favorite
+from backend.common.models.mobile_client import MobileClient
+from backend.common.models.subscription import Subscription
+from backend.common.suggestions.suggestion_creator import (
+    SuggestionCreationStatus,
+    SuggestionCreator,
+)
+
+
+@pytest.fixture
+def account_key(ndb_stub) -> ndb.Key:
+    account = Account(
+        email="test@tba.com",
+        registered=True,
+    )
+    return account.put()
+
+
+def test_deletes_account(account_key) -> None:
+    AccountDeletionHelper.delete_account(account_key)
+
+    assert account_key.get() is None
+
+
+def test_auto_reject_pending_suggestions(account_key) -> None:
+    status, suggestion = SuggestionCreator.createTeamMediaSuggestion(
+        account_key, "http://imgur.com/ruRAxDm", "frc1124", "2016"
+    )
+    assert status == SuggestionCreationStatus.SUCCESS
+    assert suggestion is not None
+
+    AccountDeletionHelper.delete_account(account_key)
+
+    suggestion = suggestion.key.get()
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.ACCOUNT_DELETED
+
+
+def test_deletes_mobile_clients(account_key) -> None:
+    user_id = str(account_key.id())
+    MobileClient(
+        user_id=user_id,
+        messaging_id="abc123",
+        client_type=ClientType.TEST,
+    ).put()
+
+    AccountDeletionHelper.delete_account(account_key)
+
+    assert MobileClient.query(MobileClient.user_id == user_id).count() == 0
+
+
+def test_deletes_mytba_data(account_key) -> None:
+    user_id = str(account_key.id())
+    Favorite(
+        user_id=user_id,
+        model_type=ModelType.TEAM,
+        model_key="frc1124",
+    ).put()
+    Subscription(
+        user_id=user_id,
+        model_type=ModelType.TEAM,
+        model_key="frc1124",
+        notification_types=[NotificationType.UPCOMING_MATCH],
+    ).put()
+
+    AccountDeletionHelper.delete_account(account_key)
+
+    assert Favorite.query(Favorite.user_id == user_id).count() == 0
+    assert Subscription.query(Subscription.user_id == user_id).count() == 0
+
+
+def test_deletes_api_keys(account_key) -> None:
+    ApiAuthAccess(
+        owner=account_key,
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    AccountDeletionHelper.delete_account(account_key)
+
+    assert ApiAuthAccess.query(ApiAuthAccess.owner == account_key).count() == 0

--- a/src/backend/common/tests/auth_test.py
+++ b/src/backend/common/tests/auth_test.py
@@ -10,6 +10,7 @@ from backend.common.auth import (
     _user_context_processor,
     create_session_cookie,
     current_user,
+    delete_user,
     revoke_session_cookie,
     verify_id_token,
 )
@@ -122,6 +123,13 @@ def test_current_user() -> None:
     with patch.object(backend_auth, "_decoded_claims", return_value={"abc": "abc"}):
         user = current_user()
     assert user is not None
+
+
+def test_delete_user() -> None:
+    with patch.object(auth, "delete_user") as mock_delete_user:
+        delete_user("test_uid")
+
+    mock_delete_user.assert_called_once_with("test_uid", app=ANY)
 
 
 def test_user_context_processor_no_claims() -> None:

--- a/src/backend/web/handlers/tests/account_overview_test.py
+++ b/src/backend/web/handlers/tests/account_overview_test.py
@@ -34,6 +34,7 @@ def test_blueprint() -> None:
     assert rules_map == {
         "/account/api/read_key_add": "account.read_key_add",
         "/account/api/read_key_delete": "account.read_key_delete",
+        "/account/delete": "account.delete",
         "/account/register": "account.register",
         "/account/logout": "account.logout",
         "/account/login": "account.login",

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -7,8 +7,10 @@ from _pytest.monkeypatch import MonkeyPatch
 from flask.testing import FlaskClient
 
 import backend
+from backend.common import auth
 from backend.common.consts.client_type import ClientType
 from backend.common.consts.model_type import ModelType
+from backend.common.helpers.account_deletion import AccountDeletionHelper
 from backend.common.helpers.tbans_helper import TBANSHelper
 from backend.common.models.account import Account
 from backend.common.models.mobile_client import MobileClient
@@ -681,3 +683,28 @@ def test_ping_not_our_client(
     assert response.status_code == 302
     parsed_response = urlparse(response.headers["Location"])
     assert parsed_response.path == "/account"
+
+
+def test_delete_confirmation(login_user, web_client: FlaskClient) -> None:
+    response = web_client.get("/account/delete")
+    assert response.status_code == 200
+
+
+def test_delete_post(login_user, web_client: FlaskClient) -> None:
+    with patch.object(
+        backend.web.handlers.account, "revoke_session_cookie"
+    ) as mock_revoke_session_cookie, patch.object(
+        AccountDeletionHelper, "delete_account"
+    ) as mock_delete_account, patch.object(
+        auth, "_delete_user"
+    ) as mock_delete_user:
+        response = web_client.post("/account/delete")
+
+    # make sure we log out the current user and that we call the deletion function
+    assert mock_revoke_session_cookie.called
+    assert mock_delete_account.called
+    assert mock_delete_user.called
+
+    assert response.status_code == 302
+    parsed_response = urlparse(response.headers["Location"])
+    assert parsed_response.path == "/"

--- a/src/backend/web/templates/account_delete.html
+++ b/src/backend/web/templates/account_delete.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Account Deletion - The Blue Alliance{% endblock %}
+
+{% block meta_description %}Delete your TBA account.{% endblock %}
+
+{% block content %}
+<div class="container">
+<h1>Delete Your Account</h1>  
+
+<form action="/account/delete" method="post">
+    <legend>Delete data for {{user.email}}</legend>
+    <p>This will delete your myTBA favorites and subscriptions, as well as linked devices for push notifications and API keys.</p>
+    <div class="alert alert-danger">
+        <p>This action can not be undone! Are you sure you want to proceed?</p>
+    </div>
+
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <a href="/account" class="btn btn-default btn-lg"><span class="glyphicon glyphicon-ban-circle"></span> Cancel Delete</a>
+    <button type="submit" class="btn btn-danger btn-lg pull-right"><span class="glyphicon glyphicon-trash"></span> Delete Account</button>
+</form>
+
+</div>
+{% endblock %}

--- a/src/backend/web/templates/account_overview.html
+++ b/src/backend/web/templates/account_overview.html
@@ -106,7 +106,10 @@
           </tr>
         </tbody>
       </table>
-      <p><a class="btn btn-primary" href="{{ url_for('account.edit') }}"><span class="glyphicon glyphicon-pencil"></span> Edit Profile</a></p>
+      <div class="row">
+        <a class="btn btn-primary" href="{{ url_for('account.edit') }}"><span class="glyphicon glyphicon-pencil"></span> Edit Profile</a>
+        <a class="btn btn-danger" href="{{ url_for('account.delete') }}"><span class="glyphicon glyphicon-remove"></span> Delete Account</a>
+      </div>
     </div>
   </div>
   <hr>


### PR DESCRIPTION
Soon, Google Play will require us to provide links to a way to delete your account which can be deep-linked from the store metadata. Details: https://support.google.com/googleplay/android-developer/answer/13327111

This implements a basic version at `/account/delete`. The algorithm will be to:
 - auto-reject all pending suggestions
 - delete mobile clients, API keys, and myTBA favorite/subscription objects
 - revoke the current session cookies
 - delete the user in firebase and delete the `Account` object