### PR TITLE
Show "total ranking points" column in 2024 rankings

### DIFF
--- a/src/backend/common/models/event_details.py
+++ b/src/backend/common/models/event_details.py
@@ -134,7 +134,7 @@ class EventDetails(CachedModel):
             if game_year == 2021:
                 # 2021 did not have matches played for rankings
                 pass
-            elif game_year in {2017, 2018, 2019, 2020, 2021, 2022, 2023}:
+            elif game_year >= 2017:
                 extra_stats_info = [{"name": "Total Ranking Points", "precision": 0}]
             elif sort_order_info is not None:
                 extra_stats_info = [

--- a/src/backend/common/models/event_details.py
+++ b/src/backend/common/models/event_details.py
@@ -114,7 +114,7 @@ class EventDetails(CachedModel):
                 if game_year == 2021:
                     # 2021 did not have matches played for rankings
                     continue
-                elif game_year in {2017, 2018, 2019, 2020, 2021, 2022, 2023}:
+                elif game_year >= 2017:
                     rank["extra_stats"] = [
                         int(round(rank["sort_orders"][0] * rank["matches_played"])),
                     ]


### PR DESCRIPTION
## Description
https://www.thebluealliance.com/event/2024isde1#rankings is currently showing the pre-2017 "Ranking Score/Match" column, rather than the post-2017 "Total Ranking Points" column. This changes that behavior, and also changes the default behavior for future years so we hopefully don't run into the same issue every year (until rankings change).

## Motivation and Context
https://www.chiefdelphi.com/t/tba-match-summaries-for-isr-district-event-1-correct/456162/10

## How Has This Been Tested?
Imported a 2016, 2017, and 2024 event locally. 2016 and 2017 showed no change. For 2024:
<details><summary>Before</summary>

![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/3719547/5e69736c-c6a6-4225-b828-bb0adb38e54c)

</details> 

<details><summary>After</summary>
<p>

![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/3719547/1a7b38fc-513c-42bc-a373-eaddf807025f)


</p>
</details> 

Statically verified from 36a5b1db5d2f74eaa3b2e108a3c98b6488425f14 and 691592f097a6a17f5f6c0b0d26024c615d19738b that these should be the only necessary changes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
