### PR TITLE
Support PING notifications with legacy FCM format

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -360,11 +360,12 @@ class TBANSHelper:
     @staticmethod
     def _ping_client(client: MobileClient) -> bool:
         client_type = client.client_type
-        if client_type in FCM_CLIENTS:
+        if client_type in FCM_CLIENTS or client_type in FCM_LEGACY_CLIENTS:
             from backend.common.models.notifications.ping import (
                 PingNotification,
             )
 
+            is_legacy_format = client_type in FCM_LEGACY_CLIENTS
             notification = PingNotification()
 
             from backend.common.models.notifications.requests.fcm_request import (
@@ -372,7 +373,10 @@ class TBANSHelper:
             )
 
             fcm_request = FCMRequest(
-                firebase_app, notification, tokens=[client.messaging_id]
+                firebase_app,
+                notification,
+                tokens=[client.messaging_id],
+                legacy_data_format=is_legacy_format,
             )
 
             batch_response = fcm_request.send()

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -733,8 +733,44 @@ class TestTBANSHelper(unittest.TestCase):
         batch_response = messaging.BatchResponse(
             [messaging.SendResponse({"name": "abc"}, None)]
         )
-        with patch.object(FCMRequest, "send", return_value=batch_response) as mock_send:
+        with patch.object(
+            FCMRequest, "__init__", mock.MagicMock(spec=FCMRequest, return_value=None)
+        ) as mock_fcm_request_constructor, patch.object(
+            FCMRequest, "send", return_value=batch_response
+        ) as mock_send:
             success = TBANSHelper._ping_client(client)
+
+            mock_fcm_request_constructor.assert_called_once()
+            assert (
+                mock_fcm_request_constructor.call_args[1]["legacy_data_format"] is False
+            )
+            mock_send.assert_called_once()
+            assert success
+
+    def test_ping_fcm_legacy(self):
+        client = MobileClient(
+            parent=ndb.Key(Account, "user_id"),
+            user_id="user_id",
+            messaging_id="token",
+            client_type=ClientType.OS_ANDROID,
+            device_uuid="uuid",
+            display_name="Phone",
+        )
+
+        batch_response = messaging.BatchResponse(
+            [messaging.SendResponse({"name": "abc"}, None)]
+        )
+        with patch.object(
+            FCMRequest, "__init__", mock.MagicMock(spec=FCMRequest, return_value=None)
+        ) as mock_fcm_request_constructor, patch.object(
+            FCMRequest, "send", return_value=batch_response
+        ) as mock_send:
+            success = TBANSHelper._ping_client(client)
+
+            mock_fcm_request_constructor.assert_called_once()
+            assert (
+                mock_fcm_request_constructor.call_args[1]["legacy_data_format"] is True
+            )
             mock_send.assert_called_once()
             assert success
 


### PR DESCRIPTION
As title.

Currently, this 500s if you try to ping an Android client. That shouldn't be. Also adds new tests for the scenario.