### PR TITLE
Overwrite event_type/award_type types in generated api

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -7,6 +7,9 @@
 import * as Oazapfts from '@oazapfts/runtime';
 import * as QS from '@oazapfts/runtime/query';
 
+import { AwardType } from '~/lib/api/AwardType';
+import { EventType } from '~/lib/api/EventType';
+
 export const defaults: Oazapfts.Defaults<Oazapfts.CustomHeaders> = {
   headers: {},
   baseUrl: 'https://www.thebluealliance.com/api/v3',
@@ -125,7 +128,7 @@ export type Event = {
   /** Event short code, as provided by FIRST. */
   event_code: string;
   /** Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py#L2 */
-  event_type: number;
+  event_type: EventType;
   district: DistrictList | null;
   /** City, town, village, etc. the event is located in. */
   city: string | null;
@@ -187,7 +190,7 @@ export type Award = {
   /** The name of the award as provided by FIRST. May vary for the same award type. */
   name: string;
   /** Type of award given. See https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/award_type.py#L6 */
-  award_type: number;
+  award_type: AwardType;
   /** The event_key of the event the award was won at. */
   event_key: string;
   /** A list of recipients of the award at the event. May have either a team_key or an awardee, both, or neither (in the case the award wasn't awarded at the event). */
@@ -217,7 +220,7 @@ export type EventSimple = {
   /** Event short code, as provided by FIRST. */
   event_code: string;
   /** Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py#L2 */
-  event_type: number;
+  event_type: EventType;
   district: DistrictList | null;
   /** City, town, village, etc. the event is located in. */
   city: string | null;

--- a/pwa/app/lib/awardUtils.ts
+++ b/pwa/app/lib/awardUtils.ts
@@ -1,8 +1,8 @@
 import { Award } from '~/api/v3';
-import { AwardType, SORT_ORDER } from '~/lib/api/AwardType';
+import { SORT_ORDER } from '~/lib/api/AwardType';
 
 export function sortAwardsComparator(a: Award, b: Award) {
-  const orderA = SORT_ORDER[a.award_type as AwardType] ?? 1000;
-  const orderB = SORT_ORDER[b.award_type as AwardType] ?? 1000;
+  const orderA = SORT_ORDER[a.award_type] ?? 1000;
+  const orderB = SORT_ORDER[b.award_type] ?? 1000;
   return orderA - orderB || a.award_type - b.award_type;
 }

--- a/pwa/app/routes/events.($year).tsx
+++ b/pwa/app/routes/events.($year).tsx
@@ -136,17 +136,17 @@ function groupBySections(events: Event[]): EventGroup[] {
     }
 
     // FOC
-    if ((event.event_type as EventType) == EventType.FOC) {
+    if (event.event_type == EventType.FOC) {
       FOCEvents.events.push(event);
     }
 
     // Preaseason
-    if ((event.event_type as EventType) == EventType.PRESEASON) {
+    if (event.event_type == EventType.PRESEASON) {
       preaseasonEvents.events.push(event);
     }
 
     // Offseason
-    if ((event.event_type as EventType) == EventType.OFFSEASON) {
+    if (event.event_type == EventType.OFFSEASON) {
       offseasonEvents.events.push(event);
     }
   });

--- a/pwa/app/routes/team.$teamNumber.($year).tsx
+++ b/pwa/app/routes/team.$teamNumber.($year).tsx
@@ -339,10 +339,10 @@ function StatsSection({
   awards: Award[];
 }) {
   const officialEvents = events.filter((e) =>
-    SEASON_EVENT_TYPES.has(e.event_type as EventType),
+    SEASON_EVENT_TYPES.has(e.event_type),
   );
   const unofficialEvents = events.filter(
-    (e) => !SEASON_EVENT_TYPES.has(e.event_type as EventType),
+    (e) => !SEASON_EVENT_TYPES.has(e.event_type),
   );
 
   const officialMatches = useMemo(

--- a/pwa/generate-api.sh
+++ b/pwa/generate-api.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+npx oazapfts ../src/backend/web/static/swagger/api_v3.json --argumentStyle=object > app/api/v3.ts
+sed -i 's/award_type: number/award_type: AwardType/g' app/api/v3.ts
+sed -i 's/event_type: number/event_type: EventType/g' app/api/v3.ts
+sed -i '1i\
+import { AwardType } from '"'"'~/lib/api/AwardType'"'"';\
+import { EventType } from '"'"'~/lib/api/EventType'"'"';' app/api/v3.ts
+npm run format:fix

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -13,7 +13,6 @@
     "format:fix": "prettier --write .",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc",
-    "generate-api": "oazapfts ../src/backend/web/static/swagger/api_v3.json --argumentStyle=object > app/api/v3.ts",
     "generate-pwa-assets": "pwa-assets-generator",
     "bundle-visualizer": "npx vite-bundle-visualizer",
     "test": "vitest ./app --coverage"


### PR DESCRIPTION
One problem we have is that we have to cast `event_type as EventType` in PWA, because eslint gets upset that the enum doesn't completely cover all `number` values (even though we know it should from the API).

Unfortunately every method of named, numeric enums in OpenAPI is janky and does not create a great developer experience.

This introduces a bash script that should be run to regenerate the API which:

1. Runs `oazapfts`
2. Replaces `award_type: number` with `award_type: AwardType`
3. Replaces `event_type: number` with `event_type: EventType`
4. Adds imports to the top of the file
5. Formats the file

<details>
<summary>Alternative solution</summary>

We can add this to the schema:

```json
{
// ...
"schemas": {
  "EventType": {
    "type": "integer",
    "description": "Enumeration of event types.",
    "enum": [
      0,
      1,
      2,
      3,
      4,
      5,
      6,
      7,
      99,
      100,
      -1
    ],
    "x-enum-descriptions": {
      "0": "REGIONAL",
      "1": "DISTRICT",
      "2": "DISTRICT_CMP",
      "3": "CMP_DIVISION",
      "4": "CMP_FINALS",
      "5": "DISTRICT_CMP_DIVISION",
      "6": "FOC",
      "7": "REMOTE",
      "99": "OFFSEASON",
      "100": "PRESEASON",
      "-1": "UNLABELED"
    }
  }
}
```

We can then enable `--useEnumType` in `oazapfts` which will generate:

```ts
export enum EventType {
  Regional = 0;
  District = 1;
  DistrictCmp = 2;
  CmpDivision = 3;
  // ....
}
```

Note that this also makes enums for everything else in the api spec, which are very common in score breakdowns, and things get a bit bloated. It *is* a viable solution, though.
</details>

<details>
<summary>Alternative 2</summary>

Just disable [the eslint rule](https://typescript-eslint.io/rules/no-unsafe-enum-comparison) but it wasn't working and I hate eslint

</details>