### PR TITLE
Use Event.city_state_country for event details location

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -517,9 +517,6 @@ class Event(CachedModel):
 
     @property
     def city_state_country(self) -> Optional[str]:
-        if not self._city_state_country and self.nl:
-            self._city_state_country = self.nl.city_state_country
-
         if not self._city_state_country:
             location_parts = []
             if self.city:

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -66,7 +66,12 @@
           <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
         {% endif %}
         {{ em.showEventDates(event) }}
-        {% if event.location or event.venue_address_safe %}
+        {% if event.city_state_country %}
+          <br><span class="glyphicon glyphicon-map-marker"></span>
+          <span itemprop="location">
+            <a href="//maps.google.com/maps?q={{ event.city_state_country|urlencode }}" target="_blank" rel="noopener noreferrer">{{event.city_state_country}}</a>
+          </span>
+        {% elif event.location or event.venue_address_safe %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
           <span itemprop="location">
           {% if event.venue_address_safe %}


### PR DESCRIPTION
Follow up from https://github.com/the-blue-alliance/the-blue-alliance/pull/5835 - did a closer read at the code and made this match the team info

Removing the `if not self._city_state_country and self.nl:` line should be no big deal - the only place that `event.city_state_country` is used is the [`mytba_live.html`](https://github.com/the-blue-alliance/the-blue-alliance/blob/c8992943722d95f27b36b06c912c38d9ad1dbad5/src/backend/web/templates/mytba_live.html#L59) and the [`event_table.html`](https://github.com/the-blue-alliance/the-blue-alliance/blob/c8992943722d95f27b36b06c912c38d9ad1dbad5/src/backend/web/templates/event_partials/event_table.html#L19) - both of which should match the location we show for the event on the details page (which no longer uses the `Event.normalized_location`)