### PR TITLE
Improve querying of api keys in admin panel

### DIFF
--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -154,7 +154,15 @@ admin_routes.add_url_rule(
     "/api_auth/edit/<auth_id>", view_func=api_auth_edit_post, methods=["POST"]
 )
 admin_routes.add_url_rule(
-    "/api_auth/manage", view_func=api_auth_manage, methods=["GET"]
+    "/api_auth/manage",
+    view_func=api_auth_manage,
+    defaults={"key_type": None},
+    methods=["GET"],
+)
+admin_routes.add_url_rule(
+    "/api_auth/manage/<regex('(read|write|admin)'):key_type>",
+    view_func=api_auth_manage,
+    methods=["GET"],
 )
 admin_routes.add_url_rule("/authkeys", view_func=authkeys_get, methods=["GET"])
 admin_routes.add_url_rule("/authkeys", view_func=authkeys_post, methods=["POST"])

--- a/src/backend/web/handlers/admin/users.py
+++ b/src/backend/web/handlers/admin/users.py
@@ -3,6 +3,7 @@ from werkzeug import Response
 
 from backend.common.consts.account_permission import AccountPermission, PERMISSIONS
 from backend.common.models.account import Account
+from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.web.profiled_render import render_template
 
 
@@ -34,8 +35,11 @@ def user_detail(user_id: str) -> str:
     if user is None:
         abort(404)
 
+    api_keys = ApiAuthAccess.query(ApiAuthAccess.owner == user.key).fetch()
+
     template_values = {
         "user": user,
+        "api_keys": api_keys,
         "permissions": PERMISSIONS,
     }
     return render_template("admin/user_details.html", template_values)

--- a/src/backend/web/templates/admin/api_manage_auth.html
+++ b/src/backend/web/templates/admin/api_manage_auth.html
@@ -5,12 +5,15 @@
 {% block content %}
 
 <h1>Manage API Authentication</h1>
+<p>Key Types: {%if key_type == 'admin' %}<b>Admin</b>{% else %}<a href="/admin/api_auth/manage/admin">Admin</a>{% endif %}, {% if key_type == 'write'%}<b>Write</b>{% else %}<a href="/admin/api_auth/manage/write">Write</a>{% endif %}, {% if key_type == 'read' %}<b>Read</b>{% else %}<a href="/admin/api_auth/manage/read">Read</a>{% endif %}</p>
+<p>Include Expired: {% if include_expired %}<b>Yes</b>{% else %}<a href="?include_expired=true">Yes</a>{% endif %}, {% if not include_expired %}<b>No</b>{% else %}<a href="?include_expired=false">No</a>{% endif %}</p>
 
+{% if key_type == 'write' %}
 <h2>Write API</h2>
+{% set write_auths = auths %}
 {% include "admin/partials/api_write_table.html" %}
 
-<hr>
-
+{% elif key_type == 'admin' %}
 <h2>Admin API</h2>
 <table class="table table-striped">
   <tr>
@@ -18,7 +21,7 @@
     <th>User</th>
     <th>X-TBA-Auth-Key</th>
   </tr>
-  {% for auth in admin_auths %}
+  {% for auth in auths %}
   <tr>
     <td><a href="/admin/api_auth/edit/{{auth.key.id()}}">{{ auth.description }}</a></td>
     <td>{% if auth.owner %}<a href="/admin/user/{{ auth.owner.id() }}">{{ auth.owner.id() }} {% endif %}</a></td>
@@ -27,6 +30,7 @@
   {% endfor %}
 </table>
 
+{% elif key_type == 'read' %}
 <h2>Read API</h2>
 <table class="table table-striped">
   <tr>
@@ -34,7 +38,7 @@
     <th>User</th>
     <th>X-TBA-Auth-Key</th>
   </tr>
-  {% for auth in read_auths %}
+  {% for auth in auths %}
   <tr>
     <td><a href="/admin/api_auth/edit/{{auth.key.id() }}">{{ auth.description }}</a></td>
     <td>{% if auth.owner %}<a href="/admin/user/{{ auth.owner.id() }}">{{ auth.owner.id() }} {% endif %}</a></td>
@@ -42,4 +46,5 @@
   </tr>
   {% endfor %}
 </table>
+{% endif %}
 {% endblock %}

--- a/src/backend/web/templates/admin/user_details.html
+++ b/src/backend/web/templates/admin/user_details.html
@@ -37,6 +37,16 @@
         </td>
     </tr>
     <tr>
+        <td>API Keys</td>
+        <td>
+            <ul>
+                {% for api_key in api_keys %}
+                    <li><a href="/admin/api_auth/edit/{{api_key.key.id()}}">{{api_key.description}}</a> {% if api_key.expiration %}(Expires: {{api_key.expiration.strftime('%Y-%m-%d')}}){% endif %}</li>
+                {% endfor %}
+            </ul>
+        </td>
+    </tr>
+    <tr>
         <td>Shadow Banned</td>
         <td>{{ user.shadow_banned }}</td>
     </tr>


### PR DESCRIPTION
This diff will simplify what has become a very expensive query...

We will:
 - show issued API keys on the admin user view
 - split the main "manage" page into separate ones for read/write/admin keys (so only "read" will remain super expensive, but we use that less)
 - hide expired keys by default