### PR TITLE
add longer cache timeouts to apiv3

### DIFF
--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from typing import Optional
 
 from flask import Response
@@ -12,6 +13,7 @@ from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
 from backend.common.models.keys import DistrictKey
 from backend.common.queries.district_query import DistrictQuery, DistrictsInYearQuery
 from backend.common.queries.event_query import DistrictEventsQuery
@@ -29,12 +31,16 @@ def district_events(
     """
     track_call_after_response("district/events", district_key, model_type)
 
+    year = int(district_key[:4])
     events = DistrictEventsQuery(district_key=district_key).fetch_dict(
         ApiMajorVersion.API_V3
     )
     if model_type is not None:
         events = filter_event_properties(events, model_type)
-    return profiled_jsonify(events)
+    return make_cached_response(
+        profiled_jsonify(events),
+        ttl=timedelta(hours=1) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -48,12 +54,16 @@ def district_teams(
     """
     track_call_after_response("district/teams", district_key, model_type)
 
+    year = int(district_key[:4])
     teams = DistrictTeamsQuery(district_key=district_key).fetch_dict(
         ApiMajorVersion.API_V3
     )
     if model_type is not None:
         teams = filter_team_properties(teams, model_type)
-    return profiled_jsonify(teams)
+    return make_cached_response(
+        profiled_jsonify(teams),
+        ttl=timedelta(hours=1) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -66,7 +76,10 @@ def district_rankings(district_key: DistrictKey) -> Response:
     track_call_after_response("district/rankings", district_key)
 
     district = DistrictQuery(district_key=district_key).fetch()
-    return profiled_jsonify(district.rankings)
+    return make_cached_response(
+        profiled_jsonify(district.rankings),
+        ttl=timedelta(seconds=61) if district.year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -78,4 +91,7 @@ def district_list_year(year: int) -> Response:
     track_call_after_response("district/list", str(year))
 
     district = DistrictsInYearQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(district)
+    return make_cached_response(
+        profiled_jsonify(district),
+        ttl=timedelta(hours=1) if year == datetime.now().year else timedelta(days=1),
+    )

--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from typing import Optional
 
 from flask import Response
@@ -14,6 +15,7 @@ from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
+from backend.common.flask_cache import make_cached_response
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.playoff_advancement_helper import PlayoffAdvancementHelper
 from backend.common.helpers.season_helper import SeasonHelper
@@ -37,10 +39,14 @@ def event(event_key: EventKey, model_type: Optional[ModelType] = None) -> Respon
     """
     track_call_after_response("event", event_key, model_type)
 
+    year = int(event_key[:4])
     event = EventQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
     if model_type is not None:
         event = filter_event_properties([event], model_type)[0]
-    return profiled_jsonify(event)
+    return make_cached_response(
+        profiled_jsonify(event),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(hours=1),
+    )
 
 
 @api_authenticated
@@ -64,7 +70,11 @@ def event_list_all(model_type: Optional[ModelType] = None) -> Response:
 
     if model_type is not None:
         events = filter_event_properties(events, model_type)
-    return profiled_jsonify(events)
+
+    return make_cached_response(
+        profiled_jsonify(events),
+        ttl=timedelta(hours=1)
+    )
 
 
 @api_authenticated
@@ -79,7 +89,10 @@ def event_list_year(year: int, model_type: Optional[ModelType] = None) -> Respon
 
     if model_type is not None:
         events = filter_event_properties(events, model_type)
-    return profiled_jsonify(events)
+    return make_cached_response(
+        profiled_jsonify(events),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -91,6 +104,7 @@ def event_detail(event_key: EventKey, detail_type: str) -> Response:
     """
     track_call_after_response(f"event/{detail_type}", event_key)
 
+    year = int(event_key[:4])
     event_details = EventDetailsQuery(event_key=event_key).fetch_dict(
         ApiMajorVersion.API_V3
     )
@@ -101,7 +115,10 @@ def event_detail(event_key: EventKey, detail_type: str) -> Response:
     if detail_type == "alliances" and detail:
         add_alliance_status(event_key, detail)
 
-    return profiled_jsonify(detail)
+    return make_cached_response(
+        profiled_jsonify(detail),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -115,10 +132,14 @@ def event_teams(
     """
     track_call_after_response("event/teams", event_key, model_type)
 
+    year = int(event_key[:4])
     teams = EventTeamsQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
     if model_type is not None:
         teams = filter_team_properties(teams, model_type)
-    return profiled_jsonify(teams)
+    return make_cached_response(
+        profiled_jsonify(teams),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -130,6 +151,7 @@ def event_teams_statuses(event_key: EventKey) -> Response:
     """
     track_call_after_response("event/teams/statuses", event_key)
 
+    year = int(event_key[:4])
     event_teams = EventEventTeamsQuery(event_key=event_key).fetch()
     statuses = {}
     for event_team in event_teams:
@@ -144,7 +166,10 @@ def event_teams_statuses(event_key: EventKey) -> Response:
                 }
             )
         statuses[event_team.team.id()] = status
-    return profiled_jsonify(statuses)
+    return make_cached_response(
+        profiled_jsonify(statuses),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -158,10 +183,14 @@ def event_matches(
     """
     track_call_after_response("event/matches", event_key, model_type)
 
+    year = int(event_key[:4])
     matches = EventMatchesQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
     if model_type is not None:
         matches = filter_match_properties(matches, model_type)
-    return profiled_jsonify(matches)
+    return make_cached_response(
+        profiled_jsonify(matches),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -173,8 +202,12 @@ def event_awards(event_key: EventKey) -> Response:
     """
     track_call_after_response("event/awards", event_key)
 
+    year = int(event_key[:4])
     awards = EventAwardsQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(awards)
+    return make_cached_response(
+        profiled_jsonify(awards),
+        ttl=timedelta(seconds=61) if year == datetime.now().year else timedelta(days=1),
+    )
 
 
 @api_authenticated
@@ -215,4 +248,7 @@ def event_playoff_advancement(event_key: EventKey) -> Response:
     output = PlayoffAdvancementHelper.create_playoff_advancement_response_for_apiv3(
         event, playoff_advancement, bracket_table
     )
-    return profiled_jsonify(output)
+    return make_cached_response(
+        profiled_jsonify(output),
+        ttl=timedelta(seconds=61) if event.year == datetime.now().year else timedelta(days=1),
+    )

--- a/src/backend/api/handlers/media.py
+++ b/src/backend/api/handlers/media.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from flask import Response
 
 from backend.api.handlers.decorators import api_authenticated
@@ -8,7 +10,7 @@ from backend.common.decorators import cached_public
 
 
 @api_authenticated
-@cached_public
+@cached_public(ttl=timedelta(days=1))
 def media_tags() -> Response:
     """
     Returns a list of media tag names and codes.


### PR DESCRIPTION
This can save some costs by caching data unrelated to the current year (and therefore unlikely to change) for longer than the default 61 seconds.