### PR TITLE
Update Slack `nag-bot` notifications 4 hours earlier

### DIFF
--- a/ops/standalone/cron-skeleton.yaml
+++ b/ops/standalone/cron-skeleton.yaml
@@ -6,7 +6,7 @@ cron:
 
 - description: Suggestion Queue Nag
   url: /tasks/do/nag_suggestions
-  schedule: every day 12:00
+  schedule: every day 08:00
   timezone: America/Los_Angeles
 
 - description: Backup Cron job

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -83,7 +83,7 @@ cron:
 
 - description: Suggestion Queue Nag
   url: /tasks/do/nag_suggestions
-  schedule: every day 12:00
+  schedule: every day 08:00
   timezone: America/Los_Angeles
 
 - description: Backup Cron job


### PR DESCRIPTION
## Description

Sets notification (cron) tasks to 08:00 AM US Pacific Time (America/Los_Angeles).

## Motivation and Context
Especially during off-seasons, and absent implementation of #1850, too many events submit webcasts at the last second, or day-of the event. This is especially true for Youtube live events that are not set up in advance, and compounded by the different channel per day required for YouTube.

The current cron time of 12:00 Pacific (3PM Eastern) leaves many events without a webcast listing for much of their competition day in many cases. My moving the suggestions nag post up a few hours, more mods will have an opportunity to see it earlier, enabling more paeople to view the streams. 8:00 AM Pacific was chosen as to try to avoid mods in the Pacific TZ to silence mod channel notifications in Slack because of an overly-early AM ping.

## How Has This Been Tested?
Not tested, trivial, yolo.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
