### PR TITLE
work around broken schedules in FRC API

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -324,7 +324,19 @@ class DatafeedFMSAPI:
         for field, value in result.items():
             if field == "teams":
                 for i, team in enumerate(value):
-                    scheduled["teams"][i].update(team)
+                    schedule_team = next(
+                        filter(
+                            lambda t: t["teamNumber"] == team["teamNumber"],
+                            scheduled["teams"],
+                        ),
+                        None,
+                    )
+                    if schedule_team is None:
+                        # 2024, Week 3: Upstream FMS sync issues leading to schedules returned with no teams
+                        # Some match results have been sync'd, so patch around this where we can
+                        scheduled["teams"].append(team)
+                    else:
+                        scheduled["teams"][i].update(team)
             else:
                 scheduled[field] = value
         return scheduled

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -128,15 +128,15 @@ class FMSAPIHybridScheduleParser(
                 team_key_names.append(team_key)
                 if "Red" in team["station"]:
                     red_teams.append(team_key)
-                    if team["surrogate"]:
+                    if team.get("surrogate", None):
                         red_surrogates.append(team_key)
-                    if team["dq"]:
+                    if team.get("dq", None):
                         red_dqs.append(team_key)
                 elif "Blue" in team["station"]:
                     blue_teams.append(team_key)
-                    if team["surrogate"]:
+                    if team.get("surrogate", None):
                         blue_surrogates.append(team_key)
-                    if team["dq"]:
+                    if team.get("dq", None):
                         blue_dqs.append(team_key)
 
             if (


### PR DESCRIPTION
This week, FMS sync issues have led to schedules getting posted with no teams, which breaks lots of things...

This diff will try to work around it, for cases where match results are publishing (and to take the teams from the results API if none are present in the schedule response).

With this, I managed to load match results for `2024onbar` locally:

![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/e06b38f8-5a48-49fd-b778-6307b2debd9c)


While prod looks like this:

![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/7ad2ec61-3162-430c-a4ba-0f5372b3cb74)
