### PR TITLE
Fix favorite icon centering

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_base.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_base.less
@@ -103,6 +103,11 @@ body {
   background-color: @TBAyellow;
   color: #ffffff;
   z-index: 10000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  
 
   .glyphicon {  // Slightly hacky
     line-height: 1.5;

--- a/src/backend/web/static/css/less_css/less/tba/tba_base.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_base.less
@@ -107,8 +107,6 @@ body {
   justify-content: center;
   align-items: center;
 
-  
-
   .glyphicon {  // Slightly hacky
     line-height: 1.5;
     margin-left: 2px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Properly centers the icon on the favorite button using flexbox.

## Motivation and Context
It is currently uncentered on Safari Mobile.

## How Has This Been Tested?
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/64214252/cc68fd60-4107-4b38-ad6c-8b2b973bc64b)


## Screenshots (if appropriate):
![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/64214252/ec75196a-b051-4882-b182-2379b466346d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
