### PR TITLE
Do cleanup for district keys and event keys for teams with empty responses

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_fms_api.py
@@ -116,7 +116,7 @@ class DatafeedFMSAPI:
         result = self._parse(api_response, FMSAPITeamDetailsParser(year))
         if result:
             models, _ = result
-            return next(iter(models), None)
+            return next(iter(models), None) if models else None
         else:
             return None
 

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -119,7 +119,7 @@ def team_details(team_key: TeamKey) -> Response:
     # Delete all DistrictTeams that are not valid in the current
     # year, since each team can only be in one district per year
     dt_keys = DistrictTeam.query(
-        DistrictTeam.team == team_key, DistrictTeam.year == year
+        DistrictTeam.team == ndb.Key(Team, team_key), DistrictTeam.year == year
     ).fetch(keys_only=True)
     for dt_key in dt_keys:
         if not district_team or dt_key.id() != district_team.key.id():
@@ -127,9 +127,9 @@ def team_details(team_key: TeamKey) -> Response:
 
     # Delete all DistrictTeam that are for any year that the team
     # does not have an event
-    dt_keys = DistrictTeam.query(DistrictTeam.team == team_key).fetch()
+    dt_keys = DistrictTeam.query(DistrictTeam.team == ndb.Key(Team, team_key)).fetch()
     et_keys = EventTeam.query(
-        EventTeam.team == team_key,
+        EventTeam.team == ndb.Key(Team, team_key),
         projection=[EventTeam.year],
         group_by=[EventTeam.year],
     ).fetch()

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -115,31 +115,30 @@ def team_details(team_key: TeamKey) -> Response:
 
     # Clean up junk district teams
     # https://www.facebook.com/groups/moardata/permalink/1310068625680096/
-    if team:
-        keys_to_delete = set()
-        # Delete all DistrictTeams that are not valid in the current
-        # year, since each team can only be in one district per year
-        dt_keys = DistrictTeam.query(
-            DistrictTeam.team == team.key, DistrictTeam.year == year
-        ).fetch(keys_only=True)
-        for dt_key in dt_keys:
-            if not district_team or dt_key.id() != district_team.key.id():
-                keys_to_delete.add(dt_key)
+    keys_to_delete = set()
+    # Delete all DistrictTeams that are not valid in the current
+    # year, since each team can only be in one district per year
+    dt_keys = DistrictTeam.query(
+        DistrictTeam.team == team_key, DistrictTeam.year == year
+    ).fetch(keys_only=True)
+    for dt_key in dt_keys:
+        if not district_team or dt_key.id() != district_team.key.id():
+            keys_to_delete.add(dt_key)
 
-        # Delete all DistrictTeam that are for any year that the team
-        # does not have an event
-        dt_keys = DistrictTeam.query(DistrictTeam.team == team.key).fetch()
-        et_keys = EventTeam.query(
-            EventTeam.team == team.key,
-            projection=[EventTeam.year],
-            group_by=[EventTeam.year],
-        ).fetch()
-        et_years = {et_key.year for et_key in et_keys}
+    # Delete all DistrictTeam that are for any year that the team
+    # does not have an event
+    dt_keys = DistrictTeam.query(DistrictTeam.team == team_key).fetch()
+    et_keys = EventTeam.query(
+        EventTeam.team == team_key,
+        projection=[EventTeam.year],
+        group_by=[EventTeam.year],
+    ).fetch()
+    et_years = {et_key.year for et_key in et_keys}
 
-        for dt_key in dt_keys:
-            if dt_key.year not in et_years:
-                keys_to_delete.add(dt_key.key)
-        DistrictTeamManipulator.delete_keys(keys_to_delete)
+    for dt_key in dt_keys:
+        if dt_key.year not in et_years:
+            keys_to_delete.add(dt_key.key)
+    DistrictTeamManipulator.delete_keys(keys_to_delete)
 
     if robot:
         robot = RobotManipulator.createOrUpdate(robot)


### PR DESCRIPTION
Two parts to this pull request -

First - if we do a `get_team_details` and we don't get a team back for a particular year our parsing is failing. This seems like an oddity with how we're doing returns from our parsers (see also https://github.com/the-blue-alliance/the-blue-alliance/pull/6916 - which that parsing seems more right). This fixes the API return from our parsers in the case of an empty array.

The second part of this PR is to clean up `DistrictTeam`/`EventTeam` for teams that do not exist. Currently the code to cleanup these dangling teams is behind a check to make sure we get a `Team` model back from the API. In the case that we stop getting a Team back from the API, existing `DistrictTeam` and `EventTeam` models will not be cleaned up.

This data deletion *feels* safe in this case since it's scoped to a given year - although we do need to clean up 2024 data, so we'll need to run a one-off job for that.