### PR TITLE
Support current-season computations in insights/district rankings

### DIFF
--- a/src/backend/common/consts/insight_type.py
+++ b/src/backend/common/consts/insight_type.py
@@ -1,0 +1,10 @@
+import enum
+
+from backend.common.consts.string_enum import StrEnum
+
+
+@enum.unique
+class InsightType(StrEnum):
+    MATCHES = "matches"
+    AWARDS = "awards"
+    PREDICTIONS = "predictions"

--- a/src/backend/tasks_cpu/handlers/conftest.py
+++ b/src/backend/tasks_cpu/handlers/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from werkzeug.test import Client
+
+
+@pytest.fixture
+def tasks_cpu_client(gae_testbed, ndb_stub, memcache_stub, taskqueue_stub) -> Client:
+    from backend.tasks_cpu.main import app
+
+    return app.test_client()

--- a/src/backend/tasks_cpu/handlers/tests/insights_test.py
+++ b/src/backend/tasks_cpu/handlers/tests/insights_test.py
@@ -1,0 +1,81 @@
+import pytest
+from freezegun import freeze_time
+from google.appengine.ext import testbed
+from werkzeug.test import Client
+
+from backend.common.consts.insight_type import InsightType
+
+
+def test_enqueue_bad_kind(tasks_cpu_client: Client) -> None:
+    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/asdf/2023")
+    assert resp.status_code == 404
+
+
+def test_enqueue_bad_year(tasks_cpu_client: Client) -> None:
+    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/matches/asdf")
+    assert resp.status_code == 404
+
+
+def test_enqueue(
+    tasks_cpu_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+) -> None:
+    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/matches/2023")
+    assert resp.status_code == 200
+
+    tasks = tasks_cpu_client = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 1
+    assert tasks[0].url == "/backend-tasks-b2/math/do/insights/matches/2023"
+
+
+def test_enqueue_no_output_in_taskqueue(tasks_cpu_client: Client) -> None:
+    resp = tasks_cpu_client.get(
+        "/backend-tasks-b2/math/enqueue/insights/matches/2023",
+        headers={
+            "X-Appengine-Taskname": "test",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.data) == 0
+
+
+@freeze_time("2020-04-01")
+def test_enqueue_defaults_to_current_season(
+    tasks_cpu_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+) -> None:
+    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/matches")
+    assert resp.status_code == 200
+
+    tasks = tasks_cpu_client = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 1
+    assert tasks[0].url == "/backend-tasks-b2/math/do/insights/matches/2020"
+
+
+def test_do_bad_kind(tasks_cpu_client: Client) -> None:
+    resp = tasks_cpu_client.get("/backend-tasks-b2/math/do/insights/asdf/2023")
+    assert resp.status_code == 404
+
+
+def test_do_bad_year(tasks_cpu_client: Client) -> None:
+    resp = tasks_cpu_client.get("/backend-tasks-b2/math/do/insights/matches/asdf")
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize("insight_type", list(InsightType))  # pyre-ignore[6]
+def test_calc(tasks_cpu_client: Client, insight_type: InsightType) -> None:
+    resp = tasks_cpu_client.get(
+        f"/backend-tasks-b2/math/do/insights/{insight_type}/2023"
+    )
+    assert resp.status_code == 200
+
+
+def test_calc_no_output_in_taskqueue(tasks_cpu_client: Client) -> None:
+    resp = tasks_cpu_client.get(
+        "/backend-tasks-b2/math/do/insights/matches/2023",
+        headers={
+            "X-Appengine-Taskname": "test",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.data) == 0

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -16,6 +16,7 @@ from backend.common.helpers.event_team_updater import EventTeamUpdater
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.matchstats_helper import MatchstatsHelper
 from backend.common.helpers.prediction_helper import PredictionHelper
+from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.manipulators.district_manipulator import DistrictManipulator
 from backend.common.manipulators.event_details_manipulator import (
     EventDetailsManipulator,
@@ -36,10 +37,14 @@ blueprint = Blueprint("math", __name__)
 
 
 @blueprint.route("/tasks/math/enqueue/district_points_calc/<int:year>")
-def enqueue_event_district_points_calc(year: Year) -> Response:
+@blueprint.route("/tasks/math/enqueue/district_points_calc", defaults={"year": None})
+def enqueue_event_district_points_calc(year: Optional[Year]) -> Response:
     """
     Enqueues calculation of district points for all season events for a given year
     """
+    if year is None:
+        year = SeasonHelper.get_current_season()
+
     event_keys: List[ndb.Key] = Event.query(
         Event.year == year, Event.event_type_enum.IN(SEASON_EVENT_TYPES)
     ).fetch(None, keys_only=True)

--- a/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
+++ b/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
@@ -71,6 +71,28 @@ def test_enqueue_event(
         assert task_resp.status_code == 200
 
 
+@freeze_time("2020-4-1")
+def test_enqueue_event_defaults_to_current_year(
+    tasks_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+    ndb_stub,
+) -> None:
+    Event(
+        id="2020event",
+        year=2020,
+        event_short="event",
+        event_type_enum=EventType.REGIONAL,
+    ).put()
+    resp = tasks_client.get("/tasks/math/enqueue/district_points_calc")
+    assert resp.status_code == 200
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 1
+    for task in tasks:
+        task_resp = tasks_client.get(task.url)
+        assert task_resp.status_code == 200
+
+
 def test_enqueue_event_skips_offseason(
     tasks_client: Client,
     taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -40,17 +40,17 @@ cron:
   timezone: America/Los_Angeles
 
 - description: Match Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/matches/2022
+  url: /backend-tasks-b2/math/enqueue/insights/matches
   schedule: every day 01:00
   timezone: America/Los_Angeles
 
 - description: Award Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/awards/2022
+  url: /backend-tasks-b2/math/enqueue/insights/awards
   schedule: every day 01:00
   timezone: America/Los_Angeles
 
 - description: Prediction Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/predictions/2022
+  url: /backend-tasks-b2/math/enqueue/insights/predictions
   schedule: every day 01:00
   timezone: America/Los_Angeles
 
@@ -65,7 +65,7 @@ cron:
   timezone: America/Los_Angeles
 
 - description: District Rankings Calculation
-  url: /tasks/math/enqueue/district_rankings_calc/2022
+  url: /tasks/math/enqueue/district_rankings_calc
   schedule: every tuesday 1:00
   timezone: America/Los_Angeles
 


### PR DESCRIPTION
Turns out we never updated the years in `cron.yaml` (I checked the console :stuck_out_tongue: )
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/88a8c2cb-8317-4b39-b83f-7d5757a7c6d5)


So, add a version of the URLs here which don't take an explicit year parameter and instead default to the current season. And let's use that instead, so we don't have to remember to change the cronjobs in the future :smile: 