### PR TITLE
Update swagger types for team event status objects

### DIFF
--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5114,7 +5114,8 @@
                 "type": "array",
                 "description": "Ordered list of values used to determine the rank. See the `sort_order_info` property for the name of each value.",
                 "items": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "record": {
@@ -5248,7 +5249,8 @@
             ]
           },
           "playoff_average": {
-            "type": "integer",
+            "type": "number",
+            "format": "double",
             "nullable": true,
             "description": "The average match score during playoffs. Year specific. May be null if not relevant for a given year."
           }
@@ -5300,7 +5302,8 @@
                   "nullable": true,
                   "description": "Additional year-specific information, may be null. See parent `sort_order_info` for details.",
                   "items": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "record": {

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5115,7 +5115,7 @@
                 "description": "Ordered list of values used to determine the rank. See the `sort_order_info` property for the name of each value.",
                 "items": {
                   "type": "number",
-                  "format": "float"
+                  "format": "double"
                 }
               },
               "record": {
@@ -5303,7 +5303,7 @@
                   "description": "Additional year-specific information, may be null. See parent `sort_order_info` for details.",
                   "items": {
                     "type": "number",
-                    "format": "float"
+                    "format": "double"
                   }
                 },
                 "record": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update swagger specs:
 * Set `playoff_average` to use the `double` format
 * Set `sort_orders` to use the `float` format

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've been working on updating the the API models for the Android app, and ran into a few unexpected types in the team event status models. I'm sure I'll find more as I keep going, but this was a good starting point.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the JSON file through https://editor.swagger.io/ and it checked out, fields now display as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would change API specifications or require data migrations)

This could be a breaking change if others are generating API models based on the Swagger specs, but the newly specific types align with the underlying Python types. The actual behavior of these APIs is also not changing.