### PR TITLE
[pwa] various minor ui fixes

### DIFF
--- a/pwa/app/routes/team.$teamNumber.($year).tsx
+++ b/pwa/app/routes/team.$teamNumber.($year).tsx
@@ -226,7 +226,7 @@ export default function TeamPage(): React.JSX.Element {
                   replace={true}
                   isActive={eventsInView.has(e.key)}
                 >
-                  {e.short_name ?? e.name}
+                  {e.short_name?.trim() ? e.short_name : e.name}
                 </TableOfContentsLink>
               </TableOfContentsItem>
             ))}

--- a/pwa/app/routes/team.$teamNumber.history.tsx
+++ b/pwa/app/routes/team.$teamNumber.history.tsx
@@ -104,6 +104,8 @@ export default function TeamPage(): React.JSX.Element {
   const { team, history, yearsParticipated, socials } =
     useLoaderData<typeof loader>();
 
+  yearsParticipated.sort((a, b) => b - a);
+
   return (
     <div className="flex flex-wrap sm:flex-nowrap">
       <div className="top-0 mr-4 pt-5 sm:sticky">
@@ -165,6 +167,7 @@ export default function TeamPage(): React.JSX.Element {
                       .map((a) => {
                         const teamRecipients = a.recipient_list
                           .filter((r) => r.awardee !== null)
+                          .filter((r) => r.awardee !== '')
                           .filter((r) => r.team_key === team.key)
                           .map((r) => r.awardee);
 


### PR DESCRIPTION
* Fixed award history showing `Finalist ()` sometimes due to awardee being empty string instead of null
* Fixed history year selector being inverted
* Fixed offseasons missing on event sidebar due to empty string for short_name instead of null