### PR TITLE
Add leaderboard insights to db && add insights API

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.8.2
+ * 3.9.0
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */
@@ -981,6 +981,22 @@ export type DistrictRanking = {
     /** Points awarded for qualification match performance. */
     qual_points: number;
   }[];
+};
+export type LeaderboardInsight = {
+  data: {
+    rankings: {
+      /** Value of the insight that the corresponding team/event/matches have, e.g. number of blue banners, or number of matches played. */
+      value: number;
+      /** Team/Event/Match keys that have the corresponding value. */
+      keys: string[];
+    }[];
+    /** What type of key is used in the rankings; either 'team', 'event', or 'match'. */
+    key_type: 'team' | 'event' | 'match';
+  };
+  /** Name of the insight. */
+  name: string;
+  /** Year the insight was measured in (year=0 for overall insights). */
+  year: number;
 };
 /**
  * Returns API status, and TBA status information.
@@ -3572,6 +3588,44 @@ export function getDistrictRankings(
         status: 404;
       }
   >(`/district/${encodeURIComponent(districtKey)}/rankings`, {
+    ...opts,
+    headers: oazapfts.mergeHeaders(opts?.headers, {
+      'If-None-Match': ifNoneMatch,
+    }),
+  });
+}
+/**
+ * Gets a list of `LeaderboardInsight` objects from a specific year. Use year=0 for overall.
+ */
+export function getInsightsLeaderboardsYear(
+  {
+    ifNoneMatch,
+    year,
+  }: {
+    ifNoneMatch?: string;
+    year: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: LeaderboardInsight[];
+      }
+    | {
+        status: 304;
+      }
+    | {
+        status: 401;
+        data: {
+          /** Authorization error description. */
+          Error: string;
+        };
+      }
+    | {
+        status: 404;
+      }
+  >(`/insights/leaderboards/${encodeURIComponent(year)}`, {
     ...opts,
     headers: oazapfts.mergeHeaders(opts?.headers, {
       'If-None-Match': ifNoneMatch,

--- a/src/backend/api/handlers/insights.py
+++ b/src/backend/api/handlers/insights.py
@@ -1,0 +1,30 @@
+from flask import Response
+
+from backend.api.handlers.decorators import api_authenticated
+from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.api.handlers.helpers.track_call import track_call_after_response
+from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.decorators import cached_public
+from backend.common.models.insight import Insight
+from backend.common.queries.insight_query import InsightsByNameAndYearQuery
+
+
+@api_authenticated
+@cached_public
+def insights_leaderboards_year(year: int) -> Response:
+    track_call_after_response("insights/leaderboards", str(year))
+    futures = []
+    for insight_type in Insight.TYPED_LEADERBOARD_MATCH_INSIGHTS.union(
+        Insight.TYPED_LEADERBOARD_AWARD_INSIGHTS
+    ):
+        futures.append(
+            InsightsByNameAndYearQuery(
+                insight_name=Insight.INSIGHT_NAMES[insight_type], year=year
+            ).fetch_dict_async(ApiMajorVersion.API_V3)
+        )
+
+    insights = []
+    for future in futures:
+        insights.extend(future.get_result())
+
+    return profiled_jsonify(insights)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -34,6 +34,7 @@ from backend.api.handlers.event import (
     event_teams_statuses,
 )
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.api.handlers.insights import insights_leaderboards_year
 from backend.api.handlers.match import match, zebra_motionworks
 from backend.api.handlers.media import media_tags
 from backend.api.handlers.status import status
@@ -264,6 +265,11 @@ api_v3.add_url_rule("/teams/<int:year>/<int:page_num>", view_func=team_list)
 api_v3.add_url_rule(
     "/teams/<int:year>/<int:page_num>/<model_type:model_type>",
     view_func=team_list,
+)
+
+# Insights
+api_v3.add_url_rule(
+    "/insights/leaderboards/<int:year>", view_func=insights_leaderboards_year
 )
 
 # Trusted API

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -1,9 +1,12 @@
 import json
-from typing import Set
+from typing import Dict, Literal, Set
 
 from google.appengine.ext import ndb
 
 from backend.common.models.cached_model import CachedModel
+
+
+LeaderboardKeyType = Literal["team"] | Literal["event"] | Literal["match"]
 
 
 class Insight(CachedModel):
@@ -36,6 +39,9 @@ class Insight(CachedModel):
     ELIM_WINNING_MARGIN_DISTRIBUTION = 20
     EINSTEIN_STREAK = 21
     MATCHES_PLAYED = 22
+    TYPED_LEADERBOARD_BLUE_BANNERS = 23
+    TYPED_LEADERBOARD_MOST_MATCHES_PLAYED = 24
+    TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT = 25
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -64,8 +70,25 @@ class Insight(CachedModel):
         ELIM_WINNING_MARGIN_DISTRIBUTION: "elim_winning_margin_distribution",
         EINSTEIN_STREAK: "einstein_streak",
         MATCHES_PLAYED: "matches_played",
+        TYPED_LEADERBOARD_BLUE_BANNERS: "typed_leaderboard_blue_banners",
+        TYPED_LEADERBOARD_MOST_MATCHES_PLAYED: "typed_leaderboard_most_matches_played",
+        TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT: "typed_leaderboard_highest_median_score_by_event",
         YEAR_SPECIFIC_BY_WEEK: "year_specific_by_week",
         YEAR_SPECIFIC: "year_specific",
+    }
+
+    TYPED_LEADERBOARD_MATCH_INSIGHTS = {
+        TYPED_LEADERBOARD_MOST_MATCHES_PLAYED,
+        TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT,
+    }
+    TYPED_LEADERBOARD_AWARD_INSIGHTS = {
+        TYPED_LEADERBOARD_BLUE_BANNERS,
+    }
+
+    TYPED_LEADERBOARD_KEY_TYPES: Dict[int, LeaderboardKeyType] = {
+        TYPED_LEADERBOARD_BLUE_BANNERS: "team",
+        TYPED_LEADERBOARD_MOST_MATCHES_PLAYED: "team",
+        TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT: "event",
     }
 
     name = ndb.StringProperty(required=True)  # general name used for sorting

--- a/src/backend/common/queries/dict_converters/insight_converter.py
+++ b/src/backend/common/queries/dict_converters/insight_converter.py
@@ -1,0 +1,37 @@
+import json
+from typing import Dict, List, NewType
+
+from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.models.insight import Insight
+from backend.common.queries.dict_converters.converter_base import ConverterBase
+
+InsightDict = NewType("InsightDict", Dict)
+
+
+class InsightConverter(ConverterBase):
+    SUBVERSIONS = {  # Increment every time a change to the dict is made
+        ApiMajorVersion.API_V3: 0,
+    }
+
+    @classmethod
+    def _convert_list(
+        cls, model_list: List[Insight], version: ApiMajorVersion
+    ) -> List[InsightDict]:
+        INSIGHT_CONVERTERS = {
+            ApiMajorVersion.API_V3: cls.insightsConverter_v3,
+        }
+        return INSIGHT_CONVERTERS[version](model_list)
+
+    @classmethod
+    def insightsConverter_v3(cls, insights: List[Insight]) -> List[InsightDict]:
+        return list(map(cls.insightConverter_v3, insights))
+
+    @classmethod
+    def insightConverter_v3(cls, insight: Insight) -> InsightDict:
+        return InsightDict(
+            {
+                "name": insight.name,
+                "data": json.loads(insight.data_json),
+                "year": insight.year,
+            }
+        )

--- a/src/backend/common/queries/insight_query.py
+++ b/src/backend/common/queries/insight_query.py
@@ -1,0 +1,28 @@
+from typing import Any, Generator, List
+
+from backend.common.models.insight import Insight
+from backend.common.models.keys import Year
+from backend.common.queries.database_query import CachedDatabaseQuery
+from backend.common.queries.dict_converters.insight_converter import (
+    InsightConverter,
+    InsightDict,
+)
+from backend.common.tasklets import typed_tasklet
+
+
+class InsightsByNameAndYearQuery(CachedDatabaseQuery[List[Insight], List[InsightDict]]):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "insights_{insight_name}_{year}"
+    DICT_CONVERTER = InsightConverter
+
+    def __init__(self, insight_name: str, year: Year) -> None:
+        super().__init__(insight_name=insight_name, year=year)
+
+    @typed_tasklet
+    def _query_async(
+        self, insight_name: str, year: Year
+    ) -> Generator[Any, Any, List[InsightDict]]:
+        insights = yield Insight.query(
+            Insight.name == insight_name, Insight.year == year
+        ).fetch_async()
+        return insights

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.8.2",
+    "version": "3.9.0",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -36,6 +36,10 @@
     {
       "name": "district",
       "description": "Calls that return district, or district-related information."
+    },
+    {
+      "name": "insight",
+      "description": "Calls that return insights, or insight-related information."
     }
   ],
   "paths": {
@@ -4102,6 +4106,67 @@
           }
         ]
       }
+    },
+    "/insights/leaderboards/{year}": {
+      "get": {
+        "tags": [
+          "insight",
+          "list"
+        ],
+        "description": "Gets a list of `LeaderboardInsight` objects from a specific year. Use year=0 for overall.",
+        "operationId": "getInsightsLeaderboardsYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LeaderboardInsight"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -7992,6 +8057,65 @@
             "description": "File identification as may be required for some types. May be null."
           }
         }
+      },
+      "LeaderboardInsight": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "rankings": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number",
+                      "description": "Value of the insight that the corresponding team/event/matches have, e.g. number of blue banners, or number of matches played."
+                    },
+                    "keys": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Team/Event/Match keys that have the corresponding value."
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "keys"
+                  ]
+                }
+              },
+              "key_type": {
+                "type": "string",
+                "enum": [
+                  "team",
+                  "event",
+                  "match"
+                ],
+                "description": "What type of key is used in the rankings; either 'team', 'event', or 'match'."
+              }
+            },
+            "required": [
+              "rankings",
+              "key_type"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the insight."
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year the insight was measured in (year=0 for overall insights)."
+          }
+        },
+        "required": [
+          "data",
+          "name",
+          "year"
+        ]
       }
     },
     "responses": {


### PR DESCRIPTION
Upgrading the old insights felt like too brittle of a task, so I felt the best option was to create a couple of new insights that are guaranteed to be typed correctly. I chose `n=25` arbitrarily, this can be adjusted.

Screenshot with a limited number of local events:

![image](https://github.com/user-attachments/assets/f947c480-b836-421f-a9e6-925defa756e9)
