### PR TITLE
Minor fix: Removal of unnecessary double quotes around utf-8 in HTTP header for webhooks

### DIFF
--- a/src/backend/common/models/notifications/requests/tests/webhook_request_test.py
+++ b/src/backend/common/models/notifications/requests/tests/webhook_request_test.py
@@ -87,7 +87,7 @@ def test_send_headers():
     )
 
     headers = {
-        "Content-Type": 'application/json; charset="utf-8"',
+        "Content-Type": 'application/json; charset=utf-8',
         "X-TBA-Version": "1",
         "X-TBA-Checksum": "82bb620ceffa9ee31480e60b98f1881251fb68c3",
         "X-TBA-HMAC": "a143b493f9a31077f7ff742dc3f59c8d73e6e2c2f09dde5f1a73c33059b77151",

--- a/src/backend/common/models/notifications/requests/webhook_request.py
+++ b/src/backend/common/models/notifications/requests/webhook_request.py
@@ -38,7 +38,7 @@ class WebhookRequest(Request):
         """Attempt to send the notification."""
         # Build the request
         headers = {
-            "Content-Type": 'application/json; charset="utf-8"',
+            "Content-Type": 'application/json; charset=utf-8',
             "X-TBA-Version": "{}".format(WEBHOOK_VERSION),
         }
         payload = self._json_string()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the double quotes surrounding utf-8 in the HTTP header for Content-Type of the POST request sent to webhooks. 
The Content-Type header should now have the correct format for describing the UTF-8 character set of the payload. 
Both the implementation and the relevant test case have been changed to reflect the correct syntax for the HTTP header.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current webhook verification & ping process would result in a 500 error when sent to a Kafka cluster (hosted by Upstash) through their webhook API. The HTTP headers sent with the request were parsed by Upstash before the data is loaded into the Kafka topic stream, so that non-standard HTTP headers are converted to message headers in the stream. As such, standard HTTP headers with incorrect syntax would result in an error. 
Removing the double quotes fixes this problem as it corrects the syntax for the Content-Type header. This fix should also affect other webhook APIs that may rely on the correct syntax for standard HTTP headers. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`pytest src/` was run with a result of: 2711 passed, 37 skipped.
This result remained the same before and after these changes. 
Note that a test case for the request was changed as it too had incorrectly included double quotes around utf-8.

## Screenshots (if appropriate):
![screenshot curl error](https://github.com/the-blue-alliance/the-blue-alliance/assets/31122258/ffc8cc97-08fd-4350-a20f-79e2c8a673e4)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
