### PR TITLE
Allow "B" teams in json awards parser

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_awards_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_awards_parser.py
@@ -63,7 +63,7 @@ class JSONAwardsParser:
                 raise ParserInputException("One of team_key or awardee must be set!")
 
             recipient = AwardRecipient(
-                team_number=int(team_key[3:]) if team_key else None,
+                team_number=team_key[3:] if team_key else None,
                 awardee=awardee,
             )
 

--- a/src/backend/api/api_trusted_parsers/json_awards_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_awards_parser.py
@@ -63,7 +63,7 @@ class JSONAwardsParser:
                 raise ParserInputException("One of team_key or awardee must be set!")
 
             recipient = AwardRecipient(
-                team_number=team_key[3:] if team_key else None,
+                team_number=(int(team_key[3:]) if team_key[3:].isdigit() else team_key[3:]) if team_key else None,
                 awardee=awardee,
             )
 


### PR DESCRIPTION
`AwardRecipient` takes a string (including something like `"254B"`) or an int.