### PR TITLE
Fix match_breakdown_2024 red auto leave

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2024.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2024.html
@@ -56,7 +56,7 @@
       <td class="redScore" colspan="2">
         {{mobility(match.alliances.red.teams.0, match.score_breakdown.red.autoLineRobot1 == 'Yes')}}
         {{mobility(match.alliances.red.teams.1, match.score_breakdown.red.autoLineRobot2 == 'Yes')}}
-        {{mobility(match.alliances.red.teams.2, match.score_breakdown.red.autoLineRobot2 == 'Yes')}}
+        {{mobility(match.alliances.red.teams.2, match.score_breakdown.red.autoLineRobot3 == 'Yes')}}
         (+{{match.score_breakdown.red.autoLeavePoints}})
       </td>
       <td>Auto Leave</td>

--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2024.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2024.html
@@ -43,8 +43,8 @@
 {% endmacro %}
 
 {% macro fouls(alliance_breakdown) %}
-{%if alliance_breakdown.foulCount%}{{alliance_breakdown.foulCount}} (+{{alliance_breakdown.foulCount * 5}}){%else%}0{%endif%} /
-{%if alliance_breakdown.techFoulCount%}{{alliance_breakdown.techFoulCount}} (+{{alliance_breakdown.techFoulCount * 12}}){%else%}0{%endif%}
+{%if alliance_breakdown.foulCount%}{{alliance_breakdown.foulCount}} (+{{alliance_breakdown.foulCount * 2}}){%else%}0{%endif%} /
+{%if alliance_breakdown.techFoulCount%}{{alliance_breakdown.techFoulCount}} (+{{alliance_breakdown.techFoulCount * 5}}){%else%}0{%endif%}
 {% endmacro %}
 
 <table class="match-table">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix match_breakdown_2024:
- red auto leave
- Foul/Tech foul points 

## Motivation and Context
Copy/paste issue.  😅
Reported here:
https://www.chiefdelphi.com/t/tba-match-summaries-for-isr-district-event-1-correct/456162

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
