### PR TITLE
Add alliance details to team detail page

### DIFF
--- a/src/backend/api/handlers/helpers/add_alliance_status.py
+++ b/src/backend/api/handlers/helpers/add_alliance_status.py
@@ -5,6 +5,7 @@ from google.appengine.ext import ndb
 from backend.common.models.alliance import EventAlliance
 from backend.common.models.event_team import EventTeam
 
+
 # Adds the alliance captain's EventTeamStatusPlayoff to the alliance status.
 def add_alliance_status(
     event_key: str, alliances: List[EventAlliance]

--- a/src/backend/api/handlers/helpers/add_alliance_status.py
+++ b/src/backend/api/handlers/helpers/add_alliance_status.py
@@ -1,19 +1,14 @@
-from typing import cast, List
+from typing import List
 
 from google.appengine.ext import ndb
 
 from backend.common.models.alliance import EventAlliance
 from backend.common.models.event_team import EventTeam
 
-
-class EventAllianceWithStatus(EventAlliance):
-    status: str
-
-
 # Adds the alliance captain's EventTeamStatusPlayoff to the alliance status.
 def add_alliance_status(
     event_key: str, alliances: List[EventAlliance]
-) -> List[EventAllianceWithStatus]:
+) -> List[EventAlliance]:
     captain_team_keys = []
     for alliance in alliances:
         if alliance["picks"]:
@@ -27,17 +22,14 @@ def add_alliance_status(
     with_status = []
     for captain_future, alliance in zip(captain_eventteams_future, alliances):
         captain = captain_future.get_result()
-        new_alliance = cast(EventAllianceWithStatus, alliance)
         if (
             captain
             and captain.status
             and captain.status.get("alliance")
             and captain.status.get("playoff")
         ):
-            new_alliance["status"] = captain.status.get("playoff")
-        else:
-            new_alliance["status"] = "unknown"
+            alliance["status"] = captain.status.get("playoff")
 
-        with_status.append(new_alliance)
+        with_status.append(alliance)
 
     return with_status

--- a/src/backend/api/handlers/helpers/tests/add_alliance_status_test.py
+++ b/src/backend/api/handlers/helpers/tests/add_alliance_status_test.py
@@ -2,13 +2,15 @@ from google.appengine.ext import ndb
 
 from backend.api.handlers.helpers.add_alliance_status import add_alliance_status
 from backend.common.consts.comp_level import CompLevel
-from backend.common.models.alliance import EventAlliance
+from backend.common.models.alliance import (
+    EventAlliance,
+    PlayoffAllianceStatus,
+    PlayoffOutcome,
+)
 from backend.common.models.event_team import EventTeam
 from backend.common.models.event_team_status import (
-    EventTeamPlayoffStatus,
     EventTeamStatus,
     EventTeamStatusAlliance,
-    EventTeamStatusPlayoff,
 )
 
 
@@ -16,7 +18,7 @@ def update_event_team(
     event_key: str,
     team_number: int,
     alliance_number: int,
-    playoff_status: EventTeamStatusPlayoff,
+    playoff_status: PlayoffAllianceStatus,
 ) -> None:
     EventTeam(
         id=f"{event_key}_frc{team_number}",
@@ -50,7 +52,7 @@ def test_unknown_status(ndb_stub):
     add_alliance_status(event_key, alliances)
     assert len(alliances) == 4
     for alliance in alliances:
-        assert alliance["status"] == "unknown"
+        assert "status" not in alliance
 
 
 def test_has_status(ndb_stub):
@@ -61,17 +63,17 @@ def test_has_status(ndb_stub):
         EventAlliance(picks=["frc7", "frc8", "frc9"]),
         EventAlliance(picks=["frc10", "frc11", "frc12"]),
     ]
-    alliance_0_playoff_status = EventTeamStatusPlayoff(
-        level=CompLevel.QF, status=EventTeamPlayoffStatus.PLAYING
+    alliance_0_playoff_status = PlayoffAllianceStatus(
+        level=CompLevel.QF, status=PlayoffOutcome.PLAYING
     )
-    alliance_1_playoff_status = EventTeamStatusPlayoff(
-        level=CompLevel.SF, status=EventTeamPlayoffStatus.ELIMINATED
+    alliance_1_playoff_status = PlayoffAllianceStatus(
+        level=CompLevel.SF, status=PlayoffOutcome.ELIMINATED
     )
-    alliance_2_playoff_status = EventTeamStatusPlayoff(
-        level=CompLevel.F, status=EventTeamPlayoffStatus.PLAYING
+    alliance_2_playoff_status = PlayoffAllianceStatus(
+        level=CompLevel.F, status=PlayoffOutcome.PLAYING
     )
-    alliance_3_playoff_status = EventTeamStatusPlayoff(
-        level=CompLevel.QF, status=EventTeamPlayoffStatus.WON
+    alliance_3_playoff_status = PlayoffAllianceStatus(
+        level=CompLevel.QF, status=PlayoffOutcome.WON
     )
 
     update_event_team(event_key, 1, 0, alliance_0_playoff_status)

--- a/src/backend/common/consts/event_type.py
+++ b/src/backend/common/consts/event_type.py
@@ -84,3 +84,12 @@ SEASON_EVENT_TYPES: Set[EventType] = {
     EventType.FOC,
     EventType.REMOTE,
 }
+
+KNOWN_EVENT_TYPE_ALLIANCE_SIZES: Dict[EventType, int] = {
+    EventType.REGIONAL: 3,
+    EventType.DISTRICT: 3,
+    EventType.DISTRICT_CMP: 3,
+    EventType.DISTRICT_CMP_DIVISION: 3,
+    EventType.CMP_DIVISION: 4,
+    EventType.CMP_FINALS: 4,
+}

--- a/src/backend/common/consts/event_type.py
+++ b/src/backend/common/consts/event_type.py
@@ -84,12 +84,3 @@ SEASON_EVENT_TYPES: Set[EventType] = {
     EventType.FOC,
     EventType.REMOTE,
 }
-
-KNOWN_EVENT_TYPE_ALLIANCE_SIZES: Dict[EventType, int] = {
-    EventType.REGIONAL: 3,
-    EventType.DISTRICT: 3,
-    EventType.DISTRICT_CMP: 3,
-    EventType.DISTRICT_CMP_DIVISION: 3,
-    EventType.CMP_DIVISION: 4,
-    EventType.CMP_FINALS: 4,
-}

--- a/src/backend/common/helpers/alliance_helper.py
+++ b/src/backend/common/helpers/alliance_helper.py
@@ -1,0 +1,183 @@
+from typing import Dict, List, Optional, Tuple
+
+from pyre_extensions import none_throws
+
+from backend.common.consts.comp_level import COMP_LEVELS_VERBOSE_FULL, CompLevel
+from backend.common.consts.event_type import EventType
+from backend.common.consts.playoff_type import DoubleElimRound, PlayoffType
+from backend.common.models.alliance import (
+    EventAlliance,
+    PlayoffAllianceStatus,
+    PlayoffOutcome,
+)
+from backend.common.models.event import Event
+from backend.common.models.keys import TeamKey
+
+
+class AllianceHelper:
+    UNKNOWN_ALLIANCE_SIZE = 99
+
+    KNOWN_MODERN_EVENT_TYPE_ALLIANCE_SIZES: Dict[EventType, int] = {
+        EventType.REGIONAL: 3,
+        EventType.DISTRICT: 3,
+        EventType.DISTRICT_CMP: 3,
+        EventType.DISTRICT_CMP_DIVISION: 3,
+        EventType.CMP_DIVISION: 4,
+        EventType.CMP_FINALS: 4,
+    }
+
+    @classmethod
+    def get_known_alliance_size(
+        cls,
+        event_type: EventType,
+        year: int,
+    ) -> int:
+
+        if year < 2014:
+            # 2014 was first year of 4 team champs divisions
+            # for now, return default for legacy events
+            return cls.UNKNOWN_ALLIANCE_SIZE
+
+        return cls.KNOWN_MODERN_EVENT_TYPE_ALLIANCE_SIZES.get(
+            event_type, cls.UNKNOWN_ALLIANCE_SIZE
+        )
+
+    @staticmethod
+    def get_ordinal_pick_from_number(n: int) -> str:
+        # https://stackoverflow.com/a/20007730
+        if 11 <= (n % 100) <= 13:
+            suffix = "th"
+        else:
+            suffix = ["th", "st", "nd", "rd", "th"][min(n % 10, 4)]
+        return f"{n}{suffix} Pick"
+
+    @classmethod
+    def get_alliance_details_and_pick_name(
+        cls, event: Event, team: TeamKey
+    ) -> Tuple[Optional[EventAlliance], Optional[str]]:
+        alliance = None
+        alliance_pick = None
+
+        if event.alliance_selections is None:
+            return (None, None)
+
+        alliance_size = cls.get_known_alliance_size(event.event_type_enum, event.year)
+
+        for alliance_check in none_throws(event.alliance_selections):
+            if team in alliance_check["picks"]:
+                alliance = alliance_check
+                if team == alliance_check["picks"][0]:
+                    alliance_pick = "Captain"
+                else:
+                    index = alliance_check["picks"].index(team)
+                    if index >= alliance_size:
+                        alliance_pick = "Backup"
+                    else:
+                        alliance_pick = cls.get_ordinal_pick_from_number(index)
+
+            if (
+                "backup" in alliance_check
+                and alliance_check["backup"]
+                and alliance_check["backup"]["in"] == team
+            ):
+                alliance = alliance_check
+                alliance_pick = "Backup"
+
+        return (alliance, alliance_pick)
+
+    @classmethod
+    def generate_playoff_level_status_string(
+        cls,
+        playoff_type: Optional[PlayoffType],
+        playoff_status: PlayoffAllianceStatus,
+    ) -> str:
+        if playoff_type in [
+            PlayoffType.DOUBLE_ELIM_4_TEAM,
+            PlayoffType.DOUBLE_ELIM_8_TEAM,
+        ]:
+            double_elim_round = playoff_status["double_elim_round"]
+            if double_elim_round == DoubleElimRound.FINALS:
+                return COMP_LEVELS_VERBOSE_FULL[CompLevel.F]
+            else:
+                return f"Double Elimination Bracket ({double_elim_round})"
+        elif playoff_type == PlayoffType.ROUND_ROBIN_6_TEAM:
+            if playoff_status["advanced_to_round_robin_finals"]:
+                return COMP_LEVELS_VERBOSE_FULL[CompLevel.F]
+            else:
+                return (
+                    f"Round Robin Bracket (Rank {playoff_status['round_robin_rank']})"
+                )
+        else:
+            return COMP_LEVELS_VERBOSE_FULL[playoff_status["level"]]
+
+    @classmethod
+    def generate_playoff_status_string(
+        cls,
+        playoff: PlayoffAllianceStatus,
+        pick: Optional[str],
+        alliance_name: Optional[str],
+        plural: bool = False,
+        include_record: bool = True,
+    ) -> List[str]:
+        level = playoff["level"]
+        status = playoff.get("status")
+        record = playoff.get("record")
+        playoff_average = playoff.get("playoff_average")
+        playoff_type = playoff.get("playoff_type")
+
+        level_str = cls.generate_playoff_level_status_string(
+            playoff_type, playoff
+        )
+
+        if status == PlayoffOutcome.PLAYING:
+            level_record = none_throws(playoff["current_level_record"])
+            record_str = "{}-{}-{}".format(
+                level_record["wins"],
+                level_record["losses"],
+                level_record["ties"],
+            )
+            if plural:
+                playoff_str = "are <b>{}</b> in the <b>{}</b>".format(
+                    record_str, level_str
+                )
+            else:
+                playoff_str = "is <b>{}</b> in the <b>{}</b>".format(
+                    record_str, level_str
+                )
+
+            if pick and alliance_name:
+                playoff_str += " as the <b>{}</b> of <b>{}</b>".format(
+                    pick, alliance_name
+                )
+            return [playoff_str]
+        else:
+            components = []
+            if pick and alliance_name:
+                components.append(
+                    "competed in the playoffs as the <b>{}</b> of <b>{}</b>".format(
+                        pick, alliance_name
+                    )
+                )
+
+            if status == PlayoffOutcome.WON:
+                if level == CompLevel.F:
+                    playoff_str = "<b>won the event</b>"
+                else:
+                    playoff_str = "<b>won the {}</b>".format(level_str)
+            elif status == PlayoffOutcome.ELIMINATED:
+                if plural:
+                    playoff_str = "were eliminated in the <b>{}</b>".format(level_str)
+                else:
+                    playoff_str = "was eliminated in the <b>{}</b>".format(level_str)
+            else:
+                raise Exception("Unknown playoff status: {}".format(status))
+            if record and include_record:
+                playoff_str += " with a playoff record of <b>{}-{}-{}</b>".format(
+                    record["wins"], record["losses"], record["ties"]
+                )
+            if playoff_average and include_record:
+                playoff_str += " with a playoff average of <b>{:.1f}</b>".format(
+                    playoff_average
+                )
+            components.append(playoff_str)
+            return components

--- a/src/backend/common/helpers/alliance_helper.py
+++ b/src/backend/common/helpers/alliance_helper.py
@@ -125,9 +125,7 @@ class AllianceHelper:
         playoff_average = playoff.get("playoff_average")
         playoff_type = playoff.get("playoff_type")
 
-        level_str = cls.generate_playoff_level_status_string(
-            playoff_type, playoff
-        )
+        level_str = cls.generate_playoff_level_status_string(playoff_type, playoff)
 
         if status == PlayoffOutcome.PLAYING:
             level_record = none_throws(playoff["current_level_record"])

--- a/src/backend/common/helpers/alliance_helper.py
+++ b/src/backend/common/helpers/alliance_helper.py
@@ -54,36 +54,35 @@ class AllianceHelper:
     @classmethod
     def get_alliance_details_and_pick_name(
         cls, event: Event, team: TeamKey
-    ) -> Tuple[Optional[EventAlliance], Optional[str]]:
-        alliance = None
-        alliance_pick = None
-
-        if event.alliance_selections is None:
-            return (None, None)
-
+    ) -> Tuple[Optional[EventAlliance], Optional[str], int]:
         alliance_size = cls.get_known_alliance_size(event.event_type_enum, event.year)
 
-        for alliance_check in none_throws(event.alliance_selections):
-            if team in alliance_check["picks"]:
-                alliance = alliance_check
-                if team == alliance_check["picks"][0]:
-                    alliance_pick = "Captain"
+        if event.alliance_selections is None:
+            return (None, None, alliance_size)
+
+        for alliance in none_throws(event.alliance_selections):
+            if team in alliance["picks"]:
+                if team == alliance["picks"][0]:
+                    return (alliance, "Captain", alliance_size)
                 else:
-                    index = alliance_check["picks"].index(team)
+                    index = alliance["picks"].index(team)
                     if index >= alliance_size:
-                        alliance_pick = "Backup"
+                        return (alliance, "Backup", alliance_size)
                     else:
-                        alliance_pick = cls.get_ordinal_pick_from_number(index)
+                        return (
+                            alliance,
+                            cls.get_ordinal_pick_from_number(index),
+                            alliance_size,
+                        )
 
             if (
-                "backup" in alliance_check
-                and alliance_check["backup"]
-                and alliance_check["backup"]["in"] == team
+                "backup" in alliance
+                and alliance["backup"]
+                and alliance["backup"]["in"] == team
             ):
-                alliance = alliance_check
-                alliance_pick = "Backup"
+                return (alliance, "Backup", alliance_size)
 
-        return (alliance, alliance_pick)
+        return (None, None, alliance_size)
 
     @classmethod
     def generate_playoff_level_status_string(

--- a/src/backend/common/helpers/event_team_status_helper.py
+++ b/src/backend/common/helpers/event_team_status_helper.py
@@ -225,9 +225,11 @@ class EventTeamStatusHelper:
                     playoff, pick, alliance_name
                 )
             else:
-                components.extend(AllianceHelper.generate_playoff_status_string(
-                    playoff, pick, alliance_name
-                ))
+                components.extend(
+                    AllianceHelper.generate_playoff_status_string(
+                        playoff, pick, alliance_name
+                    )
+                )
 
         if not components:
             return default_msg

--- a/src/backend/common/helpers/event_team_status_helper.py
+++ b/src/backend/common/helpers/event_team_status_helper.py
@@ -6,7 +6,6 @@ from pyre_extensions import none_throws
 
 from backend.common.consts.alliance_color import ALLIANCE_COLORS
 from backend.common.consts.comp_level import (
-    COMP_LEVELS_VERBOSE_FULL,
     CompLevel,
     ELIM_LEVELS,
 )
@@ -15,19 +14,22 @@ from backend.common.consts.playoff_type import (
     ORDERED_DOUBLE_ELIM_ROUNDS,
     PlayoffType,
 )
+from backend.common.helpers.alliance_helper import AllianceHelper
 from backend.common.helpers.match_helper import MatchHelper, TOrganizedMatches
 from backend.common.helpers.playoff_advancement_helper import PlayoffAdvancementHelper
 from backend.common.helpers.rankings_helper import RankingsHelper
-from backend.common.models.alliance import EventAlliance
+from backend.common.models.alliance import (
+    EventAlliance,
+    PlayoffAllianceStatus,
+    PlayoffOutcome,
+)
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_team_status import (
     EventTeamLevelStatus,
-    EventTeamPlayoffStatus,
     EventTeamRanking,
     EventTeamStatus,
     EventTeamStatusAlliance,
-    EventTeamStatusPlayoff,
     EventTeamStatusQual,
     WLTRecord,
 )
@@ -80,11 +82,11 @@ class EventTeamStatusHelper:
             playoff_average = playoff.get("playoff_average")
             playoff_type = playoff.get("playoff_type")
 
-            level_str = cls._generate_playoff_level_status_string(
-                playoff_type, playoff, level
+            level_str = AllianceHelper.generate_playoff_level_status_string(
+                playoff_type, playoff
             )
 
-            if status == EventTeamPlayoffStatus.PLAYING:
+            if status == PlayoffOutcome.PLAYING:
                 level_record = none_throws(playoff["current_level_record"])
                 record_str = "{}-{}-{}".format(
                     level_record["wins"], level_record["losses"], level_record["ties"]
@@ -93,12 +95,12 @@ class EventTeamStatusHelper:
                     record_str, level_str
                 )
             else:
-                if status == EventTeamPlayoffStatus.WON:
+                if status == PlayoffOutcome.WON:
                     if level == CompLevel.F:
                         playoff_str = "<b>Won the event</b>"
                     else:
                         playoff_str = "<b>Won the {}</b>".format(level_str)
-                elif status == EventTeamPlayoffStatus.ELIMINATED:
+                elif status == PlayoffOutcome.ELIMINATED:
                     playoff_str = "<b>Eliminated in the {}</b>".format(level_str)
                 else:
                     raise Exception("Unknown playoff status: {}".format(status))
@@ -205,16 +207,7 @@ class EventTeamStatusHelper:
             if pick == 0:
                 pick = "Captain"
             else:
-                # Convert to ordinal number http://stackoverflow.com/questions/9647202/ordinal-numbers-replacement
-                pick = "{} Pick".format(
-                    "%d%s"
-                    % (
-                        pick,
-                        "tsnrhtdd"[
-                            (pick / 10 % 10 != 1) * (pick % 10 < 4) * pick % 10 :: 4
-                        ],
-                    )
-                )
+                pick = AllianceHelper.get_ordinal_pick_from_number(pick)
             backup = alliance["backup"]
             if backup and team_key == backup["in"]:
                 pick = "Backup"
@@ -226,60 +219,15 @@ class EventTeamStatusHelper:
                 components.append(alliance_str)
 
         if playoff:
-            level = playoff["level"]
-            status = playoff.get("status")
-            record = playoff.get("record")
-            playoff_average = playoff.get("playoff_average")
-            playoff_type = playoff.get("playoff_type")
-
-            level_str = cls._generate_playoff_level_status_string(
-                playoff_type, playoff, level
-            )
-
-            if status == EventTeamPlayoffStatus.PLAYING:
-                level_record = none_throws(playoff["current_level_record"])
-                if verbose:
-                    record_str = cls._build_verbose_record(level_record)
-                else:
-                    record_str = "{}-{}-{}".format(
-                        level_record["wins"],
-                        level_record["losses"],
-                        level_record["ties"],
-                    )
-                playoff_str = "is <b>{}</b> in the <b>{}</b>".format(
-                    record_str, level_str
+            alliance_name = alliance.get("name") if alliance else None
+            if playoff["status"] == PlayoffOutcome.PLAYING:
+                components = AllianceHelper.generate_playoff_status_string(
+                    playoff, pick, alliance_name
                 )
-                if alliance:
-                    playoff_str += " as the <b>{}</b> of <b>{}</b>".format(
-                        pick, alliance["name"]
-                    )
-                components = [playoff_str]
             else:
-                if alliance:
-                    components.append(
-                        "competed in the playoffs as the <b>{}</b> of <b>{}</b>".format(
-                            pick, alliance["name"]
-                        )
-                    )
-
-                if status == EventTeamPlayoffStatus.WON:
-                    if level == CompLevel.F:
-                        playoff_str = "<b>won the event</b>"
-                    else:
-                        playoff_str = "<b>won the {}</b>".format(level_str)
-                elif status == EventTeamPlayoffStatus.ELIMINATED:
-                    playoff_str = "was <b>eliminated in the {}</b>".format(level_str)
-                else:
-                    raise Exception("Unknown playoff status: {}".format(status))
-                if record:
-                    playoff_str += " with a playoff record of <b>{}-{}-{}</b>".format(
-                        record["wins"], record["losses"], record["ties"]
-                    )
-                if playoff_average:
-                    playoff_str += " with a playoff average of <b>{:.1f}</b>".format(
-                        playoff_average
-                    )
-                components.append(playoff_str)
+                components.extend(AllianceHelper.generate_playoff_status_string(
+                    playoff, pick, alliance_name
+                ))
 
         if not components:
             return default_msg
@@ -334,32 +282,6 @@ class EventTeamStatusHelper:
 
         # TODO: Results are getting mixed unless copied. 2017-02-03 -fangeugene
         return copy.deepcopy(status)
-
-    @classmethod
-    def _generate_playoff_level_status_string(
-        cls,
-        playoff_type: Optional[PlayoffType],
-        playoff_status: EventTeamStatusPlayoff,
-        level: CompLevel,
-    ) -> str:
-        if playoff_type in [
-            PlayoffType.DOUBLE_ELIM_4_TEAM,
-            PlayoffType.DOUBLE_ELIM_8_TEAM,
-        ]:
-            double_elim_round = playoff_status["double_elim_round"]
-            if double_elim_round == DoubleElimRound.FINALS:
-                return COMP_LEVELS_VERBOSE_FULL[CompLevel.F]
-            else:
-                return f"Double Elimination Bracket ({double_elim_round})"
-        elif playoff_type == PlayoffType.ROUND_ROBIN_6_TEAM:
-            if playoff_status["advanced_to_round_robin_finals"]:
-                return COMP_LEVELS_VERBOSE_FULL[CompLevel.F]
-            else:
-                return (
-                    f"Round Robin Bracket (Rank {playoff_status['round_robin_rank']})"
-                )
-        else:
-            return COMP_LEVELS_VERBOSE_FULL[level]
 
     @classmethod
     def _build_qual_info(
@@ -490,7 +412,7 @@ class EventTeamStatusHelper:
         matches: TOrganizedMatches,
         year: Year,
         playoff_type: PlayoffType,
-    ) -> Optional[EventTeamStatusPlayoff]:
+    ) -> Optional[PlayoffAllianceStatus]:
         alliance, _ = cls._get_alliance(team_key, event_details, matches)
         complete_alliance = set(alliance["picks"]) if alliance else set()
         if alliance and alliance.get("backup"):
@@ -534,7 +456,7 @@ class EventTeamStatusHelper:
         matches: TOrganizedMatches,
         year: Year,
         playoff_type: PlayoffType,
-    ) -> Optional[EventTeamStatusPlayoff]:
+    ) -> Optional[PlayoffAllianceStatus]:
         # Matches needs to be all playoff matches at the event, to properly account for backups
         import numpy as np
 
@@ -544,7 +466,7 @@ class EventTeamStatusHelper:
         all_losses = 0
         all_ties = 0
         playoff_scores = []
-        status: Optional[EventTeamStatusPlayoff] = None
+        status: Optional[PlayoffAllianceStatus] = None
         for comp_level in reversed(ELIM_LEVELS):  # playoffs
             if matches[comp_level]:
                 level_wins = 0
@@ -577,7 +499,7 @@ class EventTeamStatusHelper:
                     if level_wins == (3 if is_bo5 else 2):
                         status = {
                             "playoff_type": playoff_type,
-                            "status": EventTeamPlayoffStatus.WON,
+                            "status": PlayoffOutcome.WON,
                             "level": comp_level,
                             "current_level_record": None,
                             "record": None,
@@ -586,7 +508,7 @@ class EventTeamStatusHelper:
                     elif level_losses == (3 if is_bo5 else 2):
                         status = {
                             "playoff_type": playoff_type,
-                            "status": EventTeamPlayoffStatus.ELIMINATED,
+                            "status": PlayoffOutcome.ELIMINATED,
                             "level": comp_level,
                             "current_level_record": None,
                             "record": None,
@@ -597,7 +519,7 @@ class EventTeamStatusHelper:
                             # This only works for past events, but 2015 is in the past so this works
                             status = {
                                 "playoff_type": playoff_type,
-                                "status": EventTeamPlayoffStatus.ELIMINATED,
+                                "status": PlayoffOutcome.ELIMINATED,
                                 "level": comp_level,
                                 "current_level_record": None,
                                 "record": None,
@@ -606,7 +528,7 @@ class EventTeamStatusHelper:
                         else:
                             status = {
                                 "playoff_type": playoff_type,
-                                "status": EventTeamPlayoffStatus.PLAYING,
+                                "status": PlayoffOutcome.PLAYING,
                                 "level": comp_level,
                                 "current_level_record": None,
                                 "record": None,
@@ -641,7 +563,7 @@ class EventTeamStatusHelper:
         matches: TOrganizedMatches,
         year: Year,
         playoff_type: PlayoffType,
-    ) -> Optional[EventTeamStatusPlayoff]:
+    ) -> Optional[PlayoffAllianceStatus]:
         if playoff_type == PlayoffType.DOUBLE_ELIM_8_TEAM:
             double_elim_matches = MatchHelper.organized_double_elim_matches(
                 matches, year
@@ -699,7 +621,7 @@ class EventTeamStatusHelper:
             # Event winner -- won two finals matches
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.WON,
+                "status": PlayoffOutcome.WON,
                 "level": latest_level,
                 "double_elim_round": latest_round,
                 "current_level_record": current_record,
@@ -710,7 +632,7 @@ class EventTeamStatusHelper:
             # Eliminated if two double elim or finals losses
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.ELIMINATED,
+                "status": PlayoffOutcome.ELIMINATED,
                 "level": latest_level,
                 "double_elim_round": latest_round,
                 "current_level_record": current_record,
@@ -722,7 +644,7 @@ class EventTeamStatusHelper:
             # at least one match on the schedule
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.PLAYING,
+                "status": PlayoffOutcome.PLAYING,
                 "level": latest_level,
                 "double_elim_round": latest_round,
                 "current_level_record": current_record,
@@ -742,7 +664,7 @@ class EventTeamStatusHelper:
         year: Year,
         playoff_type: PlayoffType,
         alliance_selections: List[EventAlliance],
-    ) -> Optional[EventTeamStatusPlayoff]:
+    ) -> Optional[PlayoffAllianceStatus]:
         round_robin_rank = None
         round_robin_record = WLTRecord(wins=0, losses=0, ties=0)
         finals_record = WLTRecord(wins=0, losses=0, ties=0)
@@ -789,7 +711,7 @@ class EventTeamStatusHelper:
             # Event winners (2+ wins in the final best-of-3)
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.WON,
+                "status": PlayoffOutcome.WON,
                 "level": CompLevel.F,
                 "current_level_record": finals_record,
                 "record": overall_record,
@@ -801,7 +723,7 @@ class EventTeamStatusHelper:
             # Event finalist (2+ losses in the final best-of-3)
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.ELIMINATED,
+                "status": PlayoffOutcome.ELIMINATED,
                 "level": CompLevel.F,
                 "current_level_record": finals_record,
                 "record": overall_record,
@@ -817,7 +739,7 @@ class EventTeamStatusHelper:
             # Eliminated in the round robin tournament
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.ELIMINATED,
+                "status": PlayoffOutcome.ELIMINATED,
                 "level": CompLevel.SF,
                 "current_level_record": round_robin_record,
                 "record": overall_record,
@@ -829,7 +751,7 @@ class EventTeamStatusHelper:
             # Still playing, if we found round robin data for them
             return {
                 "playoff_type": playoff_type,
-                "status": EventTeamPlayoffStatus.PLAYING,
+                "status": PlayoffOutcome.PLAYING,
                 "level": CompLevel.F if has_finals_match else CompLevel.SF,
                 "current_level_record": (
                     finals_record if has_finals_match else round_robin_record

--- a/src/backend/common/helpers/tests/alliance_helper_test.py
+++ b/src/backend/common/helpers/tests/alliance_helper_test.py
@@ -56,32 +56,32 @@ class Test2023njflaAllianceHelper(unittest.TestCase):
     def test_alliance_and_pick_names(self):
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc11"),
-            (self.alliance_one, "Captain"),
+            (self.alliance_one, "Captain", 3),
         )
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc1676"),
-            (self.alliance_one, "1st Pick"),
+            (self.alliance_one, "1st Pick", 3),
         )
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc4573"),
-            (self.alliance_one, "2nd Pick"),
+            (self.alliance_one, "2nd Pick", 3),
         )
 
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc3142"),
-            (self.alliance_four, "Captain"),
+            (self.alliance_four, "Captain", 3),
         )
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc1279"),
-            (self.alliance_four, "1st Pick"),
+            (self.alliance_four, "1st Pick", 3),
         )
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc1672"),
-            (self.alliance_four, "2nd Pick"),
+            (self.alliance_four, "2nd Pick", 3),
         )
         self.assertEqual(
             AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc5732"),
-            (self.alliance_four, "Backup"),
+            (self.alliance_four, "Backup", 3),
         )
 
     def test_alliance_status_string(self):

--- a/src/backend/common/helpers/tests/alliance_helper_test.py
+++ b/src/backend/common/helpers/tests/alliance_helper_test.py
@@ -1,11 +1,11 @@
 import unittest
 
 import pytest
+from pyre_extensions import none_throws
 
 from backend.common.helpers.alliance_helper import AllianceHelper
-from backend.common.models.alliance import EventAlliance
 from backend.common.models.event import Event
-from backend.tests.json_data_importer import JsonDataImporter
+from backend.tests.json_data_importer import JsonDataImporter  # noqa
 
 
 @pytest.mark.usefixtures("ndb_context")
@@ -43,7 +43,7 @@ class Test2023njflaAllianceHelper(unittest.TestCase):
             __file__, "data/2023njfla_alliances.json", "2023njfla"
         )
 
-        self.event: Event = Event.get_by_id("2023njfla")
+        self.event: Event = none_throws(Event.get_by_id("2023njfla"))
 
     def test_alliance_size(self):
         self.assertEqual(

--- a/src/backend/common/helpers/tests/alliance_helper_test.py
+++ b/src/backend/common/helpers/tests/alliance_helper_test.py
@@ -1,0 +1,113 @@
+import unittest
+
+import pytest
+
+from backend.common.helpers.alliance_helper import AllianceHelper
+from backend.common.models.alliance import EventAlliance
+from backend.common.models.event import Event
+from backend.tests.json_data_importer import JsonDataImporter
+
+
+@pytest.mark.usefixtures("ndb_context")
+class Test2023njflaAllianceHelper(unittest.TestCase):
+    alliance_one = {
+        "declines": [],
+        "name": "Alliance 1",
+        "picks": ["frc11", "frc1676", "frc4573"],
+        "status": {
+            "current_level_record": {"losses": 2, "ties": 0, "wins": 0},
+            "level": "f",
+            "playoff_average": None,
+            "record": {"losses": 3, "ties": 0, "wins": 3},
+            "status": "eliminated",
+        },
+    }
+
+    alliance_four = {
+        "declines": [],
+        "name": "Alliance 4",
+        "picks": ["frc3142", "frc1279", "frc1672", "frc5732"],
+        "status": {
+            "current_level_record": {"losses": 2, "ties": 0, "wins": 3},
+            "level": "sf",
+            "playoff_average": None,
+            "record": {"losses": 2, "ties": 0, "wins": 3},
+            "status": "eliminated",
+        },
+    }
+
+    def setUp(self) -> None:
+        test_data_importer = JsonDataImporter()
+        test_data_importer.import_event(__file__, "data/2023njfla.json")
+        test_data_importer.import_event_alliances(
+            __file__, "data/2023njfla_alliances.json", "2023njfla"
+        )
+
+        self.event: Event = Event.get_by_id("2023njfla")
+
+    def test_alliance_size(self):
+        self.assertEqual(
+            AllianceHelper.get_known_alliance_size(
+                self.event.event_type_enum, self.event.year
+            ),
+            3,
+        )
+
+    def test_alliance_and_pick_names(self):
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc11"),
+            (self.alliance_one, "Captain"),
+        )
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc1676"),
+            (self.alliance_one, "1st Pick"),
+        )
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc4573"),
+            (self.alliance_one, "2nd Pick"),
+        )
+
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc3142"),
+            (self.alliance_four, "Captain"),
+        )
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc1279"),
+            (self.alliance_four, "1st Pick"),
+        )
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc1672"),
+            (self.alliance_four, "2nd Pick"),
+        )
+        self.assertEqual(
+            AllianceHelper.get_alliance_details_and_pick_name(self.event, "frc5732"),
+            (self.alliance_four, "Backup"),
+        )
+
+    def test_alliance_status_string(self):
+        self.assertEqual(
+            AllianceHelper.generate_playoff_status_string(
+                self.alliance_one["status"],
+                "Captain",
+                "Alliance 1",
+                plural=True,
+                include_record=False,
+            ),
+            [
+                "competed in the playoffs as the <b>Captain</b> of <b>Alliance 1</b>",
+                "were eliminated in the <b>Finals</b>",
+            ],
+        )
+        self.assertEqual(
+            AllianceHelper.generate_playoff_status_string(
+                self.alliance_four["status"],
+                "1st Pick",
+                "Alliance 4",
+                plural=True,
+                include_record=False,
+            ),
+            [
+                "competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>",
+                "were eliminated in the <b>Semifinals</b>",
+            ],
+        )

--- a/src/backend/common/helpers/tests/event_team_status_helper_test.py
+++ b/src/backend/common/helpers/tests/event_team_status_helper_test.py
@@ -9,11 +9,11 @@ from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.playoff_type import DoubleElimRound, PlayoffType
 from backend.common.helpers.event_team_status_helper import EventTeamStatusHelper
+from backend.common.models.alliance import PlayoffOutcome
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_team_status import (
     EventTeamLevelStatus,
-    EventTeamPlayoffStatus,
 )
 from backend.common.models.match import Match
 from backend.common.tests.event_simulator import EventSimulator
@@ -328,7 +328,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc229", event)
@@ -370,7 +370,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc229", event)
@@ -412,7 +412,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc229", event)
@@ -454,7 +454,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc229", event)
@@ -496,7 +496,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc229", event)
@@ -538,7 +538,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 4/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc229", event)
@@ -546,7 +546,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc229", status
             ),
-            "Team 229 was <b>Rank 16/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>2nd Pick</b> of <b>Alliance 2</b>, and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 229 was <b>Rank 16/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>2nd Pick</b> of <b>Alliance 2</b>, and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc1665", event)
@@ -554,7 +554,7 @@ class TestSimulated2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc1665", status
             ),
-            "Team 1665 was <b>Rank 15/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>Backup</b> of <b>Alliance 2</b>, and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 1665 was <b>Rank 15/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>Backup</b> of <b>Alliance 2</b>, and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
 
         status = EventTeamStatusHelper.generate_team_at_event_status("frc5964", event)
@@ -578,7 +578,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 1, "ties": 0, "wins": 6},
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
         },
         "last_match_key": "2016nytr_f1m3",
         "next_match_key": None,
@@ -612,7 +612,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 3, "ties": 0, "wins": 2},
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2016nytr_sf1m2",
         "next_match_key": None,
@@ -651,7 +651,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 3, "ties": 0, "wins": 5},
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2016nytr_sf2m1",
         "next_match_key": None,
@@ -690,7 +690,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 3, "ties": 0, "wins": 5},
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2016nytr_f1m3",
         "next_match_key": None,
@@ -790,7 +790,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 was <b>Rank 6/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 was <b>Rank 6/36</b> with a record of <b>9-3-0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 4</b>, and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
         self.assertEqual(
             EventTeamStatusHelper.generate_team_at_event_alliance_status_string(
@@ -814,7 +814,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc229", status
             ),
-            "Team 229 was <b>Rank 20/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>2nd Pick</b> of <b>Alliance 2</b>, and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 229 was <b>Rank 20/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>2nd Pick</b> of <b>Alliance 2</b>, and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
         self.assertEqual(
             EventTeamStatusHelper.generate_team_at_event_alliance_status_string(
@@ -838,7 +838,7 @@ class Test2016nytrEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc1665", status
             ),
-            "Team 1665 was <b>Rank 18/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>Backup</b> of <b>Alliance 2</b>, and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 1665 was <b>Rank 18/36</b> with a record of <b>6-6-0</b> in quals, competed in the playoffs as the <b>Backup</b> of <b>Alliance 2</b>, and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
         self.assertEqual(
             EventTeamStatusHelper.generate_team_at_event_alliance_status_string(
@@ -890,7 +890,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 1, "ties": 0, "wins": 6},
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
         },
         "last_match_key": "2016nytr_f1m3",
         "next_match_key": None,
@@ -918,7 +918,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 3, "ties": 0, "wins": 2},
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2016nytr_sf1m2",
         "next_match_key": None,
@@ -946,7 +946,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 3, "ties": 0, "wins": 5},
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2016nytr_sf2m1",
         "next_match_key": None,
@@ -974,7 +974,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 3, "ties": 0, "wins": 5},
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2016nytr_f1m3",
         "next_match_key": None,
@@ -1052,7 +1052,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc5240", status
             ),
-            "Team 5240 had a record of <b>9-3-0</b> in quals and was <b>eliminated in the Semifinals</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 5240 had a record of <b>9-3-0</b> in quals and was eliminated in the <b>Semifinals</b> with a playoff record of <b>2-3-0</b>.",
         )
 
     def test_backup_out(self):
@@ -1064,7 +1064,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc229", status
             ),
-            "Team 229 had a record of <b>6-6-0</b> in quals and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 229 had a record of <b>6-6-0</b> in quals and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
 
     def test_backup_in(self):
@@ -1076,7 +1076,7 @@ class Test2016nytrEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc1665", status
             ),
-            "Team 1665 had a record of <b>6-6-0</b> in quals and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 1665 had a record of <b>6-6-0</b> in quals and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
 
     def testTeamNotPicked(self):
@@ -1104,7 +1104,7 @@ class Test2016casjEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.BRACKET_8_TEAM,
             "playoff_average": None,
             "record": {"losses": 0, "ties": 0, "wins": 6},
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
         },
         "last_match_key": "2016casj_f1m2",
         "next_match_key": None,
@@ -1162,7 +1162,7 @@ class Test2015casjEventTeamStatusHelper(unittest.TestCase):
             "playoff_type": PlayoffType.AVG_SCORE_8_TEAM,
             "playoff_average": 224.14285714285714,
             "record": None,
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
         },
         "last_match_key": "2015casj_f1m2",
         "next_match_key": None,
@@ -1197,7 +1197,7 @@ class Test2015casjEventTeamStatusHelper(unittest.TestCase):
             "playoff_type": PlayoffType.AVG_SCORE_8_TEAM,
             "playoff_average": 133.59999999999999,
             "record": None,
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2015casj_sf1m5",
         "next_match_key": None,
@@ -1288,7 +1288,7 @@ class Test2015casjEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc846", status
             ),
-            "Team 846 was <b>Rank 8/57</b> with an average score of <b>97.0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 3</b>, and was <b>eliminated in the Semifinals</b> with a playoff average of <b>133.6</b>.",
+            "Team 846 was <b>Rank 8/57</b> with an average score of <b>97.0</b> in quals, competed in the playoffs as the <b>1st Pick</b> of <b>Alliance 3</b>, and was eliminated in the <b>Semifinals</b> with a playoff average of <b>133.6</b>.",
         )
 
     def test_team_not_picked(self):
@@ -1312,7 +1312,7 @@ class Test2015casjEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.AVG_SCORE_8_TEAM,
             "playoff_average": 224.14285714285714,
             "record": None,
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
         },
         "last_match_key": "2015casj_f1m2",
         "next_match_key": None,
@@ -1340,7 +1340,7 @@ class Test2015casjEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             "playoff_type": PlayoffType.AVG_SCORE_8_TEAM,
             "playoff_average": 133.59999999999999,
             "record": None,
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
         },
         "last_match_key": "2015casj_sf1m5",
         "next_match_key": None,
@@ -1418,7 +1418,7 @@ class Test2015casjEventTeamStatusHelperNoEventDetails(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc846", status
             ),
-            "Team 846 had an average score of <b>97.0</b> in quals and was <b>eliminated in the Semifinals</b> with a playoff average of <b>133.6</b>.",
+            "Team 846 had an average score of <b>97.0</b> in quals and was eliminated in the <b>Semifinals</b> with a playoff average of <b>133.6</b>.",
         )
 
     def test_team_not_picked(self):
@@ -1444,7 +1444,7 @@ class Test2022cmptxEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 4,
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
             "level": CompLevel.F,
             "current_level_record": {"wins": 2, "losses": 1, "ties": 0},
             "record": {"wins": 5, "losses": 3, "ties": 0},
@@ -1465,7 +1465,7 @@ class Test2022cmptxEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 4,
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
             "level": CompLevel.F,
             "current_level_record": {"wins": 1, "losses": 2, "ties": 0},
             "record": {"wins": 5, "losses": 3, "ties": 0},
@@ -1486,7 +1486,7 @@ class Test2022cmptxEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 4,
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
             "level": CompLevel.SF,
             "current_level_record": {"wins": 2, "losses": 3, "ties": 0},
             "record": {"wins": 2, "losses": 3, "ties": 0},
@@ -1507,7 +1507,7 @@ class Test2022cmptxEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 4,
-            "status": EventTeamPlayoffStatus.PLAYING,
+            "status": PlayoffOutcome.PLAYING,
             "level": CompLevel.F,
             "current_level_record": {"wins": 1, "losses": 1, "ties": 0},
             "record": {"wins": 5, "losses": 2, "ties": 0},
@@ -1559,7 +1559,7 @@ class Test2022cmptxEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc4414", status
             ),
-            "Team 4414 competed in the playoffs as the <b>1st Pick</b> of <b>Turing</b> and was <b>eliminated in the Finals</b> with a playoff record of <b>5-3-0</b>.",
+            "Team 4414 competed in the playoffs as the <b>1st Pick</b> of <b>Turing</b> and was eliminated in the <b>Finals</b> with a playoff record of <b>5-3-0</b>.",
         )
 
     def test_round_robin_eliminated(self) -> None:
@@ -1572,7 +1572,7 @@ class Test2022cmptxEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc1323", status
             ),
-            "Team 1323 competed in the playoffs as the <b>1st Pick</b> of <b>Carver</b> and was <b>eliminated in the Round Robin Bracket (Rank 4)</b> with a playoff record of <b>2-3-0</b>.",
+            "Team 1323 competed in the playoffs as the <b>1st Pick</b> of <b>Carver</b> and was eliminated in the <b>Round Robin Bracket (Rank 4)</b> with a playoff record of <b>2-3-0</b>.",
         )
 
     def test_team_playing_in_finals(self) -> None:
@@ -1630,7 +1630,7 @@ class Test2023njflaEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 10,
-            "status": EventTeamPlayoffStatus.WON,
+            "status": PlayoffOutcome.WON,
             "level": CompLevel.F,
             "double_elim_round": DoubleElimRound.FINALS,
             "current_level_record": {"wins": 2, "losses": 0, "ties": 0},
@@ -1663,7 +1663,7 @@ class Test2023njflaEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 10,
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
             "level": CompLevel.F,
             "double_elim_round": DoubleElimRound.FINALS,
             "current_level_record": {"wins": 0, "losses": 2, "ties": 0},
@@ -1696,7 +1696,7 @@ class Test2023njflaEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 10,
-            "status": EventTeamPlayoffStatus.ELIMINATED,
+            "status": PlayoffOutcome.ELIMINATED,
             "level": CompLevel.SF,
             "double_elim_round": DoubleElimRound.ROUND4,
             "current_level_record": {"wins": 2, "losses": 2, "ties": 0},
@@ -1729,7 +1729,7 @@ class Test2023njflaEventTeamStatusHelper(unittest.TestCase):
         },
         "playoff": {
             "playoff_type": 10,
-            "status": EventTeamPlayoffStatus.PLAYING,
+            "status": PlayoffOutcome.PLAYING,
             "level": CompLevel.F,
             "double_elim_round": DoubleElimRound.FINALS,
             "current_level_record": {"wins": 1, "losses": 0, "ties": 0},
@@ -1790,7 +1790,7 @@ class Test2023njflaEventTeamStatusHelper(unittest.TestCase):
         self.assertDictEqual(status, self.status_11)
         self.assertEqual(
             EventTeamStatusHelper.generate_team_at_event_status_string("frc11", status),
-            "Team 11 had a record of <b>11-1-0</b> in quals, competed in the playoffs as the <b>Captain</b> of <b>Alliance 1</b>, and was <b>eliminated in the Finals</b> with a playoff record of <b>3-3-0</b>.",
+            "Team 11 had a record of <b>11-1-0</b> in quals, competed in the playoffs as the <b>Captain</b> of <b>Alliance 1</b>, and was eliminated in the <b>Finals</b> with a playoff record of <b>3-3-0</b>.",
         )
 
     def test_double_elim_eliminated(self) -> None:
@@ -1803,7 +1803,7 @@ class Test2023njflaEventTeamStatusHelper(unittest.TestCase):
             EventTeamStatusHelper.generate_team_at_event_status_string(
                 "frc1811", status
             ),
-            "Team 1811 had a record of <b>7-5-0</b> in quals, competed in the playoffs as the <b>Captain</b> of <b>Alliance 8</b>, and was <b>eliminated in the Double Elimination Bracket (Round 4)</b> with a playoff record of <b>2-2-0</b>.",
+            "Team 1811 had a record of <b>7-5-0</b> in quals, competed in the playoffs as the <b>Captain</b> of <b>Alliance 8</b>, and was eliminated in the <b>Double Elimination Bracket (Round 4)</b> with a playoff record of <b>2-2-0</b>.",
         )
 
     def test_team_playing_in_finals(self) -> None:

--- a/src/backend/common/models/alliance.py
+++ b/src/backend/common/models/alliance.py
@@ -1,7 +1,39 @@
-from typing import List, TypedDict
+import enum
+from typing import List, Optional, TypedDict
 
-from backend.common.models.event_team_status import EventTeamStatusPlayoff
+from backend.common.consts.comp_level import CompLevel
+from backend.common.consts.playoff_type import DoubleElimRound, PlayoffType
+from backend.common.consts.string_enum import StrEnum
 from backend.common.models.keys import TeamKey
+from backend.common.models.wlt import WLTRecord
+
+
+@enum.unique
+class PlayoffOutcome(StrEnum):
+    WON = "won"
+    ELIMINATED = "eliminated"
+    PLAYING = "playing"
+
+
+class _EventTeamStatusPlayoffOptional(TypedDict, total=False):
+    playoff_type: PlayoffType
+
+    # Relevant for double elim tournaments
+    double_elim_round: Optional[DoubleElimRound]
+
+    # Relevant for round robin tournaments
+    round_robin_rank: Optional[int]
+    advanced_to_round_robin_finals: Optional[bool]
+
+    # Relevant for 2015 tournaments
+    playoff_average: Optional[float]
+
+
+class PlayoffAllianceStatus(_EventTeamStatusPlayoffOptional, total=True):
+    level: CompLevel
+    current_level_record: Optional[WLTRecord]
+    record: Optional[WLTRecord]
+    status: PlayoffOutcome
 
 
 EventAllianceBackup = TypedDict("EventAllianceBackup", {"in": str, "out": str})
@@ -11,7 +43,7 @@ class _EventAllianceOptional(TypedDict, total=False):
     declines: List[TeamKey]
     name: str
     backup: EventAllianceBackup
-    status: EventTeamStatusPlayoff
+    status: PlayoffAllianceStatus
 
 
 class EventAlliance(_EventAllianceOptional, total=True):

--- a/src/backend/common/models/alliance.py
+++ b/src/backend/common/models/alliance.py
@@ -1,5 +1,6 @@
 from typing import List, TypedDict
 
+from backend.common.models.event_team_status import EventTeamStatusPlayoff
 from backend.common.models.keys import TeamKey
 
 
@@ -10,6 +11,7 @@ class _EventAllianceOptional(TypedDict, total=False):
     declines: List[TeamKey]
     name: str
     backup: EventAllianceBackup
+    status: EventTeamStatusPlayoff
 
 
 class EventAlliance(_EventAllianceOptional, total=True):

--- a/src/backend/common/models/event_team_status.py
+++ b/src/backend/common/models/event_team_status.py
@@ -1,11 +1,10 @@
 import enum
 from typing import List, Optional, TypedDict
 
-from backend.common.consts.comp_level import CompLevel
-from backend.common.consts.playoff_type import DoubleElimRound, PlayoffType
 from backend.common.consts.string_enum import StrEnum
-from backend.common.models.alliance import EventAllianceBackup
+from backend.common.models.alliance import EventAllianceBackup, PlayoffAllianceStatus
 from backend.common.models.keys import TeamKey
+from backend.common.models.wlt import WLTRecord
 
 
 @enum.unique
@@ -13,19 +12,6 @@ class EventTeamLevelStatus(StrEnum):
     NOT_STARTED = "not_started"
     PLAYING = "playing"
     COMPLETED = "completed"
-
-
-@enum.unique
-class EventTeamPlayoffStatus(StrEnum):
-    WON = "won"
-    ELIMINATED = "eliminated"
-    PLAYING = "playing"
-
-
-class WLTRecord(TypedDict):
-    wins: int
-    losses: int
-    ties: int
 
 
 class RankingSortOrderInfo(TypedDict):
@@ -50,27 +36,6 @@ class EventTeamStatusQual(TypedDict):
     sort_order_info: Optional[List[RankingSortOrderInfo]]
 
 
-class _EventTeamStatusPlayoffOptional(TypedDict, total=False):
-    playoff_type: PlayoffType
-
-    # Relevant for double elim tournaments
-    double_elim_round: Optional[DoubleElimRound]
-
-    # Relevant for round robin tournaments
-    round_robin_rank: Optional[int]
-    advanced_to_round_robin_finals: Optional[bool]
-
-    # Relevant for 2015 tournaments
-    playoff_average: Optional[float]
-
-
-class EventTeamStatusPlayoff(_EventTeamStatusPlayoffOptional, total=True):
-    level: CompLevel
-    current_level_record: Optional[WLTRecord]
-    record: Optional[WLTRecord]
-    status: EventTeamPlayoffStatus
-
-
 class EventTeamStatusAlliance(TypedDict):
     name: Optional[str]
     number: int
@@ -80,7 +45,7 @@ class EventTeamStatusAlliance(TypedDict):
 
 class EventTeamStatus(TypedDict):
     qual: Optional[EventTeamStatusQual]
-    playoff: Optional[EventTeamStatusPlayoff]
+    playoff: Optional[PlayoffAllianceStatus]
     alliance: Optional[EventTeamStatusAlliance]
     last_match_key: Optional[str]
     next_match_key: Optional[str]

--- a/src/backend/common/models/wlt.py
+++ b/src/backend/common/models/wlt.py
@@ -1,0 +1,7 @@
+from typing import TypedDict
+
+
+class WLTRecord(TypedDict):
+    wins: int
+    losses: int
+    ties: int

--- a/src/backend/web/renderers/team_renderer.py
+++ b/src/backend/web/renderers/team_renderer.py
@@ -195,29 +195,33 @@ class TeamRenderer:
                             index = alliance_check["picks"].index(team.key_name)
                             alliance_pick = f"Pick {index}"
 
-                    if "backup" in alliance_check and alliance_check["backup"] and alliance_check["backup"]["in"] == team.key_name:
+                    if (
+                        "backup" in alliance_check
+                        and alliance_check["backup"]
+                        and alliance_check["backup"]["in"] == team.key_name
+                    ):
                         alliance = alliance_check
                         alliance_pick = "the backup"
-            
-            alliance_status = None 
+
+            alliance_status = None
             if alliance and "status" in alliance:
                 status = alliance["status"]
                 if "status" in status:
                     if status["status"] == "won":
                         alliance_status = "won the event"
                     elif "double_elim_round" in status:
-                        alliance_status = f"were eliminated in {status["double_elim_round"]}"
+                        alliance_status = (
+                            f"were eliminated in {status['double_elim_round']}"
+                        )
                     elif "level" in status:
                         level = {
                             "sf": "semifinals",
                             "f": "finals",
-                            "qf": "quarterfinals"
+                            "qf": "quarterfinals",
                         }
                         level_achieved = level.get(status["level"])
                         if level_achieved:
                             alliance_status = f"were eliminated in {level_achieved}"
-                    
-
 
             participation.append(
                 {

--- a/src/backend/web/renderers/team_renderer.py
+++ b/src/backend/web/renderers/team_renderer.py
@@ -184,12 +184,8 @@ class TeamRenderer:
                     None,
                 )
 
-            alliance_size = AllianceHelper.get_known_alliance_size(
-                event.event_type_enum, event.year
-            )
-
-            alliance, alliance_pick = AllianceHelper.get_alliance_details_and_pick_name(
-                event, team.key_name
+            alliance, alliance_pick, alliance_size = (
+                AllianceHelper.get_alliance_details_and_pick_name(event, team.key_name)
             )
 
             if alliance:

--- a/src/backend/web/renderers/team_renderer.py
+++ b/src/backend/web/renderers/team_renderer.py
@@ -182,8 +182,48 @@ class TeamRenderer:
                     None,
                 )
 
+            alliance = None
+            alliance_pick = None
+            if event.details and event.details.alliance_selections:
+                for alliance_check in event.details.alliance_selections:
+                    print(alliance_check)
+                    if team.key_name in alliance_check["picks"]:
+                        alliance = alliance_check
+                        if team.key_name == alliance_check["picks"][0]:
+                            alliance_pick = "Captain"
+                        else:
+                            index = alliance_check["picks"].index(team.key_name)
+                            alliance_pick = f"Pick {index}"
+
+                    if "backup" in alliance_check and alliance_check["backup"] and alliance_check["backup"]["in"] == team.key_name:
+                        alliance = alliance_check
+                        alliance_pick = "the backup"
+            
+            alliance_status = None 
+            if alliance and "status" in alliance:
+                status = alliance["status"]
+                if "status" in status:
+                    if status["status"] == "won":
+                        alliance_status = "won the event"
+                    elif "double_elim_round" in status:
+                        alliance_status = f"were eliminated in {status["double_elim_round"]}"
+                    elif "level" in status:
+                        level = {
+                            "sf": "semifinals",
+                            "f": "finals",
+                            "qf": "quarterfinals"
+                        }
+                        level_achieved = level.get(status["level"])
+                        if level_achieved:
+                            alliance_status = f"were eliminated in {level_achieved}"
+                    
+
+
             participation.append(
                 {
+                    "alliance": alliance,
+                    "alliance_pick": alliance_pick,
+                    "alliance_status": alliance_status,
                     "event": event,
                     "matches": matches_organized,
                     "match_count": match_count,

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -144,11 +144,7 @@
 
                 {% if comp.alliance %}
                 <p>
-                They were <strong>{{comp.alliance_pick}}</strong> 
-                of <strong>{{comp.alliance.name}}</strong>
-                {% if comp.alliance_status%}
-                and {{comp.alliance_status}}
-                {% endif %}
+                They {{comp.alliance_status|safe}}.
                 </p>
 
                 <table class="table table-condensed table-striped">
@@ -156,7 +152,7 @@
                     {% for pick in comp.alliance.picks %}
                     <tr>
                       <td>
-                        {% if pick == team.key_name %}<strong>{% endif %}
+                        {% if pick == team.key_name %}<b>{% endif %}
                         {% if loop.first %}
                           Captain
                         {% else %}
@@ -166,12 +162,12 @@
                           Pick {{loop.index0}}
                         {% endif %}
                         {% endif %}
-                        {% if pick == team.key_name %}</strong>{% endif %}
+                        {% if pick == team.key_name %}</b>{% endif %}
                       </td>
                       <td>                 
-                        {% if pick == team.key_name %}<strong>{% endif %}
+                        {% if pick == team.key_name %}<b>{% endif %}
                         <a href="/team/{{ pick|digits }}/{{year}}">{{ pick|strip_frc }}</a>
-                        {% if pick == team.key_name %}</strong>{% endif %}
+                        {% if pick == team.key_name %}</b>{% endif %}
                       </td>
                     </tr>
                     {% endfor %}

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -160,7 +160,11 @@
                         {% if loop.first %}
                           Captain
                         {% else %}
+                        {% if loop.index0 >= comp.alliance_size %}
+                          Backup
+                        {% else%}
                           Pick {{loop.index0}}
+                        {% endif %}
                         {% endif %}
                         {% if pick == team.key_name %}</strong>{% endif %}
                       </td>

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -141,9 +141,52 @@
                   </ul>
                   {% endif %}
                 </p>
-                {% if comp.playlist %}
-                <a class="btn btn-default" href="{{comp.playlist}}" target="_blank" rel="noopener noreferrer">
-                  <span class="glyphicon glyphicon-play-circle"></span> Watch All Matches</a>
+
+                {% if comp.alliance %}
+                <p>
+                They were <strong>{{comp.alliance_pick}}</strong> 
+                of <strong>{{comp.alliance.name}}</strong>
+                {% if comp.alliance_status%}
+                and {{comp.alliance_status}}
+                {% endif %}
+                </p>
+
+                <table class="table table-condensed table-striped">
+                  <tbody>
+                    {% for pick in comp.alliance.picks %}
+                    <tr>
+                      <td>
+                        {% if pick == team.key_name %}<strong>{% endif %}
+                        {% if loop.first %}
+                          Captain
+                        {% else %}
+                          Pick {{loop.index0}}
+                        {% endif %}
+                        {% if pick == team.key_name %}</strong>{% endif %}
+                      </td>
+                      <td>                 
+                        {% if pick == team.key_name %}<strong>{% endif %}
+                        <a href="/team/{{ pick|digits }}/{{year}}">{{ pick|strip_frc }}</a>
+                        {% if pick == team.key_name %}</strong>{% endif %}
+                      </td>
+                    </tr>
+                    {% endfor %}
+                    {% if comp.alliance.backup %}
+                    <tr>
+                      <td>
+                        {% if comp.alliance.backup.in == team.key_name %}<strong>{% endif %}
+                        Backup for <a href="/team/{{ comp.alliance.backup.out|digits }}/{{year}}">{{ comp.alliance.backup.out|strip_frc }}</a>
+                        {% if comp.alliance.backup.in == team.key_name %}</strong>{% endif %}
+                      </td>
+                      <td>
+                        {% if comp.alliance.backup.in == team.key_name %}<strong>{% endif %}
+                        <a href="/team/{{ comp.alliance.backup.in|digits }}/{{year}}">{{ comp.alliance.backup.in|strip_frc }}</a>
+                        {% if comp.alliance.backup.in == team.key_name %}</strong>{% endif %}
+                      </td>
+                    </tr>
+                    {% endif %}
+                  </tbody>
+                </table>
                 {% endif %}
                 {% endif %}
                 {% if comp.district_points %}
@@ -179,6 +222,10 @@
                     </tbody>
                   </table>
                 {% endif %}
+                {% if comp.playlist %}
+                <a class="btn btn-default" href="{{comp.playlist}}" target="_blank" rel="noopener noreferrer">
+                  <span class="glyphicon glyphicon-play-circle"></span> Watch All Matches</a>
+                {% endif %}
               </div>
               <div class="col-sm-8" style="margin-top: 1em">
                 {% if comp.match_count > 0 %}
@@ -188,7 +235,7 @@
                     <p class="muted">No matches played.</p>
                   {% else %}
                     <p class="muted">No matches yet. Check back after {{ comp.event.start_date|strftime("%B %d, %Y") }}.</p>
-                  {% endif %}
+                  {% endif %} 
                 {% endif %}
               </div>
             </div>

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -235,7 +235,7 @@
                     <p class="muted">No matches played.</p>
                   {% else %}
                     <p class="muted">No matches yet. Check back after {{ comp.event.start_date|strftime("%B %d, %Y") }}.</p>
-                  {% endif %} 
+                  {% endif %}
                 {% endif %}
               </div>
             </div>


### PR DESCRIPTION
This PR provides details about Alliance Selection and that Alliance's progression. 

## Motivation and Context
I often find myself switching back and forth between event pages and alliance pages to determine an team's alliance, and find that the data should just be presented inline.

## How Has This Been Tested?
There seem to be no automated tests for the team renderer, so no automated tests were done. Manual tests were done with:
- District teams
- Regional teams
- Teams that were listed as backups, both in the backup field as well as a fake third pick
- Events that have specialized alliance names

## Screenshots (if appropriate):
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/10481864/5a7d0089-2c98-495a-b48a-6e9dba5d57dc)
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/10481864/38f8ebc0-f84a-4eb7-8782-8d2be1e70450)
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/10481864/f0cb24e2-c33f-4b2b-b47b-0bd21fcc26c1)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
