### PR TITLE
Fix py3 formatting

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_matches_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_matches_parser.py
@@ -61,7 +61,9 @@ class JSONMatchesParser:
         VALID_BREAKDOWN_KEYS: set[str] = (
             ScoreBreakdownKeys.get_valid_score_breakdown_keys(year)
         )
-        matches: Sequence[MatchInput] = safe_json.loads(matches_json, Sequence, validate=False)
+        matches: Sequence[MatchInput] = safe_json.loads(
+            matches_json, Sequence, validate=False
+        )
         if not isinstance(matches, list):
             raise ParserInputException("Invalid JSON. Please check input.")
 

--- a/src/backend/common/helpers/tests/matchstats_helper_test.py
+++ b/src/backend/common/helpers/tests/matchstats_helper_test.py
@@ -16,7 +16,7 @@ def auto_add_ndb_context(ndb_context) -> None:
 
 
 def api_data_to_matchstats(
-    api_data: Dict[StatType, Dict[TeamKey, float]]
+    api_data: Dict[StatType, Dict[TeamKey, float]],
 ) -> EventMatchStats:
     data: EventMatchStats = {}
     for stat_type in StatType:
@@ -47,7 +47,9 @@ def assert_coprs_values_equal(
     for component, oprs in coprs.items():
         assert oprs.keys() == expected_coprs[component].keys()
         for team_key, opr in oprs.items():
-            assert opr == pytest.approx(expected_coprs[component][team_key])  # pyre-ignore[16]
+            assert opr == pytest.approx(  # pyre-ignore[16]
+                expected_coprs[component][team_key]
+            )
 
 
 def test_compute_matchstats_no_matches() -> None:


### PR DESCRIPTION
For some reason linting was failing? Not sure. `flake8` is also failing:

![image](https://github.com/user-attachments/assets/8938642f-3d25-4752-bb1a-8296c971d5e6)
