### PR TITLE
Fix event names for 2024 cmp divisions

### DIFF
--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -72,6 +72,8 @@ class FMSAPIEventListParser(ParserJSON[Tuple[List[Event], List[District]]]):
         "roebling": ("roe", "Roebling"),
         "tesla": ("tes", "Tesla"),
         "turing": ("tur", "Turing"),
+        "johnson": ("joh", "Johnson"),
+        "milstein": ("mil", "Milstein"),
         # For Einstein, format with the name "Einstein" or "FIRST Championship" or whatever
         "cmp": ("cmp", "{}"),
         "cmpmi": ("cmpmi", "{} (Detroit)"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `johnson` and `milstein` to the event code exception list, matching the rest of the 2024 championship divisions.

## Motivation and Context
Makes division names and codes consistent with each other and previous years

## How Has This Been Tested?
Tested in local instance of TBA by syncing with frc-events API and checking division names
## Screenshots
<img width="1056" alt="image" src="https://github.com/the-blue-alliance/the-blue-alliance/assets/92497727/a0be18c3-5df1-4ccb-a863-cb7eb3734b72">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
