### PR TITLE
Remove python3.12-minimal from Docker - seems it no longer exists

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y
 
 # Setup python environment
 ENV PYTHON_VERSION python3.12
-RUN apt-get remove -y $PYTHON_VERSION-minimal
+# RUN apt-get remove -y $PYTHON_VERSION-minimal
 RUN apt-get update && apt-get install -y \
     "$PYTHON_VERSION" \
     "$PYTHON_VERSION-venv" \


### PR DESCRIPTION
Commenting this out for now (because I'm not entirely sure why we remove the minimal package) but it seems like this doesn't exist. In an earlier step we install python3.10-minimal which feels wonky. Probably a dependency for something earlier on.