### PR TITLE
Remove tba_video from insights

### DIFF
--- a/src/backend/common/helpers/insights_helper.py
+++ b/src/backend/common/helpers/insights_helper.py
@@ -576,7 +576,7 @@ class InsightsHelper(object):
             "alliances": match.alliances,
             "score_breakdown": match.score_breakdown,
             "winning_alliance": match.winning_alliance,
-            "tba_video": match.tba_video,
+            "tba_video": None,
             "youtube_videos_formatted": match.youtube_videos_formatted,
         }
 


### PR DESCRIPTION
We should deprecate tba_video everywhere, we have it all transferred to youtube anyways.