### PR TITLE
Update Homepage Templates for 2024

### DIFF
--- a/src/backend/web/handlers/index.py
+++ b/src/backend/web/handlers/index.py
@@ -49,6 +49,7 @@ def index_kickoff(template_values: Dict[str, Any]) -> str:
     effective_season_year = SeasonHelper.effective_season_year()
     template_values.update(
         {
+            "year": effective_season_year,
             "is_kickoff": SeasonHelper.is_kickoff_at_least_one_day_away(
                 year=effective_season_year
             ),
@@ -146,6 +147,7 @@ def index_offseason(template_values: Dict[str, Any]) -> str:
 
     template_values.update(
         {
+            "year": effective_season_year,
             "events": EventHelper.week_events(),
             "kickoff_datetime_utc": SeasonHelper.kickoff_datetime_utc(
                 effective_season_year

--- a/src/backend/web/templates/index/index_buildseason.html
+++ b/src/backend/web/templates/index/index_buildseason.html
@@ -30,8 +30,7 @@
       {% include "media_partials/live_special_webcast_partial.html" %}
 
       <div>
-        <a class="btn btn-default" href="https://www.firstinspires.org/covid-19" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> COVID-19 Resources</a>
-        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2023 Game and Season Resources</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> {{year}} Game and Season Resources</a>
       </div>
 
       {% if build_handler_show_ri3d %}

--- a/src/backend/web/templates/index/index_kickoff.html
+++ b/src/backend/web/templates/index/index_kickoff.html
@@ -39,7 +39,7 @@
       <p><a class="btn btn-default btn-block" href="https://www.facebook.com/events/{{kickoff_facebook_fbid}}" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-calendar"></span> RSVP on Facebook</a></p>
       {% endif %}
       <div>
-        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> {{kickoff_datetime_est|strftime("%Y")}} Game and Season Resources</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> {{year}} Game and Season Resources</a>
         <!-- <span class="glyphicon glyphicon-globe"></span> <a href="https://www.firstinspires.org/robotics/frc/kickoff" target="_blank" rel="noopener noreferrer" title="FIRST Kickoff Page"><em>FIRST</em> Kickoff Page</a><br> -->
         <br>
         <div class="fitvids">

--- a/src/backend/web/templates/index/index_offseason.html
+++ b/src/backend/web/templates/index/index_offseason.html
@@ -15,8 +15,7 @@
         <a class="btn btn-default" href="http://www.firstinspires.org/resource-library/frc/competition-manual-qa-system" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-file"></span> {{game_name}} Game Manual and Materials</a>
       </div>
       <div>
-        <a class="btn btn-default" href="https://www.firstinspires.org/covid-19" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> COVID-19 Resources</a>
-        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> 2023 Game and Season Resources</a>
+        <a class="btn btn-default" href="https://www.firstinspires.org/robotics/frc/game-and-season" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-info-sign"></span> <i>FIRST</i> {{year}} Game and Season Resources</a>
       </div>
 
       {% include "media_partials/live_special_webcast_partial.html" %}

--- a/src/backend/web/templates/index_partials/index_lhc.html
+++ b/src/backend/web/templates/index_partials/index_lhc.html
@@ -7,7 +7,7 @@
   <div class="btn-group btn-group-block-2">
     <a class="btn btn-default" href="/add-data"><span class="glyphicon glyphicon-info-sign"></span> Help Add Data</a>
     <a class="btn btn-default" href="https://github.com/the-blue-alliance" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-wrench"></span> Hack on TBA</a>
-    <a class="btn btn-default" href="https://www.paypal.com/donate/?hosted_button_id=RNFK8Y7FU9VX8" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-usd"></span> Donate on PayPal</a>
+    <a class="btn btn-default" href="/donate" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-usd"></span> Donate to TBA</a>
   </div>
   <br><br>
 </div>

--- a/src/backend/web/templates/index_partials/index_lhc_offseason.html
+++ b/src/backend/web/templates/index_partials/index_lhc_offseason.html
@@ -7,7 +7,7 @@
   <a class="btn btn-block btn-primary" href="/eventwizard"><span class="glyphicon glyphicon-pencil"></span> Add Offseason Event Data</a>
   <a class="btn btn-block btn-info" href="/add-data"><span class="glyphicon glyphicon-info-sign"></span> Adding Data Overview</a>
   <a class="btn btn-block btn-default" href="https://github.com/the-blue-alliance" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-wrench"></span> Hack on TBA</a>
-  <a class="btn btn-block btn-default" href="https://www.paypal.com/donate/?hosted_button_id=RNFK8Y7FU9VX8" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-usd"></span> Donate on PayPal</a>
+  <a class="btn btn-block btn-default" href="/donate" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-usd"></span> Donate to TBA</a>
 </div>
 
 <hr>


### PR DESCRIPTION
 - Change the donate button to link to `/donate`, which has more information instead of going directly to paypal
 -  remove hardcoded years
 - The covid-19 resource link hasn't been updated since 2021