### PR TITLE
Add /api/v3/district/<abbr>/history endpoint

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.9.6
+ * 3.9.7
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */
@@ -3428,6 +3428,44 @@ export function getDistrictsByYear(
         status: 404;
       }
   >(`/districts/${encodeURIComponent(year)}`, {
+    ...opts,
+    headers: oazapfts.mergeHeaders(opts?.headers, {
+      'If-None-Match': ifNoneMatch,
+    }),
+  });
+}
+/**
+ * Gets a list of District objects with the given district abbreviation. This accounts for district abbreviation changes, such as MAR to FMA.
+ */
+export function getDistrict(
+  {
+    ifNoneMatch,
+    districtAbbreviation,
+  }: {
+    ifNoneMatch?: string;
+    districtAbbreviation: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: DistrictList[];
+      }
+    | {
+        status: 304;
+      }
+    | {
+        status: 401;
+        data: {
+          /** Authorization error description. */
+          Error: string;
+        };
+      }
+    | {
+        status: 404;
+      }
+  >(`/district/${encodeURIComponent(districtAbbreviation)}/history`, {
     ...opts,
     headers: oazapfts.mergeHeaders(opts?.headers, {
       'If-None-Match': ifNoneMatch,

--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -12,10 +12,29 @@ from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
-from backend.common.models.keys import DistrictKey
-from backend.common.queries.district_query import DistrictQuery, DistrictsInYearQuery
+from backend.common.models.keys import DistrictAbbreviation, DistrictKey
+from backend.common.queries.district_query import (
+    DistrictAbbreviationQuery,
+    DistrictQuery,
+    DistrictsInYearQuery,
+)
 from backend.common.queries.event_query import DistrictEventsQuery
 from backend.common.queries.team_query import DistrictTeamsQuery
+
+
+@api_authenticated
+@cached_public
+def district_history(district_abbreviation: DistrictAbbreviation) -> Response:
+    """
+    Returns a list of District objects with the given district abbreviation. Accounts for abbreviation changes.
+    """
+    track_call_after_response("district", district_abbreviation)
+
+    districts = DistrictAbbreviationQuery(
+        abbreviation=district_abbreviation
+    ).fetch_dict(ApiMajorVersion.API_V3)
+
+    return profiled_jsonify(districts)
 
 
 @api_authenticated

--- a/src/backend/api/handlers/tests/district_test.py
+++ b/src/backend/api/handlers/tests/district_test.py
@@ -26,11 +26,25 @@ def test_district_events(ndb_stub, api_client: Client) -> None:
         id="2019fim",
         year=2019,
         abbreviation="fim",
+        display_name="Michigan",
     ).put()
     District(
         id="2020fim",
         year=2020,
         abbreviation="fim",
+        display_name="Michigan",
+    ).put()
+    District(
+        id="2014mar",
+        year=2014,
+        abbreviation="mar",
+        display_name="Mid-Atlantic",
+    ).put()
+    District(
+        id="2024fma",
+        year=2024,
+        abbreviation="fma",
+        display_name="Mid-Atlantic",
     ).put()
     Event(
         id="2019casj",
@@ -115,6 +129,76 @@ def test_district_events(ndb_stub, api_client: Client) -> None:
     assert len(resp.json) == 2
     assert "2020casf" in resp.json
     assert "2020casj" in resp.json
+
+    resp = api_client.get(
+        "/api/v3/district/fim/history",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json) == 2
+    assert resp.json == [
+        {
+            "abbreviation": "fim",
+            "display_name": "Michigan",
+            "key": "2019fim",
+            "year": 2019,
+        },
+        {
+            "abbreviation": "fim",
+            "display_name": "Michigan",
+            "key": "2020fim",
+            "year": 2020,
+        },
+    ]
+
+    resp = api_client.get(
+        "/api/v3/district/notadistrict/history",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp.status_code == 200
+    assert resp.json == []
+
+    resp = api_client.get(
+        "/api/v3/district/fma/history",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json) == 2
+    assert resp.json == [
+        {
+            "abbreviation": "mar",
+            "display_name": "Mid-Atlantic",
+            "key": "2014mar",
+            "year": 2014,
+        },
+        {
+            "abbreviation": "fma",
+            "display_name": "Mid-Atlantic",
+            "key": "2024fma",
+            "year": 2024,
+        },
+    ]
+
+    resp = api_client.get(
+        "/api/v3/district/mar/history",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json) == 2
+    assert resp.json == [
+        {
+            "abbreviation": "mar",
+            "display_name": "Mid-Atlantic",
+            "key": "2014mar",
+            "year": 2014,
+        },
+        {
+            "abbreviation": "fma",
+            "display_name": "Mid-Atlantic",
+            "key": "2024fma",
+            "year": 2024,
+        },
+    ]
 
 
 def test_district_teams(ndb_stub, api_client: Client) -> None:

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -17,6 +17,7 @@ from backend.api.handlers.client_api import (
 )
 from backend.api.handlers.district import (
     district_events,
+    district_history,
     district_list_year,
     district_rankings,
     district_teams,
@@ -121,6 +122,9 @@ CORS(
 api_v3.add_url_rule("/status", view_func=status)
 
 # District
+api_v3.add_url_rule(
+    "/district/<string:district_abbreviation>/history", view_func=district_history
+)
 api_v3.add_url_rule("/district/<string:district_key>/events", view_func=district_events)
 api_v3.add_url_rule(
     "/district/<string:district_key>/events/<model_type:model_type>",
@@ -298,17 +302,17 @@ trusted_api.add_url_rule(
     "/event/<string:event_key>/alliance_selections/update",
     methods=["POST"],
     view_func=update_event_alliances,
-),
+)
 trusted_api.add_url_rule(
     "/event/<string:event_key>/awards/update",
     methods=["POST"],
     view_func=update_event_awards,
-),
+)
 trusted_api.add_url_rule(
     "/event/<string:event_key>/info/update",
     methods=["POST"],
     view_func=update_event_info,
-),
+)
 trusted_api.add_url_rule(
     "/event/<string:event_key>/matches/update",
     methods=["POST"],

--- a/src/backend/common/consts/renamed_districts.py
+++ b/src/backend/common/consts/renamed_districts.py
@@ -9,10 +9,12 @@ CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
     "mar": "fma",
     "nc": "fnc",
     "in": "fin",
+    "tx": "fit",
     # New to old
     "fma": "mar",
     "fnc": "nc",
     "fin": "in",
+    "fit": "tx",
 }
 
 

--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -92,3 +92,27 @@ class TeamDistrictsQuery(CachedDatabaseQuery[List[District], List[DistrictDict]]
             [ndb.Key(District, dtk.id().split("_")[0]) for dtk in district_team_keys]
         )
         return list(filter(lambda x: x is not None, districts))
+
+
+class DistrictAbbreviationQuery(
+    CachedDatabaseQuery[List[District], List[DistrictDict]]
+):
+    CACHE_VERSION = 2
+    CACHE_KEY_FORMAT = "district_abbreviation_{abbreviation}"
+    DICT_CONVERTER = DistrictConverter
+
+    def __init__(self, abbreviation: DistrictAbbreviation) -> None:
+        super().__init__(abbreviation=abbreviation)
+
+    @typed_tasklet
+    def _query_async(
+        self, abbreviation: DistrictAbbreviation
+    ) -> Generator[Any, Any, List[District]]:
+        all_abbreviations = RenamedDistricts.get_equivalent_codes(abbreviation)
+
+        district_keys = yield District.query(
+            District.abbreviation.IN(all_abbreviations)
+        ).fetch_async(keys_only=True)
+        districts = yield ndb.get_multi_async(district_keys)
+
+        return list(sorted(districts, key=lambda x: x.year))

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.6",
+    "version": "3.9.7",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -3769,6 +3769,66 @@
           },
           {
             "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/District_List"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_abbreviation}/history": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets a list of District objects with the given district abbreviation. This accounts for district abbreviation changes, such as MAR to FMA.",
+        "operationId": "getDistrict",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
           }
         ],
         "responses": {
@@ -8648,6 +8708,15 @@
         "name": "event_key",
         "in": "path",
         "description": "TBA Event Key, eg `2016nytr`",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "district_abbreviation": {
+        "name": "district_abbreviation",
+        "in": "path",
+        "description": "District abbreviation, eg `ne` or `fim`",
         "required": true,
         "schema": {
           "type": "string"


### PR DESCRIPTION
Currently the only way to get history for a district is to hit `/api/v3/districts/<year>` for each year 2009 to `current_year` which is pretty annoying. This endpoint can help reduce client wait times.

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/8870864e-efd9-4284-a03e-cd0bc9243808)

![image](https://github.com/user-attachments/assets/3e69f189-daa7-4e26-ba77-899b36a65925)


</details>

This can be used to implement districts in `/local/bootstrap` once it lands:

1. Check if the `/local/bootstrap` input key is solely alphabetical characters (eg `ne`).
2. If so, assume its a district (since it won't be of form `frc1234` or `2024abcd`).
3. Get district history
