### PR TITLE
Change imgur direct url to no longer use h.jpg suffix, since that seems to 404 when outside of <img> tags

### DIFF
--- a/src/backend/common/models/media.py
+++ b/src/backend/common/models/media.py
@@ -156,7 +156,7 @@ class Media(CachedModel):
 
     @property
     def imgur_direct_url(self) -> str:
-        return "https://i.imgur.com/{}h.jpg".format(self.foreign_key)
+        return "https://i.imgur.com/{}.jpeg".format(self.foreign_key)
 
     @property
     def imgur_direct_url_med(self) -> str:

--- a/src/backend/common/queries/dict_converters/media_converter.py
+++ b/src/backend/common/queries/dict_converters/media_converter.py
@@ -15,7 +15,7 @@ MediaDict = NewType("MediaDict", Dict)
 
 class MediaConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        ApiMajorVersion.API_V3: 4,
+        ApiMajorVersion.API_V3: 5,
     }
 
     @classmethod


### PR DESCRIPTION
Example old response:

```json
[
  {
    "details": {},
    "direct_url": "https://i.imgur.com/BL6n8hLh.jpg",
    "foreign_key": "BL6n8hL",
    "preferred": false,
    "type": "imgur",
    "view_url": "https://imgur.com/BL6n8hL"
  }
]
```

`https://i.imgur.com/BL6n8hLh.jpg` will resolve when displayed with `<img src="https://i.imgur.com/BL6n8hLh.jpg" />`. But the same URL 404s when viewed in the URL of the browser. Presumably something has changed routing-wise on imgur's end since this was implemented.

This causes a lot of frustration for users as the typical "right click to view image" just yields a 404.