### PR TITLE
Support issuing write keys for an entire district

### DIFF
--- a/src/backend/common/models/api_auth_access.py
+++ b/src/backend/common/models/api_auth_access.py
@@ -6,6 +6,7 @@ from pyre_extensions import none_throws
 
 from backend.common.consts.auth_type import AuthType
 from backend.common.models.account import Account
+from backend.common.models.district import District
 from backend.common.models.event import Event
 
 
@@ -34,6 +35,10 @@ class ApiAuthAccess(ndb.Model):
     event_list: List[ndb.Key] = ndb.KeyProperty(  # pyre-ignore[8]
         kind=Event, repeated=True
     )  # events for which auth is granted
+    # On update, we resolve the events in these districts and add them to event_list
+    district_list: List[ndb.Key] = ndb.KeyProperty(  # pyre-ignore[8]
+        kind=District, repeated=True
+    )
     # Allow access for all events marked official
     all_official_events: bool = ndb.BooleanProperty()
     expiration: Optional[datetime.datetime] = ndb.DateTimeProperty()
@@ -92,4 +97,13 @@ class ApiAuthAccess(ndb.Model):
     def event_list_str(self) -> str:
         return ",".join(
             [none_throws(event_key.string_id()) for event_key in self.event_list]
+        )
+
+    @property
+    def district_list_str(self) -> str:
+        return ",".join(
+            [
+                none_throws(district_key.string_id())
+                for district_key in self.district_list
+            ]
         )

--- a/src/backend/web/templates/admin/api_add_auth.html
+++ b/src/backend/web/templates/admin/api_add_auth.html
@@ -20,6 +20,10 @@
             <td><input class="form-control" type="text" name="expiration" placeholder="2017-06-30"/></td>
         </tr>
         <tr>
+            <td>Districts (district keys separated by commas)</td>
+            <td><input class="form-control" type="text" name="district_list_str" placeholder="2014fim,2014ne"/></td>
+        </tr>
+        <tr>
             <td>Events (Event keys separated by commas)</td>
             <td><input class="form-control" type="text" name="event_list_str" placeholder="2014cc,2014mttd"/></td>
         </tr>

--- a/src/backend/web/templates/admin/api_edit_auth.html
+++ b/src/backend/web/templates/admin/api_edit_auth.html
@@ -27,6 +27,10 @@
             <td><input type="checkbox" name="allow_admin" {% if auth.allow_admin %}checked{% endif %}></td>
         </tr>
         <tr>
+            <td>Districts</td>
+            <td><input type="text" name="district_list_str" value="{{auth.district_list_str}}" /></td>
+        </tr>
+        <tr>
             <td>Events</td>
             <td><input type="text" name="event_list_str" value="{{auth.event_list_str}}" /></td>
         </tr>

--- a/src/backend/web/templates/admin/partials/api_write_table.html
+++ b/src/backend/web/templates/admin/partials/api_write_table.html
@@ -5,6 +5,7 @@
     <th>Expiration</th>
     <th>ID</th>
     <th>Secret</th>
+    <th>Districts</th>
     <th>Events</th>
     <th>All Official Events</th>
     <th>Event Info</th>
@@ -23,6 +24,11 @@
     <td>{% if auth.expiration %} {{ auth.expiration }} {% endif %}</td>
     <td>{{auth.key.id()}}</td>
     <td>{{auth.secret}}</td>
+    <td>
+      {% for district_key in auth.district_list %}
+        <div>{{district_key.id()}}</div>
+      {% endfor %}
+    </td>
     <td>
       {% for event_key in auth.event_list %}
         <a href="/admin/event/{{event_key.id()}}">{{event_key.id()}}</a>


### PR DESCRIPTION
This will make it easier for us to work with webcast managers for a district -- we'll resolve the list of events for the district at key creation/edit time, and include them in the valid events