### PR TITLE
[PWA] Clean up carousel styles

### DIFF
--- a/pwa/app/components/tba/teamRobotPicsCarousel.tsx
+++ b/pwa/app/components/tba/teamRobotPicsCarousel.tsx
@@ -19,7 +19,7 @@ export default function TeamRobotPicsCarousel({
       <CarouselContent className="items-center">
         {media.map((m, index) => (
           <CarouselItem key={index}>
-            <div className="rounded-lg border-4 border-neutral-600">
+            <div className="rounded-lg border border-border">
               <img
                 className="max-h-[250px] w-full rounded object-contain"
                 src={m.direct_url}
@@ -30,7 +30,7 @@ export default function TeamRobotPicsCarousel({
         ))}
       </CarouselContent>
       {media.length > 1 && (
-        <div className="mt-1 flex justify-center gap-8">
+        <div className="mt-1 flex justify-center gap-2">
           <CarouselPrevious className="relative left-0 transform-none" />
           <CarouselNext className="relative right-0 transform-none" />
         </div>

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -403,7 +403,7 @@ function TeamsTab({
                   <img
                     src={maybeImage}
                     alt={`${t.team_number}'s robot`}
-                    className="h-full w-1/3 rounded-lg border-4 border-neutral-400 object-cover"
+                    className="h-full w-1/3 rounded-lg border border-border object-cover"
                     loading="lazy"
                   />
                 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Thins border and moves buttons closer together
## Motivation and Context
The border is currently obnoxiously large (way larger than any other surface in the UI). I also changed the color to be the same as other borders, and moved buttons closer together (looks better to me).
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/55d4b7ab-3182-45b5-845f-fd18d02556e5)

After:
![image](https://github.com/user-attachments/assets/fac2d348-aaa4-402f-8762-27979ab0708e)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
