### PR TITLE
Add most matches played per year insight

### DIFF
--- a/src/backend/common/helpers/insights_helper.py
+++ b/src/backend/common/helpers/insights_helper.py
@@ -257,11 +257,11 @@ class InsightsHelper(object):
             [1, [ "frc0", "frc1", "frc12345"]],
         ]
         """
-        wins_dict = sorted(
+        sorted_wins_tuples = sorted(
             wins_dict.items(), key=lambda pair: int(pair[0][3:])
         )  # Sort by team number
         temp = defaultdict(list)
-        for team, numWins in wins_dict:
+        for team, numWins in sorted_wins_tuples:
             temp[numWins].append(team)
         return sorted(
             temp.items(), key=lambda pair: int(pair[0]), reverse=True

--- a/src/backend/common/helpers/insights_helper.py
+++ b/src/backend/common/helpers/insights_helper.py
@@ -410,7 +410,7 @@ class InsightsHelper(object):
         return [
             self._createInsight(
                 data=grouped_by_win_count,
-                name=Insight.INSIGHT_NAMES[Insight.MATCHES_BY_TEAM],
+                name=Insight.INSIGHT_NAMES[Insight.MATCHES_PLAYED],
                 year=year,
             )
         ]

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -35,6 +35,7 @@ class Insight(CachedModel):
     WINNING_MARGIN_DISTRIBUTION = 19
     ELIM_WINNING_MARGIN_DISTRIBUTION = 20
     EINSTEIN_STREAK = 21
+    MATCHES_BY_TEAM = 22
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -62,6 +63,7 @@ class Insight(CachedModel):
         WINNING_MARGIN_DISTRIBUTION: "winning_margin_distribution",
         ELIM_WINNING_MARGIN_DISTRIBUTION: "elim_winning_margin_distribution",
         EINSTEIN_STREAK: "einstein_streak",
+        MATCHES_BY_TEAM: "matches_by_team",
         YEAR_SPECIFIC_BY_WEEK: "year_specific_by_week",
         YEAR_SPECIFIC: "year_specific",
     }

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -35,7 +35,7 @@ class Insight(CachedModel):
     WINNING_MARGIN_DISTRIBUTION = 19
     ELIM_WINNING_MARGIN_DISTRIBUTION = 20
     EINSTEIN_STREAK = 21
-    MATCHES_BY_TEAM = 22
+    MATCHES_PLAYED = 22
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -63,7 +63,7 @@ class Insight(CachedModel):
         WINNING_MARGIN_DISTRIBUTION: "winning_margin_distribution",
         ELIM_WINNING_MARGIN_DISTRIBUTION: "elim_winning_margin_distribution",
         EINSTEIN_STREAK: "einstein_streak",
-        MATCHES_BY_TEAM: "matches_by_team",
+        MATCHES_PLAYED: "matches_played",
         YEAR_SPECIFIC_BY_WEEK: "year_specific_by_week",
         YEAR_SPECIFIC: "year_specific",
     }

--- a/src/backend/web/templates/insights_details.html
+++ b/src/backend/web/templates/insights_details.html
@@ -282,7 +282,7 @@
   </div>
   {% endif %}
 
-  {% if matches_by_team %}
+  {% if matches_played %}
   <div class="row">
     <div class="col-xs-12">
       <h3>Most Matches Played</h3>
@@ -291,7 +291,7 @@
           <tr><th>Number</th><th>Teams</th></tr>
         </thead>
         <tbody>
-          {% for number, team_list in matches_by_team.data[:10] %}
+          {% for number, team_list in matches_played.data[:10] %}
             {% if team_list|length < 50 %}
             <tr>
               <td>{{number}}</td>

--- a/src/backend/web/templates/insights_details.html
+++ b/src/backend/web/templates/insights_details.html
@@ -282,6 +282,33 @@
   </div>
   {% endif %}
 
+  {% if matches_by_team %}
+  <div class="row">
+    <div class="col-xs-12">
+      <h3>Most Matches Played</h3>
+      <table class="table table-striped table-condensed table-center insights-table">
+        <thead>
+          <tr><th>Number</th><th>Teams</th></tr>
+        </thead>
+        <tbody>
+          {% for number, team_list in matches_by_team.data[:10] %}
+            {% if team_list|length < 50 %}
+            <tr>
+              <td>{{number}}</td>
+              <td>
+                {% for team in team_list %}
+                <a href="/team/{{team|digits}}/{{selected_year}}">{{team|digits}}</a>{% if not loop.last %},{% endif %}
+                {% endfor %}
+              </td>
+            </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
+
   {% if regional_district_winners %}
   <div class="row">
     <div class="col-xs-12">


### PR DESCRIPTION
## Description
Adds a new insight that tracks most matches played for each team per year. Does not include offseasons.

## Motivation and Context
Been tracking this myself for a while now and would help to have this built in to TBA

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/7595639/72fefed2-6c63-45e4-ba89-cb45f8470f38)

This is from a few 2023/2019 events locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
