### PR TITLE
Check Match.push_sent in the match manipulator

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -193,9 +193,6 @@ class TBANSHelper:
 
     @classmethod
     def match_score(cls, match: Match, user_id: Optional[str] = None) -> None:
-        if match.push_sent:
-            return
-
         event = match.event.get()
 
         from backend.common.models.notifications.match_score import (

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -436,18 +436,6 @@ class TestTBANSHelper(unittest.TestCase):
             assert isinstance(notification, EventScheduleNotification)
             assert notification.event == self.event
 
-    def test_match_score_push_sent(self):
-        self.match.push_sent = True
-
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.match_score(self.match, "user_id")
-            mock_send.assert_not_called()
-
-    def test_match_score_set_push_sent(self):
-        assert not self.match.push_sent
-        TBANSHelper.match_score(self.match)
-        assert self.match.push_sent
-
     def test_match_score_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:

--- a/src/backend/common/manipulators/match_manipulator.py
+++ b/src/backend/common/manipulators/match_manipulator.py
@@ -84,13 +84,16 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
         event = match.event.get()
         # Only continue if the event is currently happening
         if event and event.now:
-            if match.has_been_played:
+            if match.has_been_played and not match.push_sent:
                 if (
                     updated_match.is_new
                     or "alliances_json" in updated_match.updated_attrs
                 ):
                     try:
                         TBANSHelper.match_score(match)
+                        # Update score sent boolean on Match object to make sure we only send a notification once
+                        match.push_sent = True
+                        MatchManipulator.createOrUpdate(match, run_post_update_hook=False)
                     except Exception as exception:
                         logging.error(
                             "Error sending match {} updates: {}".format(


### PR DESCRIPTION
Avoids using the `match.put` which was rightly pointed out is probably an issue due to how our cache works for the models