### PR TITLE
Set match.push_sent for match score notifications

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -193,6 +193,9 @@ class TBANSHelper:
 
     @classmethod
     def match_score(cls, match: Match, user_id: Optional[str] = None) -> None:
+        if match.push_sent:
+            return
+
         event = match.event.get()
 
         from backend.common.models.notifications.match_score import (
@@ -229,6 +232,10 @@ class TBANSHelper:
                 )
             if users:
                 cls._send(users, MatchScoreNotification(match))
+
+        # Update score sent boolean on Match object to make sure we only send a notification once
+        match.push_sent = True
+        match.put()
 
         # Send UPCOMING_MATCH for the N + 2 match after this one
         if not event.matches:

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -436,6 +436,18 @@ class TestTBANSHelper(unittest.TestCase):
             assert isinstance(notification, EventScheduleNotification)
             assert notification.event == self.event
 
+    def test_match_score_push_sent(self):
+        self.match.push_sent = True
+
+        with patch.object(TBANSHelper, "_send") as mock_send:
+            TBANSHelper.match_score(self.match, "user_id")
+            mock_send.assert_not_called()
+
+    def test_match_score_set_push_sent(self):
+        assert not self.match.push_sent
+        TBANSHelper.match_score(self.match)
+        assert self.match.push_sent
+
     def test_match_score_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:


### PR DESCRIPTION
Adding the `match.push_sent = True` flag + check to the FCM code