### PR TITLE
defer writes of team modcodes

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -93,7 +93,9 @@ class Event(CachedModel):
         ndb.StringProperty()
     )  # From ElasticSearch only. String because it can be like "95126-1215"
     # Normalized address from the Google Maps API, constructed using the above
-    normalized_location: Optional[Location] = cast(Location, ndb.StructuredProperty(Location))
+    normalized_location: Optional[Location] = cast(
+        Location, ndb.StructuredProperty(Location)
+    )
 
     timezone_id = (
         ndb.StringProperty()

--- a/src/backend/web/handlers/admin/team_media_mod.py
+++ b/src/backend/web/handlers/admin/team_media_mod.py
@@ -1,10 +1,10 @@
 import csv
 from datetime import datetime
 from io import StringIO
-from typing import Optional
+from typing import List, Optional
 
 from flask import abort, redirect, request, url_for
-from google.appengine.ext import ndb
+from google.appengine.ext import deferred
 
 from backend.common.models.account import Account
 from backend.common.models.keys import TeamNumber, Year
@@ -60,26 +60,29 @@ def team_media_mod_add():
     return render_template("admin/team_media_mod_add.html")
 
 
+def team_media_add_single(year: Year, csv_row: List[str]) -> None:
+    team_number = int(csv_row[0])
+    access = TeamAdminAccess(
+        id=TeamAdminAccess.render_key_name(team_number, year),
+        team_number=team_number,
+        year=year,
+        access_code=csv_row[1],
+        expiration=datetime(year=year, month=7, day=1),
+    )
+    access.put()
+
+
 def team_media_mod_add_post():
     year = int(request.form.get("year"))
     auth_codes_csv = request.form.get("auth_codes_csv")
 
     csv_data = list(csv.reader(StringIO(auth_codes_csv), delimiter=","))
-    auth_codes = []
     for row in csv_data:
-        team_number = int(row[0])
-        auth_codes.append(
-            TeamAdminAccess(
-                id=TeamAdminAccess.render_key_name(team_number, year),
-                team_number=team_number,
-                year=year,
-                access_code=row[1],
-                expiration=datetime(year=year, month=7, day=1),
-            )
-        )
-    ndb.put_multi(auth_codes)
+        # defer the actual datastore write, because with a large number
+        # of teams to add, we don't want to OOM the original request
+        deferred.defer(team_media_add_single, year, row, _queue="admin")
 
-    return redirect(url_for("admin.media_mod_list", year=year))
+    return redirect(url_for("admin.team_media_mod_list", year=year))
 
 
 def team_media_mod_edit(year: Year, team_number: TeamNumber):
@@ -89,7 +92,6 @@ def team_media_mod_edit(year: Year, team_number: TeamNumber):
 
     if not access:
         abort(404)
-        return
 
     access = access[0]
     account_email = None
@@ -112,7 +114,6 @@ def team_media_mod_edit_post(year: Year, team_number: TeamNumber):
 
     if not access:
         abort(404)
-        return
 
     access = access[0]
     access_code = request.form.get("access_code")

--- a/src/backend/web/handlers/admin/tests/team_media_mod_test.py
+++ b/src/backend/web/handlers/admin/tests/team_media_mod_test.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+
+from google.appengine.ext import deferred, testbed
+from werkzeug.test import Client
+
+from backend.common.models.account import Account
+from backend.common.models.team_admin_access import TeamAdminAccess
+
+
+def test_add_team_media_mod_deferred(
+    login_gae_admin,
+    web_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+) -> None:
+    resp = web_client.post(
+        "/admin/media/modcodes/add",
+        data={
+            "year": 2023,
+            "auth_codes_csv": "254,abc123\n255,def456",
+        },
+    )
+    assert resp.status_code == 302
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="admin")
+    assert len(tasks) == 2
+    for task in tasks:
+        deferred.run(task.payload)
+
+    access1 = TeamAdminAccess.get_by_id("frc254_2023")
+    assert access1 is not None
+    assert access1.team_number == 254
+    assert access1.year == 2023
+    assert access1.access_code == "abc123"
+    assert access1.expiration == datetime(2023, 7, 1)
+
+    access2 = TeamAdminAccess.get_by_id("frc255_2023")
+    assert access2 is not None
+    assert access2.team_number == 255
+    assert access2.year == 2023
+    assert access2.access_code == "def456"
+    assert access2.expiration == datetime(2023, 7, 1)
+
+
+def test_edit_team_media_mod_doest_exist(login_gae_admin, web_client: Client) -> None:
+    resp = web_client.get("/admin/media/modcodes/edit/254/2023")
+    assert resp.status_code == 404
+
+
+def test_edit_team_media_mod(login_gae_admin, web_client: Client) -> None:
+    account = Account(email="foo@bar.com")
+    modcode = TeamAdminAccess(
+        id="frc254_2023",
+        team_number=254,
+        year=2023,
+        access_code="abc123",
+        expiration=datetime(2023, 7, 1),
+    )
+
+    account_key = account.put()
+    modcode.put()
+
+    resp = web_client.get("/admin/media/modcodes/edit/254/2023")
+    assert resp.status_code == 200
+
+    new_access = "def456"
+    new_expiration = "2023-08-01"
+    new_email = "foo@bar.com"
+
+    resp = web_client.post(
+        "/admin/media/modcodes/edit/254/2023",
+        data={
+            "access_code": new_access,
+            "expiration": new_expiration,
+            "account_email": new_email,
+        },
+    )
+    assert resp.status_code == 302
+
+    access = TeamAdminAccess.get_by_id("frc254_2023")
+    assert access is not None
+    assert access.team_number == 254
+    assert access.year == 2023
+    assert access.access_code == "def456"
+    assert access.expiration == datetime(2023, 8, 1)
+    assert access.account == account_key


### PR DESCRIPTION
When importing a year's worth of modcodes, this OOMs. I've been manually working around it for years, but no longer.

Also, write some tests for this handler.