### PR TITLE
Add match table component

### DIFF
--- a/pwa/.eslintrc.cjs
+++ b/pwa/.eslintrc.cjs
@@ -26,6 +26,7 @@ module.exports = {
   rules: {
     // Fix for eslint not knowing how to resolve unplugin icons
     'import/no-unresolved': ['error', { ignore: ['^~icons/'] }],
+    'tailwindcss/no-custom-classname': 'off',
   },
 
   overrides: [

--- a/pwa/app/components/tba/matchResultsTable.tsx
+++ b/pwa/app/components/tba/matchResultsTable.tsx
@@ -1,0 +1,244 @@
+import { Link } from '@remix-run/react';
+import { type VariantProps, cva } from 'class-variance-authority';
+import type React from 'react';
+import { Fragment } from 'react';
+import { Match } from '~/api/v3';
+import {
+  cn,
+  sortMatchComparator,
+  timestampsAreOnDifferentDays,
+  zip,
+} from '~/lib/utils';
+import PlayCircle from '~icons/bi/play-circle';
+
+const cellVariants = cva('', {
+  variants: {
+    matchResult: {
+      winner: 'font-semibold',
+      loser: '',
+    },
+    allianceColor: {
+      red: 'bg-alliance-red-light',
+      blue: 'bg-alliance-blue-light',
+    },
+    teamOrScore: {
+      team: '',
+      score: '',
+    },
+  },
+  defaultVariants: {
+    matchResult: 'loser',
+    allianceColor: undefined,
+    teamOrScore: 'team',
+  },
+  compoundVariants: [
+    {
+      allianceColor: 'red',
+      teamOrScore: 'score',
+      class: 'bg-alliance-red-dark',
+    },
+    {
+      allianceColor: 'blue',
+      teamOrScore: 'score',
+      class: 'bg-alliance-blue-dark',
+    },
+  ],
+});
+
+interface CellProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cellVariants> {
+  dq?: boolean;
+  surrogate?: boolean;
+}
+function GridCell({
+  className,
+  matchResult,
+  allianceColor,
+  teamOrScore,
+  dq,
+  surrogate,
+  ...props
+}: CellProps) {
+  return (
+    <div
+      className={cn(
+        cellVariants({ matchResult, allianceColor, teamOrScore }),
+        className,
+        {
+          'line-through': dq,
+          'underline decoration-dotted': surrogate,
+        },
+      )}
+      {...props}
+    />
+  );
+}
+
+// TODO: Add support for single elim brackets
+function matchTitle(match: Match): string {
+  if (match.comp_level === 'f') {
+    return `Finals ${match.match_number}`;
+  }
+
+  if (match.comp_level === 'qm') {
+    return `Quals ${match.match_number}`;
+  }
+
+  return `Match ${match.set_number}`;
+}
+
+function maybeGetFirstMatchVideoURL(match: Match): string | undefined {
+  if (match.videos === undefined || match.videos.length === 0) {
+    return undefined;
+  }
+
+  return `https://www.youtube.com/watch?v=${match.videos[0].key}`;
+}
+
+// tailwindgen.com is recommended if you're editing the grid classes
+export default function MatchResultsTable({
+  matches,
+  title,
+}: {
+  matches: Match[];
+  title: string;
+}) {
+  matches.sort(sortMatchComparator);
+
+  const gridStyle = cn(
+    // always use these classes:
+    'grid items-center justify-items-center',
+    '[&>*]:justify-self-stretch [&>*]:justify-center',
+    '[&>*]:text-center [&>*]:p-[5px] [&>*]:h-full [&>*]:content-center',
+    // use these classes on mobile:
+    'grid-rows-2',
+    'grid-cols-[calc(1.25em+10px)_8em_1fr_1fr_1fr_1fr]', // 6 columns of these sizes
+    'border-[#000] border-b-[1px]',
+    '[&>*]:border-[#ddd] [&>*]:border-[1px]',
+    // use these on desktop:
+    'lg:grid-rows-1',
+    'lg:grid-cols-[calc(1.25em+6px*2)_8em_repeat(6,minmax(0,1fr))_0.9fr_0.9fr]',
+    'lg:border-[#ddd] lg:border-b-[1px]',
+    '[&>*]:lg:border-0 [&>*]:lg:border-r-[1px]', // reset the border, then apply one to the right
+  );
+
+  return (
+    <div>
+      <div className="mb-2.5 mt-5 text-2xl font-semibold">{title}</div>
+
+      <div className="border-l border-t border-[#ddd]">
+        <div className={cn(gridStyle, 'bg-[#f0f0f0] font-semibold')}>
+          <div className="row-span-2 lg:row-span-1">
+            <PlayCircle className="inline" />
+          </div>
+          <div className="row-span-2 lg:row-span-1">Match</div>
+          <div className="col-span-3 lg:col-span-3">Red Alliance</div>
+          <div className="col-span-3 col-start-3 lg:col-start-6">
+            Blue Alliance
+          </div>
+          <div className="col-start-6 row-span-2 row-start-1 lg:col-span-2 lg:col-start-9">
+            Scores
+          </div>
+        </div>
+
+        {matches.map((m, i) => (
+          <Fragment key={m.key}>
+            {i > 0 &&
+              matches[i - 1].actual_time &&
+              m.actual_time &&
+              // TODO: add timezone support
+              timestampsAreOnDifferentDays(
+                matches[i - 1].actual_time ?? m.actual_time,
+                m.actual_time,
+              ) && (
+                <div
+                  className={cn(
+                    'bg-[#f0f0f0]',
+                    'font-semibold',
+                    'grid-cols-1',
+                    'align-middle',
+                    'text-center',
+                    'grid-rows-1',
+                    'py-1',
+                    'border-b-[1px]',
+                    'border-[#000]',
+                    'lg:border-[#ddd]',
+                  )}
+                >
+                  <GridCell>End of Day</GridCell>
+                </div>
+              )}
+
+            <div className={gridStyle}>
+              {/* play button and match title */}
+              <GridCell className="row-span-2">
+                {m.videos !== undefined && m.videos.length > 0 && (
+                  <Link to={maybeGetFirstMatchVideoURL(m) ?? '#'}>
+                    <PlayCircle className="inline" />
+                  </Link>
+                )}
+              </GridCell>
+              <GridCell className="row-span-2">{matchTitle(m)}</GridCell>
+
+              {/* red alliance */}
+              {m.alliances?.red?.team_keys.map((k) => (
+                <GridCell
+                  key={k}
+                  allianceColor={'red'}
+                  matchResult={
+                    m.winning_alliance === 'red' ? 'winner' : 'loser'
+                  }
+                  dq={m.alliances?.red?.dq_team_keys?.includes(k)}
+                  surrogate={m.alliances?.red?.surrogate_team_keys?.includes(k)}
+                >
+                  <Link to={`/team/${k?.substring(3)}`}>{k?.substring(3)}</Link>
+                </GridCell>
+              ))}
+
+              {/* blue alliance */}
+              {zip(m.alliances?.blue?.team_keys, [
+                'col-start-3 row-start-2 lg:col-start-6 lg:row-start-1',
+                'col-start-4 row-start-2 lg:col-start-7 lg:row-start-1',
+                'col-start-5 row-start-2 lg:col-start-8 lg:row-start-1',
+              ]).map(([k, x]) => (
+                <GridCell
+                  key={k}
+                  allianceColor={'blue'}
+                  matchResult={
+                    m.winning_alliance === 'blue' ? 'winner' : 'loser'
+                  }
+                  className={x}
+                  dq={m.alliances?.blue?.dq_team_keys?.includes(k ?? '')}
+                  surrogate={m.alliances?.blue?.surrogate_team_keys?.includes(
+                    k ?? '',
+                  )}
+                >
+                  <Link to={`/team/${k?.substring(3)}`}>{k?.substring(3)}</Link>
+                </GridCell>
+              ))}
+
+              {/* scores */}
+              <GridCell
+                className="col-start-6 row-start-1 lg:col-start-9"
+                allianceColor={'red'}
+                matchResult={m.winning_alliance === 'red' ? 'winner' : 'loser'}
+                teamOrScore={'score'}
+              >
+                {m.alliances?.red?.score}
+              </GridCell>
+              <GridCell
+                className="col-start-6 lg:col-start-10"
+                allianceColor={'blue'}
+                matchResult={m.winning_alliance === 'blue' ? 'winner' : 'loser'}
+                teamOrScore={'score'}
+              >
+                {m.alliances?.blue?.score}
+              </GridCell>
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/pwa/app/lib/utils.ts
+++ b/pwa/app/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { Match } from '~/api/v3';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -7,4 +8,55 @@ export function cn(...inputs: ClassValue[]) {
 
 export function parseDateString(date: string) {
   return new Date(date);
+}
+
+export function sortMatchComparator(a: Match, b: Match) {
+  const compLevelValues: Record<string, number> = {
+    f: 5,
+    sf: 4,
+    qf: 3,
+    ef: 2,
+    qm: 1,
+  };
+  if (a.comp_level !== b.comp_level) {
+    return (
+      (compLevelValues[a.comp_level] ?? 0) -
+      (compLevelValues[b.comp_level] ?? 0)
+    );
+  }
+
+  return a.set_number - b.set_number || a.match_number - b.match_number;
+}
+
+export function timestampsAreOnDifferentDays(
+  timestamp1: number,
+  timestamp2: number,
+): boolean {
+  const date1 = new Date(timestamp1 * 1000);
+  const date2 = new Date(timestamp2 * 1000);
+
+  return (
+    date1.getFullYear() !== date2.getFullYear() ||
+    date1.getMonth() !== date2.getMonth() ||
+    date1.getDate() !== date2.getDate()
+  );
+}
+
+export function zip<T extends unknown[]>(...arrays: (T | undefined)[]): T[] {
+  if (arrays.length === 0) {
+    return [];
+  }
+
+  // Treat undefined arrays as empty arrays
+  const validArrays = arrays.map((arr) => arr ?? []);
+
+  const minLength = Math.min(...validArrays.map((arr) => arr.length));
+
+  const zipped: T[] = [];
+  for (let i = 0; i < minLength; i++) {
+    const tuple = validArrays.map((arr) => arr[i]) as T;
+    zipped.push(tuple);
+  }
+
+  return zipped;
 }

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -1,8 +1,10 @@
 import { json, LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
+import { useMemo } from 'react';
 import { getEvent, getEventAlliances, getEventMatches } from '~/api/v3';
 import AllianceSelectionTable from '~/components/tba/allianceSelectionTable';
 import InlineIcon from '~/components/tba/inlineIcon';
+import MatchResultsTable from '~/components/tba/matchResultsTable';
 import { Badge } from '~/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { parseDateString } from '~/lib/utils';
@@ -44,6 +46,11 @@ export default function EventPage() {
     day: 'numeric',
     year: 'numeric',
   });
+
+  const quals = useMemo(
+    () => matches.filter((m) => m.comp_level === 'qm'),
+    [matches],
+  );
 
   return (
     <>
@@ -146,10 +153,17 @@ export default function EventPage() {
         </TabsList>
 
         <TabsContent value="results">
-          <div className="flex">
-            <div className="w-1/2 shrink-0">{matches.length} matches</div>
+          <div className="flex flex-wrap gap-4 lg:flex-nowrap">
+            <div className="basis-full lg:basis-1/2">
+              <MatchResultsTable
+                matches={quals}
+                title="Qualification Matches"
+              />
+            </div>
 
-            <AllianceSelectionTable alliances={alliances} />
+            <div className="basis-full lg:basis-1/2">
+              <AllianceSelectionTable alliances={alliances} />
+            </div>
           </div>
         </TabsContent>
 

--- a/pwa/tailwind.config.ts
+++ b/pwa/tailwind.config.ts
@@ -52,6 +52,14 @@ const config = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        'alliance-blue': {
+          light: '#eef',
+          dark: '#ddf',
+        },
+        'alliance-red': {
+          light: '#fee',
+          dark: '#fdd',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
Adds new tailwind-based match table. Misses a lot of edge cases (e.g. round robins) but this gets the core UI implemented.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/04e07661-5b91-4296-92fb-e717da7d2af7)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
