### PR TITLE
Create history API endpoint

### DIFF
--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -47,6 +47,7 @@ from backend.api.handlers.team import (
     team_event_status,
     team_events,
     team_events_statuses_year,
+    team_history,
     team_history_districts,
     team_history_robots,
     team_list,
@@ -191,6 +192,7 @@ api_v3.add_url_rule(
 )
 
 # Team History
+api_v3.add_url_rule("/team/<string:team_key>/history", view_func=team_history)
 api_v3.add_url_rule(
     "/team/<string:team_key>/years_participated", view_func=team_years_participated
 )

--- a/src/backend/common/models/history.py
+++ b/src/backend/common/models/history.py
@@ -1,0 +1,9 @@
+from typing import List, TypedDict
+
+from backend.common.models.award import Award
+from backend.common.models.event import Event
+
+
+class History(TypedDict):
+    events: List[Event]
+    awards: List[Award]

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -587,6 +587,63 @@
         ]
       }
     },
+    "/team/{team_key}/history": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets the history for the team referenced by the given key, including their events and awards.",
+        "operationId": "getTeamHistory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with team's history including events and awards.",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/History"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/team/{team_key}/years_participated": {
       "get": {
         "tags": [
@@ -8263,6 +8320,27 @@
           "data",
           "name",
           "year"
+        ]
+      },
+      "History": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
+          },
+          "awards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Award"
+            }
+          }
+        },
+        "required": [
+          "events",
+          "awards"
         ]
       }
     },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b2408651-d753-4f43-b546-d6a10e678529)

I'd like to add a total match record here but I'm not sure the best way to do that. Typically for WLT we just iterate over the matches but that seems highly dumb here. Likely best to do some sort of db count/groupby? But I don't know how.

I don't know why regenerating the api moved some types around but whatever.