### PR TITLE
Include venue and location in venue_address_safe

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -559,20 +559,20 @@ class Event(CachedModel):
                     none_throws(self.location).encode("utf-8"),
                 )
         else:
-            if not self.venue or not self.location:
-                self._venue_address_safe = None
-            else:
-                self._venue_address_safe = self.venue_address.replace("\r\n", "\n")
-                if self.venue not in self._venue_address_safe:
-                    self._venue_address_safe = "{}\n{}".format(
-                        none_throws(self.venue),
-                        self._venue_address_safe,
-                    )
-                if self.location not in self._venue_address_safe:
-                    self._venue_address_safe = "{}\n{}".format(
-                        self._venue_address_safe,
-                        none_throws(self.location),
-                    )
+            self._venue_address_safe = self.venue_address.replace("\r\n", "\n")
+            if self.venue is not None and self.venue not in self._venue_address_safe:
+                self._venue_address_safe = "{}\n{}".format(
+                    none_throws(self.venue),
+                    self._venue_address_safe,
+                )
+            if (
+                self.location is not None
+                and self.location not in self._venue_address_safe
+            ):
+                self._venue_address_safe = "{}\n{}".format(
+                    self._venue_address_safe,
+                    none_throws(self.location),
+                )
         return self._venue_address_safe
 
     @property

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -559,7 +559,20 @@ class Event(CachedModel):
                     none_throws(self.location).encode("utf-8"),
                 )
         else:
-            self._venue_address_safe = self.venue_address.replace("\r\n", "\n")
+            if not self.venue or not self.location:
+                self._venue_address_safe = None
+            else:
+                self._venue_address_safe = self.venue_address.replace("\r\n", "\n")
+                if self.venue not in self._venue_address_safe:
+                    self._venue_address_safe = "{}\n{}".format(
+                        none_throws(self.venue),
+                        self._venue_address_safe,
+                    )
+                if self.location not in self._venue_address_safe:
+                    self._venue_address_safe = "{}\n{}".format(
+                        self._venue_address_safe,
+                        none_throws(self.location),
+                    )
         return self._venue_address_safe
 
     @property

--- a/src/backend/common/models/tests/event_test.py
+++ b/src/backend/common/models/tests/event_test.py
@@ -510,3 +510,37 @@ def test_rankings() -> None:
 
     event._details = None
     assert event.rankings == rankings
+
+
+def test_venue_address():
+    event = Event(
+        id="2024cc",
+        year=2024,
+        event_short="cc",
+        venue="Bellarmine College Preparatory",
+        venue_address="Bellarmine College Preparatory\n960 W. Hedding St.\nSan Jose, CA, USA",
+        city="San Jose",
+        state_prov="CA",
+        country="USA",
+    )
+    assert event.venue_or_venue_from_address == "Bellarmine College Preparatory"
+    assert (
+        event.venue_address_safe
+        == "Bellarmine College Preparatory\n960 W. Hedding St.\nSan Jose, CA, USA"
+    )
+
+    event = Event(
+        id="2024cabe",
+        year=2024,
+        event_short="cabe",
+        venue="Berkeley High School",
+        venue_address="1980 Allston Way",
+        city="Berkeley",
+        state_prov="CA",
+        country="USA",
+    )
+    assert event.venue_or_venue_from_address == "Berkeley High School"
+    assert (
+        event.venue_address_safe
+        == "Berkeley High School\n1980 Allston Way\nBerkeley, CA, USA"
+    )


### PR DESCRIPTION
There's a small chance this breaks some really old events, but we will watch out for those and add them to unit tests.

This fixes gmaps links for events like https://www.thebluealliance.com/event/2024cabe

Maps link before: http://maps.google.com/maps?q=1980%20Allston%20Way

Maps link after: http://maps.google.com/maps?q=Berkeley%20High%20School%0A1980%20Allston%20Way%0ABerkeley%2C%20CA%2C%20USA