### PR TITLE
Enable remix.future.v3_singleFetch

### DIFF
--- a/pwa/vite.config.ts
+++ b/pwa/vite.config.ts
@@ -7,6 +7,12 @@ import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+declare module '@remix-run/node' {
+  // or cloudflare, deno, etc.
+  interface Future {
+    v3_singleFetch: true;
+  }
+}
 function getCommitHash(): string {
   try {
     return child.execSync('git rev-parse --short HEAD').toString();
@@ -25,6 +31,7 @@ export default defineConfig({
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
         v3_lazyRouteDiscovery: true,
+        v3_singleFetch: true,
       },
       presets: [RemixPWAPreset()],
     }),


### PR DESCRIPTION
https://remix.run/docs/en/2.13.1/start/future-flags#v3_singleFetch

Required for RR7 upgrade.

>With this flag, Remix uses a single fetch for data requests during client-side navigations. This simplifies data loading by treating data requests the same as document requests, eliminating the need to handle headers and caching differently. For advanced use cases, you can still opt into fine-grained revalidations