### PR TITLE
Kickoff TBANS notifications via deferred. Batch subscription fetches

### DIFF
--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -1543,3 +1543,33 @@ class TestTBANSHelper(unittest.TestCase):
         assert (
             TBANSHelper._debug_string(exception) == 'code / message / {"mock": "mock"}'
         )
+
+    def test_batch_send_subscriptions(self):
+        subscriptions = [
+            Subscription(
+                parent=ndb.Key(Account, f"user_id_{i}"),
+                user_id=f"user_id_{i}",
+                model_key="frc1",
+                model_type=ModelType.TEAM,
+                notification_types=[NotificationType.MATCH_SCORE],
+            )
+            for i in range(750)
+        ]
+        notification = MockNotification()
+        with patch.object(TBANSHelper, "_send_subscriptions") as mock_send:
+            TBANSHelper._batch_send_subscriptions(subscriptions, notification)
+
+        assert len(mock_send.mock_calls) == 2
+
+    def test_send_subscriptions(self):
+        subscription = Subscription(
+            parent=ndb.Key(Account, "user_id_1"),
+            user_id="user_id_1",
+            model_key="frc1",
+            model_type=ModelType.TEAM,
+            notification_types=[NotificationType.MATCH_SCORE],
+        )
+        notification = MockNotification()
+        with patch.object(TBANSHelper, "_send") as mock_send:
+            TBANSHelper._send_subscriptions([subscription], notification)
+            mock_send.assert_called_once_with(["user_id_1"], notification)

--- a/src/backend/common/manipulators/award_manipulator.py
+++ b/src/backend/common/manipulators/award_manipulator.py
@@ -1,9 +1,8 @@
 import json
-import logging
-import traceback
 from typing import List, Set
 
 from google.appengine.api import taskqueue
+from google.appengine.ext import deferred
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
@@ -87,10 +86,11 @@ def award_post_update_hook(updated_models: List[TUpdatedModel[Award]]) -> None:
         # Send push notifications if the awards post was within +/- 1 day of the Event
         event = event_key.get()
         if event and event.within_a_day:
-            try:
-                TBANSHelper.awards(event)
-            except Exception as exception:
-                logging.error(
-                    "Error sending {} award updates: {}".format(event.id(), exception)
-                )
-                logging.error(traceback.format_exc())
+            deferred.defer(
+                TBANSHelper.awards,
+                event,
+                _name=f"{event.key_name}_awards",
+                _target="py3-tasks-io",
+                _queue="push-notifications",
+                _url="/_ah/queue/deferred_notification_send",
+            )

--- a/src/backend/common/manipulators/tests/award_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/award_manipulator_test.py
@@ -184,11 +184,14 @@ class TestAwardManipulator(unittest.TestCase):
         assert len(tasks) == 1
 
         for task in tasks:
-            with patch.object(TBANSHelper, "awards") as mock_awards:
-                deferred.run(task.payload)
+            deferred.run(task.payload)
 
-        # Make sure we attempted to dispatch push notifications
-        mock_awards.assert_called_with(self.event)
+        tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="push-notifications"
+        )
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert task.name == "2013casj_awards"
 
     def test_postUpdateHook_notifications_notWithinADay(self):
         AwardManipulator.createOrUpdate(self.new_award)

--- a/src/backend/common/manipulators/tests/event_details_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/event_details_manipulator_test.py
@@ -150,13 +150,14 @@ class TestEventDetailsManipulator(unittest.TestCase):
         assert len(tasks) == 1
 
         for task in tasks:
-            with patch.object(
-                TBANSHelper, "alliance_selection"
-            ) as mock_alliance_selection:
-                deferred.run(task.payload)
+            deferred.run(task.payload)
 
-        # Make sure we attempted to dispatch push notifications
-        mock_alliance_selection.assert_called_with(self.event)
+        tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="push-notifications"
+        )
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert task.name == "2011ct_alliance_selection"
 
     def test_postUpdateHook_notifications_notWithinADay(self):
         self.old_event_details.put()

--- a/src/backend/common/models/subscription.py
+++ b/src/backend/common/models/subscription.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Generator, List, Optional
+from typing import cast, List
 
 from google.appengine.ext import ndb
 
@@ -8,7 +8,6 @@ from backend.common.consts.notification_type import (
     RENDER_NAMES as NOTIFICATION_RENDER_NAMES,
 )
 from backend.common.models.mytba import MyTBAModel
-from backend.common.tasklets import typed_tasklet
 
 
 class Subscription(MyTBAModel):
@@ -33,10 +32,8 @@ class Subscription(MyTBAModel):
         ]
 
     @classmethod
-    @typed_tasklet
-    def users_subscribed_to_event(
-        cls, event, notification_type
-    ) -> Generator[Any, Any, Optional[List[str]]]:
+    @ndb.tasklet
+    def subscriptions_for_event(cls, event, notification_type):
         """
         Get user IDs subscribed to an Event or the year an Event occurs in and a given notification type.
         Ex: (model_key == `2020miket` or `2020*`) and (notification_type == NotificationType.UPCOMING_MATCH)
@@ -46,21 +43,18 @@ class Subscription(MyTBAModel):
             notification_type (consts.notification_type.NotificationType): A NotificationType for the Subscription.
 
         Returns:
-            list (string): List of user IDs with Subscriptions to the given Event/notification type.
+            list (Subscription): List of Subscriptions to the given Event/notification type.
         """
-        users = yield Subscription.query(
-            Subscription.model_key.IN([event.key_name, "{}*".format(event.year)]),  # pyre-ignore[16]
+        subscriptions = yield Subscription.query(
+            Subscription.model_key.IN([event.key_name, "{}*".format(event.year)]),
             Subscription.notification_types == notification_type,
-            Subscription.model_type == ModelType.EVENT,
-            projection=[Subscription.user_id],
+            Subscription.model_type == ModelType.EVENT
         ).fetch_async()
-        return list(set([user.user_id for user in users]))
+        return subscriptions
 
     @classmethod
-    @typed_tasklet
-    def users_subscribed_to_team(
-        cls, team, notification_type
-    ) -> Generator[Any, Any, Optional[List[str]]]:
+    @ndb.tasklet
+    def subscriptions_for_team(cls, team, notification_type):
         """
         Get user IDs subscribed to a Team and a given notification type.
         Ex: team_key == `frc7332` and notification_type == NotificationType.UPCOMING_MATCH
@@ -70,21 +64,19 @@ class Subscription(MyTBAModel):
             notification_type (consts.notification_type.NotificationType): A NotificationType for the Subscription.
 
         Returns:
-            list (string): List of user IDs with Subscriptions to the given Team/notification type.
+            list (Subscription): List of Subscriptions to the given Team/notification type.
+            The ONLY populated field on the Subscription will be the user_id.
         """
-        users = yield Subscription.query(
+        subscription = yield Subscription.query(
             Subscription.model_key == team.key_name,
             Subscription.notification_types == notification_type,
-            Subscription.model_type == ModelType.TEAM,
-            projection=[Subscription.user_id],
+            Subscription.model_type == ModelType.TEAM
         ).fetch_async()
-        return list(set([user.user_id for user in users]))
+        return subscription
 
     @classmethod
-    @typed_tasklet
-    def users_subscribed_to_match(
-        cls, match, notification_type
-    ) -> Generator[Any, Any, Optional[List[str]]]:
+    @ndb.tasklet
+    def subscriptions_for_match(cls, match, notification_type):
         """
         Get user IDs subscribed to a Match and a given notification type.
         Ex: team_key == `2020miket_qm1` and notification_type == NotificationType.UPCOMING_MATCH
@@ -94,12 +86,11 @@ class Subscription(MyTBAModel):
             notification_type (consts.notification_type.NotificationType): A NotificationType for the Subscription.
 
         Returns:
-            list (string): List of user IDs with Subscriptions to the given Team/notification type.
+            list (Subscription): List of Subscriptions to the given Team/notification type.
         """
-        users = yield Subscription.query(
+        subscriptions = yield Subscription.query(
             Subscription.model_key == match.key_name,
             Subscription.notification_types == notification_type,
-            Subscription.model_type == ModelType.MATCH,
-            projection=[Subscription.user_id],
+            Subscription.model_type == ModelType.MATCH
         ).fetch_async()
-        return list(set([user.user_id for user in users]))
+        return subscriptions

--- a/src/backend/common/models/tests/subscription_test.py
+++ b/src/backend/common/models/tests/subscription_test.py
@@ -28,73 +28,86 @@ def test_notification_names():
     ]
 
 
-def test_users_subscribed_to_event_year():
+def test_subscriptions_for_event_year():
     event = EventTestCreator.create_future_event()
     # Make sure we match year*
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=f"{event.year}*",
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=f"{event.year}*",
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.MATCH_SCORE]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_event(event, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
+    subscriptions_future = Subscription.subscriptions_for_event(event, NotificationType.UPCOMING_MATCH)
+    subscriptions = subscriptions_future.get_result()
+    assert len(subscriptions) == 1
+    assert subscriptions[0].user_id == "user_id_1"
 
 
-def test_users_subscribed_to_event_key():
+def test_subscriptions_for_event_key():
     event = EventTestCreator.create_future_event()
     # Make sure we match an event key
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=event.key_name,
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key='2020mike2',
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_event(event, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
+    subscriptions_future = Subscription.subscriptions_for_event(event, NotificationType.UPCOMING_MATCH)
+    subscriptions = subscriptions_future.get_result()
+    assert len(subscriptions) == 1
+    assert subscriptions[0].user_id == "user_id_1"
 
 
-def test_users_subscribed_to_event_year_key():
+def test_subscriptions_for_event_year_key():
     event = EventTestCreator.create_future_event()
     # Make sure we fetch both key and year together
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=event.key_name,
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=f"{event.year}*",
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_event(event, NotificationType.UPCOMING_MATCH)
-    assert sorted(users.get_result()) == ['user_id_1', 'user_id_2']
+    subscriptions_future = Subscription.subscriptions_for_event(event, NotificationType.UPCOMING_MATCH)
+    subscriptions = subscriptions_future.get_result()
+    assert len(subscriptions) == 2
+    assert one in subscriptions
+    assert two in subscriptions
 
 
-def test_users_subscribed_to_event_model_type():
+def test_subscriptions_for_event_model_type():
     Team(
         id="frc7332",
         team_number=7332
@@ -102,48 +115,56 @@ def test_users_subscribed_to_event_model_type():
     event = EventTestCreator.create_future_event()
 
     # Make sure we filter for model types
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=event.key_name,
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=event.teams[0].key_name,
         model_type=ModelType.TEAM,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_event(event, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
-
-
-def test_users_subscribed_to_event_unique():
-    event = EventTestCreator.create_future_event()
-    # Make sure we filter for duplicates
-    Subscription(
-        parent=ndb.Key(Account, 'user_id_1'),
-        user_id='user_id_1',
-        model_key=event.key_name,
-        model_type=ModelType.EVENT,
-        notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
-        parent=ndb.Key(Account, 'user_id_1'),
-        user_id='user_id_1',
-        model_key=f'{event.year}*',
-        model_type=ModelType.EVENT,
-        notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-
-    users = Subscription.users_subscribed_to_event(event, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
+    subscriptions_future = Subscription.subscriptions_for_event(event, NotificationType.UPCOMING_MATCH)
+    subscriptions = subscriptions_future.get_result()
+    assert len(subscriptions) == 1
+    assert subscriptions[0].user_id == "user_id_1"
 
 
-def test_users_subscribed_to_team_key():
+# def test_subscriptions_for_event_distinct():
+#     event = EventTestCreator.create_future_event()
+#     # Make sure we filter for duplicates
+#     one = Subscription(
+#         parent=ndb.Key(Account, 'user_id_1'),
+#         user_id='user_id_1',
+#         model_key=event.key_name,
+#         model_type=ModelType.EVENT,
+#         notification_types=[NotificationType.UPCOMING_MATCH]
+#     )
+#     one.put()
+#     two = Subscription(
+#         parent=ndb.Key(Account, 'user_id_1'),
+#         user_id='user_id_1',
+#         model_key=f'{event.year}*',
+#         model_type=ModelType.EVENT,
+#         notification_types=[NotificationType.UPCOMING_MATCH]
+#     )
+#     two.put()
+
+#     subscriptions_future = Subscription.subscriptions_for_event(event, NotificationType.UPCOMING_MATCH)
+#     subscriptions = subscriptions_future.get_result()
+#     assert len(subscriptions) == 1
+#     assert subscriptions[0].user_id == "user_id_1"
+
+
+def test_subscriptions_for_team_key():
     team = Team(
         id="frc7332",
         team_number=7332
@@ -151,26 +172,31 @@ def test_users_subscribed_to_team_key():
     team.put()
 
     # Make sure we match a team key
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=team.key_name,
         model_type=ModelType.TEAM,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=team.key_name,
         model_type=ModelType.TEAM,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_team(team, NotificationType.UPCOMING_MATCH)
-    assert sorted(users.get_result()) == ['user_id_1', 'user_id_2']
+    subscriptions_future = Subscription.subscriptions_for_team(team, NotificationType.UPCOMING_MATCH)
+    subscriptions = subscriptions_future.get_result()
+    assert len(subscriptions) == 2
+    assert one in subscriptions
+    assert two in subscriptions
 
 
-def test_users_subscribed_to_team_model_type():
+def test_subscriptions_for_team_model_type():
     team = Team(
         id="frc7332",
         team_number=7332
@@ -180,50 +206,56 @@ def test_users_subscribed_to_team_model_type():
     event = EventTestCreator.create_future_event()
 
     # Make sure we filter for model types
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=event.key_name,
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=team.key_name,
         model_type=ModelType.TEAM,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-
-    users = Subscription.users_subscribed_to_team(team, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_2']
-
-
-def test_users_subscribed_to_team_unique():
-    team = Team(
-        id="frc7332",
-        team_number=7332
     )
-    team.put()
+    two.put()
 
-    # Make sure we filter for duplicates
-    Subscription(
-        parent=ndb.Key(Account, 'user_id_1'),
-        user_id='user_id_1',
-        model_key=team.key_name,
-        model_type=ModelType.TEAM,
-        notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
-        parent=ndb.Key(Account, 'user_id_1'),
-        user_id='user_id_1',
-        model_key=team.key_name,
-        model_type=ModelType.TEAM,
-        notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    subscriptions = Subscription.subscriptions_for_team(team, NotificationType.UPCOMING_MATCH)
+    assert subscriptions.get_result() == [two]
 
-    users = Subscription.users_subscribed_to_team(team, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
+
+# def test_subscriptions_for_team_distinct():
+#     team = Team(
+#         id="frc7332",
+#         team_number=7332
+#     )
+#     team.put()
+
+#     # Make sure we filter for duplicates
+#     one = Subscription(
+#         parent=ndb.Key(Account, 'user_id_1'),
+#         user_id='user_id_1',
+#         model_key=team.key_name,
+#         model_type=ModelType.TEAM,
+#         notification_types=[NotificationType.UPCOMING_MATCH]
+#     )
+#     one.put()
+#     two = Subscription(
+#         parent=ndb.Key(Account, 'user_id_1'),
+#         user_id='user_id_1',
+#         model_key=team.key_name,
+#         model_type=ModelType.TEAM,
+#         notification_types=[NotificationType.UPCOMING_MATCH]
+#     )
+#     two.put()
+
+#     subscriptions_future = Subscription.subscriptions_for_team(team, NotificationType.UPCOMING_MATCH)
+#     subscriptions = subscriptions_future.get_result()
+#     assert len(subscriptions) == 1
+#     assert subscriptions[0].user_id == "user_id_1"
 
 
 def setup_matches() -> Match:
@@ -233,67 +265,78 @@ def setup_matches() -> Match:
     return event.matches[0]
 
 
-def test_users_subscribed_to_match_key():
+def test_subscriptions_for_match_key():
     match = setup_matches()
     # Make sure we match a match key
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=match.key_name,
         model_type=ModelType.MATCH,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=match.key_name,
         model_type=ModelType.MATCH,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_match(match, NotificationType.UPCOMING_MATCH)
-    assert sorted(users.get_result()) == ['user_id_1', 'user_id_2']
+    subscriptions_future = Subscription.subscriptions_for_match(match, NotificationType.UPCOMING_MATCH)
+    subscriptions = subscriptions_future.get_result()
+    assert len(subscriptions) == 2
+    assert one in subscriptions
+    assert two in subscriptions
 
 
-def test_users_subscribed_to_match_model_type():
+def test_subscriptions_for_match_model_type():
     match = setup_matches()
     # Make sure we filter for model types
-    Subscription(
+    one = Subscription(
         parent=ndb.Key(Account, 'user_id_1'),
         user_id='user_id_1',
         model_key=match.key_name,
         model_type=ModelType.MATCH,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
+    )
+    one.put()
+    two = Subscription(
         parent=ndb.Key(Account, 'user_id_2'),
         user_id='user_id_2',
         model_key=match.key_name,
         model_type=ModelType.EVENT,
         notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+    )
+    two.put()
 
-    users = Subscription.users_subscribed_to_match(match, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
+    subscriptions = Subscription.subscriptions_for_match(match, NotificationType.UPCOMING_MATCH)
+    assert subscriptions.get_result() == [one]
 
 
-def test_users_subscribed_to_match_unique():
-    match = setup_matches()
-    # Make sure we filter for duplicates
-    Subscription(
-        parent=ndb.Key(Account, 'user_id_1'),
-        user_id='user_id_1',
-        model_key=match.key_name,
-        model_type=ModelType.MATCH,
-        notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
-    Subscription(
-        parent=ndb.Key(Account, 'user_id_1'),
-        user_id='user_id_1',
-        model_key=match.key_name,
-        model_type=ModelType.MATCH,
-        notification_types=[NotificationType.UPCOMING_MATCH]
-    ).put()
+# def test_subscriptions_for_match_distinct():
+#     match = setup_matches()
+#     # Make sure we filter for duplicates
+#     one = Subscription(
+#         parent=ndb.Key(Account, 'user_id_1'),
+#         user_id='user_id_1',
+#         model_key=match.key_name,
+#         model_type=ModelType.MATCH,
+#         notification_types=[NotificationType.UPCOMING_MATCH]
+#     )
+#     one.put()
+#     two = Subscription(
+#         parent=ndb.Key(Account, 'user_id_1'),
+#         user_id='user_id_1',
+#         model_key=match.key_name,
+#         model_type=ModelType.MATCH,
+#         notification_types=[NotificationType.UPCOMING_MATCH]
+#     )
+#     two.put()
 
-    users = Subscription.users_subscribed_to_match(match, NotificationType.UPCOMING_MATCH)
-    assert users.get_result() == ['user_id_1']
+#     subscriptions_future = Subscription.subscriptions_for_match(match, NotificationType.UPCOMING_MATCH)
+#     subscriptions = subscriptions_future.get_result()
+#     assert len(subscriptions) == 1
+#     assert subscriptions[0].user_id == "user_id_1"


### PR DESCRIPTION
More work on #5119 

First step is getting the notification dispatching out of the way of the post updates hook. The `TBANSHelper` calls are now deferred and will be run on the `push-notification` queue.

Next, we've setup the `Subscriptions` class methods to fetch subscriptions (changed from user IDs - more on this later) to be async. This will allow us to do several at a time and then wait for the response. Although I suspect fetching the subscriptions is not the problem - it's the previous `list(set([user.user_id for user in subscriptions]))` call.

The call above to get the user_id on a user object (despite the projection) is likely the problem for the long list of ndb queries that are timing out these calls. Instead of de-deduplicating the list of user IDs before sending the subscriptions, we'll batch the subscriptions into chunks of 500-per, fetch the user IDs for those 500 subscriptions, and dispatch those 500 notifications. If there are duplicate user IDs in the subscriptions, we **will** end up sending multiple notifications.

As a note - I could **not** get the queries to distinct using the `projection=[Subscription.user_id]` and  `distinct=True` kwargs. I'm unsure if this is an issue in our implementation of ndb or just something that doesn't work (cc @phil-lopreiato)

This should - at the very least - reduce the notifications being sent to only one, since now we'll be failing in the `push-notification` queue where retries are set to zero.