### PR TITLE
Add Season Endpoint

### DIFF
--- a/src/backend/api/handlers/status.py
+++ b/src/backend/api/handlers/status.py
@@ -10,6 +10,7 @@ from backend.common.models.sitevar import Sitevar
 from backend.common.sitevars.apistatus import ApiStatus
 from backend.common.sitevars.apistatus_fmsapi_down import ApiStatusFMSApiDown
 
+from backend.common.helpers.season_helper import SeasonHelper
 
 @api_authenticated
 @cached_public
@@ -29,3 +30,23 @@ def status() -> Response:
     status["down_events"] = down_events_list if down_events_list is not None else []
 
     return profiled_jsonify(status)
+
+@api_authenticated
+@cached_public
+def season() -> Response:
+    track_call_after_response("season", "status")
+
+    # TODO: Remove Sitevar usage for Sitevar classes
+    down_events_sitevar_future = Sitevar.get_by_id_async("apistatus.down_events")
+
+    season = dict()
+    season.update(cast(dict, ApiStatus.status()))
+    season.update({"kickoff_time_utc": SeasonHelper.kickoff_datetime_utc})
+
+    down_events_sitevar = down_events_sitevar_future.get_result()
+    down_events_list = down_events_sitevar.contents if down_events_sitevar else None
+
+    season["is_datafeed_down"] = ApiStatusFMSApiDown.get()
+    season["down_events"] = down_events_list if down_events_list is not None else []
+
+    return profiled_jsonify(season)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -37,6 +37,8 @@ from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.match import match, zebra_motionworks
 from backend.api.handlers.media import media_tags
 from backend.api.handlers.status import status
+from backend.api.handlers.status import season
+
 from backend.api.handlers.team import (
     team,
     team_awards,
@@ -110,6 +112,7 @@ CORS(
 
 # Overall Status
 api_v3.add_url_rule("/status", view_func=status)
+api_v3.add_url_rule("/status/season", view_func=season)
 
 # District
 api_v3.add_url_rule("/district/<string:district_key>/events", view_func=district_events)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Responding to an issue asking for more information on the season in the status endpoint. This creates a new endpoint called season with the kickoff time in UTC and future data.

## Motivation and Context
This adds data from the FRC API to the Blue Alliance API for easier access. https://github.com/the-blue-alliance/the-blue-alliance/issues/5248

## How Has This Been Tested?
Tested in a Flask Server.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
