### PR TITLE
Call APIv3 from eventwizard, support 2024 rankings

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -29,7 +29,7 @@ def api_authenticated(func):
 
             if auth_key:
                 auth = ApiAuthAccess.get_by_id(auth_key)
-                if auth and auth.is_read_key:
+                if auth:
                     auth_owner_id = auth.owner.id() if auth.owner else None
                 else:
                     return (

--- a/src/backend/web/static/javascript/tba_js/eventwizard.js
+++ b/src/backend/web/static/javascript/tba_js/eventwizard.js
@@ -311,10 +311,11 @@ $('#rankings-ok').hide();
 $('#fetch-matches').click(function(e) {
   e.preventDefault();
   $('#match_play_load_status').html("Loading matches");
+  var auth_id = $('#auth_id').val();
   $.ajax({
-    url: '/api/v2/event/' + $('#event_key').val() + '/matches',
+    url: '/api/v3/event/' + $('#event_key').val() + '/matches/simple',
     dataType: 'json',
-    headers: {'X-TBA-App-Id': 'tba-web:match-input:v01'},
+    headers: {'X-TBA-Auth-Key': auth_id},
     success: function(matches) {
       $("#match-table").empty();
       $('#match_play_load_status').html("Loaded "+matches.length+" matches");
@@ -330,8 +331,8 @@ $('#fetch-matches').click(function(e) {
 
         var trRed = $('<tr>');
         trRed.append($('<td>', {rowspan: 2, text: match.key.split('_')[1], 'style': 'border-top-width: 4px;border-left-width:4px;border-bottom-width:4px;'}));
-        for (j in match.alliances.red.teams) {
-          trRed.append($('<td>', {'class': 'red', 'data-matchKey-redTeam': match.key, 'text': match.alliances.red.teams[j].substring(3), 'style':'border-top-width:4px;'}));
+        for (j in match.alliances.red.team_keys) {
+          trRed.append($('<td>', {'class': 'red', 'data-matchKey-redTeam': match.key, 'text': match.alliances.red.team_keys[j].substring(3), 'style':'border-top-width:4px;'}));
         }
         trRed.append($('<td>', {'style':'background-color: #FF9999;border-top-width:4px;'}).append($('<input>', {'id': match.key + '-redScore', 'type': 'text', 'type': 'number', 'value': match.alliances.red.score, 'tabIndex':tabIndex}).css('max-width', '50px')));
         trRed.append($('<td>', {rowspan: 2, 'style': 'border-top-width: 4px;border-right-width:4px;border-bottom-width:4px;width:17%'}).append($('<input>', {'id': match.key+"_video", 'placeholder': 'YouTube URL'})));
@@ -340,8 +341,8 @@ $('#fetch-matches').click(function(e) {
         $("#match-table").append(trRed);
 
         var trBlue = $('<tr>');
-        for (j in match.alliances.blue.teams) {
-          trBlue.append($('<td>', {'class': 'blue', 'data-matchKey-blueTeam': match.key, 'text': match.alliances.blue.teams[j].substring(3), 'style':'border-bottom-width:4px;'}));
+        for (j in match.alliances.blue.team_keys) {
+          trBlue.append($('<td>', {'class': 'blue', 'data-matchKey-blueTeam': match.key, 'text': match.alliances.blue.team_keys[j].substring(3), 'style':'border-bottom-width:4px;'}));
         }
         trBlue.append($('<td>', {'style':'background-color: #9999FF;border-bottom-width:4px;'}).append($('<input>', {'id': match.key + '-blueScore', 'type': 'text', 'type': 'number', 'value': match.alliances.blue.score,'tabIndex':tabIndex+1}).css('max-width', '50px')));
         $("#match-table").append(trBlue);
@@ -352,7 +353,7 @@ $('#fetch-matches').click(function(e) {
 
     },
     error: function(data) {
-      alert("Something went wrong! Please check your Event Key.");
+      alert("Something went wrong! Please check your Event Key and Auth Key.");
     }
   });
 });

--- a/src/backend/web/static/javascript/tba_js/eventwizard_apiwrite.js
+++ b/src/backend/web/static/javascript/tba_js/eventwizard_apiwrite.js
@@ -326,8 +326,13 @@ $('#rankings_file').change(function(){
         //var is_num = [true, true, true, true, true, false, true, true];
 
         // 2019 Headers
-        var headers = ['Rank', 'Team', 'RS', 'Cargo Pts', 'Panel Pts', 'HAB Pts', 'Sandstorm', 'W-L-T', 'DQ', 'Played'];
-        var display_headers = ['Rank', 'Team', 'Ranking Score', 'Cargo', 'Hatch Panel', 'HAB Climb', 'Sandstorm Bonus', 'Record (W-L-T)', 'DQ', 'Played'];
+        //var headers = ['Rank', 'Team', 'RS', 'Cargo Pts', 'Panel Pts', 'HAB Pts', 'Sandstorm', 'W-L-T', 'DQ', 'Played'];
+        //var display_headers = ['Rank', 'Team', 'Ranking Score', 'Cargo', 'Hatch Panel', 'HAB Climb', 'Sandstorm Bonus', 'Record (W-L-T)', 'DQ', 'Played'];
+        //var is_num = [true, true, true, true, true, false, true, true];
+
+        // 2024 Headers
+        var headers = ['Rank', 'Team', 'RS', 'CO-OP', 'Match Pts', 'Auto Pts', 'Stage Pts', 'W-L-T', 'DQ', 'Played'];
+        var display_headers = ['Rank', 'Team', 'Ranking Score', 'Avg Coop', 'Avg Match', 'Avg Auto', 'Avg Stage', 'Record (W-L-T)', 'DQ', 'Played'];
         var is_num = [true, true, true, true, true, false, true, true];
 
         $('#rankings_preview').empty();


### PR DESCRIPTION
This was still calling APIv2 (!!!!!) and apparently we missed migrating it.

This diff will:
 - call APIv3 instead
 -  allow write endpoint API keys to use the read API
 - support rankings

![image](https://github.com/user-attachments/assets/6e7774ca-03ce-4d2b-aa65-ad0053990303)

Rankings parsing:

![image](https://github.com/user-attachments/assets/d91fea67-4462-408d-b07f-5e6e798c5175)

Rankings rendering: 
![image](https://github.com/user-attachments/assets/37b27c9b-e04e-43d6-808d-803fd94a4762)
