### PR TITLE
Handle all errors from verifying clientapi tokens

### DIFF
--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 from typing import Any, Dict, Optional
 
 from firebase_admin import auth
@@ -19,8 +18,7 @@ _SESSION_KEY = "session"
 def _verify_id_token(id_token: str) -> Optional[dict]:
     try:
         return auth.verify_id_token(id_token, check_revoked=True, app=app())
-    except (exceptions.DefaultCredentialsError, auth.ExpiredIdTokenError):
-        logging.warning("Error validing clientapi token", exc_info=True)
+    except Exception:
         return None
 
 


### PR DESCRIPTION
Fixing lots of errors in the logs for these clientapi token validation failing. They all seem to be around the token expiring
<img width="1382" alt="Screenshot 2024-03-24 at 11 37 33 AM" src="https://github.com/the-blue-alliance/the-blue-alliance/assets/516458/01a78ef9-c416-4ded-ac97-e6116360b3a7">
