### PR TITLE
Increase `Event.within_a_day` threshold to 2 days before event

### DIFF
--- a/src/backend/common/helpers/tests/event_helper_test.py
+++ b/src/backend/common/helpers/tests/event_helper_test.py
@@ -487,9 +487,9 @@ def test_end_date_or_distant_future(
 @pytest.mark.parametrize(
     "current_date,expected_event_keys",
     [
-        (datetime.datetime(2019, 3, 1), [f"event_{i}" for i in range(1, 3)]),
-        (datetime.datetime(2019, 3, 4), [f"event_{i}" for i in range(3, 6)]),
-        (datetime.datetime(2019, 3, 6), [f"event_{i}" for i in range(5, 8)]),
+        (datetime.datetime(2019, 3, 1), [f"event_{i}" for i in range(1, 4)]),
+        (datetime.datetime(2019, 3, 4), [f"event_{i}" for i in range(3, 7)]),
+        (datetime.datetime(2019, 3, 6), [f"event_{i}" for i in range(5, 9)]),
     ],
 )
 def test_within_a_day(ndb_context, current_date, expected_event_keys):

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -336,7 +336,7 @@ class Event(CachedModel):
 
     @property
     def within_a_day(self) -> bool:
-        return self.withinDays(-1, 1)
+        return self.withinDays(-2, 1)
 
     @property
     def past(self) -> bool:


### PR DESCRIPTION
## Motivation and Context
A few events this summer have had cache issues towards the start of the event, either from the event dates not including a setup day or from unknown cache compounding (per Eugene, could be any combination of memcache, Google edge cache, Cloudflare, and browser).

## How Has This Been Tested?
Not tested.
