### PR TITLE
Automatically remove DistrictTeam for teams without an event in a given year

### DIFF
--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -3,7 +3,7 @@ import logging
 import re
 from typing import List, Optional, Set
 
-from flask import Blueprint, Response, make_response, render_template, request, url_for
+from flask import Blueprint, make_response, render_template, request, Response, url_for
 from google.appengine.api import taskqueue
 from google.appengine.ext import ndb
 from markupsafe import Markup

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -3,14 +3,7 @@ import logging
 import re
 from typing import List, Optional, Set
 
-from flask import (
-    Blueprint,
-    make_response,
-    render_template,
-    request,
-    Response,
-    url_for,
-)
+from flask import Blueprint, Response, make_response, render_template, request, url_for
 from google.appengine.api import taskqueue
 from google.appengine.ext import ndb
 from markupsafe import Markup
@@ -49,7 +42,6 @@ from backend.common.sitevars.apistatus import ApiStatus
 from backend.common.sitevars.cmp_registration_hacks import ChampsRegistrationHacks
 from backend.common.suggestions.suggestion_creator import SuggestionCreator
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
-
 
 blueprint = Blueprint("frc_api", __name__)
 
@@ -124,13 +116,27 @@ def team_details(team_key: TeamKey) -> Response:
     # Clean up junk district teams
     # https://www.facebook.com/groups/moardata/permalink/1310068625680096/
     if team:
+        keys_to_delete = set()
+        # Delete all DistrictTeam that are not valid in the current year
         dt_keys = DistrictTeam.query(
             DistrictTeam.team == team.key, DistrictTeam.year == year
         ).fetch(keys_only=True)
-        keys_to_delete = set()
         for dt_key in dt_keys:
             if not district_team or dt_key.id() != district_team.key.id():
                 keys_to_delete.add(dt_key)
+
+        # Delete all DistrictTeam that are for any year that the team is not have an event in
+        dt_keys = DistrictTeam.query(DistrictTeam.team == team.key).fetch()
+        et_keys = EventTeam.query(
+            EventTeam.team == team.key,
+            projection=[EventTeam.year],
+            group_by=[EventTeam.year],
+        ).fetch()
+        et_years = {et_key.year for et_key in et_keys}
+
+        for dt_key in dt_keys:
+            if dt_key.year not in et_years:
+                keys_to_delete.add(dt_key.key)
         DistrictTeamManipulator.delete_keys(keys_to_delete)
 
     if robot:

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -117,7 +117,8 @@ def team_details(team_key: TeamKey) -> Response:
     # https://www.facebook.com/groups/moardata/permalink/1310068625680096/
     if team:
         keys_to_delete = set()
-        # Delete all DistrictTeam that are not valid in the current year
+        # Delete all DistrictTeams that are not valid in the current
+        # year, since each team can only be in one district per year
         dt_keys = DistrictTeam.query(
             DistrictTeam.team == team.key, DistrictTeam.year == year
         ).fetch(keys_only=True)
@@ -125,7 +126,8 @@ def team_details(team_key: TeamKey) -> Response:
             if not district_team or dt_key.id() != district_team.key.id():
                 keys_to_delete.add(dt_key)
 
-        # Delete all DistrictTeam that are for any year that the team is not have an event in
+        # Delete all DistrictTeam that are for any year that the team
+        # does not have an event
         dt_keys = DistrictTeam.query(DistrictTeam.team == team.key).fetch()
         et_keys = EventTeam.query(
             EventTeam.team == team.key,

--- a/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
@@ -5,11 +5,9 @@ from freezegun import freeze_time
 from google.appengine.ext import ndb, testbed
 from werkzeug.test import Client
 
-from backend.common.consts.event_type import EventType
 from backend.common.consts.media_type import MediaType
 from backend.common.models.district import District
 from backend.common.models.district_team import DistrictTeam
-from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.models.media import Media
 from backend.common.models.robot import Robot


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Right now, once a team is listed in a district, they will get new `DistrictTeam` records for every year after that.

## Motivation and Context
The result of this is that we list teams who are no longer competing in current district listings, which is very confusing, and incorrect.

The biggest functional change here is that each time we update the `team_details` for a team, we're checking all `DistrictTeam`s for that team to make sure that each year the team has a corresponding `EventTeam` i.e. they went to at least one event.  2020/2021 was a question mark for me, but any team that actually competed has the "remote" events, so we're good there.

I've added a new spec, just to cover this specific case, as well as updated the other specs to including having a `EventTeam` for that year, since that's now required.

In all of my research, this dependency on having `EventTeam`s before updating `team_details` _SEEMS_ okay, as events are updated/added way more often, as well as before teams, but this is something that some with a better understanding of the API calls/timing of such should probably verify/confirm.

## How Has This Been Tested?
Tested locally.
Wrote additional tests for the added functionality.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
