### PR TITLE
Only enqueue stats one per manipulator batch

### DIFF
--- a/src/backend/common/manipulators/tests/match_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/match_manipulator_test.py
@@ -251,6 +251,7 @@ def test_updateHook_enqueueStats(ndb_context, taskqueue_stub) -> None:
         set_number=1,
         match_number=1,
     )
+    test_match._updated_attrs = ["alliances_json"]
     MatchManipulator._run_post_update_hook([test_match])
 
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="post-update-hooks")
@@ -258,7 +259,7 @@ def test_updateHook_enqueueStats(ndb_context, taskqueue_stub) -> None:
     for task in tasks:
         deferred.run(task.payload)
 
-    stats_tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    stats_tasks = taskqueue_stub.get_filtered_tasks(queue_names="stats")
     assert len(stats_tasks) > 0
 
     tasks_urls = [t.url for t in stats_tasks]
@@ -322,7 +323,7 @@ def test_postUpdateHook_notifications(ndb_context, taskqueue_stub) -> None:
         year=2012,
         set_number=1,
         match_number=1,
-        push_sent=False
+        push_sent=False,
     )
     MatchManipulator.createOrUpdate(test_match)
 
@@ -365,5 +366,7 @@ def test_postUpdateHook_notification_pushSent(ndb_context, taskqueue_stub) -> No
         with patch.object(Event, "now", return_value=True):
             deferred.run(task.payload)
 
-    tasks = taskqueue_stub.get_filtered_tasks(name="2012ct_qm1_match_score", queue_names="push-notifications")
+    tasks = taskqueue_stub.get_filtered_tasks(
+        name="2012ct_qm1_match_score", queue_names="push-notifications"
+    )
     assert len(tasks) == 0

--- a/src/queue.yaml
+++ b/src/queue.yaml
@@ -17,6 +17,9 @@ queue:
   retry_parameters:
     task_age_limit: 1h
 
+- name: stats
+  rate: 10/s
+
 - name: firebase
   rate: 50/s
 


### PR DESCRIPTION
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/256bce5a-995c-43a2-98bb-d63ce051d0c8)


We have an insane number of tasks in the default queue, which all look to be match stats.

We really only need to enqueue an update once per *batch*, not once per match.