### PR TITLE
Add component opr api endpoint

### DIFF
--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -84,7 +84,7 @@ class ModelTypeConverter(BaseConverter):
 
 
 class EventDetailTypeConverter(BaseConverter):
-    regex = r"alliances|district_points|insights|oprs|predictions|rankings"
+    regex = r"alliances|district_points|insights|oprs|coprs|predictions|rankings"
 
 
 configure_logging()

--- a/src/backend/common/queries/dict_converters/event_details_converter.py
+++ b/src/backend/common/queries/dict_converters/event_details_converter.py
@@ -11,7 +11,7 @@ EventDetailsDict = NewType("EventDetailsDict", Dict)
 
 class EventDetailsConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        ApiMajorVersion.API_V3: 3,
+        ApiMajorVersion.API_V3: 4,
     }
 
     @classmethod
@@ -36,6 +36,14 @@ class EventDetailsConverter(ConverterBase):
                             team = "frc{}".format(team)
                         normalized_oprs[stat_type][team] = value
 
+        normalized_coprs = defaultdict(dict)
+        if event_details and event_details.coprs:
+            for copr_type, coprs in event_details.coprs.items():
+                for team, value in coprs.items():
+                    if "frc" not in team:
+                        team = "frc{}".format(team)
+                    normalized_coprs[copr_type][team] = value
+
         rankings = {}
         if event_details:
             rankings = event_details.renderable_rankings
@@ -55,6 +63,7 @@ class EventDetailsConverter(ConverterBase):
             "oprs": normalized_oprs if normalized_oprs else {},  # OPRs, DPRs, CCWMs
             "predictions": event_details.predictions if event_details else {},
             "rankings": rankings,
+            "coprs": normalized_coprs,
         }
 
         return EventDetailsDict(event_details_dict)


### PR DESCRIPTION
## Description
Adds `/event/{key}/coprs` API endpoint. This **does not** touch any Swagger stuff, so we will need to add that in a followup PR.

Note that all events from 2016-2022 should have their cOPRs generated at some point; these events are aggressively cached so they haven't ever actually run since cOPRs were introduced. An admin will need to do this.

## Motivation and Context
COPRs are currently only available via web interface. This helps scouts a lot and prevents the need for web scraping.

## How Has This Been Tested?
Manually with 2 events - one with cOPRs generated, one without (returns `{}` for events without cOPRs).

## Screenshots (if appropriate):
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/7595639/4868c4de-d3f2-4561-8d87-d2151d454241)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
