### PR TITLE
Fetch matches using v3 hybrid schedule

### DIFF
--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import call, patch
 
 import pytest
@@ -14,9 +15,6 @@ from backend.tasks_io.datafeeds.parsers.fms_api.fms_api_match_parser import (
     FMSAPIHybridScheduleParser,
     FMSAPIMatchDetailsParser,
 )
-from backend.tasks_io.datafeeds.parsers.fms_api.simple_json_parser import (
-    FMSAPISimpleJsonParser,
-)
 
 
 @pytest.fixture(autouse=True)
@@ -25,31 +23,26 @@ def fms_api_secrets(ndb_stub):
 
 
 def test_get_event_matches() -> None:
-    response = URLFetchResult.mock_for_content("", 200, "")
+    schedule_response = URLFetchResult.mock_for_content(
+        "", 200, json.dumps({"Schedule": []})
+    )
+    score_response = URLFetchResult.mock_for_content("", 200, "")
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "match_schedule", return_value=InstantFuture(response)
-    ) as mock_schedule_api, patch.object(
-        FRCAPI, "matches", return_value=InstantFuture(response)
-    ) as mock_matches_api, patch.object(
-        FRCAPI, "match_scores", return_value=InstantFuture(response)
+        FRCAPI, "hybrid_schedule", return_value=InstantFuture(schedule_response)
+    ) as mock_hybrid_schedule_api, patch.object(
+        FRCAPI, "match_scores", return_value=InstantFuture(score_response)
     ) as mock_match_scores_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
     ) as mock_schedule_parse, patch.object(
         FMSAPIMatchDetailsParser, "parse"
-    ) as mock_match_detail_parser, patch.object(
-        FMSAPISimpleJsonParser, "parse"
-    ) as mock_json_parse:
+    ) as mock_match_detail_parser:
         mock_schedule_parse.side_effect = ([], [])
-        mock_json_parse.return_value = {"Schedule": [], "Matches": []}
         mock_match_detail_parser.return_value = {}
         df.get_event_matches("2020miket").get_result()
 
-    mock_schedule_api.assert_has_calls(
-        [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
-    )
-    mock_matches_api.assert_has_calls(
+    mock_hybrid_schedule_api.assert_has_calls(
         [call(2020, "miket", "qual"), call(2020, "miket", "playoff")]
     )
     mock_match_scores_api.assert_has_calls(
@@ -61,31 +54,26 @@ def test_get_event_matches() -> None:
 
 
 def test_get_event_matches_cmp() -> None:
-    response = URLFetchResult.mock_for_content("", 200, "")
+    schedule_response = URLFetchResult.mock_for_content(
+        "", 200, json.dumps({"Schedule": []})
+    )
+    score_response = URLFetchResult.mock_for_content("", 200, "")
 
     df = DatafeedFMSAPI()
     with patch.object(
-        FRCAPI, "match_schedule", return_value=InstantFuture(response)
-    ) as mock_schedule_api, patch.object(
-        FRCAPI, "matches", return_value=InstantFuture(response)
-    ) as mock_matches_api, patch.object(
-        FRCAPI, "match_scores", return_value=InstantFuture(response)
+        FRCAPI, "hybrid_schedule", return_value=InstantFuture(schedule_response)
+    ) as mock_hybrid_schedule_api, patch.object(
+        FRCAPI, "match_scores", return_value=InstantFuture(score_response)
     ) as mock_match_scores_api, patch.object(
         FMSAPIHybridScheduleParser, "parse"
     ) as mock_schedule_parse, patch.object(
         FMSAPIMatchDetailsParser, "parse"
-    ) as mock_match_detail_parser, patch.object(
-        FMSAPISimpleJsonParser, "parse"
-    ) as mock_json_parse:
+    ) as mock_match_detail_parser:
         mock_schedule_parse.side_effect = ([], [])
-        mock_json_parse.return_value = {"Schedule": [], "Matches": []}
         mock_match_detail_parser.return_value = {}
         df.get_event_matches("2014gal").get_result()
 
-    mock_schedule_api.assert_has_calls(
-        [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
-    )
-    mock_matches_api.assert_has_calls(
+    mock_hybrid_schedule_api.assert_has_calls(
         [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
     )
     mock_match_scores_api.assert_has_calls(


### PR DESCRIPTION
FIRST has added back the hybrid schedule endpoint for us in v3 (same schema as the original v2 version).

Update the datafeed to call that instead, which will cut the number of API calls we make for matches by 1/3.

We need to keep the merging logic around for running the simulator against old events, but at least it's now not on the critical path anymore