### PR TITLE
[pwa] Adjust insight leaderboard table styling

### DIFF
--- a/pwa/app/routes/insights.($year).tsx
+++ b/pwa/app/routes/insights.($year).tsx
@@ -9,6 +9,9 @@ import {
 } from '@remix-run/react';
 import React from 'react';
 
+import BiChevronBarDown from '~icons/bi/chevron-bar-down';
+import BiChevronBarUp from '~icons/bi/chevron-bar-up';
+
 import { LeaderboardInsight, getInsightsLeaderboardsYear } from '~/api/v3';
 import { Button } from '~/components/ui/button';
 import {
@@ -133,19 +136,33 @@ function Leaderboard({ leaderboard }: { leaderboard: LeaderboardInsight }) {
 
   return (
     <div className="m-3">
-      <Card>
-        <CardHeader>
-          <CardTitle>{displayName}</CardTitle>
+      <Card className="border-gray-300">
+        <CardHeader className="px-6 pb-1 pt-4">
+          <CardTitle>
+            <div className="flex justify-between align-middle">
+              <div className="self-center">{displayName}</div>
+              <Button
+                variant={'ghost'}
+                onClick={() => {
+                  setExpanded(!expanded);
+                }}
+                size={'sm'}
+              >
+                {expanded ? <BiChevronBarUp /> : <BiChevronBarDown />}
+                <span className="sr-only">Toggle</span>
+              </Button>
+            </div>
+          </CardTitle>
           <CardDescription>
             {leaderboard.year > 0 ? leaderboard.year : 'Overall'}
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="pb-3">
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-[6ch] text-center">#</TableHead>
-                <TableHead className="text-left capitalize">
+                <TableHead className="h-8 w-[6ch] text-center">#</TableHead>
+                <TableHead className="h-8 text-left capitalize">
                   {leaderboard.data.key_type}
                 </TableHead>
               </TableRow>
@@ -167,18 +184,6 @@ function Leaderboard({ leaderboard }: { leaderboard: LeaderboardInsight }) {
                 ))}
             </TableBody>
           </Table>
-
-          {leaderboard.data.rankings.length > PRE_EXPANDED_ROWS && (
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={() => {
-                setExpanded((prev) => !prev);
-              }}
-            >
-              {expanded ? 'Show Less' : 'Show More'}
-            </Button>
-          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
<details>
<summary>Details</summary>

![image](https://github.com/user-attachments/assets/07e9dbf2-7a62-460b-98de-7c647b0a5cc6)

![image](https://github.com/user-attachments/assets/c5e54c56-914b-450e-9d1f-35a7f965a12e)

</details>

Moved the button up top and much smaller, adjusted some whitespace