### PR TITLE
clarify add/remove team social media on admin panel

### DIFF
--- a/src/backend/web/handlers/admin/team.py
+++ b/src/backend/web/handlers/admin/team.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from flask import abort, redirect, request, url_for
 from werkzeug.wrappers import Response
 
+from backend.common.consts.media_type import SOCIAL_TYPES
 from backend.common.manipulators.robot_manipulator import RobotManipulator
 from backend.common.manipulators.team_manipulator import TeamManipulator
 from backend.common.models.district_team import DistrictTeam
@@ -63,8 +64,12 @@ def team_detail(team_number: int) -> str:
     years_participated = sorted(TeamParticipationQuery(team.key_name).fetch())
 
     team_medias_by_year = defaultdict(list)
+    team_social_media = list()
     for media in team_medias:
-        team_medias_by_year[media.year].append(media)
+        if media.media_type_enum in SOCIAL_TYPES:
+            team_social_media.append(media)
+        else:
+            team_medias_by_year[media.year].append(media)
     media_years = sorted(
         team_medias_by_year.keys(),
         key=lambda m: 0 if media.year is None else media.year,
@@ -76,6 +81,7 @@ def team_detail(team_number: int) -> str:
         "team": team,
         "team_media_years": media_years,
         "team_medias_by_year": team_medias_by_year,
+        "team_social_media": team_social_media,
         "robots": robots,
         "district_teams": district_teams,
         "years_participated": years_participated,

--- a/src/backend/web/templates/admin/team_details.html
+++ b/src/backend/web/templates/admin/team_details.html
@@ -123,7 +123,7 @@
     <button class="btn btn-primary" type="submit"><span class="glyphicon glyphicon-thumbs-up"></span> Update Website</button>
 </form>
 
-<h2>Add Media</h2>
+<h2>Add Media / Social Media</h2>
 <form action="/admin/media/add_media" method="post">
     <table class="table table-striped table-hover table-condensed">
         <tr>
@@ -131,7 +131,7 @@
             <td><input class="form-control" name="media_url" type="text" placeholder="https://www.chiefdelphi.com/media/photos/39142"></td>
         </tr>
         <tr>
-            <td>Year (can be blank)</td>
+            <td>Year (leave blank for socials)</td>
             <td><input class="form-control" name="year" type="text"></td>
         </tr>
     </table>
@@ -142,6 +142,15 @@
     <button class="btn btn-primary" type="submit"><span class="glyphicon glyphicon-thumbs-up"></span> Add Media</button>
 </form>
 
+<h2>Social Media</h2>
+  <ul>
+  <table class="table table-striped table-hover table-condensed">
+  <tr><th>Media</th><th>Details</th><th>Tags</th></tr>
+    {% for media in team_social_media %}
+    {% include "admin/partials/admin_media_display.html" %}
+    {%endfor %}
+  </table>
+  </ul>
 
 <h2>Media</h2>
 {% for year in team_media_years %}


### PR DESCRIPTION
The current view is a bit confusing (because social media links show under "no year")

This diff will separate them out into their own listing

![image](https://github.com/user-attachments/assets/acf3b5d8-bdd3-48f0-b673-bd7b98867998)
