### PR TITLE
Add notables insights and API routes

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.9.1
+ * 3.9.2
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */
@@ -1001,6 +1001,17 @@ export type LeaderboardInsight = {
   /** Year the insight was measured in (year=0 for overall insights). */
   year: number;
 };
+export type NotablesInsight = {
+  data: {
+    entries: {
+      /** A list of events this team achieved the notable at. This type may change over time. */
+      context: string[];
+      team_key: string;
+    }[];
+  };
+  name: string;
+  year: number;
+}[];
 /**
  * Returns API status, and TBA status information.
  */
@@ -3629,6 +3640,44 @@ export function getInsightsLeaderboardsYear(
         status: 404;
       }
   >(`/insights/leaderboards/${encodeURIComponent(year)}`, {
+    ...opts,
+    headers: oazapfts.mergeHeaders(opts?.headers, {
+      'If-None-Match': ifNoneMatch,
+    }),
+  });
+}
+/**
+ * Gets a list of `NotablesInsight` objects from a specific year. Use year=0 for overall.
+ */
+export function getInsightsNotablesYear(
+  {
+    ifNoneMatch,
+    year,
+  }: {
+    ifNoneMatch?: string;
+    year: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: NotablesInsight[];
+      }
+    | {
+        status: 304;
+      }
+    | {
+        status: 401;
+        data: {
+          /** Authorization error description. */
+          Error: string;
+        };
+      }
+    | {
+        status: 404;
+      }
+  >(`/insights/notables/${encodeURIComponent(year)}`, {
     ...opts,
     headers: oazapfts.mergeHeaders(opts?.headers, {
       'If-None-Match': ifNoneMatch,

--- a/src/backend/api/handlers/insights.py
+++ b/src/backend/api/handlers/insights.py
@@ -5,7 +5,10 @@ from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
-from backend.common.queries.insight_query import InsightsLeaderboardsYearQuery
+from backend.common.queries.insight_query import (
+    InsightsLeaderboardsYearQuery,
+    InsightsNotablesYearQuery,
+)
 
 
 @api_authenticated
@@ -16,4 +19,13 @@ def insights_leaderboards_year(year: int) -> Response:
     insights = InsightsLeaderboardsYearQuery(year=year).fetch_dict(
         ApiMajorVersion.API_V3
     )
+    return profiled_jsonify(insights)
+
+
+@api_authenticated
+@cached_public
+def insights_notables_year(year: int) -> Response:
+    track_call_after_response("insights/notables", str(year))
+
+    insights = InsightsNotablesYearQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
     return profiled_jsonify(insights)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -34,7 +34,10 @@ from backend.api.handlers.event import (
     event_teams_statuses,
 )
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
-from backend.api.handlers.insights import insights_leaderboards_year
+from backend.api.handlers.insights import (
+    insights_leaderboards_year,
+    insights_notables_year,
+)
 from backend.api.handlers.match import match, zebra_motionworks
 from backend.api.handlers.media import media_tags
 from backend.api.handlers.status import status
@@ -273,6 +276,7 @@ api_v3.add_url_rule(
 api_v3.add_url_rule(
     "/insights/leaderboards/<int:year>", view_func=insights_leaderboards_year
 )
+api_v3.add_url_rule("/insights/notables/<int:year>", view_func=insights_notables_year)
 
 # Trusted API
 trusted_api = Blueprint("trusted_api", __name__, url_prefix="/api/trusted/v1")

--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -315,5 +315,6 @@ def insight_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuer
     queries: List[CachedDatabaseQuery] = []
     for year in years:
         queries.append(insight_query.InsightsLeaderboardsYearQuery(year))
+        queries.append(insight_query.InsightsNotablesYearQuery(year))
 
     return _queries_to_cache_keys_and_queries(queries)

--- a/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
+++ b/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
@@ -559,7 +559,7 @@ class TestDatabaseCacheClearer(unittest.TestCase):
         }
         cache_keys = [q[0] for q in get_affected_queries.insight_updated(affected_refs)]
 
-        self.assertEqual(len(cache_keys), 3)
+        self.assertEqual(len(cache_keys), 6)
         self.assertTrue(
             insight_query.InsightsLeaderboardsYearQuery(0).cache_key in cache_keys
         )
@@ -568,4 +568,13 @@ class TestDatabaseCacheClearer(unittest.TestCase):
         )
         self.assertTrue(
             insight_query.InsightsLeaderboardsYearQuery(2024).cache_key in cache_keys
+        )
+        self.assertTrue(
+            insight_query.InsightsNotablesYearQuery(0).cache_key in cache_keys
+        )
+        self.assertTrue(
+            insight_query.InsightsNotablesYearQuery(2023).cache_key in cache_keys
+        )
+        self.assertTrue(
+            insight_query.InsightsNotablesYearQuery(2024).cache_key in cache_keys
         )

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -44,6 +44,10 @@ class Insight(CachedModel):
     TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT = 25
     TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_SCORE = 26
     TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE = 27
+    TYPED_NOTABLES_HALL_OF_FAME = 28
+    TYPED_NOTABLES_DIVISION_WINNERS = 29
+    TYPED_NOTABLES_WORLD_CHAMPIONS = 30
+    TYPED_NOTABLES_WFA = 31
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -79,6 +83,10 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE: "typed_leaderboard_highest_match_clean_combined_score",
         YEAR_SPECIFIC_BY_WEEK: "year_specific_by_week",
         YEAR_SPECIFIC: "year_specific",
+        TYPED_NOTABLES_HALL_OF_FAME: "notables_hall_of_fame",
+        TYPED_NOTABLES_DIVISION_WINNERS: "notables_division_winners",
+        TYPED_NOTABLES_WORLD_CHAMPIONS: "notables_world_champions",
+        TYPED_NOTABLES_WFA: "notables_wfa",
     }
 
     TYPED_LEADERBOARD_MATCH_INSIGHTS = {
@@ -97,6 +105,13 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT: "event",
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_SCORE: "match",
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE: "match",
+    }
+
+    NOTABLE_INSIGHTS = {
+        TYPED_NOTABLES_HALL_OF_FAME,
+        TYPED_NOTABLES_DIVISION_WINNERS,
+        TYPED_NOTABLES_WORLD_CHAMPIONS,
+        TYPED_NOTABLES_WFA,
     }
 
     name = ndb.StringProperty(required=True)  # general name used for sorting

--- a/src/backend/common/queries/insight_query.py
+++ b/src/backend/common/queries/insight_query.py
@@ -33,3 +33,24 @@ class InsightsLeaderboardsYearQuery(
             Insight.year == year,
         ).fetch_async()
         return insights
+
+
+class InsightsNotablesYearQuery(CachedDatabaseQuery[List[Insight], List[InsightDict]]):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "insights_notables_{year}"
+    DICT_CONVERTER = InsightConverter
+
+    def __init__(self, year: Year) -> None:
+        super().__init__(year=year)
+
+    @typed_tasklet
+    def _query_async(self, year: Year) -> Generator[Any, Any, List[Insight]]:
+        insight_names = []
+        for insight_type in Insight.NOTABLE_INSIGHTS:
+            insight_names.append(Insight.INSIGHT_NAMES[insight_type])
+
+        insights = yield Insight.query(
+            Insight.name.IN(insight_names),
+            Insight.year == year,
+        ).fetch_async()
+        return insights

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.1",
+    "version": "3.9.2",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.2: Add NotablesInsight. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -4167,6 +4167,67 @@
           }
         ]
       }
+    },
+    "/insights/notables/{year}": {
+      "get": {
+        "tags": [
+          "insight",
+          "list"
+        ],
+        "description": "Gets a list of `NotablesInsight` objects from a specific year. Use year=0 for overall.",
+        "operationId": "getInsightsNotablesYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotablesInsight"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -4821,23 +4882,23 @@
           },
           "current_level_record": {
             "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/WLT_Record"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+              {
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "record": {
             "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/WLT_Record"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+              {
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "type": "string",
@@ -4906,13 +4967,13 @@
                 },
                 "record": {
                   "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/WLT_Record"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                    {
+                      "$ref": "#/components/schemas/WLT_Record"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "rank": {
                   "type": "integer",
@@ -8149,6 +8210,55 @@
           "name",
           "year"
         ]
+      },
+      "NotablesInsight": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "entries": {
+                "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "context": {
+                        "type": "array",
+                        "description": "A list of events this team achieved the notable at. This type may change over time.",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "team_key": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "context",
+                      "team_key"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "entries"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "year": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "data",
+            "name",
+            "year"
+          ]
+        }
       }
     },
     "responses": {


### PR DESCRIPTION
This adds "Notables" insights, which can be thought of as 'achievements' that teams may get once (maybe more?) per year. This includes like winning a division, winning HOF, winning WFA, etc.

The `context` data can be used for tooltips on the frontend. The frontend can do really whatever it wants here. We probably want to have a few "derived" leaderboards - like division winners - which can be calculated entirely on the frontend due to the small data size.

![image](https://github.com/user-attachments/assets/e4a9ca32-7248-4d0f-8af0-ec5bcf588864)

![image](https://github.com/user-attachments/assets/bab913f0-3937-452f-bea0-b9e95a3f2534)

