### PR TITLE
Fix white-on-white text in API docs for version numbers

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_api.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_api.less
@@ -1,0 +1,4 @@
+.title pre {
+  background-color: unset;
+  border: unset;
+}

--- a/src/backend/web/static/css/less_css/tba_style.main.less
+++ b/src/backend/web/static/css/less_css/tba_style.main.less
@@ -14,6 +14,7 @@
 @import "less/tba/tba_dropdown_menu.less";
 
 @import "less/tba/tba_about.less";
+@import "less/tba/tba_api.less";
 @import "less/tba/tba_blue_banners.less";
 @import "less/tba/tba_bracket_table.less";
 @import "less/tba/tba_double_elim_bracket_table.less";


### PR DESCRIPTION
This has driven me crazy for years

## Before

<img width="1481" alt="Screenshot 2024-08-11 at 12 19 02 PM" src="https://github.com/user-attachments/assets/edb6bf91-aed9-4465-a162-65c6f00528d7">

### After

<img width="1531" alt="Screenshot 2024-08-11 at 12 19 07 PM" src="https://github.com/user-attachments/assets/74699b49-d6fd-4924-8a1c-10c16570f39c">
