### PR TITLE
Update match_breakdown_2024.html

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2024.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2024.html
@@ -132,7 +132,7 @@
     </tr>
     {% endif %}
 
-    {% if "teleopAmpNoteCount" in match.score_breakdown.red %}
+    {% if "teleopSpeakerNoteCount" in match.score_breakdown.red %}
     <tr>
     <td class="red" colspan="2">
         {{speaker(


### PR DESCRIPTION
fixed incorrect if statement

## Description
Changed which variable the if looks for when determining whether or not to do a detailed account of speaker note counts

## Motivation and Context
The if statement would have hidden the speaker note counts if the amp note counts are missing, not if the speaker ones are. That could cause an error (probably) and is unintentional.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
