### PR TITLE
deploy dispatch.yaml from py3 repo

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -348,3 +348,25 @@ jobs:
           project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
       - name: Deploy
         run: ./ops/deploy/deploy_module.sh src/tasks_cpu.yaml
+  deploy-dispatch:
+    name: Deploy Dispatch
+    runs-on: ubuntu-latest
+    needs: [deploy-queues, deploy-web, deploy-api, deploy-tasks-io, deploy-tasks-cpu]
+    if: contains(github.event.commits[0].message, '[nodeploy]') == false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+      - name: Setup Google Cloud Platform
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: "latest"
+          project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+      - name: Deploy
+        run: ./ops/deploy/deploy_dispatch.sh

--- a/ops/deploy/deploy_dispatch.sh
+++ b/ops/deploy/deploy_dispatch.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+set -e
+
+# This needs to exist for as long as we stil need to support routing for the py2 instance
+# once that's gone, we can remove this, and simply deploy based on src/dispatch.yaml
+# Until then, this is the same command + version from the old py2 deploy step
+# https://github.com/the-blue-alliance/the-blue-alliance/blob/3dafb6697bd9d5511afaf7240eab733bd11b26a6/.github/workflows/push_py2.yml#L196C14-L196C70
+
+mv ops/prod_dispatch.yaml src/dispatch.yaml
+gcloud app deploy src/dispatch.yaml --version prod-2 --quiet

--- a/ops/prod_dispatch.yaml
+++ b/ops/prod_dispatch.yaml
@@ -1,0 +1,60 @@
+# This dispatch file applies to prod, not local dev
+# CI will renme this file appropriately and deploy it
+# The "default" module means "py2"
+# Cleaning this up is tracked in https://github.com/the-blue-alliance/the-blue-alliance/issues/5388
+
+dispatch:
+# Pin these pages to py2
+- url: "www.thebluealliance.com/_/account/*"
+  service: default
+- url: "www.thebluealliance.com/search*"
+  service: default
+# match py2 css and javascript (py3 is prefixed with py3_)
+- url: "www.thebluealliance.com/css/*"
+  service: default
+- url: "www.thebluealliance.com/js/*"
+  service: default
+  
+# APIs on py3 (both apiv3 and trusted api)
+- url: "www.thebluealliance.com/api/*"
+  service: py3-api
+
+# Send low-frequency long-running tasks to backend module
+# Uses B2 instance for higher CPU/memory limits
+- url: "*/backend-tasks-b2/*"
+  service: py3-tasks-cpu
+
+# Send low-frequency long-running tasks to backend module
+- url: "*/backend-tasks/*"
+  service: py3-tasks-io
+
+# Handles latency-insensive tasks
+- url: "*/tasks/*"
+  service: py3-tasks-io
+
+# API docs (swagger)
+- url: "*/swagger/*"
+  service: py3-web
+
+# mobile client API to py3
+- url: "*/clientapi/*"
+  service: py3-api
+  
+# Default catch-all to py3
+- url: "www.thebluealliance.com/*"
+  service: py3-web
+
+# Explicitly choose py2 or py3 based on host
+- url: "py3.thebluealliance.com/*"
+  service: py3-web
+  
+- url: "py2.thebluealliance.com/*"
+  service: default
+
+# Beta PWA
+# - url: "beta.thebluealliance.com/*"
+#   service: pwa-ssr
+
+# Send everything else to default module
+- url: "*/"
+  service: default

--- a/src/dispatch.yaml
+++ b/src/dispatch.yaml
@@ -1,3 +1,7 @@
+# WARNING: this dispatch file only applies to the local devserver currently
+# The dispatch rules for prod can be found in ops/prod_dispatch.yaml
+# Cleaning this up is tracked in https://github.com/the-blue-alliance/the-blue-alliance/issues/5388
+
 dispatch:
   - url: "*/api/*"
     service: py3-api


### PR DESCRIPTION
Towards https://github.com/the-blue-alliance/the-blue-alliance/issues/5388

GH Actions [dropped support for python2](https://www.github.com/actions/setup-python/issues/672); it's not worth investing in any more forward fixes.

For the time being, we need different dispatch rules for the local devserver and prod (for as long as we still have py2 serving endpoints), so we add a separate file which the CI knows how to handle at deploy-time. The contents were copied from the [`master` branch](https://github.com/the-blue-alliance/the-blue-alliance/blob/master/dispatch.yaml)

Once we remove the last few py2 URL rules, we can kill the service in GAE, and consolidate on a single dispatch file.