### PR TITLE
Work around matches with scheduled teams [1, 2,3]

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -321,22 +321,33 @@ class DatafeedFMSAPI:
 
     @classmethod
     def _merge_match(cls, scheduled: Dict, result: Dict) -> Dict:
+        # Over the years, both "Teams" and "teams" have been used in FRC API responses...
+        teams_key = "Teams" if "Teams" in scheduled else "teams"
+
+        # 2024, Week 4: As part of attempting to restore sync,
+        # schedules sync with teams [1, 2, 3] in to-be-played playoff matches
+        # In a case where the only teams for a match are those three, overwrite
+        # the team numbers in each station to None
+        schedule_team_numbers = [t["teamNumber"] for t in scheduled.get(teams_key)]
+        if set(schedule_team_numbers) == {1, 2, 3}:
+            scheduled["teams"] = [{**t, "teamNumber": None} for t in scheduled.get(teams_key)]
+
         for field, value in result.items():
-            if field == "teams":
-                for i, team in enumerate(value):
-                    schedule_team = next(
+            if field == teams_key:
+                for team in value:
+                    schedule_idx, schedule_team = next(
                         filter(
-                            lambda t: t["teamNumber"] == team["teamNumber"],
-                            scheduled["teams"],
+                            lambda t: t[1]["teamNumber"] == team["teamNumber"],
+                            enumerate(scheduled["teams"]),
                         ),
-                        None,
+                        (None, None),
                     )
                     if schedule_team is None:
                         # 2024, Week 3: Upstream FMS sync issues leading to schedules returned with no teams
                         # Some match results have been sync'd, so patch around this where we can
                         scheduled["teams"].append(team)
                     else:
-                        scheduled["teams"][i].update(team)
+                        scheduled["teams"][schedule_idx].update(team)
             else:
                 scheduled[field] = value
         return scheduled

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -112,7 +112,6 @@ class FMSAPIHybridScheduleParser(
             red_dqs: List[TeamKey] = []
             blue_dqs: List[TeamKey] = []
             team_key_names: List[TeamKey] = []
-            null_team = False
 
             # Sort by station to ensure correct ordering. Kind of hacky.
             sorted_teams = list(
@@ -121,9 +120,19 @@ class FMSAPIHybridScheduleParser(
                     key=lambda team: team["station"],
                 )
             )
+
+            null_team = any(t["teamNumber"] is None for t in sorted_teams)
+            if (
+                null_team
+                and match["scoreRedFinal"] is None
+                and match["scoreBlueFinal"] is None
+            ):
+                continue
+
             for team in sorted_teams:
                 if team["teamNumber"] is None:
-                    null_team = True
+                    continue
+
                 team_key = "frc{}".format(team["teamNumber"])
                 team_key_names.append(team_key)
                 if "Red" in team["station"]:
@@ -138,13 +147,6 @@ class FMSAPIHybridScheduleParser(
                         blue_surrogates.append(team_key)
                     if team.get("dq", None):
                         blue_dqs.append(team_key)
-
-            if (
-                null_team
-                and match["scoreRedFinal"] is None
-                and match["scoreBlueFinal"] is None
-            ):
-                continue
 
             alliances = {
                 "red": {

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -254,7 +254,7 @@ def event_detail(event_key: EventKey) -> Response:
         "teams_b": teams_b,
         "num_teams": num_teams,
         "oprs": oprs,
-        "bracket_table": bracket_table,
+        "bracket_table": bracket_table or {},
         "playoff_advancement": playoff_advancement,
         "playoff_template": playoff_template,
         "playoff_advancement_tiebreakers": PlayoffAdvancementHelper.ROUND_ROBIN_TIEBREAKERS.get(

--- a/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_bracket_table.html
@@ -65,7 +65,7 @@
     <!-- Upper Bracket -->
     <tr>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 1', bracket_table.sf.get('sf1'), 'Alliance 1', 'Alliance 8') }}
+        {{ bracket_match('Match 1', bracket_table.get('sf', {}).get('sf1'), 'Alliance 1', 'Alliance 8') }}
       </td>
     </tr>
 
@@ -79,7 +79,7 @@
       <td></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 7', bracket_table.sf.get('sf7'), 'Winner of M1', 'Winner of M2') }}
+        {{ bracket_match('Match 7', bracket_table.get('sf', {}).get('sf7'), 'Winner of M1', 'Winner of M2') }}
       </td>
     </tr>
 
@@ -92,7 +92,7 @@
 
     <tr>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 2', bracket_table.sf.get('sf2'), 'Alliance 4', 'Alliance 5') }}
+        {{ bracket_match('Match 2', bracket_table.get('sf', {}).get('sf2'), 'Alliance 4', 'Alliance 5') }}
       </td>
     </tr>
 
@@ -104,7 +104,7 @@
       <td colspan="4"></td>
       <td class="dash" colspan="2"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 11', bracket_table.sf.get('sf11'), 'Winner of M7', 'Winner of M8') }}
+        {{ bracket_match('Match 11', bracket_table.get('sf', {}).get('sf11'), 'Winner of M7', 'Winner of M8') }}
       </td>
     </tr>
 
@@ -120,7 +120,7 @@
 
     <tr>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 3', bracket_table.sf.get('sf3'), 'Alliance 3', 'Alliance 6') }}
+        {{ bracket_match('Match 3', bracket_table.get('sf', {}).get('sf3'), 'Alliance 3', 'Alliance 6') }}
       </td>
     </tr>
 
@@ -134,7 +134,7 @@
       <td></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 8', bracket_table.sf.get('sf8'), 'Winner of M3', 'Winner of M4') }}
+        {{ bracket_match('Match 8', bracket_table.get('sf', {}).get('sf8'), 'Winner of M3', 'Winner of M4') }}
       </td>
     </tr>
 
@@ -143,15 +143,13 @@
       <td colspan="10"></td>
       <td class="dash" colspan="1"></td>
       <td rowspan="2" class="match">
-        {% if bracket_table.f %}
-          {{ bracket_match('Finals', bracket_table.f.get('f1'), 'Winner of M11', 'Winner of M13') }}
-        {% endif %}
+        {{ bracket_match('Finals', bracket_table.get('f', {}).get('f1'), 'Winner of M11', 'Winner of M13') }}
       </td>
     </tr>
 
     <tr>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 4', bracket_table.sf.get('sf4'), 'Alliance 2', 'Alliance 7') }}
+        {{ bracket_match('Match 4', bracket_table.get('sf', {}).get('sf4'), 'Alliance 2', 'Alliance 7') }}
       </td>
     </tr>
 
@@ -168,7 +166,7 @@
       <td colspan="11"></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 13', bracket_table.sf.get('sf13'), 'Loser of M11', 'Winner of M12') }}
+        {{ bracket_match('Match 13', bracket_table.get('sf', {}).get('sf13'), 'Loser of M11', 'Winner of M12') }}
       </td>
     </tr>
 
@@ -177,7 +175,7 @@
       <td class="dash" colspan="1"></td>
 
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 10', bracket_table.sf.get('sf10'), 'Loser of M8', 'Winner of M5') }}
+        {{ bracket_match('Match 10', bracket_table.get('sf', {}).get('sf10'), 'Loser of M8', 'Winner of M5') }}
       </td>
       <td colspan="3"></td>
       <td rowspan="3">
@@ -199,12 +197,12 @@
     <tr>
       <td colspan="3"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 5', bracket_table.sf.get('sf5'), 'Loser of M1', 'Loser of M2') }}
+        {{ bracket_match('Match 5', bracket_table.get('sf', {}).get('sf5'), 'Loser of M1', 'Loser of M2') }}
       </td>
       <td colspan="3"></td>
       <td class="dash"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 12', bracket_table.sf.get('sf12'), 'Winner of M10', 'Winner of M9') }}
+        {{ bracket_match('Match 12', bracket_table.get('sf', {}).get('sf12'), 'Winner of M10', 'Winner of M9') }}
       </td>
     </tr>
 
@@ -216,7 +214,7 @@
       <td colspan="5"></td>
       <td class="dash" colspan="1"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match('Match 9', bracket_table.sf.get('sf9'), 'Loser of M7', 'Winner of M6') }}
+        {{ bracket_match('Match 9', bracket_table.get('sf', {}).get('sf9'), 'Loser of M7', 'Winner of M6') }}
       </td>
     </tr>
 
@@ -230,7 +228,7 @@
     <tr>
       <td colspan="3"></td>
       <td rowspan="2" class="match">
-        {{ bracket_match( 'Match 6', bracket_table.sf.get('sf6'), 'Loser of M3', 'Loser of M4') }}
+        {{ bracket_match( 'Match 6', bracket_table.get('sf', {}).get('sf6'), 'Loser of M3', 'Loser of M4') }}
       </td>
     </tr>
 


### PR DESCRIPTION
FMS seems to be publishing unplayed finals matches with the placeholder teams now (when teamNumber would be None previously).

So now, filter those out


Two currently broken events: 

`2024vafal`
Prod:
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/d4523e5f-b5f3-486a-81de-b5343d7d0925)

Local:
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/15bd8cf2-3008-4f5d-b598-7cfa207f246e)


`2024nytr`
Prod:
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/8c441486-182a-4d18-b4ea-507ac2a4e145)

Local:
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/2754863/c775b1a8-f15c-452b-937b-4013435206d2)
