### PR TITLE
Fix 500 when fetching team without avatar

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -128,10 +128,10 @@ class DatafeedFMSAPI:
         api_response = yield self.api.team_avatar(year, team_number)
         result = self._parse(api_response, FMSAPITeamAvatarParser(year))
         if result:
-            (avatars, keys_to_delete), _ = result
-            return (avatars, keys_to_delete)
-        else:
-            return [], set()
+            (avatar_result, _) = result
+            if avatar_result:
+                return avatar_result
+        return [], set()
 
     # Returns a tuple: (list(Event), list(District))
     @typed_tasklet


### PR DESCRIPTION
Not something we generally see, but we were error-ing when fetching a team via the `/backend-tasks/get/team_avatar/{team_key}` endpoint to get an avatar when the team did not have an avatar uploaded. This was just because our object was `None` and we couldn't unpack a `None` as a tuple