### PR TITLE
Fix calculating district rankings periodically

### DIFF
--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -111,10 +111,14 @@ def event_district_points_calc(event_key: EventKey) -> Response:
 
 
 @blueprint.route("/tasks/math/enqueue/district_rankings_calc/<int:year>")
-def enqueue_district_rankings_calc(year: Year) -> Response:
+@blueprint.route("/tasks/math/enqueue/district_rankings_calc", defaults={"year": None})
+def enqueue_district_rankings_calc(year: Optional[Year]) -> Response:
     """
     Enqueues calculation of rankings for all districts for a given year
     """
+
+    if year is None:
+        year = SeasonHelper.get_current_season()
 
     districts = DistrictsInYearQuery(int(year)).fetch()
     district_keys = [district.key.id() for district in districts]

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -66,7 +66,7 @@ cron:
 
 - description: District Rankings Calculation
   url: /tasks/math/enqueue/district_rankings_calc
-  schedule: every tuesday 1:00
+  schedule: every day 1:05
   timezone: America/Los_Angeles
 
 #- description: Upcoming match notification sending


### PR DESCRIPTION
We needed a handler to default the year when unset, as `cron.yaml` calls `/tasks/math/enqueue/district_rankings_calc`