### PR TITLE
fix ops test failure by removing conflicting packages

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -21,11 +21,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y
 
 # Setup python environment
 ENV PYTHON_VERSION python3.12
+RUN apt-get remove -y $PYTHON_VERSION-minimal
 RUN apt-get update && apt-get install -y \
     "$PYTHON_VERSION" \
     "$PYTHON_VERSION-venv" \
     "$PYTHON_VERSION-dev" \
-    "$PYTHON_VERSION-distutils" \
     python3-pip
 RUN update-alternatives --install /usr/bin/python python "/usr/bin/$PYTHON_VERSION" 1
 RUN update-alternatives --install /usr/bin/python3 python3 "/usr/bin/$PYTHON_VERSION" 1


### PR DESCRIPTION
github copilot suggested this

removed distutils because of this error

```
#13 1.545 Fetched 15.3 MB in 1s (10.9 MB/s)
#13 1.545 Reading package lists...
#13 2.278 Reading package lists...
#13 2.981 Building dependency tree...
#13 3.129 Reading state information...
#13 3.176 E: Unable to locate package python3.12-distutils
#13 3.176 E: Couldn't find any package by glob 'python3.12-distutils'
#13 3.176 E: Couldn't find any package by regex 'python3.12-distutils'
#13 ERROR: process "/bin/sh -c apt-get update && apt-get install -y     \"$PYTHON_VERSION\"     \"$PYTHON_VERSION-venv\"     \"$PYTHON_VERSION-dev\"     \"$PYTHON_VERSION-distutils\"     python3-pip" did not complete successfully: exit code: 100
------
 > [ 7/26] RUN apt-get update && apt-get install -y     "python3.12"     "python3.12-venv"     "python3.12-dev"     "python3.12-distutils"     python3-pip:
0.891 Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [3475 kB]
1.256 Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1516 kB]
1.294 Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [2753 kB]
1.367 Get:15 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [33.8 kB]



3.176 E: Unable to locate package python3.12-distutils
3.176 E: Couldn't find any package by glob 'python3.12-distutils'
3.176 E: Couldn't find any package by regex 'python3.12-distutils'
------
Dockerfile:25
```