### PR TITLE
[pwa] add RP dots, team highlights to match table

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -374,7 +374,7 @@ export type MatchScoreBreakdown2016Alliance = {
   teleopDefensesBreached?: boolean;
   teleopChallengePoints?: number;
   teleopScalePoints?: number;
-  teleopTowerCaptured?: number;
+  teleopTowerCaptured?: boolean;
   towerFaceA?: string;
   towerFaceB?: string;
   towerFaceC?: string;

--- a/pwa/app/components/tba/matchResultsTable.tsx
+++ b/pwa/app/components/tba/matchResultsTable.tsx
@@ -9,6 +9,7 @@ import PlayCircle from '~icons/bi/play-circle';
 
 import { Event, Match, Team } from '~/api/v3';
 import { TeamLink } from '~/components/tba/links';
+import RpDots from '~/components/tba/rpDot';
 import {
   TooltipContent,
   TooltipProvider,
@@ -58,6 +59,7 @@ interface CellProps
     VariantProps<typeof cellVariants> {
   dq?: boolean;
   surrogate?: boolean;
+  teamHighlight?: boolean;
 }
 function GridCell({
   className,
@@ -66,6 +68,7 @@ function GridCell({
   teamOrScore,
   dq,
   surrogate,
+  teamHighlight,
   ...props
 }: CellProps) {
   return (
@@ -76,6 +79,7 @@ function GridCell({
         {
           'line-through': dq,
           'underline decoration-dotted': surrogate,
+          underline: teamHighlight,
         },
       )}
       {...props}
@@ -195,7 +199,11 @@ export default function MatchResultsTable(props: MatchResultsTableProps) {
 }
 
 // todo: add support for specific-team underlines
-function MatchResultsTableGroup({ matches, event }: MatchResultsTableProps) {
+function MatchResultsTableGroup({
+  matches,
+  event,
+  team,
+}: MatchResultsTableProps) {
   const gridStyle = cn(
     // always use these classes:
     'grid items-center justify-items-center',
@@ -283,6 +291,7 @@ function MatchResultsTableGroup({ matches, event }: MatchResultsTableProps) {
                   }
                   dq={dq}
                   surrogate={surrogate}
+                  teamHighlight={team?.key === k}
                 >
                   <ConditionalTooltip dq={dq} surrogate={surrogate}>
                     <TeamLink teamOrKey={k} year={event.year}>
@@ -312,6 +321,7 @@ function MatchResultsTableGroup({ matches, event }: MatchResultsTableProps) {
                   className={x}
                   dq={dq}
                   surrogate={surrogate}
+                  teamHighlight={team?.key === k}
                 >
                   <ConditionalTooltip dq={dq} surrogate={surrogate}>
                     <TeamLink teamOrKey={k} year={event.year}>
@@ -324,19 +334,39 @@ function MatchResultsTableGroup({ matches, event }: MatchResultsTableProps) {
 
             {/* scores */}
             <GridCell
-              className="col-start-6 row-start-1 lg:col-start-9"
+              className="relative col-start-6 row-start-1 lg:col-start-9"
               allianceColor={'red'}
               matchResult={m.winning_alliance === 'red' ? 'winner' : 'loser'}
               teamOrScore={'score'}
+              teamHighlight={
+                team !== undefined &&
+                m.alliances.red.team_keys.includes(team.key)
+              }
             >
+              {m.score_breakdown && (
+                <RpDots
+                  score_breakdown={m.score_breakdown.red}
+                  year={Number(m.key.substring(0, 4))}
+                />
+              )}
               {m.alliances.red.score}
             </GridCell>
             <GridCell
-              className="col-start-6 lg:col-start-10"
+              className="relative col-start-6 lg:col-start-10"
               allianceColor={'blue'}
               matchResult={m.winning_alliance === 'blue' ? 'winner' : 'loser'}
               teamOrScore={'score'}
+              teamHighlight={
+                team !== undefined &&
+                m.alliances.blue.team_keys.includes(team.key)
+              }
             >
+              {m.score_breakdown && (
+                <RpDots
+                  score_breakdown={m.score_breakdown.blue}
+                  year={Number(m.key.substring(0, 4))}
+                />
+              )}
               {m.alliances.blue.score}
             </GridCell>
           </div>

--- a/pwa/app/components/tba/rpDot.tsx
+++ b/pwa/app/components/tba/rpDot.tsx
@@ -1,0 +1,65 @@
+import { Match } from '~/api/v3';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '~/components/ui/tooltip';
+import {
+  RANKING_POINT_LABELS,
+  getBonusRankingPoints,
+} from '~/lib/rankingPoints';
+import { cn } from '~/lib/utils';
+
+function RpDot({
+  rpIndex,
+  tooltipText,
+}: {
+  rpIndex: number;
+  tooltipText: string;
+}) {
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <svg
+            className={cn('h-[4px] absolute top-[2px] left-[3px] w-[4px]', {
+              'ml-0': rpIndex === 0,
+              'ml-[6px]': rpIndex === 1,
+            })}
+          >
+            <circle cx={2} cy={2} r={2} />
+          </svg>
+        </TooltipTrigger>
+        <TooltipContent>
+          <span className="font-normal">{tooltipText}</span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default function RpDots({
+  score_breakdown,
+  year,
+}: {
+  score_breakdown: NonNullable<Match['score_breakdown']>['red'];
+  year: number;
+}) {
+  const rpsAchieved = getBonusRankingPoints(score_breakdown);
+  const tooltipTexts = RANKING_POINT_LABELS[year];
+
+  return (
+    <>
+      {rpsAchieved.map((rp, index) =>
+        rp ? (
+          <RpDot
+            key={index}
+            rpIndex={index}
+            tooltipText={tooltipTexts[index]}
+          />
+        ) : null,
+      )}
+    </>
+  );
+}

--- a/pwa/app/components/tba/teamEventAppearance.tsx
+++ b/pwa/app/components/tba/teamEventAppearance.tsx
@@ -69,7 +69,7 @@ export default function TeamEventAppearance({
         />
       </div>
       <div>
-        <MatchResultsTable matches={matches} event={event} />
+        <MatchResultsTable matches={matches} event={event} team={team} />
       </div>
     </div>
   );

--- a/pwa/app/lib/rankingPoints.test.ts
+++ b/pwa/app/lib/rankingPoints.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  type MatchScoreBreakdown,
+  getBonusRankingPoints,
+  isScoreBreakdown2016,
+  isScoreBreakdown2017,
+  isScoreBreakdown2018,
+  isScoreBreakdown2019,
+  isScoreBreakdown2020,
+  isScoreBreakdown2022,
+  isScoreBreakdown2023,
+  isScoreBreakdown2024,
+} from '~/lib/rankingPoints';
+
+describe('rankingPoints', () => {
+  test.each([
+    [{ teleopDefensesBreached: true }, true],
+    [{ teleopDefensesBreached: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2016 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2016(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ kPaRankingPointAchieved: true }, true],
+    [{ kPaRankingPointAchieved: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2017 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2017(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ autoQuestRankingPoint: true }, true],
+    [{ autoQuestRankingPoint: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2018 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2018(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ completeRocketRankingPoint: true }, true],
+    [{ completeRocketRankingPoint: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2019 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2019(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ shieldEnergizedRankingPoint: true }, true],
+    [{ shieldEnergizedRankingPoint: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2020 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2020(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ cargoBonusRankingPoint: true }, true],
+    [{ cargoBonusRankingPoint: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2022 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2022(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ sustainabilityBonusAchieved: true }, true],
+    [{ sustainabilityBonusAchieved: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2023 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2023(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ melodyBonusAchieved: true }, true],
+    [{ melodyBonusAchieved: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2024 (%#)',
+    (score_breakdown: MatchScoreBreakdown, expected) => {
+      expect(isScoreBreakdown2024(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ teleopDefensesBreached: true }, [true, false]],
+    [
+      { teleopDefensesBreached: false, teleopTowerCaptured: true },
+      [false, true],
+    ],
+    [{ teleopDefensesBreached: true, teleopTowerCaptured: true }, [true, true]],
+
+    // 2017
+    [{ kPaRankingPointAchieved: true }, [true, false]],
+    [
+      { kPaRankingPointAchieved: false, rotorRankingPointAchieved: true },
+      [false, true],
+    ],
+    [
+      { kPaRankingPointAchieved: true, rotorRankingPointAchieved: true },
+      [true, true],
+    ],
+
+    // 2018
+    [{ autoQuestRankingPoint: true }, [true, false]],
+    [
+      { autoQuestRankingPoint: false, faceTheBossRankingPoint: true },
+      [false, true],
+    ],
+    [
+      { autoQuestRankingPoint: true, faceTheBossRankingPoint: true },
+      [true, true],
+    ],
+
+    // 2019
+    [{ completeRocketRankingPoint: true }, [true, false]],
+    [
+      { completeRocketRankingPoint: false, habDockingRankingPoint: true },
+      [false, true],
+    ],
+    [
+      { completeRocketRankingPoint: true, habDockingRankingPoint: true },
+      [true, true],
+    ],
+
+    // 2020
+    [{ shieldEnergizedRankingPoint: true }, [true, false]],
+    [
+      {
+        shieldEnergizedRankingPoint: false,
+        shieldOperationalRankingPoint: true,
+      },
+      [false, true],
+    ],
+    [
+      {
+        shieldEnergizedRankingPoint: true,
+        shieldOperationalRankingPoint: true,
+      },
+      [true, true],
+    ],
+
+    // 2022
+    [{ cargoBonusRankingPoint: true }, [true, false]],
+    [
+      { cargoBonusRankingPoint: false, hangarBonusRankingPoint: true },
+      [false, true],
+    ],
+    [
+      { cargoBonusRankingPoint: true, hangarBonusRankingPoint: true },
+      [true, true],
+    ],
+
+    // 2023
+    [{ sustainabilityBonusAchieved: true }, [true, false]],
+    [
+      { sustainabilityBonusAchieved: false, activationBonusAchieved: true },
+      [false, true],
+    ],
+    [
+      { sustainabilityBonusAchieved: true, activationBonusAchieved: true },
+      [true, true],
+    ],
+
+    // 2024
+    [{ melodyBonusAchieved: true }, [true, false]],
+    [
+      { melodyBonusAchieved: false, ensembleBonusAchieved: true },
+      [false, true],
+    ],
+    [{ melodyBonusAchieved: true, ensembleBonusAchieved: true }, [true, true]],
+  ])(`getBonusRankingPoints (%#)`, (score_breakdown, expected) => {
+    expect(getBonusRankingPoints(score_breakdown)).toEqual(expected);
+  });
+});

--- a/pwa/app/lib/rankingPoints.ts
+++ b/pwa/app/lib/rankingPoints.ts
@@ -1,0 +1,158 @@
+import {
+  Match,
+  MatchScoreBreakdown2016Alliance,
+  MatchScoreBreakdown2017Alliance,
+  MatchScoreBreakdown2018Alliance,
+  MatchScoreBreakdown2019Alliance,
+  MatchScoreBreakdown2020Alliance,
+  MatchScoreBreakdown2022Alliance,
+  MatchScoreBreakdown2023Alliance,
+  MatchScoreBreakdown2024Alliance,
+} from '~/api/v3';
+
+export const RANKING_POINT_LABELS: Record<number, string[]> = {
+  2016: ['Defenses Breached', 'Tower Captured'],
+  2017: ['Pressure Reached', 'All Rotors Engaged'],
+  2018: ['Auto Quest', 'Face The Boss'],
+  2019: ['Complete Rocket', 'Hab Docking'],
+  2020: ['Shield Energized', 'Shield Operational'],
+  2022: ['Cargo Bonus', 'Hangar Bonus'],
+  2023: ['Sustainability Bonus', 'Activation Bonus'],
+  2024: ['Melody Bonus', 'Ensemble Bonus'],
+};
+
+export type MatchScoreBreakdown = NonNullable<Match['score_breakdown']>['red'];
+
+export function isScoreBreakdown2016(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2016Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2016Alliance)
+      .teleopDefensesBreached !== undefined
+  );
+}
+
+export function isScoreBreakdown2017(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2017Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2017Alliance)
+      .kPaRankingPointAchieved !== undefined
+  );
+}
+
+export function isScoreBreakdown2018(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2018Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2018Alliance)
+      .autoQuestRankingPoint !== undefined
+  );
+}
+
+export function isScoreBreakdown2019(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2019Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2019Alliance)
+      .completeRocketRankingPoint !== undefined
+  );
+}
+
+export function isScoreBreakdown2020(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2020Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2020Alliance)
+      .shieldEnergizedRankingPoint !== undefined
+  );
+}
+
+export function isScoreBreakdown2022(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2022Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2022Alliance)
+      .cargoBonusRankingPoint !== undefined
+  );
+}
+
+export function isScoreBreakdown2023(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2023Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2023Alliance)
+      .sustainabilityBonusAchieved !== undefined
+  );
+}
+
+export function isScoreBreakdown2024(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2024Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2024Alliance).melodyBonusAchieved !==
+    undefined
+  );
+}
+
+export function getBonusRankingPoints(
+  scoreBreakdown: MatchScoreBreakdown,
+): boolean[] {
+  if (isScoreBreakdown2016(scoreBreakdown)) {
+    return [
+      scoreBreakdown.teleopDefensesBreached ?? false,
+      scoreBreakdown.teleopTowerCaptured ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2017(scoreBreakdown)) {
+    return [
+      scoreBreakdown.kPaRankingPointAchieved ?? false,
+      scoreBreakdown.rotorRankingPointAchieved ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2018(scoreBreakdown)) {
+    return [
+      scoreBreakdown.autoQuestRankingPoint ?? false,
+      scoreBreakdown.faceTheBossRankingPoint ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2019(scoreBreakdown)) {
+    return [
+      scoreBreakdown.completeRocketRankingPoint ?? false,
+      scoreBreakdown.habDockingRankingPoint ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2020(scoreBreakdown)) {
+    return [
+      scoreBreakdown.shieldEnergizedRankingPoint ?? false,
+      scoreBreakdown.shieldOperationalRankingPoint ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2022(scoreBreakdown)) {
+    return [
+      scoreBreakdown.cargoBonusRankingPoint ?? false,
+      scoreBreakdown.hangarBonusRankingPoint ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2023(scoreBreakdown)) {
+    return [
+      scoreBreakdown.sustainabilityBonusAchieved ?? false,
+      scoreBreakdown.activationBonusAchieved ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2024(scoreBreakdown)) {
+    return [
+      scoreBreakdown.melodyBonusAchieved ?? false,
+      scoreBreakdown.ensembleBonusAchieved ?? false,
+    ];
+  }
+
+  return [];
+}

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -6753,7 +6753,7 @@
             "type": "integer"
           },
           "teleopTowerCaptured": {
-            "type": "integer"
+            "type": "boolean"
           },
           "towerFaceA": {
             "type": "string"


### PR DESCRIPTION
<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/848acebb-95c5-4ba6-bc5c-de03374eaa35)

![image](https://github.com/user-attachments/assets/e7113801-92bd-4f55-b3c1-7cbcdfff100d)


</details>

---

[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/the-blue-alliance/the-blue-alliance/pull/6950).
* #7006
* __->__ #6950