### PR TITLE
Move FRC API calls to async NDB urlfetch

### DIFF
--- a/src/backend/common/frc_api/tests/frcapi_test.py
+++ b/src/backend/common/frc_api/tests/frcapi_test.py
@@ -1,12 +1,20 @@
 from unittest.mock import patch
 
 import pytest
+from google.appengine.ext import testbed
 
 from backend.common.frc_api import FRCAPI
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+
+
+@pytest.fixture(autouse=True)
+def auto_add_urlfetch_stub(
+    urlfetch_stub: testbed.urlfetch_stub.URLFetchServiceStub,
+) -> None:
+    pass
 
 
 def test_init_no_fmsapi_secrets(ndb_stub) -> None:
@@ -19,29 +27,17 @@ def test_init_no_fmsapi_secrets(ndb_stub) -> None:
 def test_init_fmsapi_secrets(ndb_stub) -> None:
     FMSApiSecrets.put(FMSApiSecretsContentType(username="zach", authkey="authkey"))
     api = FRCAPI()
-
-    assert api.session is not None
-
-    auth_token = api.session.headers["Authorization"]
-    assert auth_token == "Basic emFjaDphdXRoa2V5"
+    assert api.auth_token == "emFjaDphdXRoa2V5"
 
 
 def test_init_auth_token() -> None:
     api = FRCAPI("test")
-
-    assert api.session is not None
-
-    auth_token = api.session.headers["Authorization"]
-    assert auth_token == "Basic test"
+    assert api.auth_token == "test"
 
 
 def test_init_with_credentials() -> None:
     api = FRCAPI.with_credentials("zach", "authkey")
-
-    assert api.session is not None
-
-    auth_token = api.session.headers["Authorization"]
-    assert auth_token == "Basic emFjaDphdXRoa2V5"
+    assert api.auth_token == "emFjaDphdXRoa2V5"
 
 
 def test_root() -> None:
@@ -179,20 +175,25 @@ def test_team_avatars() -> None:
 @pytest.mark.parametrize(
     "endpoint", ["/2020/awards/MIKET", "2020/awards/MIKET", "///2020/awards/MIKET"]
 )
-def test_get(endpoint: str) -> None:
+def test_get(
+    endpoint: str, urlfetch_stub: testbed.urlfetch_stub.URLFetchServiceStub
+) -> None:
     api = FRCAPI("zach")
 
     expected_url = "https://frc-api.firstinspires.org/v3.0/2020/awards/MIKET"
     expected_headers = {
         "Accept": "application/json",
+        "Authorization": "Basic zach",
         "Cache-Control": "no-cache, max-age=10",
         "Pragma": "no-cache",
     }
 
-    with patch.object(api.session, "get") as mock_get:
-        api._get(endpoint)
+    with patch.object(urlfetch_stub, "_Dynamic_Fetch") as mock_fetch:
+        api._get(endpoint).get_result()
 
-    # TODO: Reenable SSL verification. Disabled on 2024-08-31 due to FIRST SSL issues.
-    mock_get.assert_called_once_with(
-        expected_url, headers=expected_headers, verify=False
-    )
+    assert mock_fetch.call_count == 1
+    called_request = mock_fetch.call_args[0][0]
+    assert called_request.Url == expected_url
+
+    called_headers = {h.Key: h.Value for h in called_request.header}
+    assert called_headers == expected_headers

--- a/src/backend/common/urlfetch.py
+++ b/src/backend/common/urlfetch.py
@@ -1,0 +1,50 @@
+import json
+from typing import Mapping, Optional
+
+from google.appengine.api import urlfetch_service_pb2
+from google.appengine.api.urlfetch import _URLFetchResult
+from pyre_extensions import JSON
+
+
+class URLFetchResult:
+    """
+    A strongly typed abstraction of GAE's URLFetchResult
+    """
+
+    request_url: str
+
+    content: str
+    status_code: int
+    content_was_truncated: bool
+    header_msg: str
+    headers: Mapping[str, str]
+
+    # If a redirect was followed, the ultimate URL
+    final_url: Optional[str]
+
+    def __init__(self, url: str, res: _URLFetchResult) -> None:
+        self.request_url = url
+        self.content = res.content
+        self.status_code = res.status_code
+        self.content_was_truncated = res.content_was_truncated
+        self.final_url = res.final_url
+        self.header_msg = res.header_msg
+        self.headers = res.headers
+
+    @property
+    def url(self) -> str:
+        return self.final_url or self.request_url
+
+    def json(self) -> Optional[JSON]:
+        if not self.content:
+            return None
+        return json.loads(self.content)
+
+    @classmethod
+    def mock_for_content(
+        cls, url: str, status_code: int, content: str
+    ) -> "URLFetchResult":
+        response_proto = urlfetch_service_pb2.URLFetchResponse()
+        response_proto.Content = content.encode()
+        response_proto.StatusCode = status_code
+        return cls(url, _URLFetchResult(response_proto))

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_awards_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_awards_test.py
@@ -1,17 +1,18 @@
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, patch
 
 import pytest
 from google.appengine.ext import ndb
-from requests import Response
 
 from backend.common.consts.event_type import EventType
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_awards_parser import (
     FMSAPIAwardsParser,
@@ -32,13 +33,15 @@ def test_get_awards_event(first_code, event_short):
         year=2020,
     )
 
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2020/awards/MIKET/0"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/awards/MIKET/0",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "awards", return_value=response
+        FRCAPI, "awards", return_value=InstantFuture(response)
     ) as mock_awards, patch.object(
         FMSAPIAwardsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -60,13 +63,15 @@ def test_get_awards_event_cmp(first_code, event_short):
         year=2014,
     )
 
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2014/awards/GALILEO/0"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/awards/GALILEO/0",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "awards", return_value=response
+        FRCAPI, "awards", return_value=InstantFuture(response)
     ) as mock_awards, patch.object(
         FMSAPIAwardsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -98,13 +103,15 @@ def test_get_awards_event_cmp_2015(teams):
             year=2015,
         ).put()
 
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2014/awards/GALILEO/7332"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/awards/GALILEO/7332",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "awards", return_value=response
+        FRCAPI, "awards", return_value=InstantFuture(response)
     ) as mock_awards, patch.object(
         FMSAPIAwardsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -138,13 +145,15 @@ def test_get_awards_event_cmp_2017(teams):
             year=2017,
         ).put()
 
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2014/awards/GALILEO/7332"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/awards/GALILEO/7332",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "awards", return_value=response
+        FRCAPI, "awards", return_value=InstantFuture(response)
     ) as mock_awards, patch.object(
         FMSAPIAwardsParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_distrct_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_distrct_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_district_list_parser import (
     FMSAPIDistrictListParser,
@@ -23,15 +24,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_district_list() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "district_list", return_value=response
+        FRCAPI, "district_list", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIDistrictListParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -45,15 +46,15 @@ def test_get_district_list() -> None:
 
 
 def test_get_district_rankings() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "district_rankings", return_value=response
+        FRCAPI, "district_rankings", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIDistrictRankingsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -68,15 +69,15 @@ def test_get_district_rankings() -> None:
 
 
 def test_get_district_rankings_paginated() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "district_rankings", return_value=response
+        FRCAPI, "district_rankings", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIDistrictRankingsParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_alliances_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_alliances_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_event_alliances_parser import (
     FMSAPIEventAlliancesParser,
@@ -20,15 +21,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_alliances() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/alliances?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/alliances?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "alliances", return_value=response
+        FRCAPI, "alliances", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventAlliancesParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -43,15 +44,15 @@ def test_get_event_alliances() -> None:
 
 
 def test_get_event_alliances_cmp() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2014/teams?eventCode=GALILEO&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/teams?eventCode=GALILEO&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "alliances", return_value=response
+        FRCAPI, "alliances", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventAlliancesParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_match_parser import (
     FMSAPIHybridScheduleParser,
@@ -24,17 +25,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_matches() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = ""
+    response = URLFetchResult.mock_for_content("", 200, "")
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "match_schedule", return_value=response
+        FRCAPI, "match_schedule", return_value=InstantFuture(response)
     ) as mock_schedule_api, patch.object(
-        FRCAPI, "matches", return_value=response
+        FRCAPI, "matches", return_value=InstantFuture(response)
     ) as mock_matches_api, patch.object(
-        FRCAPI, "match_scores", return_value=response
+        FRCAPI, "match_scores", return_value=InstantFuture(response)
     ) as mock_match_scores_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
     ) as mock_schedule_parse, patch.object(
@@ -62,17 +61,15 @@ def test_get_event_matches() -> None:
 
 
 def test_get_event_matches_cmp() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = ""
+    response = URLFetchResult.mock_for_content("", 200, "")
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "match_schedule", return_value=response
+        FRCAPI, "match_schedule", return_value=InstantFuture(response)
     ) as mock_schedule_api, patch.object(
-        FRCAPI, "matches", return_value=response
+        FRCAPI, "matches", return_value=InstantFuture(response)
     ) as mock_matches_api, patch.object(
-        FRCAPI, "match_scores", return_value=response
+        FRCAPI, "match_scores", return_value=InstantFuture(response)
     ) as mock_match_scores_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
     ) as mock_schedule_parse, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_rankings_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_rankings_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_event_rankings_parser import (
     FMSAPIEventRankingsParser,
@@ -20,15 +21,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_rankings() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/rankings?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/rankings?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "rankings", return_value=response
+        FRCAPI, "rankings", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventRankingsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -43,15 +44,15 @@ def test_get_event_rankings() -> None:
 
 
 def test_get_event_rankings_cmp() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2014/teams?eventCode=GALILEO&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/teams?eventCode=GALILEO&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "rankings", return_value=response
+        FRCAPI, "rankings", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventRankingsParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_team_avatars_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_team_avatars_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_team_avatar_parser import (
     FMSAPITeamAvatarParser,
@@ -20,15 +21,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_teams() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/avatars?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/avatars?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_team_avatars", return_value=response
+        FRCAPI, "event_team_avatars", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamAvatarParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -43,15 +44,15 @@ def test_get_event_teams() -> None:
 
 
 def test_get_event_teams_paginated() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/avatars?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/avatars?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_team_avatars", return_value=response
+        FRCAPI, "event_team_avatars", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamAvatarParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -66,15 +67,15 @@ def test_get_event_teams_paginated() -> None:
 
 
 def test_get_event_teams_cmp() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2014/avatars?eventCode=GALILEO&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/avatars?eventCode=GALILEO&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_team_avatars", return_value=response
+        FRCAPI, "event_team_avatars", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamAvatarParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_teams_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_teams_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_team_details_parser import (
     FMSAPITeamDetailsParser,
@@ -20,15 +21,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_teams() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_teams", return_value=response
+        FRCAPI, "event_teams", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamDetailsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -43,15 +44,15 @@ def test_get_event_teams() -> None:
 
 
 def test_get_event_teams_paginated() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/teams?eventCode=MIKET&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_teams", return_value=response
+        FRCAPI, "event_teams", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamDetailsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -66,15 +67,15 @@ def test_get_event_teams_paginated() -> None:
 
 
 def test_get_event_teams_cmp() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2014/teams?eventCode=GALILEO&page=1"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/teams?eventCode=GALILEO&page=1",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_teams", return_value=response
+        FRCAPI, "event_teams", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamDetailsParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_event_list_parser import (
     FMSAPIEventListParser,
@@ -20,13 +21,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_list() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2020/events"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/events",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_list", return_value=response
+        FRCAPI, "event_list", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventListParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -40,13 +43,15 @@ def test_get_event_list() -> None:
 
 
 def test_get_event_details() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2020/events?eventCode=MIKET"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/events?eventCode=MIKET",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_info", return_value=response
+        FRCAPI, "event_info", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventListParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -60,15 +65,15 @@ def test_get_event_details() -> None:
 
 
 def test_get_event_details_cmp() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = (
-        "https://frc-api.firstinspires.org/v3.0/2014/events?eventCode=GALILEO"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2014/events?eventCode=GALILEO",
+        200,
+        "",
     )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "event_info", return_value=response
+        FRCAPI, "event_info", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPIEventListParser, "__init__", return_value=None
     ) as mock_init, patch.object(

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_teams_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_teams_test.py
@@ -1,13 +1,14 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_team_avatar_parser import (
     FMSAPITeamAvatarParser,
@@ -23,13 +24,15 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_team_details() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2020/teams?teamNumber=254"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/teams?teamNumber=254",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "team_details", return_value=response
+        FRCAPI, "team_details", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamDetailsParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -44,13 +47,15 @@ def test_get_team_details() -> None:
 
 
 def test_get_team_avatar() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/2020/avatars?teamNumber=254"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/avatars?teamNumber=254",
+        200,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "team_avatar", return_value=response
+        FRCAPI, "team_avatar", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamAvatarParser, "__init__", return_value=None
     ) as mock_init, patch.object(
@@ -65,13 +70,15 @@ def test_get_team_avatar() -> None:
 
 
 def test_get_team_avatar_parser_failed() -> None:
-    response = Mock(spec=Response)
-    response.status_code = 500
-    response.url = "https://frc-api.firstinspires.org/v3.0/2020/avatars?teamNumber=254"
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/2020/avatars?teamNumber=254",
+        500,
+        "",
+    )
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "team_avatar", return_value=response
+        FRCAPI, "team_avatar", return_value=InstantFuture(response)
     ) as mock_api, patch.object(
         FMSAPITeamAvatarParser, "__init__", return_value=None
     ) as mock_init:

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -1,10 +1,10 @@
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-from requests import Response
 
 from backend.common.frc_api import FRCAPI
+from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
 from backend.common.sitevars.apistatus_fmsapi_down import ApiStatusFMSApiDown
 from backend.common.sitevars.fms_api_secrets import (
@@ -12,6 +12,7 @@ from backend.common.sitevars.fms_api_secrets import (
 )
 from backend.common.sitevars.fms_api_secrets import FMSApiSecrets
 from backend.common.storage.clients.in_memory_client import InMemoryClient
+from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
 
@@ -86,14 +87,16 @@ def test_get_root(fms_api_secrets):
         "apiVersion": "3.0",
         "status": "normal",
     }
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/"
-    response.json.return_value = content
-    response.content = json.dumps(content).encode()
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/",
+        200,
+        json.dumps(content),
+    )
 
     df = DatafeedFMSAPI(save_response=True)
-    with patch.object(FRCAPI, "root", return_value=response) as mock_root:
+    with patch.object(
+        FRCAPI, "root", return_value=InstantFuture(response)
+    ) as mock_root:
         df.get_root_info() is None
 
     mock_root.assert_called_once_with()
@@ -101,36 +104,40 @@ def test_get_root(fms_api_secrets):
 
 def test_get_root_failure(fms_api_secrets):
     content = {}
-    response = Mock(spec=Response)
-    response.status_code = 500
-    response.url = "https://frc-api.firstinspires.org/v3.0/"
-    response.json.return_value = content
-    response.content = json.dumps(content).encode()
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/",
+        500,
+        json.dumps(content),
+    )
 
     df = DatafeedFMSAPI(save_response=True)
-    with patch.object(FRCAPI, "root", return_value=response) as mock_root:
+    with patch.object(
+        FRCAPI, "root", return_value=InstantFuture(response)
+    ) as mock_root:
         assert df.get_root_info() is None
 
     mock_root.assert_called_once_with()
 
 
 def test_mark_api_down(fms_api_secrets):
-    response1 = Mock(spec=Response)
-    response1.status_code = 500
-    response1.url = "https://frc-api.firstinspires.org/v3.0/"
+    response1 = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/",
+        500,
+        "",
+    )
 
-    response2 = Mock(spec=Response)
-    response2.status_code = 200
-    response2.url = "https://frc-api.firstinspires.org/v3.0/"
-    response2.json.return_value = {}
-    response2.content = b"{}"
+    response2 = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/",
+        200,
+        "{}",
+    )
 
     df = DatafeedFMSAPI(save_response=True)
-    with patch.object(FRCAPI, "root", return_value=response1):
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response1)):
         assert df.get_root_info() is None
         assert ApiStatusFMSApiDown.get() is True
 
-    with patch.object(FRCAPI, "root", return_value=response2):
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response2)):
         assert df.get_root_info() == {}
         assert ApiStatusFMSApiDown.get() is False
 
@@ -144,14 +151,14 @@ def test_save_response(fms_api_secrets, monkeypatch: pytest.MonkeyPatch):
         "apiVersion": "3.0",
         "status": "normal",
     }
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/root"
-    response.json.return_value = content
-    response.content = json.dumps(content).encode()
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/root",
+        200,
+        json.dumps(content),
+    )
 
     df = DatafeedFMSAPI(save_response=True)
-    with patch.object(FRCAPI, "root", return_value=response):
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
         df.get_root_info()
 
     client = InMemoryClient.get()
@@ -160,7 +167,7 @@ def test_save_response(fms_api_secrets, monkeypatch: pytest.MonkeyPatch):
 
     f = client.read(files[0])
     assert f is not None
-    assert f == response.content.decode()
+    assert f == response.content
 
 
 def test_save_response_unchanged(fms_api_secrets, monkeypatch: pytest.MonkeyPatch):
@@ -172,14 +179,15 @@ def test_save_response_unchanged(fms_api_secrets, monkeypatch: pytest.MonkeyPatc
         "apiVersion": "3.0",
         "status": "normal",
     }
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/root"
-    response.json.return_value = content
-    response.content = json.dumps(content).encode()
+
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/root",
+        200,
+        json.dumps(content),
+    )
 
     df = DatafeedFMSAPI(save_response=True)
-    with patch.object(FRCAPI, "root", return_value=response):
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
         df.get_root_info()
 
     client = InMemoryClient.get()
@@ -187,7 +195,7 @@ def test_save_response_unchanged(fms_api_secrets, monkeypatch: pytest.MonkeyPatc
     assert len(files) == 1
     f_name = files[0]
 
-    with patch.object(FRCAPI, "root", return_value=response):
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
         df.get_root_info()
 
     # Since the content didn't change, we shouldn't have written another
@@ -203,14 +211,15 @@ def test_save_response_updated(fms_api_secrets, monkeypatch: pytest.MonkeyPatch)
         "apiVersion": "3.0",
         "status": "normal",
     }
-    response = Mock(spec=Response)
-    response.status_code = 200
-    response.url = "https://frc-api.firstinspires.org/v3.0/root"
-    response.json.return_value = content
-    response.content = json.dumps(content).encode()
+
+    response = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/root",
+        200,
+        json.dumps(content),
+    )
 
     df = DatafeedFMSAPI(save_response=True)
-    with patch.object(FRCAPI, "root", return_value=response):
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
         df.get_root_info()
 
     client = InMemoryClient.get()
@@ -224,12 +233,12 @@ def test_save_response_updated(fms_api_secrets, monkeypatch: pytest.MonkeyPatch)
         "apiVersion": "3.0",
         "status": "normal",
     }
-    response2 = Mock(spec=Response)
-    response2.status_code = 200
-    response2.url = "https://frc-api.firstinspires.org/v3.0/root"
-    response2.json.return_value = content2
-    response2.content = json.dumps(content2).encode()
-    with patch.object(FRCAPI, "root", return_value=response2):
+    response2 = URLFetchResult.mock_for_content(
+        "https://frc-api.firstinspires.org/v3.0/root",
+        200,
+        json.dumps(content2),
+    )
+    with patch.object(FRCAPI, "root", return_value=InstantFuture(response2)):
         df.get_root_info()
 
     # Since the content is different, we should have two items
@@ -238,8 +247,8 @@ def test_save_response_updated(fms_api_secrets, monkeypatch: pytest.MonkeyPatch)
 
     f = client.read(files[0])
     assert f is not None
-    assert f == response.content.decode()
+    assert f == response.content
 
     f2 = client.read(files[1])
     assert f2 is not None
-    assert f2 == response2.content.decode()
+    assert f2 == response2.content


### PR DESCRIPTION
This setup is a vestige of when we originally tried to run things without the GAE standard library and used vanilla `requests`. However, since we have this available, we should use the async interface, which should allow the datafeed service to run more cheaply.