### PR TITLE
Add net total game pieces COPR, add amplification rate COPR

### DIFF
--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -120,6 +120,23 @@ MANUAL_COMPONENTS = {
                 match.score_breakdown[color].get("autoSpeakerNoteCount", 0),
             ]
         ),
+        "Total Overall Game Pieces": lambda match, color: sum(
+            [
+                match.score_breakdown[color].get("autoAmpNoteCount", 0),
+                match.score_breakdown[color].get("autoSpeakerNoteCount", 0),
+                match.score_breakdown[color].get("teleopAmpNoteCount", 0),
+                match.score_breakdown[color].get("teleopSpeakerNoteCount", 0),
+                match.score_breakdown[color].get("teleopSpeakerNoteAmplifiedCount", 0),
+            ]
+        ),
+        "Amplification Rate": lambda match, color: match.score_breakdown[color].get(
+            "teleopSpeakerNoteAmplifiedCount", 0
+        )
+        / max(
+            1,
+            match.score_breakdown[color].get("teleopSpeakerNoteCount", 0)
+            + match.score_breakdown[color].get("teleopSpeakerNoteAmplifiedCount", 0),
+        ),
     },
 }
 


### PR DESCRIPTION
## Description
Adds 2 more component OPRs - total game pieces and amplification rate. Amplification rate is the percentage of teleop speaker notes scored that are amplified.

## Motivation and Context
Total GPs was not previously available. Amplification rate will become an increasingly important stat as the season progresses.

## How Has This Been Tested?
Locally on `2024mabos`.

## Screenshots (if appropriate):
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/7595639/98007a3b-75ad-4c95-ab4f-4ecc4155b566)
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/7595639/30c46bd7-701d-435d-9114-85ed52c39145)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
