### PR TITLE
Add PWA label to dependabot PRs in /pwa

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+    - PWA
   groups:
     remix-run:
       patterns:


### PR DESCRIPTION
This puts them in here https://github.com/the-blue-alliance/the-blue-alliance/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen+label%3APWA