### PR TITLE
Add cronjob to expire old API keys

### DIFF
--- a/src/backend/tasks_io/handlers/tasks.py
+++ b/src/backend/tasks_io/handlers/tasks.py
@@ -1,7 +1,13 @@
-from flask import abort, Blueprint, make_response, redirect
+import datetime
+from typing import cast, List
+
+from flask import abort, Blueprint, make_response, redirect, request
+from google.appengine.ext import ndb
 from markupsafe import Markup
+from pyre_extensions import none_throws
 from werkzeug.wrappers import Response
 
+from backend.common.consts.auth_type import WRITE_TYPE_NAMES
 from backend.common.helpers.event_remapteams_helper import EventRemapTeamsHelper
 from backend.common.manipulators.award_manipulator import AwardManipulator
 from backend.common.manipulators.event_details_manipulator import (
@@ -9,6 +15,7 @@ from backend.common.manipulators.event_details_manipulator import (
 )
 from backend.common.manipulators.match_manipulator import MatchManipulator
 from backend.common.manipulators.team_manipulator import TeamManipulator
+from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, TeamKey
 from backend.common.models.team import Team
@@ -64,4 +71,38 @@ def remap_teams(event_key: EventKey) -> str:
     # Remap awards
     EventRemapTeamsHelper.remapteams_awards(event.awards, event.remap_teams)
     AwardManipulator.createOrUpdate(event.awards, auto_union=False)
+    return ""
+
+
+@blueprint.route("/tasks/do/archive_api_keys")
+def archive_api_keys() -> str:
+    keys: List[ApiAuthAccess] = ApiAuthAccess.query(
+        ndb.AND(
+            cast(ndb.IntegerProperty, ApiAuthAccess.auth_types_enum).IN(
+                list(WRITE_TYPE_NAMES.keys())
+            ),
+            ApiAuthAccess.expiration == None,  # noqa: E711
+        )
+    ).fetch()
+
+    current_year = datetime.datetime.now().year
+    new_expiration = datetime.datetime(month=1, day=1, year=current_year)
+    to_update = []
+
+    for key in keys:
+        event_years = (
+            int(none_throws(event_key.string_id())[:4]) for event_key in key.event_list
+        )
+        if all(event_year < current_year for event_year in event_years):
+            key.expiration = new_expiration
+            to_update.append(key)
+
+    if to_update:
+        ndb.put_multi(to_update)
+
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return f"Updated: {','.join([t.key.id() for t in to_update])}"
+
     return ""

--- a/src/backend/tasks_io/handlers/tests/tasks_test.py
+++ b/src/backend/tasks_io/handlers/tests/tasks_test.py
@@ -1,9 +1,15 @@
+import datetime
 import urllib.parse
 from unittest.mock import patch
 
+from freezegun import freeze_time
+from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 from werkzeug.test import Client
 
+from backend.common.consts.auth_type import AuthType
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.event import Event
 from backend.common.models.team import Team
 from backend.common.sitevars.website_blacklist import WebsiteBlacklist
 
@@ -40,3 +46,68 @@ def test_blacklist_website_team(tasks_client: Client):
     assert redirect_url.path == "/backend-tasks/get/team_details/frc7332"
 
     assert not none_throws(Team.get_by_id("frc7332")).website
+
+
+@freeze_time("2025-01-01")
+def test_archive_api_keys(tasks_client: Client) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.MATCH_VIDEO],
+        event_list=[ndb.Key(Event, "2024test")],
+    ).put()
+
+    resp = tasks_client.get("/tasks/do/archive_api_keys")
+    assert resp.status_code == 200
+
+    key = ApiAuthAccess.get_by_id("test_auth_key")
+    assert key is not None
+    assert key.expiration == datetime.datetime(year=2025, month=1, day=1)
+
+
+@freeze_time("2025-01-01")
+def test_archive_api_keys_ignores_read_keys(tasks_client: Client) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    resp = tasks_client.get("/tasks/do/archive_api_keys")
+    assert resp.status_code == 200
+
+    key = ApiAuthAccess.get_by_id("test_auth_key")
+    assert key is not None
+    assert key.expiration is None
+
+
+@freeze_time("2025-01-01")
+def test_archive_api_keys_ignores_current_year_events(tasks_client: Client) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.MATCH_VIDEO],
+        event_list=[ndb.Key(Event, "2025test")],
+    ).put()
+
+    resp = tasks_client.get("/tasks/do/archive_api_keys")
+    assert resp.status_code == 200
+
+    key = ApiAuthAccess.get_by_id("test_auth_key")
+    assert key is not None
+    assert key.expiration is None
+
+
+@freeze_time("2025-01-01")
+def test_archive_api_keys_ignores_existing_expiration(tasks_client: Client) -> None:
+    initial_expiration = datetime.datetime(year=2024, month=7, day=1)
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.MATCH_VIDEO],
+        event_list=[ndb.Key(Event, "2024test")],
+        expiration=initial_expiration,
+    ).put()
+
+    resp = tasks_client.get("/tasks/do/archive_api_keys")
+    assert resp.status_code == 200
+
+    key = ApiAuthAccess.get_by_id("test_auth_key")
+    assert key is not None
+    assert key.expiration == initial_expiration

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -98,3 +98,7 @@ cron:
 - description: Update Team Search Indexes
   url: /tasks/enqueue/update_all_team_search_index
   schedule: every monday 04:00
+
+- descriptions: Archive Old API Keys
+  url: /tasks/do/archive_api_keys
+  schedule: 1 of jan 1:00


### PR DESCRIPTION
This will prevent old keys for piling up and polluting the admin view (and if they're for old events, we don't need them anyway)