### PR TITLE
Link grouped pwa dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,14 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    remix-run:
+      patterns:
+        - "@remix-run/*"
+    embla-carousel:
+      patterns:
+        - "embla-carousel-autoplay"
+        - "embla-carousel-react"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
removes need for #6336 and #6338 in the future