### PR TITLE
Add most unique teams played with/against insight

### DIFF
--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -46,6 +46,7 @@ class Insight(CachedModel):
     TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE = 27
     TYPED_LEADERBOARD_MOST_AWARDS = 28
     TYPED_LEADERBOARD_MOST_NON_CHAMPS_EVENT_WINS = 29
+    TYPED_LEADERBOARD_MOST_UNIQUE_TEAMS_PLAYED_WITH_AGAINST = 30
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -81,6 +82,7 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE: "typed_leaderboard_highest_match_clean_combined_score",
         TYPED_LEADERBOARD_MOST_AWARDS: "typed_leaderboard_most_awards",
         TYPED_LEADERBOARD_MOST_NON_CHAMPS_EVENT_WINS: "typed_leaderboard_most_non_champs_event_wins",
+        TYPED_LEADERBOARD_MOST_UNIQUE_TEAMS_PLAYED_WITH_AGAINST: "typed_leaderboard_most_unique_teams_played_with_against",
         YEAR_SPECIFIC_BY_WEEK: "year_specific_by_week",
         YEAR_SPECIFIC: "year_specific",
     }
@@ -90,6 +92,7 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_HIGHEST_MEDIAN_SCORE_BY_EVENT,
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_SCORE,
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE,
+        TYPED_LEADERBOARD_MOST_UNIQUE_TEAMS_PLAYED_WITH_AGAINST,
     }
     TYPED_LEADERBOARD_AWARD_INSIGHTS = {
         TYPED_LEADERBOARD_BLUE_BANNERS,
@@ -105,6 +108,7 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_COMBINED_SCORE: "match",
         TYPED_LEADERBOARD_MOST_AWARDS: "team",
         TYPED_LEADERBOARD_MOST_NON_CHAMPS_EVENT_WINS: "team",
+        TYPED_LEADERBOARD_MOST_UNIQUE_TEAMS_PLAYED_WITH_AGAINST: "team",
     }
 
     name = ndb.StringProperty(required=True)  # general name used for sorting


### PR DESCRIPTION
Not extremely useful but I thought it'd be fun to see results.

<details>
<summary>Details</summary>

Overall:

![image](https://github.com/user-attachments/assets/56b9093c-8c44-49f9-b90b-e9d2cece99ff)

Yearly:

![image](https://github.com/user-attachments/assets/206aa205-8dd1-4eb1-9252-3053c3d99e02)

</details>