### PR TITLE
[PWA] Add stats block to team pages

### DIFF
--- a/pwa/app/lib/api/EventType.ts
+++ b/pwa/app/lib/api/EventType.ts
@@ -18,3 +18,14 @@ export const CMP_EVENT_TYPES = new Set([
   EventType.CMP_DIVISION,
   EventType.CMP_FINALS,
 ]);
+
+export const SEASON_EVENT_TYPES = new Set([
+  EventType.REGIONAL,
+  EventType.DISTRICT,
+  EventType.DISTRICT_CMP_DIVISION,
+  EventType.DISTRICT_CMP,
+  EventType.CMP_DIVISION,
+  EventType.CMP_FINALS,
+  EventType.FOC,
+  EventType.REMOTE,
+]);

--- a/pwa/app/lib/matchUtils.ts
+++ b/pwa/app/lib/matchUtils.ts
@@ -1,4 +1,4 @@
-import { Event, Match } from '~/api/v3';
+import { Event, Match, WltRecord } from '~/api/v3';
 import { PlayoffType } from '~/lib/api/PlayoffType';
 
 const COMP_LEVEL_SORT_ORDER = {
@@ -66,4 +66,39 @@ export function matchTitleShort(match: Match, event: Event): string {
   // todo later in development: replace this with reasonable fallback
   console.log(match.key, event);
   return 'IF YOU SEE THIS PLEASE PING JUSTIN/EUGENE WITH EVENT KEY';
+}
+
+function matchHasBeenPlayed(match: Match) {
+  return match.alliances.red.score !== -1 && match.alliances.blue.score !== -1;
+}
+
+export function calculateTeamRecordFromMatches(
+  teamKey: string,
+  matches: Match[],
+): WltRecord {
+  const won = matches.filter(
+    (m) =>
+      (m.winning_alliance === 'red' &&
+        m.alliances.red.team_keys.includes(teamKey)) ||
+      (m.winning_alliance === 'blue' &&
+        m.alliances.blue.team_keys.includes(teamKey)),
+  ).length;
+
+  const lost = matches.filter(
+    (m) =>
+      (m.winning_alliance === 'red' &&
+        m.alliances.blue.team_keys.includes(teamKey)) ||
+      (m.winning_alliance === 'blue' &&
+        m.alliances.red.team_keys.includes(teamKey)),
+  ).length;
+
+  const tied = matches.filter(
+    (m) =>
+      (m.alliances.blue.team_keys.includes(teamKey) ||
+        m.alliances.red.team_keys.includes(teamKey)) &&
+      m.winning_alliance === '' &&
+      matchHasBeenPlayed(m),
+  ).length;
+
+  return { wins: won, losses: lost, ties: tied };
 }

--- a/pwa/app/lib/utils.ts
+++ b/pwa/app/lib/utils.ts
@@ -2,7 +2,7 @@ import { Params } from '@remix-run/react';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-import { getStatus } from '~/api/v3';
+import { WltRecord, getStatus } from '~/api/v3';
 
 // TODO: Generate this from the API
 const VALID_YEARS: number[] = [];
@@ -77,4 +77,8 @@ export function zip<T extends unknown[]>(...arrays: (T | undefined)[]): T[] {
   }
 
   return zipped;
+}
+
+export function stringifyRecord(record: WltRecord): string {
+  return `${record.wins}-${record.losses}-${record.ties}`;
 }


### PR DESCRIPTION
I plan to add to this in the future, with things like award count, playoff record, qual record, etc (which will be expandable and hidden by default).

Also need to figure out a better way to center shorter blocks like 368s.

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/84c00059-e1ae-4cf9-9258-3f9558011f0e)

![image](https://github.com/user-attachments/assets/b7ac27a0-18a9-45bb-874c-df2e8ebfecf2)

![image](https://github.com/user-attachments/assets/d464cd85-b386-4941-b247-e3bc1aa28cf1)

![image](https://github.com/user-attachments/assets/548b6bc5-79c7-4776-9cb7-dd3a17f30020)

</details>