### PR TITLE
Add district-specific insights

### DIFF
--- a/src/backend/common/consts/renamed_districts.py
+++ b/src/backend/common/consts/renamed_districts.py
@@ -4,17 +4,23 @@ from google.appengine.ext import ndb
 
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey
 
-CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
-    # Old to new
+OLD_TO_NEW: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
     "mar": "fma",
     "nc": "fnc",
     "in": "fin",
     "tx": "fit",
-    # New to old
+}
+
+NEW_TO_OLD: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
     "fma": "mar",
     "fnc": "nc",
     "fin": "in",
     "fit": "tx",
+}
+
+CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
+    **OLD_TO_NEW,
+    **NEW_TO_OLD,
 }
 
 
@@ -45,3 +51,7 @@ class RenamedDistricts:
         districts = yield ndb.get_multi_async(keys)
         districts = list(filter(lambda d: d is not None, districts))
         return len(districts) > 0
+
+    @staticmethod
+    def get_latest_district_code(code: DistrictAbbreviation) -> DistrictAbbreviation:
+        return OLD_TO_NEW.get(code, code)

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -1,9 +1,10 @@
 import json
-from typing import Dict, Literal, Set
+from typing import Dict, Literal, Optional, Set
 
 from google.appengine.ext import ndb
 
 from backend.common.models.cached_model import CachedModel
+from backend.common.models.district import DistrictAbbreviation
 
 
 LeaderboardKeyType = Literal["team"] | Literal["event"] | Literal["match"]
@@ -141,6 +142,10 @@ class Insight(CachedModel):
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
 
+    district_abbreviation: Optional[DistrictAbbreviation] = ndb.StringProperty(
+        required=False
+    )
+
     _json_attrs: Set[str] = {
         "data_json",
     }
@@ -168,11 +173,13 @@ class Insight(CachedModel):
         """
         Returns the string of the key_name of the Insight object before writing it.
         """
-        return self.render_key_name(self.year, self.name)
+        return self.render_key_name(self.year, self.name, self.district_abbreviation)
 
     @classmethod
-    def render_key_name(cls, year, name):
+    def render_key_name(cls, year, name, district_abbreviation):
+        suffix = f"_{district_abbreviation}" if district_abbreviation else ""
+
         if year == 0:
-            return "insights" + "_" + str(name)
+            return "insights" + "_" + str(name) + suffix
         else:
-            return str(year) + "insights" + "_" + str(name)
+            return str(year) + "insights" + "_" + str(name) + suffix

--- a/src/backend/tasks_cpu/templates/math/year_insights_do.html
+++ b/src/backend/tasks_cpu/templates/math/year_insights_do.html
@@ -1,5 +1,5 @@
 <h2>Calculated the following Insights for {{year}} {{kinds}}:</h2>
 {% for insight in insights %}
-    <h3>{{insight.name}}</h3>
+    <h3>{{insight.name}} ({{insight.key_name}})</h3>
     <p>{{insight.data_json}}</p>
 {% endfor %}

--- a/src/backend/web/handlers/index.py
+++ b/src/backend/web/handlers/index.py
@@ -178,7 +178,7 @@ def index_insights(template_values: Dict[str, Any]) -> str:
 
     insights = ndb.get_multi(
         [
-            ndb.Key(Insight, Insight.render_key_name(year, insight_name))
+            ndb.Key(Insight, Insight.render_key_name(year, insight_name, None))
             for insight_name in Insight.INSIGHT_NAMES.values()
         ]
     )

--- a/src/backend/web/handlers/insights.py
+++ b/src/backend/web/handlers/insights.py
@@ -21,7 +21,7 @@ def insights_overview() -> Response:
 
     insights = ndb.get_multi(
         [
-            ndb.Key(Insight, Insight.render_key_name(0, insight_name))
+            ndb.Key(Insight, Insight.render_key_name(0, insight_name, None))
             for insight_name in Insight.INSIGHT_NAMES.values()
         ]
     )
@@ -57,7 +57,7 @@ def insights_detail(year: int) -> Response:
 
     insights = ndb.get_multi(
         [
-            ndb.Key(Insight, Insight.render_key_name(year, insight_name))
+            ndb.Key(Insight, Insight.render_key_name(year, insight_name, None))
             for insight_name in Insight.INSIGHT_NAMES.values()
         ]
     )

--- a/src/backend/web/handlers/tests/insights_test.py
+++ b/src/backend/web/handlers/tests/insights_test.py
@@ -7,7 +7,7 @@ from backend.common.models.insight import Insight
 
 def test_overall_insights(web_client: Client) -> None:
     Insight(
-        id=Insight.render_key_name(0, "blue_banners"),
+        id=Insight.render_key_name(0, "blue_banners", None),
         year=0,
         name="blue_banners",
         data_json=json.dumps({}),
@@ -21,7 +21,7 @@ def test_overall_insights(web_client: Client) -> None:
 
 def test_detail_insights(web_client: Client) -> None:
     Insight(
-        id=Insight.render_key_name(2022, "blue_banners"),
+        id=Insight.render_key_name(2022, "blue_banners", None),
         year=2022,
         name="blue_banners",
         data_json=json.dumps({}),


### PR DESCRIPTION
Creates district-specific insights by adding a `district_abbreviation` field to the `Insight` model. The keys have a suffix of `_{district_abbreviation}` if it's present; they're untouched if no district is attached.

District abbreviation is used instead of district key because otherwise there would not be a straightforward way to do overall insights (year=0), as there is no `0fim` district key for example.
