### PR TITLE
Set push notification retry limit to 0

### DIFF
--- a/src/queue.yaml
+++ b/src/queue.yaml
@@ -26,6 +26,7 @@ queue:
 - name: push-notifications
   rate: 10/s
   retry_parameters:
+    task_retry_limit: 0
     task_age_limit: 3m
     min_backoff_seconds: 10
     max_backoff_seconds: 30


### PR DESCRIPTION
Set this in the web interface but a deploy overwrote this (expected). Going to add this to the ymal so it persists. Should help with push notification tasks timing out and then retrying.