### PR TITLE
Allow extra RP fields for 2023

### DIFF
--- a/src/backend/common/helpers/score_breakdown_keys.py
+++ b/src/backend/common/helpers/score_breakdown_keys.py
@@ -136,6 +136,7 @@ VALID_BREAKDOWNS: Dict[Year, Set[str]] = {
             "foulPoints",
             "rp",
             "totalPoints",
+            # fields added by TBA:
             "tba_gameData",
         ]
     ),
@@ -352,6 +353,9 @@ VALID_BREAKDOWNS: Dict[Year, Set[str]] = {
             "teleopPoints",
             "totalChargeStationPoints",
             "totalPoints",
+            # fields added by TBA:
+            "tba_extraRp1",
+            "tba_extraRp2",
         ]
     ),
 }


### PR DESCRIPTION
## Description
This allows adding `extraRp1` and `extraRp2` fields to score breakdowns through the write API. These are not used by the FRC API, so we could consider prefixing them with `tba_` as well (I brought this up as an option on Slack but we didn't reach a consensus).

## Motivation and Context
Offseasons sometimes want to add extra ranking points for various things (e.g. the additional cargo threshold at 2022cc, rainbow link bonus at 2023mirr). Supporting breakdown fields for this purpose makes it easier to submit and retrieve data about these RPs, and also allows for disambiguation if multiple extra ranking points are used.

## How Has This Been Tested?
Submitted a couple matches through the write API on a local instance. Also verified that insights are unchanged with these fields added or removed from matches. (I would like to eventually support these in insights, but that will be a more involved change.)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
