### PR TITLE
Splay daily event/team datafeed requests

### DIFF
--- a/src/backend/common/helpers/event_short_name_helper.py
+++ b/src/backend/common/helpers/event_short_name_helper.py
@@ -44,7 +44,6 @@ class EventShortNameHelper:
         # Strip out current year
         if year is not None:
             name_str = name_str.replace(str(year), "").strip()
-            print(name_str)
 
         # Special cases for district championship divisions
         if event_type == EventType.DISTRICT_CMP_DIVISION:

--- a/src/backend/common/sitevars/turbo_mode.py
+++ b/src/backend/common/sitevars/turbo_mode.py
@@ -30,7 +30,6 @@ class TurboMode(Sitevar[ContentType]):
     def cache_ttl(cls, request_path: str, default_ttl: int) -> int:
         cfg = cls.get()
         path_regex = cfg.get("regex", "")
-        print(f"view: {request_path}")
         if not path_regex or path_regex == "$^":
             return default_ttl
 

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_team_avatar_parser_test.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_team_avatar_parser_test.py
@@ -75,7 +75,6 @@ def test_parse_avatars(test_data_importer, ndb_stub):
 
     # Spot check delete keys
     assert len(media_keys_to_delete) == 59
-    print(media_keys_to_delete)
     first_delete = next(
         iter(
             [

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -242,7 +242,6 @@ def event_matchstats_calc(event_key: EventKey) -> Response:
         abort(404)
 
     matchstats_dict = MatchstatsHelper.calculate_matchstats(event.matches, event.year)
-    print(matchstats_dict)
     if not any([v != {} for v in matchstats_dict.values()]):
         logging.warning("Matchstat calculation for {} failed!".format(event_key))
         matchstats_dict = None

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -1,12 +1,12 @@
 cron:
 - description: FIRST event list scraping. Also includes event details/event teams/team details scraping.
   url: /backend-tasks/enqueue/event_list/current
-  schedule: every day 02:00
+  schedule: every day 01:00
   timezone: America/Los_Angeles
 
 - description: FIRST team detail scraping
   url: /tasks/enqueue/fmsapi_team_details_rolling
-  schedule: every day 02:30
+  schedule: every day 03:30
   timezone: America/Los_Angeles
 
 - description: FIRST match scraping for current events


### PR DESCRIPTION
This is an attempt to optimize usage/costs a bit.

We are currently slamming app engine every day, and it ends up scaling up to almost 40 instances at peak

![image](https://github.com/user-attachments/assets/8ebc2dff-b40c-47a8-98bb-c5ff2046f844)


And the initial requests for new instances are always slow:

![image](https://github.com/user-attachments/assets/637fdc06-2bde-4ed3-a723-9ea44c8a0fab)


For example, a trace like this:

![image](https://github.com/user-attachments/assets/6fbfef0e-cd1f-4d18-b655-6667a8cf2da2)

We end up waiting almost 5 minutes before we actually get to executing the requests...

So my theory is - if we splay the daily work out over a few hours, we can run steady with a handful of warm instances, rather than big spikes. And we can maybe smooth out the cost cuve too (if we don't end up paying for dead instance time)