### PR TITLE
Allow passing webcast `date` field to trusted API

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_event_info_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_event_info_parser.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from typing import AnyStr, Dict, List, Optional, TypedDict
 
 from pyre_extensions import safe_json
@@ -17,6 +18,7 @@ class _WebcastUrlDict(TypedDict, total=False):
     url: str
     type: WebcastType
     channel: str
+    date: str
 
 
 class EventInfoInput(TypedDict, total=False):
@@ -57,7 +59,13 @@ class JSONEventInfoParser:
                 else:
                     raise ParserInputException(f"Invalid webcast: {webcast!r}")
 
-                if "date" not in parsed_webcast and "date" in webcast:
+                if "date" in webcast:
+                    try:
+                        datetime.strptime(webcast["date"], "%Y-%m-%d")
+                    except ValueError as e:
+                        raise ParserInputException(
+                            f"Invalid webcast date: {webcast['date']!r}: {e}"
+                        )
                     parsed_webcast["date"] = webcast["date"]
                 webcast_list.append(parsed_webcast)
 

--- a/src/backend/api/api_trusted_parsers/json_event_info_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_event_info_parser.py
@@ -49,14 +49,18 @@ class JSONEventInfoParser:
                         raise ParserInputException(
                             f"Unknown webcast url {webcast['url']}!"
                         )
-                    webcast_list.append(parsed_webcast)
                 elif "type" in webcast and "channel" in webcast:
-                    webcast_list.append(
-                        Webcast(
-                            type=webcast["type"],
-                            channel=webcast["channel"],
-                        )
+                    parsed_webcast = Webcast(
+                        type=webcast["type"],
+                        channel=webcast["channel"],
                     )
+                else:
+                    raise ParserInputException(f"Invalid webcast: {webcast!r}")
+
+                if "date" not in parsed_webcast and "date" in webcast:
+                    parsed_webcast["date"] = webcast["date"]
+                webcast_list.append(parsed_webcast)
+
             parsed_info["webcasts"] = webcast_list
 
         if info_dict.get("remap_teams"):


### PR DESCRIPTION
## Description
This allows requests to the write API to provide dates for webcasts.

Note: 
* unsure what documentation updates are necessary. The `webcasts` field was not fully described in the API docs to begin with.
* also unsure what validation is necessary here. Suggestions do not appear to perform any validation on the dates either.

## Motivation and Context
Webcast suggestions can provide the `date` field, but write API requests cannot.

## How Has This Been Tested?
Local testing through write API, both with `url` and `type`+`channel` payloads.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
