### PR TITLE
Add district/key/awards endpoint

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -3511,7 +3511,7 @@ export function getDistrictEvents(
   });
 }
 /**
- * Gets a list of events in the given district.
+ * Gets a list of awards in the given district.
  */
 export function getDistrictAwards(
   {

--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -3437,7 +3437,7 @@ export function getDistrictsByYear(
 /**
  * Gets a list of District objects with the given district abbreviation. This accounts for district abbreviation changes, such as MAR to FMA.
  */
-export function getDistrict(
+export function getDistrictHistory(
   {
     ifNoneMatch,
     districtAbbreviation,
@@ -3504,6 +3504,44 @@ export function getDistrictEvents(
         status: 404;
       }
   >(`/district/${encodeURIComponent(districtKey)}/events`, {
+    ...opts,
+    headers: oazapfts.mergeHeaders(opts?.headers, {
+      'If-None-Match': ifNoneMatch,
+    }),
+  });
+}
+/**
+ * Gets a list of events in the given district.
+ */
+export function getDistrictAwards(
+  {
+    ifNoneMatch,
+    districtKey,
+  }: {
+    ifNoneMatch?: string;
+    districtKey: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Award[];
+      }
+    | {
+        status: 304;
+      }
+    | {
+        status: 401;
+        data: {
+          /** Authorization error description. */
+          Error: string;
+        };
+      }
+    | {
+        status: 404;
+      }
+  >(`/district/${encodeURIComponent(districtKey)}/awards`, {
     ...opts,
     headers: oazapfts.mergeHeaders(opts?.headers, {
       'If-None-Match': ifNoneMatch,
@@ -3716,7 +3754,7 @@ export function getDistrictRankings(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: DistrictRanking[];
+        data: DistrictRanking[] | null;
       }
     | {
         status: 304;

--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -13,6 +13,7 @@ from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey
+from backend.common.queries.award_query import EventAwardsQuery
 from backend.common.queries.district_query import (
     DistrictAbbreviationQuery,
     DistrictQuery,
@@ -98,3 +99,30 @@ def district_list_year(year: int) -> Response:
 
     district = DistrictsInYearQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
     return profiled_jsonify(district)
+
+
+@api_authenticated
+@cached_public
+def district_awards(district_key: DistrictKey) -> Response:
+    """
+    Returns a list of awards for a given DistrictKey.
+    """
+    track_call_after_response("district/awards", district_key)
+
+    events = DistrictEventsQuery(district_key=district_key).fetch_dict(
+        ApiMajorVersion.API_V3
+    )
+    futures = []
+    for event in events:
+        futures.append(
+            EventAwardsQuery(event_key=event["key"]).fetch_dict_async(
+                ApiMajorVersion.API_V3
+            )
+        )
+
+    awards = []
+    for future in futures:
+        partial_awards = future.get_result()
+        awards += partial_awards
+
+    return profiled_jsonify(awards)

--- a/src/backend/api/handlers/tests/district_test.py
+++ b/src/backend/api/handlers/tests/district_test.py
@@ -8,8 +8,10 @@ from backend.api.handlers.tests.helpers import (
     validate_simple_team_keys,
 )
 from backend.common.consts.auth_type import AuthType
+from backend.common.consts.award_type import AwardType
 from backend.common.consts.event_type import EventType
 from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.award import Award
 from backend.common.models.district import District
 from backend.common.models.district_ranking import DistrictRanking
 from backend.common.models.district_team import DistrictTeam
@@ -334,3 +336,56 @@ def test_district_list_year(ndb_stub, api_client: Client) -> None:
     district_keys = set([d["key"] for d in resp.json])
     assert "2020ne" in district_keys
     assert "2020fim" in district_keys
+
+
+def test_district_awards(ndb_stub, api_client: Client) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    District(
+        id="2024ne",
+        year=2024,
+        abbreviation="ne",
+    ).put()
+
+    Team(
+        id="frc2713",
+        team_number=2713,
+    ).put()
+
+    Event(
+        id="2024necmp",
+        year=2024,
+        event_short="necmp",
+        district_key=ndb.Key(District, "2024ne"),
+        event_type_enum=EventType.DISTRICT_CMP,
+    ).put()
+
+    Award(
+        id="2024necmp_1",
+        name_str="Winner",
+        event=ndb.Key(Event, "2024necmp"),
+        award_type_enum=AwardType.WINNER,
+        event_type_enum=EventType.DISTRICT_CMP,
+        year=2024,
+        team_list=[ndb.Key(Team, "frc2713")],
+    ).put()
+
+    resp = api_client.get(
+        "/api/v3/district/2024ne/awards",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+
+    assert resp.status_code == 200
+    assert len(resp.json) == 1
+    assert resp.json == [
+        {
+            "award_type": AwardType.WINNER,
+            "event_key": "2024necmp",
+            "name": "Winner",
+            "recipient_list": [],
+            "year": 2024,
+        }
+    ]

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -16,6 +16,7 @@ from backend.api.handlers.client_api import (
     update_model_preferences,
 )
 from backend.api.handlers.district import (
+    district_awards,
     district_events,
     district_history,
     district_list_year,
@@ -125,6 +126,7 @@ api_v3.add_url_rule("/status", view_func=status)
 api_v3.add_url_rule(
     "/district/<string:district_abbreviation>/history", view_func=district_history
 )
+api_v3.add_url_rule("/district/<string:district_key>/awards", view_func=district_awards)
 api_v3.add_url_rule("/district/<string:district_key>/events", view_func=district_events)
 api_v3.add_url_rule(
     "/district/<string:district_key>/events/<model_type:model_type>",

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3945,7 +3945,7 @@
           "event",
           "list"
         ],
-        "description": "Gets a list of events in the given district.",
+        "description": "Gets a list of awards in the given district.",
         "operationId": "getDistrictAwards",
         "parameters": [
           {

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5,7 +5,7 @@
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
     "version": "3.9.7",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -3822,7 +3822,7 @@
           "district"
         ],
         "description": "Gets a list of District objects with the given district abbreviation. This accounts for district abbreviation changes, such as MAR to FMA.",
-        "operationId": "getDistrict",
+        "operationId": "getDistrictHistory",
         "parameters": [
           {
             "$ref": "#/components/parameters/If-None-Match"
@@ -3916,6 +3916,68 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/awards": {
+      "get": {
+        "tags": [
+          "district",
+          "event",
+          "list"
+        ],
+        "description": "Gets a list of events in the given district.",
+        "operationId": "getDistrictAwards",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Award"
                   }
                 }
               }
@@ -4296,7 +4358,8 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/District_Ranking"
-                  }
+                  },
+                  "nullable": "true"
                 }
               }
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2b7b59e3-b343-471c-b5ae-3a6431130bd8)

Currently the only way to get these is making a per-event request which is inefficient, especially at the size of something like Michigan.

Also renames getDistrict to getDistrictHistory, and clarifies that district rankings are nullable. (Example: `2025ne` rankings before 2025 has begun: https://www.thebluealliance.com/api/v3/district/2025ne/rankings)