### PR TITLE
Fix eventwizard parsing of schedule times

### DIFF
--- a/src/backend/web/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/src/backend/web/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -97,7 +97,7 @@ $('#schedule_file').change(function(){
 
         //parse the excel to array of matches
         //headers start on 5th row
-        var matches = XLSX.utils.sheet_to_json(sheet, {range:4});
+        var matches = XLSX.utils.sheet_to_json(sheet, {range:4, raw: false});
         var request_body = [];
 
         $('#schedule_preview').empty();


### PR DESCRIPTION
It seems like FMS Schedule Reports now have the match time as actual "date" objects in excel (previously it was just the string of the text)

This means we see data like:
![image](https://github.com/user-attachments/assets/72278136-934f-4c04-906c-bf5b7e74ec3c)


With this diff, we get the correct version:
![image](https://github.com/user-attachments/assets/482bedb3-1af3-4e9e-83d0-11556f1ab544)
