### PR TITLE
Partial revert of 829637bcd4b5b51866e5ae6c9e24174a49d35ac3

### DIFF
--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -66,12 +66,7 @@
           <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
         {% endif %}
         {{ em.showEventDates(event) }}
-        {% if event.city_state_country %}
-          <br><span class="glyphicon glyphicon-map-marker"></span>
-          <span itemprop="location">
-            <a href="//maps.google.com/maps?q={{ event.city_state_country|urlencode }}" target="_blank" rel="noopener noreferrer">{{event.city_state_country}}</a>
-          </span>
-        {% elif event.location or event.venue_address_safe %}
+        {% if event.location or event.venue_address_safe %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
           <span itemprop="location">
           {% if event.venue_address_safe %}


### PR DESCRIPTION
Partial revert of https://github.com/the-blue-alliance/the-blue-alliance/pull/5836 - forgot we'd drop the venue name by using that `city_state_country`.

A follow up would be to remove `city_state_country` altogether from the event and use `location` - unsure why that logic is duplicated