### PR TITLE
[PWA] Add expandable team annual stats section

### DIFF
--- a/pwa/app/lib/matchUtils.ts
+++ b/pwa/app/lib/matchUtils.ts
@@ -1,4 +1,4 @@
-import { Event, Match, WltRecord } from '~/api/v3';
+import { Event, Match, MatchAlliance, WltRecord } from '~/api/v3';
 import { PlayoffType } from '~/lib/api/PlayoffType';
 
 const COMP_LEVEL_SORT_ORDER = {
@@ -72,17 +72,51 @@ function matchHasBeenPlayed(match: Match) {
   return match.alliances.red.score !== -1 && match.alliances.blue.score !== -1;
 }
 
-export function calculateTeamRecordFromMatches(
+function getMaybeUnpenalizedScores(m: Match): { blue: number; red: number } {
+  if (m.score_breakdown === null) {
+    return { blue: m.alliances.blue.score, red: m.alliances.red.score };
+  }
+
+  // 2015 used snake_case
+  if (
+    'foul_points' in m.score_breakdown.red &&
+    'foul_points' in m.score_breakdown.blue
+  ) {
+    return {
+      blue: m.alliances.blue.score - (m.score_breakdown.blue.foul_points ?? 0),
+      red: m.alliances.red.score - (m.score_breakdown.red.foul_points ?? 0),
+    };
+  }
+
+  // 2016+ uses camelCase
+  if (
+    'foulPoints' in m.score_breakdown.red &&
+    'foulPoints' in m.score_breakdown.blue
+  ) {
+    return {
+      blue: m.alliances.blue.score - (m.score_breakdown.blue.foulPoints ?? 0),
+      red: m.alliances.red.score - (m.score_breakdown.red.foulPoints ?? 0),
+    };
+  }
+
+  // uhh, this shouldn't happen, but...
+  return { blue: m.alliances.blue.score, red: m.alliances.red.score };
+}
+
+export function calculateTeamRecordsFromMatches(
   teamKey: string,
   matches: Match[],
-): WltRecord {
+): {
+  quals: WltRecord;
+  playoff: WltRecord;
+} {
   const won = matches.filter(
     (m) =>
       (m.winning_alliance === 'red' &&
         m.alliances.red.team_keys.includes(teamKey)) ||
       (m.winning_alliance === 'blue' &&
         m.alliances.blue.team_keys.includes(teamKey)),
-  ).length;
+  );
 
   const lost = matches.filter(
     (m) =>
@@ -90,7 +124,7 @@ export function calculateTeamRecordFromMatches(
         m.alliances.blue.team_keys.includes(teamKey)) ||
       (m.winning_alliance === 'blue' &&
         m.alliances.red.team_keys.includes(teamKey)),
-  ).length;
+  );
 
   const tied = matches.filter(
     (m) =>
@@ -98,7 +132,66 @@ export function calculateTeamRecordFromMatches(
         m.alliances.red.team_keys.includes(teamKey)) &&
       m.winning_alliance === '' &&
       matchHasBeenPlayed(m),
-  ).length;
+  );
 
-  return { wins: won, losses: lost, ties: tied };
+  const quals: WltRecord = {
+    wins: won.filter((m) => m.comp_level === 'qm').length,
+    losses: lost.filter((m) => m.comp_level === 'qm').length,
+    ties: tied.filter((m) => m.comp_level === 'qm').length,
+  };
+
+  const playoff: WltRecord = {
+    wins: won.filter((m) => m.comp_level !== 'qm').length,
+    losses: lost.filter((m) => m.comp_level !== 'qm').length,
+    ties: tied.filter((m) => m.comp_level !== 'qm').length,
+  };
+
+  return { quals, playoff };
+}
+
+export function getTeamsUnpenalizedHighScore(
+  teamKey: string,
+  matches: Match[],
+):
+  | {
+      match: Match;
+      score: number;
+      alliance: MatchAlliance;
+    }
+  | undefined {
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  const matchesWithTeam = matches.filter(
+    (m) =>
+      m.alliances.red.team_keys.includes(teamKey) ||
+      m.alliances.blue.team_keys.includes(teamKey),
+  );
+
+  if (matchesWithTeam.length === 0) {
+    return undefined;
+  }
+
+  const highScoreMatch = matchesWithTeam
+    .map((m) => {
+      const unpenalized = getMaybeUnpenalizedScores(m);
+
+      if (m.alliances.red.team_keys.includes(teamKey)) {
+        return {
+          match: m,
+          score: unpenalized.red,
+          alliance: m.alliances.red,
+        };
+      }
+
+      return {
+        match: m,
+        score: unpenalized.blue,
+        alliance: m.alliances.blue,
+      };
+    })
+    .sort((a, b) => b.score - a.score)[0];
+
+  return highScoreMatch;
 }

--- a/pwa/app/lib/utils.ts
+++ b/pwa/app/lib/utils.ts
@@ -98,3 +98,15 @@ export function pluralize(
 ) {
   return `${includeNumber ? `${count} ` : ''}${count === 1 ? singular : plural}`;
 }
+
+export function addRecords(record1: WltRecord, record2: WltRecord): WltRecord {
+  return {
+    wins: record1.wins + record2.wins,
+    losses: record1.losses + record2.losses,
+    ties: record1.ties + record2.ties,
+  };
+}
+
+export function winrateFromRecord(record: WltRecord): number {
+  return record.wins / Math.max(1, record.wins + record.losses + record.ties);
+}


### PR DESCRIPTION
I expect in the future to add a toggle to include/exclude offseason data on the left side. For now its just official data (awards / matches / high score).

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/b941c858-fea2-4dc0-ac89-81b90fd93e35)

![image](https://github.com/user-attachments/assets/d87fdc0f-3f4a-42be-9d81-40ef27ef1f86)

![image](https://github.com/user-attachments/assets/ff6962d8-4eda-4694-9a4d-9fa97907956b)

![image](https://github.com/user-attachments/assets/74379a73-602a-496b-8517-cf010321cb52)

![image](https://github.com/user-attachments/assets/dc6e8c0c-af13-41cd-b1f2-55affac5e874)

</details>