### PR TITLE
run coverage workflow on python 3.12

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -114,11 +114,12 @@ jobs:
             python:
               - '**/*.py'
               - '**/requirements.txt'
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         if: steps.changes.outputs.python == 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
+          cache: "pip"
       - name: Install Dependencies
         if: steps.changes.outputs.python == 'true'
         run: |


### PR DESCRIPTION
This is blocking https://github.com/the-blue-alliance/the-blue-alliance/pull/6553, which requires at least 3.9 in the new release