### PR TITLE
[PWA] Add basic event appearance to team page. Fix team-event-status nullability

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.9.3
+ * 3.9.4
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */
@@ -1725,7 +1725,7 @@ export function getTeamEventsStatusesByYear(
     | {
         status: 200;
         data: {
-          [key: string]: TeamEventStatus;
+          [key: string]: TeamEventStatus | null;
         };
       }
     | {
@@ -1941,7 +1941,7 @@ export function getTeamEventStatus(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: TeamEventStatus;
+        data: TeamEventStatus | null;
       }
     | {
         status: 304;
@@ -2926,7 +2926,7 @@ export function getEventTeamsStatuses(
     | {
         status: 200;
         data: {
-          [key: string]: TeamEventStatus;
+          [key: string]: TeamEventStatus | null;
         };
       }
     | {

--- a/pwa/app/components/tba/matchResultsTable.tsx
+++ b/pwa/app/components/tba/matchResultsTable.tsx
@@ -198,7 +198,7 @@ function MatchResultsTableGroup({ matches, event }: MatchResultsTableProps) {
   );
 
   return (
-    <div className="border-l border-t border-[#ddd]">
+    <div className="min-w-[25rem] border-l border-t border-[#ddd] md:min-w-[35rem]">
       <div className={cn(gridStyle, 'bg-[#f0f0f0] font-semibold')}>
         <div className="row-span-2 lg:row-span-1">
           <PlayCircle className="inline" />

--- a/pwa/app/components/tba/teamEventAppearance.tsx
+++ b/pwa/app/components/tba/teamEventAppearance.tsx
@@ -1,0 +1,63 @@
+import { Link } from '@remix-run/react';
+
+import BiCalendar from '~icons/bi/calendar';
+import BiPinMapFill from '~icons/bi/pin-map-fill';
+
+import { Event, Match, TeamEventStatus } from '~/api/v3';
+import InlineIcon from '~/components/tba/inlineIcon';
+import MatchResultsTable from '~/components/tba/matchResultsTable';
+import { Badge } from '~/components/ui/badge';
+import { getEventDateString } from '~/lib/eventUtils';
+
+export default function TeamEventAppearance({
+  event,
+  matches,
+  status,
+}: {
+  event: Event;
+  matches: Match[];
+  status: TeamEventStatus | null;
+}): JSX.Element {
+  return (
+    <div className="flex flex-wrap gap-x-8 [&>*]:sm:flex-1">
+      <div className="">
+        <h2 className="text-2xl">
+          <Link to={`/event/${event.key}`}>{event.name}</Link>
+        </h2>
+        <InlineIcon>
+          <BiCalendar />
+          {getEventDateString(event, 'long')}
+          {event.week !== null && (
+            <Badge variant={'secondary'} className="ml-2">
+              Week {event.week + 1}
+            </Badge>
+          )}
+        </InlineIcon>
+        <InlineIcon>
+          <BiPinMapFill />
+          <a
+            href={`https://maps.google.com/?q=${event.city}, ${event.state_prov}, ${event.country}`}
+          >
+            {event.city}, {event.state_prov}, {event.country}
+          </a>
+        </InlineIcon>
+
+        <div className="my-3" />
+
+        <TeamStatus status={status} />
+      </div>
+      <div>
+        <MatchResultsTable matches={matches} event={event} />
+      </div>
+    </div>
+  );
+}
+
+function TeamStatus({ status }: { status: TeamEventStatus | null }) {
+  // todo: build this out with better mid-event, future-event logic handling
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: status?.overall_status_str ?? '' }}
+    />
+  );
+}

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.3",
+    "version": "3.9.4",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -1187,7 +1187,14 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/Team_Event_Status"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Team_Event_Status"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
                 }
@@ -1510,7 +1517,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Team_Event_Status"
+                  "nullable": true,
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Team_Event_Status"
+                    }
+                  ]
                 }
               }
             }
@@ -3058,7 +3070,14 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/Team_Event_Status"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Team_Event_Status"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
                 }


### PR DESCRIPTION
Statuses may be null for future events. Currently, `2024cc` is the best example of this.

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/502af831-e37d-4d0e-b138-9c8f3218cea1)

![image](https://github.com/user-attachments/assets/263137d2-8bf1-4d44-830c-0160418b8ee0)

![image](https://github.com/user-attachments/assets/4cb7c0c2-b05b-4db2-bba3-68499430de9b)

</details>

Few known issues here, like quals still being in round 1, not displaying awards yet, etc, but its progress