### PR TITLE
Add insights API converter, queries, etc. Add "notables" insights API endpoint.;

### DIFF
--- a/src/backend/api/handlers/insights.py
+++ b/src/backend/api/handlers/insights.py
@@ -1,0 +1,85 @@
+from flask import Response
+
+from backend.api.handlers.decorators import api_authenticated
+from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.api.handlers.helpers.track_call import track_call_after_response
+from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.consts.insight_type import LEADERBOARD_INSIGHTS, NOTABLES_INSIGHTS
+from backend.common.decorators import cached_public
+from backend.common.models.insight import Insight
+from backend.common.queries.insight_query import (
+    InsightsByNameAndYearQuery,
+    InsightsByNameQuery,
+)
+
+
+@cached_public
+def insights_leaderboards_all() -> Response:
+    track_call_after_response("insights/leaderboards/all")
+    futures = []
+    for insight_type in LEADERBOARD_INSIGHTS:
+        futures.append(
+            InsightsByNameQuery(
+                insight_name=Insight.INSIGHT_NAMES[insight_type]
+            ).fetch_dict_async(ApiMajorVersion.API_V3)
+        )
+
+    insights = []
+    for future in futures:
+        insights.extend(future.get_result())
+
+    return profiled_jsonify(insights)
+
+
+@cached_public
+def insights_leaderboards_year(year: int) -> Response:
+    track_call_after_response("insights/leaderboards", year)
+    futures = []
+    for insight_type in LEADERBOARD_INSIGHTS:
+        futures.append(
+            InsightsByNameAndYearQuery(
+                insight_name=Insight.INSIGHT_NAMES[insight_type], year=year
+            ).fetch_dict_async(ApiMajorVersion.API_V3)
+        )
+
+    insights = []
+    for future in futures:
+        insights.extend(future.get_result())
+
+    return profiled_jsonify(insights)
+
+
+@cached_public
+def insights_notables_all() -> Response:
+    track_call_after_response("insights/notables/all")
+    futures = []
+    for notable_type in NOTABLES_INSIGHTS:
+        futures.append(
+            InsightsByNameQuery(
+                insight_name=Insight.INSIGHT_NAMES[notable_type]
+            ).fetch_dict_async(ApiMajorVersion.API_V3)
+        )
+
+    insights = []
+    for future in futures:
+        insights.extend(future.get_result())
+
+    return profiled_jsonify(insights)
+
+
+@cached_public
+def insights_notables_year(year: int) -> Response:
+    track_call_after_response("insights/notables", year)
+    futures = []
+    for notable_type in NOTABLES_INSIGHTS:
+        futures.append(
+            InsightsByNameAndYearQuery(
+                insight_name=Insight.INSIGHT_NAMES[notable_type], year=year
+            ).fetch_dict_async(ApiMajorVersion.API_V3)
+        )
+
+    insights = []
+    for future in futures:
+        insights.extend(future.get_result())
+
+    return profiled_jsonify(insights)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -34,6 +34,12 @@ from backend.api.handlers.event import (
     event_teams_statuses,
 )
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.api.handlers.insights import (
+    insights_leaderboards_all,
+    insights_leaderboards_year,
+    insights_notables_all,
+    insights_notables_year,
+)
 from backend.api.handlers.match import match, zebra_motionworks
 from backend.api.handlers.media import media_tags
 from backend.api.handlers.status import status
@@ -265,6 +271,20 @@ api_v3.add_url_rule(
     "/teams/<int:year>/<int:page_num>/<model_type:model_type>",
     view_func=team_list,
 )
+
+# Insights
+api_v3.add_url_rule("/insights/leaderboards/all", view_func=insights_leaderboards_all)
+api_v3.add_url_rule(
+    "/insights/leaderboards/<int:year>", view_func=insights_leaderboards_year
+)
+# api_v3.add_url_rule("/insights/leaderboards/<string:name>", view_func=None)
+# api_v3.add_url_rule("/insights/leaderboard/<string:name>/<int:year>", view_func=None)
+
+api_v3.add_url_rule("/insights/notables/all", view_func=insights_notables_all)
+api_v3.add_url_rule("/insights/notables/<int:year>", view_func=insights_notables_year)
+# api_v3.add_url_rule("/insights/notables/<string:name>", view_func=None)
+# api_v3.add_url_rule("/insights/notable/<string:name>/<int:year>", view_func=None)
+
 
 # Trusted API
 trusted_api = Blueprint("trusted_api", __name__, url_prefix="/api/trusted/v1")

--- a/src/backend/common/consts/insight_type.py
+++ b/src/backend/common/consts/insight_type.py
@@ -1,6 +1,7 @@
 import enum
 
 from backend.common.consts.string_enum import StrEnum
+from backend.common.models.insight import Insight
 
 
 @enum.unique
@@ -8,3 +9,16 @@ class InsightType(StrEnum):
     MATCHES = "matches"
     AWARDS = "awards"
     PREDICTIONS = "predictions"
+    LEADERBOARD = "leaderboard"
+    NOTABLES = "notables"
+
+
+LEADERBOARD_INSIGHTS = [
+    Insight.BLUE_BANNERS,
+    Insight.MATCHES_PLAYED,
+]
+
+NOTABLES_INSIGHTS = [
+    Insight.CA_WINNER,
+    Insight.WORLD_CHAMPIONS,
+]

--- a/src/backend/common/helpers/insights_helper.py
+++ b/src/backend/common/helpers/insights_helper.py
@@ -776,7 +776,7 @@ class InsightsHelper(object):
         Returns a list of Insights where, depending on the Insight, the data
         is either a team or a list of teams
         """
-        ca_winner = None
+        ca_winners = []
         world_champions = []
         world_finalists = []
         division_winners = []
@@ -787,7 +787,7 @@ class InsightsHelper(object):
                 team_key_name = team_key.id()
                 if award.event_type_enum == EventType.CMP_FINALS:
                     if award.award_type_enum == AwardType.CHAIRMANS:
-                        ca_winner = team_key_name
+                        ca_winners.append(team_key_name)
                     elif award.award_type_enum == AwardType.WINNER:
                         world_champions.append(team_key_name)
                     elif award.award_type_enum == AwardType.FINALIST:
@@ -804,10 +804,10 @@ class InsightsHelper(object):
         division_finalists = self._sortTeamList(division_finalists)
 
         insights = []
-        if ca_winner is not None:
+        if ca_winners != []:
             insights += [
                 self._createInsight(
-                    ca_winner, Insight.INSIGHT_NAMES[Insight.CA_WINNER], year
+                    ca_winners, Insight.INSIGHT_NAMES[Insight.CA_WINNER], year
                 )
             ]
         if world_champions != []:

--- a/src/backend/common/queries/dict_converters/insight_converter.py
+++ b/src/backend/common/queries/dict_converters/insight_converter.py
@@ -1,0 +1,37 @@
+import json
+from typing import Dict, List, NewType
+
+from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.models.insight import Insight
+from backend.common.queries.dict_converters.converter_base import ConverterBase
+
+InsightDict = NewType("InsightDict", Dict)
+
+
+class InsightConverter(ConverterBase):
+    SUBVERSIONS = {  # Increment every time a change to the dict is made
+        ApiMajorVersion.API_V3: 0,
+    }
+
+    @classmethod
+    def _convert_list(
+        cls, model_list: List[Insight], version: ApiMajorVersion
+    ) -> List[InsightDict]:
+        INSIGHT_CONVERTERS = {
+            ApiMajorVersion.API_V3: cls.insightsConverter_v3,
+        }
+        return INSIGHT_CONVERTERS[version](model_list)
+
+    @classmethod
+    def insightsConverter_v3(cls, insights: List[Insight]) -> List[InsightDict]:
+        return list(map(cls.insightConverter_v3, insights))
+
+    @classmethod
+    def insightConverter_v3(cls, insight: Insight) -> InsightDict:
+        return InsightDict(
+            {
+                "name": insight.name,
+                "data": json.loads(insight.data_json),
+                "year": insight.year,
+            }
+        )

--- a/src/backend/common/queries/insight_query.py
+++ b/src/backend/common/queries/insight_query.py
@@ -1,0 +1,42 @@
+from typing import Any, Generator, List
+
+from backend.common.models.insight import Insight
+from backend.common.models.keys import Year
+from backend.common.queries.database_query import CachedDatabaseQuery
+from backend.common.queries.dict_converters.insight_converter import (
+    InsightConverter,
+    InsightDict,
+)
+from backend.common.tasklets import typed_tasklet
+
+
+class InsightsByNameQuery(CachedDatabaseQuery[List[Insight], List[InsightDict]]):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "insights_{insight_name}"
+    DICT_CONVERTER = InsightConverter
+
+    def __init__(self, insight_name: str) -> None:
+        super().__init__(insight_name=insight_name)
+
+    @typed_tasklet
+    def _query_async(self, insight_name: str) -> Generator[Any, Any, List[InsightDict]]:
+        insights = yield Insight.query(Insight.name == insight_name).fetch_async()
+        return insights
+
+
+class InsightsByNameAndYearQuery(CachedDatabaseQuery[List[Insight], List[InsightDict]]):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "insights_{insight_name}_{year}"
+    DICT_CONVERTER = InsightConverter
+
+    def __init__(self, insight_name: str, year: Year) -> None:
+        super().__init__(insight_name=insight_name, year=year)
+
+    @typed_tasklet
+    def _query_async(
+        self, insight_name: str, year: Year
+    ) -> Generator[Any, Any, List[InsightDict]]:
+        insights = yield Insight.query(
+            Insight.name == insight_name, Insight.year == year
+        ).fetch_async()
+        return insights


### PR DESCRIPTION
## Description
This adds a new API category, `/insights/`, which currently has one endpoint - `/insights/notables`. This endpoint returns a dictionary that is currently the following shape:

```json
{
  "cmp_winners": {
    ...
    "2023": [
      "frc1323",
      "frc2609",
      "frc4096",
      "frc4414"
    ],
    "2024": [
      "frc321",
      "frc1690",
      "frc4522",
      "frc9432"
    ]
  },
  "hof": {
    ...
    "2019": [
      "frc1816",
      "frc1902"
    ],
    "2021": [
      "frc503",
      "frc4613"
    ],
    "2022": [
      "frc1629"
    ],
    ...
  }
}
```

This endpoint and API route is extremely likely to change in the short term and as such, I don't recommend documenting it via OpenAPI at this time.

In order to get the HOF winners, the `CA_WINNER` insight needed to be fixed. Previously, it was only assigning one team per year. The insight's data format is now a list of team keys rather than a single team key. This does not affect anything else in the repo as literally nothing used it and it hasn't been touched in [over a decade](https://github.com/the-blue-alliance/the-blue-alliance/commit/b890c1585815a2a47a36aefbce9db70042ae2bfe).

## Motivation and Context
Insights are currently not exposed in the API at all. Exposing them can do two things:
1. Help third party tools retrieve stats that TBA already calculates, like most matches played, HOF, etc
2. Provide an avenue for the experimental PWA frontend to access insights

## How Has This Been Tested?
Tested locally with bootstrapped 2015-2024 data.

## Screenshots (if appropriate):

![image](https://github.com/the-blue-alliance/the-blue-alliance/assets/7595639/4dca21ee-6be5-409e-aa5c-7da5834103d7)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change API specifications or require data migrations)
