### PR TITLE
Bump tasks-io instance to F2

### DIFF
--- a/src/tasks_io.yaml
+++ b/src/tasks_io.yaml
@@ -3,7 +3,7 @@ runtime: python312
 entrypoint: gunicorn -b :$PORT backend.tasks_io.main:app
 app_engine_apis: true
 
-instance_class: F1
+instance_class: F2
 automatic_scaling:
   max_idle_instances: 1
 


### PR DESCRIPTION
Tasks are timing out, bumping to F2 temporarily for champs