### PR TITLE
Apidocs webhooks fixes

### DIFF
--- a/src/backend/web/handlers/apidocs.py
+++ b/src/backend/web/handlers/apidocs.py
@@ -1,10 +1,9 @@
 from datetime import timedelta
 
-from flask import Blueprint, make_response, redirect, request, Response, url_for
+from flask import Blueprint, jsonify, make_response, redirect, request, Response, url_for
 from pyre_extensions import none_throws
 from werkzeug.wrappers import Response as WerkzeugResponse
 
-from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.common.auth import current_user
 from backend.common.consts.notification_type import (
     ENABLED_NOTIFICATIONS,
@@ -54,13 +53,22 @@ def apidocs_v3() -> str:
 @blueprint.route("/webhooks")
 @cached_public(ttl=timedelta(weeks=1))
 def apidocs_webhooks() -> str:
-    template_values = {"enabled": ENABLED_NOTIFICATIONS, "types": NOTIFICATION_TYPES, "testing_enabled": False}
+    template_values = {
+        "enabled": ENABLED_NOTIFICATIONS,
+        "types": NOTIFICATION_TYPES,
+        "testing_enabled": False,
+    }
     return render_template("apidocs_webhooks.html", template_values)
+
 
 @blueprint.route("/webhooks/authenticated")
 @require_login
 def apidocs_webhooks_testing() -> str:
-    template_values = {"enabled": ENABLED_NOTIFICATIONS, "types": NOTIFICATION_TYPES, "testing_enabled": True}
+    template_values = {
+        "enabled": ENABLED_NOTIFICATIONS,
+        "types": NOTIFICATION_TYPES,
+        "testing_enabled": True,
+    }
     return render_template("apidocs_webhooks.html", template_values)
 
 
@@ -75,11 +83,9 @@ def apidocs_webhooks_notification(type: int) -> Response:
     user_id = str(user.uid)
 
     success_response = make_response("ok", 200)
+
     def error_response(message: str):
-        return make_response(
-            profiled_jsonify({"Error": message}),
-            400
-        )
+        return make_response(jsonify({"Error": message}), 400)
 
     try:
         notification_type = NotificationType(type)

--- a/src/backend/web/handlers/apidocs.py
+++ b/src/backend/web/handlers/apidocs.py
@@ -4,6 +4,7 @@ from flask import Blueprint, make_response, redirect, request, Response, url_for
 from pyre_extensions import none_throws
 from werkzeug.wrappers import Response as WerkzeugResponse
 
+from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.common.auth import current_user
 from backend.common.consts.notification_type import (
     ENABLED_NOTIFICATIONS,
@@ -68,12 +69,16 @@ def apidocs_webhooks_notification(type: int) -> Response:
     user_id = str(user.uid)
 
     success_response = make_response("ok", 200)
-    error_response = make_response("", 400)
+    def error_response(message: str):
+        return make_response(
+            profiled_jsonify({"Error": message}),
+            400
+        )
 
     try:
         notification_type = NotificationType(type)
     except ValueError:
-        return error_response
+        return error_response("Invalid notification type")
 
     if notification_type in [
         NotificationType.ALLIANCE_SELECTION,
@@ -82,13 +87,13 @@ def apidocs_webhooks_notification(type: int) -> Response:
     ]:
         # Handle our Event dispatches
         if not event_key:
-            return error_response
+            return error_response("Event key not specified")
 
         from backend.common.models.event import Event
 
         event = Event.get_by_id(event_key)
         if not event:
-            return error_response
+            return error_response(f"Event {event_key} not found")
 
         if notification_type == NotificationType.ALLIANCE_SELECTION:
             TBANSHelper.alliance_selection(event, user_id=user_id)
@@ -100,7 +105,7 @@ def apidocs_webhooks_notification(type: int) -> Response:
             TBANSHelper.event_schedule(event, user_id=user_id)
             return success_response
 
-        return error_response
+        return error_response("Unexpected error")
     elif notification_type in [
         NotificationType.UPCOMING_MATCH,
         NotificationType.MATCH_SCORE,
@@ -109,13 +114,13 @@ def apidocs_webhooks_notification(type: int) -> Response:
     ]:
         # Handle our Match dispatches
         if not match_key:
-            return error_response
+            return error_response("Match key not specified")
 
         from backend.common.models.match import Match
 
         match = Match.get_by_id(match_key)
         if not match:
-            return error_response
+            return error_response(f"Match {match_key} not found")
 
         if notification_type == NotificationType.UPCOMING_MATCH:
             TBANSHelper.match_upcoming(match, user_id=user_id)
@@ -130,8 +135,8 @@ def apidocs_webhooks_notification(type: int) -> Response:
             TBANSHelper.match_video(match, user_id=user_id)
             return success_response
 
-        return error_response
+        return error_response("Unexpected error")
 
     # TODO: Need to handle district_points_updated here as well
 
-    return error_response
+    return error_response(f"Unknown notification_type {notification_type}")

--- a/src/backend/web/handlers/apidocs.py
+++ b/src/backend/web/handlers/apidocs.py
@@ -13,7 +13,7 @@ from backend.common.consts.notification_type import (
 from backend.common.consts.notification_type import TYPES as NOTIFICATION_TYPES
 from backend.common.decorators import cached_public
 from backend.common.helpers.tbans_helper import TBANSHelper
-from backend.web.decorators import enforce_login
+from backend.web.decorators import enforce_login, require_login
 from backend.web.profiled_render import render_template
 
 
@@ -54,7 +54,13 @@ def apidocs_v3() -> str:
 @blueprint.route("/webhooks")
 @cached_public(ttl=timedelta(weeks=1))
 def apidocs_webhooks() -> str:
-    template_values = {"enabled": ENABLED_NOTIFICATIONS, "types": NOTIFICATION_TYPES}
+    template_values = {"enabled": ENABLED_NOTIFICATIONS, "types": NOTIFICATION_TYPES, "testing_enabled": False}
+    return render_template("apidocs_webhooks.html", template_values)
+
+@blueprint.route("/webhooks/authenticated")
+@require_login
+def apidocs_webhooks_testing() -> str:
+    template_values = {"enabled": ENABLED_NOTIFICATIONS, "types": NOTIFICATION_TYPES, "testing_enabled": True}
     return render_template("apidocs_webhooks.html", template_values)
 
 

--- a/src/backend/web/templates/account_overview.html
+++ b/src/backend/web/templates/account_overview.html
@@ -346,7 +346,7 @@
      {% endif %}
       </table>
       <p><a class="btn btn-default" href="/webhooks/add"><span class="glyphicon glyphicon-plus"></span> Add Webhook</a></p>
-      <p>Check out our <a href="/apidocs/webhooks">Webhooks API documentation</a> for more info.</p>
+      <p>Check out our <a href="/apidocs/webhooks/authenticated">Webhooks API documentation</a> for more info.</p>
     </div>
   </div>
 </div>

--- a/src/backend/web/templates/apidocs_partials/apidocs_webhooks_test.html
+++ b/src/backend/web/templates/apidocs_partials/apidocs_webhooks_test.html
@@ -1,41 +1,46 @@
 {% if type in enabled %}
-<h4>Test Notification</h4>
-    <form method="POST" action="/apidocs/webhooks/test/{{ type.value }}" class="form-horizontal" role="form" onsubmit="event.preventDefault()">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <div class="row">
-            {% if event_key %}
-            <div class="form-group">
-                <label class="col-sm-2 control-label">Event Key</label>
-                <div class="col-sm-10">
-                    <input type="text" class="form-control" required value="{{ event_key }}" name="event_key">
+    <h4>Test Notification</h4>
+    {% if testing_enabled %}
+        <form method="POST" action="/apidocs/webhooks/test/{{ type.value }}" class="form-horizontal" role="form"
+            onsubmit="event.preventDefault()">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <div class="row">
+                {% if event_key %}
+                <div class="form-group">
+                    <label class="col-sm-2 control-label">Event Key</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" required value="{{ event_key }}" name="event_key">
+                    </div>
+                </div>
+                {% endif %}
+                {% if match_key %}
+                <div class="form-group">
+                    <label class="col-sm-2 control-label">Match Key</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" required value="{{ match_key }}" name="match_key">
+                    </div>
+                </div>
+                {% endif %}
+                {% if district_key %}
+                <div class="form-group">
+                    <label class="col-sm-2 control-label">District Key</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" required value="{{ district_key }}" name="district_key">
+                    </div>
+                </div>
+                {% endif %}
+                <div class="form-group">
+                    <div class="col-sm-2"></div>
+                    <div class="col-sm-10">
+                        <button class="btn btn-info webhook-send-btn" type="submit">Send Test {{ enabled[type] }}</button>
+                    </div>
                 </div>
             </div>
-            {% endif %}
-            {% if match_key %}
-            <div class="form-group">
-                <label class="col-sm-2 control-label">Match Key</label>
-                <div class="col-sm-10">
-                    <input type="text" class="form-control" required value="{{ match_key }}" name="match_key">
-                </div>
+            <div class="row">
+                <div class="alert webhook-alert"></div>
             </div>
-            {% endif %}
-            {% if district_key %}
-            <div class="form-group">
-                <label class="col-sm-2 control-label">District Key</label>
-                <div class="col-sm-10">
-                    <input type="text" class="form-control" required value="{{ district_key }}" name="district_key">
-                </div>
-            </div>
-            {% endif %}
-            <div class="form-group">
-                <div class="col-sm-2"></div>
-                <div class="col-sm-10">
-                    <button class="btn btn-info webhook-send-btn" type="submit">Send Test {{ enabled[type] }}</button>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="alert webhook-alert"></div>
-        </div>
-    </form>
+        </form>
+    {% else %}
+        <a class="btn btn-default" href="/apidocs/webhooks/authenticated">Log In to Send Test Notifications</a>
+    {% endif %}
 {% endif %}

--- a/src/backend/web/templates/apidocs_webhooks.html
+++ b/src/backend/web/templates/apidocs_webhooks.html
@@ -641,10 +641,7 @@ $( document ).ready(function() {
             $(this.form).find('.webhook-alert')
                 .addClass(data === 'ok' ? 'alert-success' : 'alert-danger')
                 .css('display', 'block')
-                .text(data === 'ok' ? 'Sent webhook!' : 
-                    (data.responseJSON && data.responseJSON.Error) ? data.responseJSON.Error : 
-                    'Something went horribly wrong. Refresh the page and try again.'
-                );
+                .text(responseText);
 
             $(this).attr('disabled', false)
                 .removeClass('disabled');

--- a/src/backend/web/templates/apidocs_webhooks.html
+++ b/src/backend/web/templates/apidocs_webhooks.html
@@ -631,31 +631,28 @@ $( document ).ready(function() {
         $(this.form).find('.webhook-alert').removeClass('alert-success');
         $(this.form).find('.webhook-alert').removeClass('alert-danger');
 
-        $.post(this.form.action, $(this.form).serialize()).done(function (data) {
-            if (data === "ok") {
-                $(this.form).find('.webhook-alert').addClass('alert-success');
-            } else {
-                $(this.form).find('.webhook-alert').addClass('alert-danger');
-            }
+        $.post(this.form.action, $(this.form).serialize()).always(function (data) {
+            let responseText;
+            if (data === 'ok') responseText = 'Sent webhook!';
+            else if (data.responseJSON && data.responseJSON.Error) responseText = data.responseJSON.Error;
+            else if (data.status === 401) responseText = 'Please log in before sending test notifications.';
+            else responseText = 'Something went horribly wrong. Refresh the page and try again.';
+            
+            $(this.form).find('.webhook-alert')
+                .addClass(data === 'ok' ? 'alert-success' : 'alert-danger')
+                .css('display', 'block')
+                .text(data === 'ok' ? 'Sent webhook!' : 
+                    (data.responseJSON && data.responseJSON.Error) ? data.responseJSON.Error : 
+                    'Something went horribly wrong. Refresh the page and try again.'
+                );
 
-            $(this.form).find('.webhook-alert').css('display', 'block');
-            $(this.form).find('.webhook-alert').text(data === "ok" ? "Sent webhook!" : data);
-
-            $(this).attr('disabled', false);
-            $(this).removeClass('disabled');
+            $(this).attr('disabled', false)
+                .removeClass('disabled');
 
             setTimeout(function() {
                 $(this.form).find('.webhook-alert').css('display', 'none');
             }.bind(this), 5000)
-        }.bind(this)).fail(function (error) {
-            if (error.status == 401) {
-              alert('Please login before sending test notifications.');
-            } else {
-              alert('Something went horribly wrong. Try again.');
-            }
-            $(this).attr('disabled', false);
-            $(this).removeClass('disabled');
-        });
+        }.bind(this));
     });
 
     $('.webhook-alert').hide();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
1. The alert div below the send test notification button now provides more helpful errors
2. Fixed the 400 Unauthorized error when sending test notifications

## Description
<!--- Describe your changes in detail -->
For a while (at least a year), sending test webhook notifications has been broken. I discovered today that it was caused by the page caching, wherein the CSRF token rendered into the page belonged to whoever happened to load the page at the time it was re-rendered and cached, and would eventually become stale and invalid. I discussed with @ZachOrr and we came to the conclusion that the testing functions should be placed behind a privileged page. I gave the cached variant of the page a "Log in to send test notifications" button, which takes you to the authenticated variant of the page which has cache disabled, allowing the CSRF token being rendered to be accurate/up-to-date, fixing the 400 CSRF token expired error.

Second, I improved the error handling. If there's a user error involving an incorrect or not-specified key, the alert div below the button will show the specific error. And if there's an unexpected error (e.g. network error, or, god forbid, a CSRF issue), it'll display "Something went horribly wrong. Refresh the page and try again." in the same box instead of with an `alert()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Webhook test notifications ain't workin!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the error handling functionality by putting in incorrect or empty keys when sending test notifications. The CSRF token stuff works fine in my environment, but unfortunately, the webhook notifications don't actually _send_ from my development instance. I haven't modified any of the code responsible for the webhook sending code, though, so I suspect it'll work in production. But it'll have to be tested in the production environment just to be sure. However, since webhook test notifications have been broken for over a year, the risk involved in the possibility webhook test notifications not working with this code change is zero.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
