### PR TITLE
Asyncify FRC API Datafeed

### DIFF
--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/test_fms_api_match_tiebreaker.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/test_fms_api_match_tiebreaker.py
@@ -64,9 +64,9 @@ def test_2017flwp_sequence(ndb_stub, taskqueue_stub) -> None:
         file_time = datetime.datetime.strptime(time_str, "%Y-%m-%d %H_%M_%S.%f")
         query_time = file_time + datetime.timedelta(seconds=30)
         MatchManipulator.createOrUpdate(
-            DatafeedFMSAPI(
-                sim_time=query_time, sim_api_version="v2.0"
-            ).get_event_matches("2017{}".format(event_code)),
+            DatafeedFMSAPI(sim_time=query_time, sim_api_version="v2.0")
+            .get_event_matches("2017{}".format(event_code))
+            .get_result(),
             run_post_update_hook=False,
         )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
@@ -141,7 +141,9 @@ def test_2017flwp(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 4, 21, 22), sim_api_version="v2.0"
-        ).get_event_matches("2017flwp")
+        )
+        .get_event_matches("2017flwp")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -165,7 +167,9 @@ def test_2017flwp(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 4, 21, 35), sim_api_version="v2.0"
-        ).get_event_matches("2017flwp")
+        )
+        .get_event_matches("2017flwp")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -202,9 +206,13 @@ def test_2017pahat(ndb_stub, taskqueue_stub) -> None:
     )
     event.put()
 
-    matches = DatafeedFMSAPI(
-        sim_time=datetime.datetime(2017, 3, 5, 20, 45), sim_api_version="v2.0"
-    ).get_event_matches("2017pahat")
+    matches = (
+        DatafeedFMSAPI(
+            sim_time=datetime.datetime(2017, 3, 5, 20, 45), sim_api_version="v2.0"
+        )
+        .get_event_matches("2017pahat")
+        .get_result()
+    )
     MatchManipulator.createOrUpdate(matches)
 
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
@@ -228,7 +236,9 @@ def test_2017pahat(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 5, 21, 2), sim_api_version="v2.0"
-        ).get_event_matches("2017pahat")
+        )
+        .get_event_matches("2017pahat")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -276,9 +286,9 @@ def test_2017scmb_sequence(ndb_stub, taskqueue_stub) -> None:
         file_time = datetime.datetime.strptime(time_str, "%Y-%m-%d %H_%M_%S.%f")
         query_time = file_time + datetime.timedelta(seconds=30)
         MatchManipulator.createOrUpdate(
-            DatafeedFMSAPI(
-                sim_time=query_time, sim_api_version="v2.0"
-            ).get_event_matches("2017{}".format(event_code)),
+            DatafeedFMSAPI(sim_time=query_time, sim_api_version="v2.0")
+            .get_event_matches("2017{}".format(event_code))
+            .get_result(),
             run_post_update_hook=False,
         )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
@@ -353,7 +363,9 @@ def test_2017scmb(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 4, 19, 17), sim_api_version="v2.0"
-        ).get_event_matches("2017scmb")
+        )
+        .get_event_matches("2017scmb")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -378,7 +390,9 @@ def test_2017scmb(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 4, 19, 50), sim_api_version="v2.0"
-        ).get_event_matches("2017scmb")
+        )
+        .get_event_matches("2017scmb")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -413,7 +427,9 @@ def test_2017scmb(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 4, 20, 12), sim_api_version="v2.0"
-        ).get_event_matches("2017scmb")
+        )
+        .get_event_matches("2017scmb")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -458,7 +474,9 @@ def test_2017scmb(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 4, 20, 48), sim_api_version="v2.0"
-        ).get_event_matches("2017scmb")
+        )
+        .get_event_matches("2017scmb")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -522,7 +540,9 @@ def test_2017ncwin(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 5, 21, 2), sim_api_version="v2.0"
-        ).get_event_matches("2017ncwin")
+        )
+        .get_event_matches("2017ncwin")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -547,7 +567,9 @@ def test_2017ncwin(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 5, 21, 30), sim_api_version="v2.0"
-        ).get_event_matches("2017ncwin")
+        )
+        .get_event_matches("2017ncwin")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -582,7 +604,9 @@ def test_2017ncwin(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 5, 21, 35), sim_api_version="v2.0"
-        ).get_event_matches("2017ncwin")
+        )
+        .get_event_matches("2017ncwin")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -627,7 +651,9 @@ def test_2017ncwin(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2017, 3, 5, 21, 51), sim_api_version="v2.0"
-        ).get_event_matches("2017ncwin")
+        )
+        .get_event_matches("2017ncwin")
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -693,7 +719,9 @@ def test_2023ncash_double_elim(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2023, 3, 5, 20, 58), sim_api_version="v3.0"
-        ).get_event_matches(event.key_name)
+        )
+        .get_event_matches(event.key_name)
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)
@@ -712,7 +740,9 @@ def test_2023ncash_double_elim(ndb_stub, taskqueue_stub) -> None:
     MatchManipulator.createOrUpdate(
         DatafeedFMSAPI(
             sim_time=datetime.datetime(2023, 3, 5, 21, 19), sim_api_version="v3.0"
-        ).get_event_matches(event.key_name)
+        )
+        .get_event_matches(event.key_name)
+        .get_result()
     )
     _, keys_to_delete = MatchHelper.delete_invalid_matches(event.matches, event)
     MatchManipulator.delete_keys(keys_to_delete)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_awards_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_awards_test.py
@@ -47,7 +47,7 @@ def test_get_awards_event(first_code, event_short):
     ) as mock_init, patch.object(
         FMSAPIAwardsParser, "parse"
     ) as mock_parse:
-        df.get_awards(event)
+        df.get_awards(event).get_result()
 
     mock_awards.assert_called_once_with(2020, event_code="miket")
     mock_init.assert_called_once_with(event)
@@ -77,7 +77,7 @@ def test_get_awards_event_cmp(first_code, event_short):
     ) as mock_init, patch.object(
         FMSAPIAwardsParser, "parse"
     ) as mock_parse:
-        df.get_awards(event)
+        df.get_awards(event).get_result()
 
     mock_awards.assert_called_once_with(2014, event_code="galileo")
     mock_init.assert_called_once_with(event)
@@ -117,7 +117,7 @@ def test_get_awards_event_cmp_2015(teams):
     ) as mock_init, patch.object(
         FMSAPIAwardsParser, "parse"
     ) as mock_parse:
-        df.get_awards(event)
+        df.get_awards(event).get_result()
 
     mock_awards.assert_has_calls(
         [call(2015, event_code="gaca"), call(2015, event_code="galileo")]
@@ -159,7 +159,7 @@ def test_get_awards_event_cmp_2017(teams):
     ) as mock_init, patch.object(
         FMSAPIAwardsParser, "parse"
     ) as mock_parse:
-        df.get_awards(event)
+        df.get_awards(event).get_result()
 
     mock_awards.assert_has_calls(
         [call(2017, event_code="garo"), call(2017, event_code="galileo")]

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_distrct_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_distrct_test.py
@@ -38,7 +38,7 @@ def test_get_district_list() -> None:
     ) as mock_init, patch.object(
         FMSAPIDistrictListParser, "parse"
     ) as mock_parse:
-        df.get_district_list(2020)
+        df.get_district_list(2020).get_result()
 
     mock_api.assert_called_once_with(2020)
     mock_init.assert_called_once_with(2020)
@@ -61,7 +61,7 @@ def test_get_district_rankings() -> None:
         FMSAPIDistrictRankingsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = ({}, False)
-        df.get_district_rankings("2020ne")
+        df.get_district_rankings("2020ne").get_result()
 
     mock_api.assert_called_once_with(2020, "ne", 1)
     mock_init.assert_called_once_with()
@@ -84,7 +84,7 @@ def test_get_district_rankings_paginated() -> None:
         FMSAPIDistrictRankingsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [({}, True), ({}, False)]
-        df.get_district_rankings("2020ne")
+        df.get_district_rankings("2020ne").get_result()
 
     mock_api.assert_has_calls([call(2020, "ne", 1), call(2020, "ne", 2)])
     mock_init.assert_called_once_with()

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_alliances_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_alliances_test.py
@@ -36,7 +36,7 @@ def test_get_event_alliances() -> None:
         FMSAPIEventAlliancesParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_event_alliances("2020miket")
+        df.get_event_alliances("2020miket").get_result()
 
     mock_api.assert_called_once_with(2020, "miket")
     mock_init.assert_called_once_with()
@@ -59,7 +59,7 @@ def test_get_event_alliances_cmp() -> None:
         FMSAPIEventAlliancesParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_event_alliances("2014gal")
+        df.get_event_alliances("2014gal").get_result()
 
     mock_api.assert_called_once_with(2014, "galileo")
     mock_init.assert_called_once_with()

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
@@ -44,7 +44,7 @@ def test_get_event_matches() -> None:
         mock_schedule_parse.side_effect = ([], [])
         mock_json_parse.return_value = {"Schedule": [], "Matches": []}
         mock_match_detail_parser.return_value = {}
-        df.get_event_matches("2020miket")
+        df.get_event_matches("2020miket").get_result()
 
     mock_schedule_api.assert_has_calls(
         [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
@@ -80,7 +80,7 @@ def test_get_event_matches_cmp() -> None:
         mock_schedule_parse.side_effect = ([], [])
         mock_json_parse.return_value = {"Schedule": [], "Matches": []}
         mock_match_detail_parser.return_value = {}
-        df.get_event_matches("2014gal")
+        df.get_event_matches("2014gal").get_result()
 
     mock_schedule_api.assert_has_calls(
         [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_rankings_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_rankings_test.py
@@ -36,7 +36,7 @@ def test_get_event_rankings() -> None:
         FMSAPIEventRankingsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_event_rankings("2020miket")
+        df.get_event_rankings("2020miket").get_result()
 
     mock_api.assert_called_once_with(2020, "miket")
     mock_init.assert_called_once_with(2020)
@@ -59,7 +59,7 @@ def test_get_event_rankings_cmp() -> None:
         FMSAPIEventRankingsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_event_rankings("2014gal")
+        df.get_event_rankings("2014gal").get_result()
 
     mock_api.assert_called_once_with(2014, "galileo")
     mock_init.assert_called_once_with(2014)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_team_avatars_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_team_avatars_test.py
@@ -36,7 +36,7 @@ def test_get_event_teams() -> None:
         FMSAPITeamAvatarParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [(([], []), False)]
-        df.get_event_team_avatars("2020miket")
+        df.get_event_team_avatars("2020miket").get_result()
 
     mock_api.assert_called_once_with(2020, "miket", 1)
     mock_init.assert_called_once_with(2020)
@@ -59,7 +59,7 @@ def test_get_event_teams_paginated() -> None:
         FMSAPITeamAvatarParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [(([], []), True), (([], []), False)]
-        df.get_event_team_avatars("2020miket")
+        df.get_event_team_avatars("2020miket").get_result()
 
     mock_api.assert_has_calls([call(2020, "miket", 1), call(2020, "miket", 2)])
     mock_init.assert_called_once_with(2020)
@@ -82,7 +82,7 @@ def test_get_event_teams_cmp() -> None:
         FMSAPITeamAvatarParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [(([], []), False)]
-        df.get_event_team_avatars("2014gal")
+        df.get_event_team_avatars("2014gal").get_result()
 
     mock_api.assert_called_once_with(2014, "galileo", 1)
     mock_init.assert_called_once_with(2014)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_teams_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_teams_test.py
@@ -36,7 +36,7 @@ def test_get_event_teams() -> None:
         FMSAPITeamDetailsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_event_teams("2020miket")
+        df.get_event_teams("2020miket").get_result()
 
     mock_api.assert_called_once_with(2020, "miket", 1)
     mock_init.assert_called_once_with(2020)
@@ -59,7 +59,7 @@ def test_get_event_teams_paginated() -> None:
         FMSAPITeamDetailsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], True), ([], False)]
-        df.get_event_teams("2020miket")
+        df.get_event_teams("2020miket").get_result()
 
     mock_api.assert_has_calls([call(2020, "miket", 1), call(2020, "miket", 2)])
     mock_init.assert_called_once_with(2020)
@@ -82,7 +82,7 @@ def test_get_event_teams_cmp() -> None:
         FMSAPITeamDetailsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_event_teams("2014gal")
+        df.get_event_teams("2014gal").get_result()
 
     mock_api.assert_called_once_with(2014, "galileo", 1)
     mock_init.assert_called_once_with(2014)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_test.py
@@ -35,7 +35,7 @@ def test_get_event_list() -> None:
     ) as mock_init, patch.object(
         FMSAPIEventListParser, "parse"
     ) as mock_parse:
-        df.get_event_list(2020)
+        df.get_event_list(2020).get_result()
 
     mock_api.assert_called_once_with(2020)
     mock_init.assert_called_once_with(2020)
@@ -57,7 +57,7 @@ def test_get_event_details() -> None:
     ) as mock_init, patch.object(
         FMSAPIEventListParser, "parse"
     ) as mock_parse:
-        df.get_event_details("2020miket")
+        df.get_event_details("2020miket").get_result()
 
     mock_api.assert_called_once_with(2020, "miket")
     mock_init.assert_called_once_with(2020, short="miket")
@@ -79,7 +79,7 @@ def test_get_event_details_cmp() -> None:
     ) as mock_init, patch.object(
         FMSAPIEventListParser, "parse"
     ) as mock_parse:
-        df.get_event_details("2014gal")
+        df.get_event_details("2014gal").get_result()
 
     mock_api.assert_called_once_with(2014, "galileo")
     mock_init.assert_called_once_with(2014, short="gal")

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_teams_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_teams_test.py
@@ -39,7 +39,7 @@ def test_get_team_details() -> None:
         FMSAPITeamDetailsParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [([], False)]
-        df.get_team_details(2020, "frc254")
+        df.get_team_details(2020, "frc254").get_result()
 
     mock_api.assert_called_once_with(2020, 254)
     mock_init.assert_called_once_with(2020)
@@ -62,7 +62,7 @@ def test_get_team_avatar() -> None:
         FMSAPITeamAvatarParser, "parse"
     ) as mock_parse:
         mock_parse.side_effect = [(([], []), False)]
-        df.get_team_avatar(2020, "frc254")
+        df.get_team_avatar(2020, "frc254").get_result()
 
     mock_api.assert_called_once_with(2020, 254)
     mock_init.assert_called_once_with(2020)
@@ -82,7 +82,7 @@ def test_get_team_avatar_parser_failed() -> None:
     ) as mock_api, patch.object(
         FMSAPITeamAvatarParser, "__init__", return_value=None
     ) as mock_init:
-        assert df.get_team_avatar(2020, "frc254") == ([], set())
+        assert df.get_team_avatar(2020, "frc254").get_result() == ([], set())
 
     mock_api.assert_called_once_with(2020, 254)
     mock_init.assert_called_once_with(2020)

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_test.py
@@ -97,7 +97,7 @@ def test_get_root(fms_api_secrets):
     with patch.object(
         FRCAPI, "root", return_value=InstantFuture(response)
     ) as mock_root:
-        df.get_root_info() is None
+        df.get_root_info().get_result() is None
 
     mock_root.assert_called_once_with()
 
@@ -114,7 +114,7 @@ def test_get_root_failure(fms_api_secrets):
     with patch.object(
         FRCAPI, "root", return_value=InstantFuture(response)
     ) as mock_root:
-        assert df.get_root_info() is None
+        assert df.get_root_info().get_result() is None
 
     mock_root.assert_called_once_with()
 
@@ -134,11 +134,11 @@ def test_mark_api_down(fms_api_secrets):
 
     df = DatafeedFMSAPI(save_response=True)
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response1)):
-        assert df.get_root_info() is None
+        assert df.get_root_info().get_result() is None
         assert ApiStatusFMSApiDown.get() is True
 
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response2)):
-        assert df.get_root_info() == {}
+        assert df.get_root_info().get_result() == {}
         assert ApiStatusFMSApiDown.get() is False
 
 
@@ -159,7 +159,7 @@ def test_save_response(fms_api_secrets, monkeypatch: pytest.MonkeyPatch):
 
     df = DatafeedFMSAPI(save_response=True)
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
-        df.get_root_info()
+        df.get_root_info().get_result()
 
     client = InMemoryClient.get()
     files = client.get_files()
@@ -188,7 +188,7 @@ def test_save_response_unchanged(fms_api_secrets, monkeypatch: pytest.MonkeyPatc
 
     df = DatafeedFMSAPI(save_response=True)
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
-        df.get_root_info()
+        df.get_root_info().get_result()
 
     client = InMemoryClient.get()
     files = client.get_files()
@@ -196,7 +196,7 @@ def test_save_response_unchanged(fms_api_secrets, monkeypatch: pytest.MonkeyPatc
     f_name = files[0]
 
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
-        df.get_root_info()
+        df.get_root_info().get_result()
 
     # Since the content didn't change, we shouldn't have written another
     assert client.get_files() == [f_name]
@@ -220,7 +220,7 @@ def test_save_response_updated(fms_api_secrets, monkeypatch: pytest.MonkeyPatch)
 
     df = DatafeedFMSAPI(save_response=True)
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response)):
-        df.get_root_info()
+        df.get_root_info().get_result()
 
     client = InMemoryClient.get()
     files = client.get_files()
@@ -239,7 +239,7 @@ def test_save_response_updated(fms_api_secrets, monkeypatch: pytest.MonkeyPatch)
         json.dumps(content2),
     )
     with patch.object(FRCAPI, "root", return_value=InstantFuture(response2)):
-        df.get_root_info()
+        df.get_root_info().get_result()
 
     # Since the content is different, we should have two items
     files = client.get_files()

--- a/src/backend/tasks_io/handlers/tests/district_rankings_calc_test.py
+++ b/src/backend/tasks_io/handlers/tests/district_rankings_calc_test.py
@@ -6,6 +6,7 @@ from google.appengine.ext import testbed
 from werkzeug.test import Client
 
 from backend.common.consts.event_type import EventType
+from backend.common.futures import InstantFuture
 from backend.common.helpers.district_helper import (
     DistrictHelper,
     DistrictRankingTeamTotal,
@@ -59,7 +60,7 @@ def test_enqueue_event(
     taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
     ndb_stub,
 ) -> None:
-    district_rankings_mock.return_value = {}
+    district_rankings_mock.return_value = InstantFuture({})
     District(
         id="2020test",
         year=2020,
@@ -87,7 +88,7 @@ def test_enqueue_default_year(
     ndb_stub,
 ) -> None:
     season_helper_mock.return_value = 2020
-    district_rankings_mock.return_value = {}
+    district_rankings_mock.return_value = InstantFuture({})
     District(
         id="2020test",
         year=2020,

--- a/src/backend/tasks_io/handlers/tests/frc_api_awards_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_awards_test.py
@@ -9,6 +9,7 @@ from werkzeug.test import Client
 
 from backend.common.consts.award_type import AwardType
 from backend.common.consts.event_type import EventType
+from backend.common.futures import InstantFuture
 from backend.common.models.award import Award
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
@@ -132,7 +133,7 @@ def test_get_event_not_found(tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_awards")
 def test_get_no_awards(api_mock: mock.Mock, tasks_client: Client) -> None:
     e = create_event(official=True)
-    api_mock.return_value = []
+    api_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get("/tasks/get/fmsapi_awards/2019casj")
     assert resp.status_code == 200
@@ -143,7 +144,7 @@ def test_get_no_awards(api_mock: mock.Mock, tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_awards")
 def test_get_no_output_in_taskqueue(api_mock: mock.Mock, tasks_client: Client) -> None:
     e = create_event(official=True)
-    api_mock.return_value = []
+    api_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get(
         "/tasks/get/fmsapi_awards/2019casj", headers={"X-Appengine-Taskname": "test"}
@@ -156,17 +157,19 @@ def test_get_no_output_in_taskqueue(api_mock: mock.Mock, tasks_client: Client) -
 @mock.patch.object(DatafeedFMSAPI, "get_awards")
 def test_get_awards_single(api_mock: mock.Mock, tasks_client: Client) -> None:
     e = create_event(official=True)
-    api_mock.return_value = [
-        Award(
-            id="2019casj_1",
-            year=2019,
-            award_type_enum=AwardType.WINNER,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            team_list=[ndb.Key(Team, "frc254")],
-        )
-    ]
+    api_mock.return_value = InstantFuture(
+        [
+            Award(
+                id="2019casj_1",
+                year=2019,
+                award_type_enum=AwardType.WINNER,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                team_list=[ndb.Key(Team, "frc254")],
+            )
+        ]
+    )
 
     resp = tasks_client.get("/tasks/get/fmsapi_awards/2019casj")
     assert resp.status_code == 200
@@ -191,26 +194,28 @@ def test_get_awards_single(api_mock: mock.Mock, tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_awards")
 def test_get_awards_multiple(api_mock: mock.Mock, tasks_client: Client) -> None:
     e = create_event(official=True)
-    api_mock.return_value = [
-        Award(
-            id="2019casj_1",
-            year=2019,
-            award_type_enum=AwardType.WINNER,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            team_list=[ndb.Key(Team, "frc254")],
-        ),
-        Award(
-            id="2019casj_0",
-            year=2019,
-            award_type_enum=AwardType.CHAIRMANS,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            team_list=[ndb.Key(Team, "frc1337")],
-        ),
-    ]
+    api_mock.return_value = InstantFuture(
+        [
+            Award(
+                id="2019casj_1",
+                year=2019,
+                award_type_enum=AwardType.WINNER,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                team_list=[ndb.Key(Team, "frc254")],
+            ),
+            Award(
+                id="2019casj_0",
+                year=2019,
+                award_type_enum=AwardType.CHAIRMANS,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                team_list=[ndb.Key(Team, "frc1337")],
+            ),
+        ]
+    )
 
     resp = tasks_client.get("/tasks/get/fmsapi_awards/2019casj")
     assert resp.status_code == 200
@@ -232,26 +237,28 @@ def test_get_awards_multiple(api_mock: mock.Mock, tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_awards")
 def test_get_awards_team_dedup(api_mock: mock.Mock, tasks_client: Client) -> None:
     e = create_event(official=True)
-    api_mock.return_value = [
-        Award(
-            id="2019casj_1",
-            year=2019,
-            award_type_enum=AwardType.WINNER,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            team_list=[ndb.Key(Team, "frc254")],
-        ),
-        Award(
-            id="2019casj_0",
-            year=2019,
-            award_type_enum=AwardType.CHAIRMANS,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            team_list=[ndb.Key(Team, "frc254")],
-        ),
-    ]
+    api_mock.return_value = InstantFuture(
+        [
+            Award(
+                id="2019casj_1",
+                year=2019,
+                award_type_enum=AwardType.WINNER,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                team_list=[ndb.Key(Team, "frc254")],
+            ),
+            Award(
+                id="2019casj_0",
+                year=2019,
+                award_type_enum=AwardType.CHAIRMANS,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                team_list=[ndb.Key(Team, "frc254")],
+            ),
+        ]
+    )
 
     resp = tasks_client.get("/tasks/get/fmsapi_awards/2019casj")
     assert resp.status_code == 200
@@ -272,36 +279,38 @@ def test_get_awards_team_dedup(api_mock: mock.Mock, tasks_client: Client) -> Non
 @mock.patch.object(DatafeedFMSAPI, "get_awards")
 def test_get_awards_remapteams(api_mock: mock.Mock, tasks_client: Client) -> None:
     e = create_event(official=True, remap_teams={"frc9000": "frc254B"})
-    api_mock.return_value = [
-        Award(
-            id="2019casj_1",
-            year=2019,
-            award_type_enum=AwardType.WINNER,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            recipient_json_list=[
-                json.dumps(
-                    {"name_str": "", "team_number": "254"},
-                )
-            ],
-            team_list=[ndb.Key(Team, "frc254")],
-        ),
-        Award(
-            id="2019casj_0",
-            year=2019,
-            award_type_enum=AwardType.CHAIRMANS,
-            event_type_enum=EventType.REGIONAL,
-            event=ndb.Key(Event, "2019casj"),
-            name_str="Winner",
-            recipient_json_list=[
-                json.dumps(
-                    {"name_str": "", "team_number": "9000"},
-                )
-            ],
-            team_list=[ndb.Key(Team, "frc9000")],
-        ),
-    ]
+    api_mock.return_value = InstantFuture(
+        [
+            Award(
+                id="2019casj_1",
+                year=2019,
+                award_type_enum=AwardType.WINNER,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                recipient_json_list=[
+                    json.dumps(
+                        {"name_str": "", "team_number": "254"},
+                    )
+                ],
+                team_list=[ndb.Key(Team, "frc254")],
+            ),
+            Award(
+                id="2019casj_0",
+                year=2019,
+                award_type_enum=AwardType.CHAIRMANS,
+                event_type_enum=EventType.REGIONAL,
+                event=ndb.Key(Event, "2019casj"),
+                name_str="Winner",
+                recipient_json_list=[
+                    json.dumps(
+                        {"name_str": "", "team_number": "9000"},
+                    )
+                ],
+                team_list=[ndb.Key(Team, "frc9000")],
+            ),
+        ]
+    )
 
     resp = tasks_client.get("/tasks/get/fmsapi_awards/2019casj")
     assert resp.status_code == 200

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_alliances_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_alliances_test.py
@@ -7,6 +7,7 @@ from google.appengine.ext import testbed
 from werkzeug.test import Client
 
 from backend.common.consts.event_type import EventType
+from backend.common.futures import InstantFuture
 from backend.common.models.alliance import EventAlliance
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
@@ -148,7 +149,7 @@ def test_get_no_event(tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_event_alliances")
 def test_get_no_alliances(fmsapi_event_alliances_mock, tasks_client: Client) -> None:
     create_event(official=True)
-    fmsapi_event_alliances_mock.return_value = []
+    fmsapi_event_alliances_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get("/tasks/get/fmsapi_event_alliances/2020nyny")
     assert resp.status_code == 200
@@ -160,7 +161,7 @@ def test_get_no_events_no_output_in_taskqueue(
     fmsapi_event_alliances_mock, tasks_client: Client
 ) -> None:
     create_event(official=True)
-    fmsapi_event_alliances_mock.return_value = []
+    fmsapi_event_alliances_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get(
         "/tasks/get/fmsapi_event_alliances/2020nyny",
@@ -177,7 +178,7 @@ def test_get(
 ) -> None:
     create_event(official=True)
     alliances = [EventAlliance(picks=["frc254"])]
-    fmsapi_event_alliances_mock.return_value = alliances
+    fmsapi_event_alliances_mock.return_value = InstantFuture(alliances)
 
     resp = tasks_client.get("/tasks/get/fmsapi_event_alliances/2020nyny")
     assert resp.status_code == 200
@@ -196,7 +197,7 @@ def test_get_remapteams(
 ) -> None:
     create_event(official=True, remap_teams={"frc254": "frc9000"})
     alliances = [EventAlliance(picks=["frc254"])]
-    fmsapi_event_alliances_mock.return_value = alliances
+    fmsapi_event_alliances_mock.return_value = InstantFuture(alliances)
 
     resp = tasks_client.get("/tasks/get/fmsapi_event_alliances/2020nyny")
     assert resp.status_code == 200

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_district_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_district_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from werkzeug.test import Client
 
+from backend.common.futures import InstantFuture
 from backend.common.models.district import District
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
@@ -13,7 +14,9 @@ def test_district_list_bad_year(tasks_client: Client) -> None:
 
 @mock.patch.object(DatafeedFMSAPI, "get_district_list")
 def test_district_list_get_year(api_mock, tasks_client: Client) -> None:
-    api_mock.return_value = [District(id="2020ne", year=2020, abbreviation="ne")]
+    api_mock.return_value = InstantFuture(
+        [District(id="2020ne", year=2020, abbreviation="ne")]
+    )
 
     resp = tasks_client.get("/backend-tasks/get/district_list/2020")
     assert resp.status_code == 200
@@ -27,7 +30,9 @@ def test_district_list_get_year(api_mock, tasks_client: Client) -> None:
 def test_district_list_get_year_no_output_in_taskqueue(
     api_mock, tasks_client: Client
 ) -> None:
-    api_mock.return_value = [District(id="2020ne", year=2020, abbreviation="ne")]
+    api_mock.return_value = InstantFuture(
+        [District(id="2020ne", year=2020, abbreviation="ne")]
+    )
 
     resp = tasks_client.get(
         "/backend-tasks/get/district_list/2020",
@@ -54,7 +59,7 @@ def test_district_rankings_no_district(tasks_client: Client) -> None:
 def test_district_rankings(api_mock, tasks_client: Client) -> None:
     District(id="2020ne", year=2020, abbreviation="ne").put()
     advancement = {"frc254": {"dcmp": True, "cmp": True}}
-    api_mock.return_value = advancement
+    api_mock.return_value = InstantFuture(advancement)
 
     resp = tasks_client.get(
         "/backend-tasks/get/district_rankings/2020ne",
@@ -74,7 +79,7 @@ def test_district_rankings_no_output_in_taskqueue(
 ) -> None:
     District(id="2020ne", year=2020, abbreviation="ne").put()
     advancement = {"frc254": {"dcmp": True, "cmp": True}}
-    api_mock.return_value = advancement
+    api_mock.return_value = InstantFuture(advancement)
 
     resp = tasks_client.get(
         "/backend-tasks/get/district_rankings/2020ne",

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_list_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_list_test.py
@@ -5,6 +5,7 @@ from google.appengine.ext import testbed
 from werkzeug.test import Client
 
 from backend.common.consts.event_type import EventType
+from backend.common.futures import InstantFuture
 from backend.common.models.district import District
 from backend.common.models.event import Event
 from backend.common.sitevars.apistatus import ApiStatus
@@ -85,8 +86,8 @@ def test_get_bad_year(tasks_client: Client) -> None:
 def test_get_no_events(
     event_list_mock, district_list_mock, tasks_client: Client
 ) -> None:
-    event_list_mock.return_value = ([], [])
-    district_list_mock.return_value = []
+    event_list_mock.return_value = InstantFuture(([], []))
+    district_list_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get("/backend-tasks/get/event_list/2020")
     assert resp.status_code == 200
@@ -98,8 +99,8 @@ def test_get_no_events(
 def test_get_no_events_no_output_in_taskqueue(
     event_list_mock, district_list_mock, tasks_client: Client
 ) -> None:
-    event_list_mock.return_value = ([], [])
-    district_list_mock.return_value = []
+    event_list_mock.return_value = InstantFuture(([], []))
+    district_list_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get(
         "/backend-tasks/get/event_list/2020",
@@ -134,8 +135,8 @@ def test_get(
             abbreviation="fim",
         )
     ]
-    event_list_mock.return_value = (events, districts)
-    district_list_mock.return_value = districts
+    event_list_mock.return_value = InstantFuture((events, districts))
+    district_list_mock.return_value = InstantFuture(districts)
 
     resp = tasks_client.get("/backend-tasks/get/event_list/2019")
     assert resp.status_code == 200
@@ -185,8 +186,8 @@ def test_get_match_offseasons(
             abbreviation="fim",
         )
     ]
-    event_list_mock.return_value = (events, districts)
-    district_list_mock.return_value = districts
+    event_list_mock.return_value = InstantFuture((events, districts))
+    district_list_mock.return_value = InstantFuture(districts)
 
     resp = tasks_client.get("/backend-tasks/get/event_list/2019")
     assert resp.status_code == 200

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
@@ -10,6 +10,7 @@ from werkzeug.test import Client
 
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.event_type import EventType
+from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
 from backend.common.models.match import Match
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
@@ -116,7 +117,7 @@ def test_get_no_event(tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_event_matches")
 def test_get_no_matches(fmsapi_matches_mock, tasks_client: Client) -> None:
     create_event(official=True)
-    fmsapi_matches_mock.return_value = []
+    fmsapi_matches_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get("/tasks/get/fmsapi_matches/2020nyny")
     assert resp.status_code == 200
@@ -128,7 +129,7 @@ def test_get_no_matches_no_output_in_taskqueue(
     fmsapi_matches_mock, tasks_client: Client
 ) -> None:
     create_event(official=True)
-    fmsapi_matches_mock.return_value = []
+    fmsapi_matches_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get(
         "/tasks/get/fmsapi_matches/2020nyny",
@@ -156,7 +157,7 @@ def test_get(
         )
     ]
 
-    fmsapi_matches_mock.return_value = matches
+    fmsapi_matches_mock.return_value = InstantFuture(matches)
 
     resp = tasks_client.get("/tasks/get/fmsapi_matches/2020nyny")
     assert resp.status_code == 200
@@ -192,7 +193,7 @@ def test_get_remap_teams(
         )
     ]
 
-    fmsapi_matches_mock.return_value = matches
+    fmsapi_matches_mock.return_value = InstantFuture(matches)
 
     resp = tasks_client.get("/tasks/get/fmsapi_matches/2020nyny")
     assert resp.status_code == 200
@@ -232,7 +233,7 @@ def test_delete_invalid(
         ),
     ]
 
-    fmsapi_matches_mock.return_value = matches
+    fmsapi_matches_mock.return_value = InstantFuture(matches)
 
     # Add existing matches
     [m.put() for m in matches]
@@ -285,7 +286,7 @@ def test_no_delete_invalid(
         ),
     ]
 
-    fmsapi_matches_mock.return_value = matches
+    fmsapi_matches_mock.return_value = InstantFuture(matches)
 
     # Add existing matches
     [m.put() for m in matches]

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_rankings_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_rankings_test.py
@@ -7,6 +7,7 @@ from google.appengine.ext import testbed
 from werkzeug.test import Client
 
 from backend.common.consts.event_type import EventType
+from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_ranking import EventRanking
@@ -113,7 +114,7 @@ def test_get_no_event(tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_event_rankings")
 def test_get_no_rankings(fmsapi_event_rankings_mock, tasks_client: Client) -> None:
     create_event(official=True)
-    fmsapi_event_rankings_mock.return_value = []
+    fmsapi_event_rankings_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get("/tasks/get/fmsapi_event_rankings/2020nyny")
     assert resp.status_code == 200
@@ -125,7 +126,7 @@ def test_get_no_events_no_output_in_taskqueue(
     fmsapi_event_rankings_mock, tasks_client: Client
 ) -> None:
     create_event(official=True)
-    fmsapi_event_rankings_mock.return_value = []
+    fmsapi_event_rankings_mock.return_value = InstantFuture([])
 
     resp = tasks_client.get(
         "/tasks/get/fmsapi_event_rankings/2020nyny",
@@ -152,7 +153,7 @@ def test_get(
             sort_orders=[],
         )
     ]
-    fmsapi_event_rankings_mock.return_value = rankings
+    fmsapi_event_rankings_mock.return_value = InstantFuture(rankings)
 
     resp = tasks_client.get("/tasks/get/fmsapi_event_rankings/2020nyny")
     assert resp.status_code == 200
@@ -181,7 +182,7 @@ def test_get_remapteams(
             sort_orders=[],
         )
     ]
-    fmsapi_event_rankings_mock.return_value = rankings
+    fmsapi_event_rankings_mock.return_value = InstantFuture(rankings)
 
     resp = tasks_client.get("/tasks/get/fmsapi_event_rankings/2020nyny")
     assert resp.status_code == 200

--- a/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
@@ -6,6 +6,7 @@ from google.appengine.ext import ndb, testbed
 from werkzeug.test import Client
 
 from backend.common.consts.media_type import MediaType
+from backend.common.futures import InstantFuture
 from backend.common.models.district import District
 from backend.common.models.district_team import DistrictTeam
 from backend.common.models.event_team import EventTeam
@@ -21,7 +22,7 @@ def test_enqueue_rolling(
     tasks_client: Client,
     taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
 ) -> None:
-    team_details_mock.return_value = (None, None, None)
+    team_details_mock.return_value = InstantFuture((None, None, None))
 
     # Create 10 teams
     [
@@ -87,10 +88,12 @@ def test_fetch_team_details(api_mock, tasks_client: Client) -> None:
         team=ndb.Key("Team", "frc254"),
         year=2019,
     ).put()
-    api_mock.return_value = (
-        Team(id="frc254", team_number=254),
-        DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
-        Robot(id="frc254_2019", team=ndb.Key(Team, "frc254"), year=2019),
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc254", team_number=254),
+            DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
+            Robot(id="frc254_2019", team=ndb.Key(Team, "frc254"), year=2019),
+        )
     )
     resp = tasks_client.get("/backend-tasks/get/team_details/frc254")
     assert resp.status_code == 200
@@ -112,10 +115,12 @@ def test_fetch_team_details_no_output_in_taskqueue(
         team=ndb.Key("Team", "frc254"),
         year=2019,
     ).put()
-    api_mock.return_value = (
-        Team(id="frc254", team_number=254),
-        DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
-        Robot(id="frc254_2019", team=ndb.Key(Team, "frc254"), year=2019),
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc254", team_number=254),
+            DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
+            Robot(id="frc254_2019", team=ndb.Key(Team, "frc254"), year=2019),
+        )
     )
     resp = tasks_client.get(
         "/backend-tasks/get/team_details/frc254",
@@ -132,10 +137,12 @@ def test_fetch_team_details_no_output_in_taskqueue(
 
 @mock.patch.object(DatafeedFMSAPI, "get_team_details")
 def test_fetch_team_details_empty(api_mock, tasks_client: Client) -> None:
-    api_mock.return_value = (
-        None,
-        None,
-        None,
+    api_mock.return_value = InstantFuture(
+        (
+            None,
+            None,
+            None,
+        )
     )
     resp = tasks_client.get("/backend-tasks/get/team_details/frc254")
     assert resp.status_code == 200
@@ -151,10 +158,12 @@ def test_fetch_team_details_empty(api_mock, tasks_client: Client) -> None:
 @mock.patch.object(DatafeedFMSAPI, "get_team_details")
 def test_fetch_team_clears_districtteams(api_mock, tasks_client: Client) -> None:
     DistrictTeam(id="2019ne_frc254", team=ndb.Key(Team, "frc254"), year=2019).put()
-    api_mock.return_value = (
-        Team(id="frc254", team_number=254),
-        None,
-        None,
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc254", team_number=254),
+            None,
+            None,
+        )
     )
     resp = tasks_client.get("/backend-tasks/get/team_details/frc254")
     assert resp.status_code == 200
@@ -175,10 +184,12 @@ def test_fetch_team_fixes_district_teams(api_mock, tasks_client: Client) -> None
         team=ndb.Key("Team", "frc254"),
         year=2019,
     ).put()
-    api_mock.return_value = (
-        Team(id="frc254", team_number=254),
-        DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
-        None,
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc254", team_number=254),
+            DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
+            None,
+        )
     )
     resp = tasks_client.get("/backend-tasks/get/team_details/frc254")
     assert resp.status_code == 200
@@ -207,10 +218,12 @@ def test_fetch_team_removes_bad_district_teams(api_mock, tasks_client: Client) -
         team=ndb.Key("Team", "frc254"),
         year=2019,
     ).put()
-    api_mock.return_value = (
-        Team(id="frc254", team_number=254),
-        DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
-        None,
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc254", team_number=254),
+            DistrictTeam(id="2019fim_frc254", team=ndb.Key(Team, "frc254"), year=2019),
+            None,
+        )
     )
     resp = tasks_client.get("/backend-tasks/get/team_details/frc254")
     assert resp.status_code == 200
@@ -231,9 +244,15 @@ def test_fetch_team_avatar_bad_key(tasks_client: Client) -> None:
 
 @mock.patch.object(DatafeedFMSAPI, "get_team_avatar")
 def test_fetch_team_avatar(api_mock, tasks_client: Client) -> None:
-    api_mock.return_value = (
-        [Media(id="avatar_media", foreign_key="", media_type_enum=MediaType.AVATAR)],
-        [],
+    api_mock.return_value = InstantFuture(
+        (
+            [
+                Media(
+                    id="avatar_media", foreign_key="", media_type_enum=MediaType.AVATAR
+                )
+            ],
+            [],
+        )
     )
     resp = tasks_client.get("/backend-tasks/get/team_avatar/frc254")
     assert resp.status_code == 200
@@ -247,9 +266,15 @@ def test_fetch_team_avatar(api_mock, tasks_client: Client) -> None:
 def test_fetch_team_avatar_no_output_in_taskqueue(
     api_mock, tasks_client: Client
 ) -> None:
-    api_mock.return_value = (
-        [Media(id="avatar_media", foreign_key="", media_type_enum=MediaType.AVATAR)],
-        [],
+    api_mock.return_value = InstantFuture(
+        (
+            [
+                Media(
+                    id="avatar_media", foreign_key="", media_type_enum=MediaType.AVATAR
+                )
+            ],
+            [],
+        )
     )
     resp = tasks_client.get(
         "/backend-tasks/get/team_avatar/frc254",


### PR DESCRIPTION
This pushes the async-ification up one layer from 18fd3d6530aea860164f923212ee9b44367f9ac3, where we can now await requests in parallel for those endpoints which end up making multiple API calls