### PR TITLE
Add try/catch to TBANS defer adds - will catch TaskAlreadyExistsError or TombstonedTaskError

### DIFF
--- a/src/backend/common/manipulators/award_manipulator.py
+++ b/src/backend/common/manipulators/award_manipulator.py
@@ -86,11 +86,15 @@ def award_post_update_hook(updated_models: List[TUpdatedModel[Award]]) -> None:
         # Send push notifications if the awards post was within +/- 1 day of the Event
         event = event_key.get()
         if event and event.within_a_day:
-            deferred.defer(
-                TBANSHelper.awards,
-                event,
-                _name=f"{event.key_name}_awards",
-                _target="py3-tasks-io",
-                _queue="push-notifications",
-                _url="/_ah/queue/deferred_notification_send",
-            )
+            # Catch TaskAlreadyExistsError + TombstonedTaskError
+            try:
+                deferred.defer(
+                    TBANSHelper.awards,
+                    event,
+                    _name=f"{event.key_name}_awards",
+                    _target="py3-tasks-io",
+                    _queue="push-notifications",
+                    _url="/_ah/queue/deferred_notification_send",
+                )
+            except Exception:
+                pass

--- a/src/backend/common/manipulators/event_details_manipulator.py
+++ b/src/backend/common/manipulators/event_details_manipulator.py
@@ -69,14 +69,18 @@ def event_details_post_update_hook(
             and event.within_a_day
             and "alliance_selections" in updated_model.updated_attrs
         ):
-            deferred.defer(
-                TBANSHelper.alliance_selection,
-                event,
-                _name=f"{event.key_name}_alliance_selection",
-                _target="py3-tasks-io",
-                _queue="push-notifications",
-                _url="/_ah/queue/deferred_notification_send",
-            )
+            # Catch TaskAlreadyExistsError + TombstonedTaskError
+            try:
+                deferred.defer(
+                    TBANSHelper.alliance_selection,
+                    event,
+                    _name=f"{event.key_name}_alliance_selection",
+                    _target="py3-tasks-io",
+                    _queue="push-notifications",
+                    _url="/_ah/queue/deferred_notification_send",
+                )
+            except Exception:
+                pass
 
 
 """ndb


### PR DESCRIPTION
Adding named tasks in https://github.com/the-blue-alliance/the-blue-alliance/pull/5830 - we need to make sure we catch these tasks having already been added/run