### PR TITLE
Fix nullable event details

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.9.2
+ * 3.9.3
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */

--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -2621,7 +2621,7 @@ export function getEventOpRs(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: EventOpRs;
+        data: EventOpRs | null;
       }
     | {
         status: 304;
@@ -2659,7 +2659,7 @@ export function getEventCopRs(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: EventCopRs;
+        data: EventCopRs | null;
       }
     | {
         status: 304;
@@ -2735,7 +2735,7 @@ export function getEventRankings(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: EventRanking;
+        data: EventRanking | null;
       }
     | {
         status: 304;

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -238,7 +238,7 @@ export default function EventPage() {
               </InlineIcon>
             </TabsTrigger>
           )}
-          {rankings.rankings.length > 0 && (
+          {rankings && rankings.rankings.length > 0 && (
             <TabsTrigger value="rankings">
               <InlineIcon>
                 <BiListOl />
@@ -288,14 +288,16 @@ export default function EventPage() {
           </div>
         </TabsContent>
 
-        <TabsContent value="rankings">
-          <RankingsTable
-            rankings={rankings}
-            winners={
-              alliances?.find((a) => a.status?.status === 'won')?.picks ?? []
-            }
-          />
-        </TabsContent>
+        {rankings && (
+          <TabsContent value="rankings">
+            <RankingsTable
+              rankings={rankings}
+              winners={
+                alliances?.find((a) => a.status?.status === 'won')?.picks ?? []
+              }
+            />
+          </TabsContent>
+        )}
 
         <TabsContent value="awards">
           <AwardsTab awards={awards} />

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -2559,7 +2559,9 @@
                   "nullable": true,
                   "allOf": [
                     {
-                  "$ref": "#/components/schemas/Event_OPRs"}]
+                      "$ref": "#/components/schemas/Event_OPRs"
+                    }
+                  ]
                 }
               }
             }
@@ -2618,7 +2620,10 @@
                 "schema": {
                   "nullable": true,
                   "allOf": [
-                    {"$ref": "#/components/schemas/Event_COPRs"}]
+                    {
+                      "$ref": "#/components/schemas/Event_COPRs"
+                    }
+                  ]
                 }
               }
             }
@@ -2738,7 +2743,11 @@
               "application/json": {
                 "schema": {
                   "nullable": true,
-                  "allOf": [{"$ref": "#/components/schemas/Event_Ranking"}]
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_Ranking"
+                    }
+                  ]
                 }
               }
             }

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.2",
+    "version": "3.9.3",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -2556,7 +2556,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_OPRs"
+                  "nullable": true,
+                  "allOf": [
+                    {
+                  "$ref": "#/components/schemas/Event_OPRs"}]
                 }
               }
             }
@@ -2613,7 +2616,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_COPRs"
+                  "nullable": true,
+                  "allOf": [
+                    {"$ref": "#/components/schemas/Event_COPRs"}]
                 }
               }
             }
@@ -2732,7 +2737,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_Ranking"
+                  "nullable": true,
+                  "allOf": [{"$ref": "#/components/schemas/Event_Ranking"}]
                 }
               }
             }


### PR DESCRIPTION
Some event details (e.g. rankings) can be null

e.g.
https://www.thebluealliance.com/api/v3/event/2024xxcha/rankings
```
null
```

vs.

https://www.thebluealliance.com/api/v3/event/2024cc/rankings
```
{
  "extra_stats_info": [],
  "rankings": [],
  "sort_order_info": [
    {
      "name": "Ranking Score",
      "precision": 2
    },
    {
      "name": "Avg Coop",
      "precision": 2
    },
    {
      "name": "Avg Match",
      "precision": 2
    },
    {
      "name": "Avg Auto",
      "precision": 2
    },
    {
      "name": "Avg Stage",
      "precision": 2
    }
  ]
}
```