### PR TITLE
Add ability to favorite eventteams

### DIFF
--- a/docs/common/Current-User.md
+++ b/docs/common/Current-User.md
@@ -13,6 +13,23 @@ def route() -> str:
       # User is not signed in, or user's session has expired
 ```
 
+### First time local setup
+
+If you want to test myTBA (or other sign-in related features) locally, you'll need to provide a couple of Firebase secrets in order for the initialization sequence to succeed.
+
+1. Go to https://console.firebase.google.com/
+2. Create project
+3. Enter a project name, such as `tba-dev`
+4. Disable Google Analytics, hit Create Project
+5. Go to Project Settings
+6. Create a web platform App
+7. Enter a name, such as `tba-dev`
+8. Hit Register app
+9. Copy the `appId` and `authDomain` to `src/backend/web/static/javascript/tba_js/tba_keys.js`. You may need to `chmod` this depending on your local environment and how the file was made.
+10. Go to http://localhost:8080/account/login and Sign in with Google.
+
+Nothing actually gets used in your Firebase project, so you won't be charged for anything. TBA uses the Firebase emulator to provide two fake accounts (see below) - however in order to connect to the emulator, auth initialization must succeed, and in order for that to succeed, it must have a valid app ID and auth domain.
+
 ### Firebase Auth Emulator
 
 By default, the development container will run using the Firebase auth emulator (generally available at [localhost:4000/auth](http://localhost:4000/auth). If you're using a [`google_application_credentials` key](https://github.com/the-blue-alliance/the-blue-alliance/wiki/GAE-Firebase-Setup#setup-google-service-account-keys) locally and would like to hit an upstream Firebase project for authentication, set the `auth_use_prod` option in [[tba_dev_config.json|tba_dev_config]] to `true`.

--- a/docs/common/Current-User.md
+++ b/docs/common/Current-User.md
@@ -26,7 +26,8 @@ If you want to test myTBA (or other sign-in related features) locally, you'll ne
 7. Enter a name, such as `tba-dev`
 8. Hit Register app
 9. Copy the `appId` and `authDomain` to `src/backend/web/static/javascript/tba_js/tba_keys.js`. You may need to `chmod` this depending on your local environment and how the file was made.
-10. Go to http://localhost:8080/account/login and Sign in with Google.
+10. Run `./ops/build/run_buildweb.sh` to rebuild JS bundles.
+11. Go to http://localhost:8080/account/login and Sign in with Google.
 
 Nothing actually gets used in your Firebase project, so you won't be charged for anything. TBA uses the Firebase emulator to provide two fake accounts (see below) - however in order to connect to the emulator, auth initialization must succeed, and in order for that to succeed, it must have a valid app ID and auth domain.
 

--- a/src/backend/common/helpers/mytba.py
+++ b/src/backend/common/helpers/mytba.py
@@ -1,17 +1,78 @@
 from dataclasses import dataclass
 from datetime import datetime
+from functools import cached_property
 from itertools import groupby
-from typing import Dict, List, Optional, Set, Type
+from typing import cast, Dict, List, Optional, Set, Type
 
 from google.appengine.ext import ndb
 
+from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.model_type import ModelType
 from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
 from backend.common.models.favorite import Favorite
+from backend.common.models.keys import EventKey
 from backend.common.models.match import Match
 from backend.common.models.mytba import MyTBAModel
 from backend.common.models.subscription import Subscription
 from backend.common.models.team import Team
+from backend.common.models.wlt import WLTRecord
+from backend.common.queries.match_query import EventMatchesQuery
+
+
+@dataclass
+class AttendanceStatsHelper:
+    event_teams: List[EventTeam]
+    events: List[Event]
+    teams: List[Team]
+    matches: Dict[EventKey, List[Match]]
+
+    @property
+    def event_count(self) -> int:
+        return len(self.events)
+
+    @property
+    def total_days(self) -> int:
+        return sum(
+            (
+                (obj.end_date - obj.start_date).days + 1
+                for obj in self.events
+                if obj.start_date and obj.end_date
+            ),
+        )
+
+    @property
+    def total_matches(self) -> int:
+        return sum(len(matches) for matches in self.matches.values())
+
+    @cached_property
+    def record(self) -> WLTRecord:
+        wlt = WLTRecord(wins=0, losses=0, ties=0)
+        for event_team_key, matches in self.matches.items():
+            _, team = event_team_key.split("_")
+
+            for match in matches:
+                if match.winning_alliance == "":
+                    wlt["ties"] += 1
+                else:
+                    alliance = match.alliances[
+                        cast(AllianceColor, match.winning_alliance)
+                    ]
+                    if team in alliance["teams"]:
+                        wlt["wins"] += 1
+                    else:
+                        wlt["losses"] += 1
+
+        return wlt
+
+    @property
+    def winrate(self) -> float:
+        record = self.record
+        return (
+            100
+            * record["wins"]
+            / max(1, record["wins"] + record["losses"] + record["ties"])
+        )
 
 
 @dataclass
@@ -81,6 +142,61 @@ class MyTBA:
             group[0]: [match for match in group[1]]
             for group in groupby(self.matches, key=lambda x: x.event)
         }
+
+    @property
+    def event_teams_models(self) -> List[MyTBAModel]:
+        return [
+            model for model in self.models if model.model_type == ModelType.EVENT_TEAM
+        ]
+
+    @property
+    def event_teams(self) -> List[EventTeam]:
+        event_team_keys = {
+            ndb.Key(EventTeam, model.model_key) for model in self.event_teams_models
+        }
+        futures = ndb.get_multi_async(event_team_keys)
+        return [f.get_result() for f in futures]
+
+    @property
+    def attendance_stats_helper(self) -> AttendanceStatsHelper:
+        event_teams = self.event_teams
+        team_futures = ndb.get_multi_async(
+            {event_team.team for event_team in event_teams}
+        )
+        event_futures = ndb.get_multi_async(
+            {event_team.event for event_team in event_teams}
+        )
+
+        teams = sorted(
+            [f.get_result() for f in team_futures], key=lambda t: t.team_number
+        )
+        events = sorted(
+            [f.get_result() for f in event_futures], key=lambda e: e.end_date
+        )
+
+        matches_futures = {
+            event.key.string_id(): EventMatchesQuery(
+                event_key=event.key.string_id()
+            ).fetch_async()
+            for event in events
+        }
+        matches = {k: v.get_result() for k, v in matches_futures.items()}
+        event_team_matches: Dict[EventKey, List[Match]] = {}
+        for event_team in event_teams:
+            if event_team.key_name not in event_team_matches:
+                event_team_matches[event_team.key_name] = []
+
+            for match in matches[event_team.event.string_id()]:
+                for team_key in match.team_keys:
+                    if team_key.string_id() == event_team.team.string_id():
+                        event_team_matches[event_team.key_name].append(match)
+
+        return AttendanceStatsHelper(
+            event_teams=event_teams,
+            events=events,
+            teams=teams,
+            matches=event_team_matches,
+        )
 
     def favorite(self, model_type: ModelType, model_key: str) -> Optional[Favorite]:
         return self._first_model(Favorite, model_type, model_key)  # pyre-ignore[7]

--- a/src/backend/common/models/keys.py
+++ b/src/backend/common/models/keys.py
@@ -16,3 +16,4 @@ MatchKey = str
 AwardKey = str
 MediaKey = str
 RobotKey = str
+UserEventTeamKey = str

--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -36,6 +36,7 @@ from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.mytba_helper import MyTBAHelper
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
 from backend.common.models.favorite import Favorite
 from backend.common.models.keys import EventKey, TeamNumber
 from backend.common.models.subscription import Subscription
@@ -43,7 +44,6 @@ from backend.common.models.team import Team
 from backend.common.sitevars.notifications_enable import NotificationsEnable
 from backend.web.decorators import enforce_login, require_login, require_login_only
 from backend.web.redirect import is_safe_url, safe_next_redirect
-
 
 blueprint = Blueprint("account", __name__, url_prefix="/account")
 
@@ -241,6 +241,7 @@ def mytba() -> str:
         (event, MatchHelper.natural_sorted_matches(mytba_event_matches[event.key]))
         for event in mytba_event_matches_events
     ]
+    attendance_stats_helper = mytba.attendance_stats_helper
 
     template_values = {
         "event_fav_sub": [
@@ -279,6 +280,7 @@ def mytba() -> str:
         ],
         "status": request.args.get("status"),
         "year": SeasonHelper.effective_season_year(),
+        "attendance_stats_helper": attendance_stats_helper,
     }
     return render_template("mytba.html", **template_values)
 
@@ -457,6 +459,75 @@ def mytba_event_post(event_key: EventKey) -> Response:
     return safe_next_redirect(
         url_for("account.mytba", _anchor="my-events", status="event_updated")
     )
+
+
+@blueprint.get("/mytba/eventteam/<int:team_number>")
+@require_login
+def mytba_eventteam_get(team_number: TeamNumber) -> str:
+    team = Team.get_by_id(f"frc{team_number}")
+    if not team:
+        abort(404)
+
+    user = none_throws(current_user())
+
+    event_teams = EventTeam.query(EventTeam.team == team.key).fetch(1000)
+
+    favorites = Favorite.query(
+        Favorite.model_type == ModelType.EVENT_TEAM,
+        Favorite.model_key.IN(  # pyre-ignore[16]
+            [f"{et.event.string_id()}_{team.key.string_id()}" for et in event_teams]
+        ),
+        ancestor=none_throws(user.account_key),
+    ).fetch(1000)
+
+    already_favorited = set()
+    if favorites:
+        already_favorited = {f.model_key for f in favorites}
+
+    template_values = {
+        "team": team,
+        "event_teams": event_teams,
+        "already_favorited": already_favorited,
+    }
+    return render_template("mytba_eventteam.html", **template_values)
+
+
+@blueprint.post("/mytba/eventteam/<int:team_number>")
+@require_login
+def mytba_eventteam_post(team_number: TeamNumber) -> Response:
+    team = Team.get_by_id(f"frc{team_number}")
+    if not team:
+        abort(404)
+
+    team_key = f"frc{team_number}"
+
+    user = none_throws(current_user())
+    event_teams = EventTeam.query(EventTeam.team == team.key).fetch(1000)
+    for event_team in event_teams:
+        MyTBAHelper.remove_favorite(
+            account_key=none_throws(user.account_key),
+            model_key=f"{event_team.event.string_id()}_{team.key.string_id()}",
+            model_type=ModelType.EVENT_TEAM,
+        )
+        print(
+            f"Removing favorite {team_key} @ {event_team.event.string_id()}", flush=True
+        )
+
+    favorites = request.form.getlist("favorite_events")
+    if favorites:
+        for event_key in favorites:
+            MyTBAHelper.add_favorite(
+                Favorite(
+                    parent=none_throws(user.account_key),
+                    user_id=none_throws(user.account_key).id(),
+                    model_type=ModelType.EVENT_TEAM,
+                    model_key=f"{event_key}_{team_key}",
+                )
+            )
+            print(f"Favoriting {team_key} @ {event_key}", flush=True)
+
+    response = redirect(url_for("account.mytba"))
+    return response
 
 
 @blueprint.route("/ping", methods=["POST"])

--- a/src/backend/web/handlers/tests/account_overview_test.py
+++ b/src/backend/web/handlers/tests/account_overview_test.py
@@ -42,6 +42,7 @@ def test_blueprint() -> None:
         "/account/mytba": "account.mytba",
         "/account/mytba/team/<int:team_number>": "account.mytba_team_post",
         "/account/mytba/event/<string:event_key>": "account.mytba_event_post",
+        "/account/mytba/eventteam/<int:team_number>": "account.mytba_eventteam_post",
         "/account": "account.overview",
         "/account/ping": "account.ping",
     }

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -11,6 +11,7 @@ from backend.common import auth
 from backend.common.consts.client_type import ClientType
 from backend.common.consts.model_type import ModelType
 from backend.common.helpers.account_deletion import AccountDeletionHelper
+from backend.common.helpers.mytba import AttendanceStatsHelper
 from backend.common.helpers.tbans_helper import TBANSHelper
 from backend.common.models.account import Account
 from backend.common.models.mobile_client import MobileClient
@@ -557,12 +558,15 @@ def test_mytba(
     mock_match_favorite = Mock()
     mock_match_subscription = Mock()
     mock_match_subscription.notification_names = []
+    mock_eventteam_favorite = Mock()
 
     def mock_favorite(model_type, key):
         if model_type == ModelType.EVENT:
             return mock_event_favorite
         elif model_type == ModelType.TEAM:
             return mock_team_favorite
+        elif model_type == ModelType.EVENT_TEAM:
+            return mock_eventteam_favorite
         return mock_match_favorite
 
     def mock_subscription(model_type, key):
@@ -574,6 +578,9 @@ def test_mytba(
 
     mock_mytba.favorite.side_effect = mock_favorite
     mock_mytba.subscription.side_effect = mock_subscription
+    mock_mytba.attendance_stats_helper = AttendanceStatsHelper(
+        event_teams=[], events=[], teams=[], matches={}
+    )
 
     mock_year = 2012
 

--- a/src/backend/web/templates/mytba.html
+++ b/src/backend/web/templates/mytba.html
@@ -49,6 +49,9 @@
         <li class="active"><a href="#my-teams" data-toggle="tab">My Teams <span class="badge">{{team_fav_sub|length}}</span></a></li>
         <li><a href="#my-events" data-toggle="tab">My Events <span class="badge">{{event_fav_sub|length}}</span></a></li>
         <li><a href="#my-matches" data-toggle="tab">My Matches <span class="badge">{{event_match_fav_sub|length}}</span></a></li>
+        {% if attendance_stats_helper.teams|length > 0 %}
+        <li><a href="#my-eventteams" data-toggle="tab">My Attendance</a></li>
+        {% endif %}
       </ul>
 
       <div class="tab-content">
@@ -152,6 +155,9 @@
           {% else %}
             <p>You have no matches!</p>
           {% endif %}
+        </div>
+        <div class="tab-pane" id="my-eventteams">
+          {% include "mytba_partials/my_eventteams.html" %}
         </div>
       </div>
     </div>

--- a/src/backend/web/templates/mytba_eventteam.html
+++ b/src/backend/web/templates/mytba_eventteam.html
@@ -1,6 +1,7 @@
-{% extends "base.html" %} {% block title %}myTBA Team {{team.team_number}} - The
-Blue Alliance{% endblock %} {% block meta_description %}Manage your favorites
-and subscriptions{% endblock %} {% block content %}
+{% extends "base.html" %}
+{% block title %}myTBA Team {{team.team_number}} - TheBlue Alliance{% endblock %}
+{% block meta_description %}Manage your favorites and subscriptions{% endblock %}
+{% block content %}
 <div class="container">
   <div class="row">
     <div class="col-md-8 col-md-offset-2">
@@ -21,11 +22,11 @@ and subscriptions{% endblock %} {% block content %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         <table class="table">
-          {% for event_team in event_teams %}
+          {% for event in team_events %}
           <tr>
             <td>
-              <a href="/event/{{ event_team.event.string_id() }}"
-                >{{ event_team.event.string_id() }}</a
+              <a href="/event/{{ event.key.string_id() }}"
+                >{{ event.key.string_id() }}</a
               >
             </td>
 
@@ -35,8 +36,8 @@ and subscriptions{% endblock %} {% block content %}
                   <input
                     type="checkbox"
                     name="favorite_events"
-                    value="{{ event_team.event.string_id() }}"
-                    {% if event_team.key_name in already_favorited %}checked{% endif %}
+                    value="{{ event.key.string_id() }}"
+                    {% if event.key.string_id() ~ '_' ~ team.key.string_id() in already_favorited %}checked{% endif %}
                   />
                 </li>
               </ul>

--- a/src/backend/web/templates/mytba_eventteam.html
+++ b/src/backend/web/templates/mytba_eventteam.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %} {% block title %}myTBA Team {{team.team_number}} - The
+Blue Alliance{% endblock %} {% block meta_description %}Manage your favorites
+and subscriptions{% endblock %} {% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-md-8 col-md-offset-2">
+      <ol class="breadcrumb">
+        <li>
+          <a href="{{ url_for('account.overview') }}">Account Overview</a>
+        </li>
+        <li><a href="/account/mytba#my-teams">Manage myTBA</a></li>
+        <li class="active">Team {{team.team_number}}</li>
+      </ol>
+
+      <h1>myTBA Team: {{team.team_number}} - {{team.nickname}}</h1>
+      <p>Edit your attendance for this team.</p>
+
+      <form method="post">
+        <input name="action" type="hidden" value="subscription_year_add" />
+        <input name="account_id" type="hidden" value="{{ user.uid }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+        <table class="table">
+          {% for event_team in event_teams %}
+          <tr>
+            <td>
+              <a href="/event/{{ event_team.event.string_id() }}"
+                >{{ event_team.event.string_id() }}</a
+              >
+            </td>
+
+            <td>
+              <ul style="list-style-type: none">
+                <li>
+                  <input
+                    type="checkbox"
+                    name="favorite_events"
+                    value="{{ event_team.event.string_id() }}"
+                    {% if event_team.key_name in already_favorited %}checked{% endif %}
+                  />
+                </li>
+              </ul>
+            </td>
+          </tr>
+
+          {% endfor %}
+        </table>
+
+        <td>
+          <button type="submit" class="btn btn-primary">
+            <span class="glyphicon glyphicon-thumbs-up"></span> Save
+          </button>
+        </td>
+        <a href="/account/mytba#my-teams" class="btn btn-default"
+          ><span class="glyphicon glyphicon-thumbs-down"></span> Cancel</a
+        >
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/backend/web/templates/mytba_partials/my_eventteams.html
+++ b/src/backend/web/templates/mytba_partials/my_eventteams.html
@@ -1,0 +1,46 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>End Date</th>
+      <th>Week</th>
+      <th>Type</th>
+      <th>Location</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    {% for event in attendance_stats_helper.events %}
+    <tr>
+      <td>{{ event.name }}</td>
+      <td>{{ event.end_date }}</td>
+      <td>{{ event.week_str }}</td>
+      <td>{{ event.event_type_str }}</td>
+      <td>{{ event.city }}, {{ event.state_prov }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<table class="table">
+  <tr>
+    <th>Event Count</th>
+    <td>{{ attendance_stats_helper.event_count }}</td>
+  </tr>
+  <tr>
+    <th>Total Days</th>
+    <td>{{ attendance_stats_helper.total_days }}</td>
+  </tr>
+  <tr>
+    <th>Total Matches</th>
+    <td>{{ attendance_stats_helper.total_matches }}</td>
+  </tr>
+  <tr>
+    <th>Record</th>
+    <td>
+      {{ attendance_stats_helper.record.wins }}-{{
+      attendance_stats_helper.record.losses }}-{{
+      attendance_stats_helper.record.ties }} ({{ attendance_stats_helper.winrate | round(1) }}%)
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/fa57401e-60bb-46ac-a423-eeb9b6666ce8)

![image](https://github.com/user-attachments/assets/c856ed8e-0177-4945-bc07-61052dd85665)

</details>


You can only navigate to this via url currently, it's not linked in the UI. The idea here is that you can keep a running track of all the events you have personally competed at, and view stats about your teams. This is implemented by favoriting EventTeam models.

This is hidden by default because it's largely a proof of concept and something I'd rather only implement once between py3 vs PWA.