### PR TITLE
Add missing autoLineRobot1 field to 2024 score breakdown keys to fix the write API.

### DIFF
--- a/src/backend/common/helpers/score_breakdown_keys.py
+++ b/src/backend/common/helpers/score_breakdown_keys.py
@@ -360,6 +360,7 @@ VALID_BREAKDOWNS: Dict[Year, Set[str]] = {
     ),
     2024: set(
         [
+            "autoLineRobot1",
             "endGameRobot1",
             "autoLineRobot2",
             "endGameRobot2",


### PR DESCRIPTION
Add missing `autoLineRobot1` field to 2024 score breakdown keys to fix the write API.

## Description
I was updating Cheesy Arena for 2024 and ran into this error while publishing match results:
```
{
  "Error": "Invalid score breakdown fields for 2024: ['autoLineRobot1']. Valid keys are: ['adjustPoints', 'autoAmpNoteCount', 'autoAmpNotePoints', 'autoLeavePoints', 'autoLineRobot2', 'autoLineRobot3', 'autoPoints', 'autoSpeakerNoteCount', 'autoSpeakerNotePoints', 'autoTotalNotePoints', 'coopNotePlayed', 'coopertitionCriteriaMet', 'endGameHarmonyPoints', 'endGameNoteInTrapPoints', 'endGameOnStagePoints', 'endGameParkPoints', 'endGameRobot1', 'endGameRobot2', 'endGameRobot3', 'endGameSpotLightBonusPoints', 'endGameTotalStagePoints', 'ensembleBonusAchieved', 'foulCount', 'foulPoints', 'g206Penalty', 'g408Penalty', 'g424Penalty', 'melodyBonusAchieved', 'micCenterStage', 'micStageLeft', 'micStageRight', 'rp', 'techFoulCount', 'teleopAmpNoteCount', 'teleopAmpNotePoints', 'teleopPoints', 'teleopSpeakerNoteAmplifiedCount', 'teleopSpeakerNoteAmplifiedPoints', 'teleopSpeakerNoteCount', 'teleopSpeakerNotePoints', 'teleopTotalNotePoints', 'totalPoints', 'trapCenterStage', 'trapStageLeft', 'trapStageRight']"
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Publishing 2024 match results from Cheesy Arena now works after making this change locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
