### PR TITLE
Update api_v3 spec to OpenAPI 3.1

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -764,17 +764,15 @@ export type Match = {
   post_result_time: number | null;
   /** Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null. */
   score_breakdown:
-    | (
-        | MatchScoreBreakdown2015
-        | MatchScoreBreakdown2016
-        | MatchScoreBreakdown2017
-        | MatchScoreBreakdown2018
-        | MatchScoreBreakdown2019
-        | MatchScoreBreakdown2020
-        | MatchScoreBreakdown2022
-        | MatchScoreBreakdown2023
-        | MatchScoreBreakdown2024
-      )
+    | MatchScoreBreakdown2015
+    | MatchScoreBreakdown2016
+    | MatchScoreBreakdown2017
+    | MatchScoreBreakdown2018
+    | MatchScoreBreakdown2019
+    | MatchScoreBreakdown2020
+    | MatchScoreBreakdown2022
+    | MatchScoreBreakdown2023
+    | MatchScoreBreakdown2024
     | null;
   /** Array of video objects associated with this match. */
   videos: {

--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.9.7
+ * 3.9.9
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */
@@ -296,9 +296,9 @@ export type TeamEventStatusPlayoff = {
   playoff_average?: number | null;
 } | null;
 export type TeamEventStatus = {
-  qual?: TeamEventStatusRank;
-  alliance?: TeamEventStatusAlliance;
-  playoff?: TeamEventStatusPlayoff;
+  qual?: TeamEventStatusRank | null;
+  alliance?: TeamEventStatusAlliance | null;
+  playoff?: TeamEventStatusPlayoff | null;
   /** An HTML formatted string suitable for display to the user containing the team's alliance pick status. */
   alliance_status_str?: string;
   /** An HTML formatter string suitable for display to the user containing the team's playoff status. */
@@ -306,9 +306,9 @@ export type TeamEventStatus = {
   /** An HTML formatted string suitable for display to the user containing the team's overall status summary of the event. */
   overall_status_str?: string;
   /** TBA match key for the next match the team is scheduled to play in at this event, or null. */
-  next_match_key?: string;
+  next_match_key?: string | null;
   /** TBA match key for the last match the team played in at this event, or null. */
-  last_match_key?: string;
+  last_match_key?: string | null;
 };
 export type MatchAlliance = {
   /** Score for this alliance. Will be null or -1 for an unplayed match. */

--- a/pwa/app/lib/rankingPoints.ts
+++ b/pwa/app/lib/rankingPoints.ts
@@ -16,6 +16,7 @@ export const RANKING_POINT_LABELS: Record<number, string[]> = {
   2018: ['Auto Quest', 'Face The Boss'],
   2019: ['Complete Rocket', 'Hab Docking'],
   2020: ['Shield Energized', 'Shield Operational'],
+  2021: ['Shield Energized', 'Shield Operational'], // Used at Chezy 2021
   2022: ['Cargo Bonus', 'Hangar Bonus'],
   2023: ['Sustainability Bonus', 'Activation Bonus'],
   2024: ['Melody Bonus', 'Ensemble Bonus'],

--- a/pwa/app/root.tsx
+++ b/pwa/app/root.tsx
@@ -257,6 +257,8 @@ export const meta: MetaFunction = ({ error }) => {
 
 export function ErrorBoundary() {
   const error = useRouteError();
+  console.error(error);
+
   const isRouteError = isRouteErrorResponse(error);
   captureRemixErrorBoundaryError(error);
   return (

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
@@ -1574,10 +1574,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Team_Event_Status"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -2502,11 +2504,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Elimination_Alliance"
-                  },
-                  "nullable": true
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Elimination_Alliance"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -2563,10 +2571,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Event_Insights"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -2625,10 +2635,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Event_OPRs"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -2687,10 +2699,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Event_COPRs"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -2749,10 +2763,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Event_Predictions"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -2811,10 +2827,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Event_Ranking"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -2874,10 +2892,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "allOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Event_District_Points"
+                    },
+                    {
+                      "type": "null"
                     }
                   ]
                 }
@@ -4355,11 +4375,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/District_Ranking"
-                  },
-                  "nullable": "true"
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/District_Ranking"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -4642,18 +4668,24 @@
             "description": "Official long name registered with FIRST."
           },
           "city": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "City of team derived from parsing the address registered with FIRST."
           },
           "state_prov": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "State of team derived from parsing the address registered with FIRST."
           },
           "country": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Country of team derived from parsing the address registered with FIRST."
           }
         }
@@ -4696,72 +4728,98 @@
             "description": "Official long name registered with FIRST."
           },
           "school_name": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Name of team school or affilited group registered with FIRST."
           },
           "city": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "City of team derived from parsing the address registered with FIRST."
           },
           "state_prov": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "State of team derived from parsing the address registered with FIRST."
           },
           "country": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Country of team derived from parsing the address registered with FIRST."
           },
           "address": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Will be NULL, for future development."
           },
           "postal_code": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Postal code from the team address."
           },
           "gmaps_place_id": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Will be NULL, for future development."
           },
           "gmaps_url": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Will be NULL, for future development.",
             "format": "url"
           },
           "lat": {
-            "type": "number",
-            "nullable": true,
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Will be NULL, for future development.",
             "format": "double"
           },
           "lng": {
-            "type": "number",
-            "nullable": true,
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Will be NULL, for future development.",
             "format": "double"
           },
           "location_name": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Will be NULL, for future development."
           },
           "website": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Official website associated with the team.",
             "format": "url"
           },
           "rookie_year": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "First year the team officially competed."
           }
         }
@@ -4836,18 +4894,24 @@
             ]
           },
           "city": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "City, town, village, etc. the event is located in."
           },
           "state_prov": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "State or Province the event is located in."
           },
           "country": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Country the event is located in."
           },
           "start_date": {
@@ -4928,18 +4992,24 @@
             ]
           },
           "city": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "City, town, village, etc. the event is located in."
           },
           "state_prov": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "State or Province the event is located in."
           },
           "country": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Country the event is located in."
           },
           "start_date": {
@@ -4957,8 +5027,10 @@
             "description": "Year the event data is for."
           },
           "short_name": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Same as `name` but doesn't include event specifiers, such as 'Regional' or 'District'. May be null."
           },
           "event_type_string": {
@@ -4966,46 +5038,62 @@
             "description": "Event Type, eg Regional, District, or Offseason."
           },
           "week": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "Week of the event relative to the first official season event, zero-indexed. Only valid for Regionals, Districts, and District Championships. Null otherwise. (Eg. A season with a week 0 'preseason' event does not count, and week 1 events will show 0 here. Seasons with a week 0.5 regional event will show week 0 for those event(s) and week 1 for week 1 events and so on.)"
           },
           "address": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Address of the event's venue, if available."
           },
           "postal_code": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Postal code from the event address."
           },
           "gmaps_place_id": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Google Maps Place ID for the event address."
           },
           "gmaps_url": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Link to address location on Google Maps.",
             "format": "url"
           },
           "lat": {
-            "type": "number",
-            "nullable": true,
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Latitude for the event address.",
             "format": "double"
           },
           "lng": {
-            "type": "number",
-            "nullable": true,
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Longitude for the event address.",
             "format": "double"
           },
           "location_name": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Name of the location at the address for the event, eg. Blue Alliance High School."
           },
           "timezone": {
@@ -5013,18 +5101,24 @@
             "description": "Timezone name."
           },
           "website": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The event's website, if any."
           },
           "first_event_id": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The FIRST internal Event ID, used to link to the event on the FRC webpage."
           },
           "first_event_code": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Public facing event code used by FIRST (on frc-events.firstinspires.org, for example)"
           },
           "webcasts": {
@@ -5041,18 +5135,24 @@
             }
           },
           "parent_event_key": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The TBA Event key that represents the event's parent. Used to link back to the event from a division event. It is also the inverse relation of `divison_keys`."
           },
           "playoff_type": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "Playoff Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py#L4, or null."
           },
           "playoff_type_string": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "String representation of the `playoff_type`, or null."
           }
         }
@@ -5195,8 +5295,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Alliance name, may be null."
           },
           "number": {
@@ -5213,71 +5315,84 @@
         }
       },
       "Team_Event_Status_alliance_backup": {
-        "type": "object",
-        "nullable": true,
-        "properties": {
-          "out": {
-            "type": "string",
-            "description": "TBA key for the team replaced by the backup."
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "out": {
+                "type": "string",
+                "description": "TBA key for the team replaced by the backup."
+              },
+              "in": {
+                "type": "string",
+                "description": "TBA key for the backup team called in."
+              }
+            }
           },
-          "in": {
-            "type": "string",
-            "description": "TBA key for the backup team called in."
+          {
+            "type": "null"
           }
-        },
+        ],
         "description": "Backup status, may be null."
       },
       "Team_Event_Status_playoff": {
-        "type": "object",
-        "nullable": true,
-        "properties": {
-          "level": {
-            "type": "string",
-            "description": "The highest playoff level the team reached.",
-            "enum": [
-              "qm",
-              "ef",
-              "qf",
-              "sf",
-              "f"
-            ]
-          },
-          "current_level_record": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WLT_Record"
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "level": {
+                "type": "string",
+                "description": "The highest playoff level the team reached.",
+                "enum": [
+                  "qm",
+                  "ef",
+                  "qf",
+                  "sf",
+                  "f"
+                ]
               },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "record": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WLT_Record"
+              "current_level_record": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WLT_Record"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
-              {
-                "type": "null"
+              "record": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WLT_Record"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "type": "string",
+                "description": "Current competition status for the playoffs.",
+                "enum": [
+                  "won",
+                  "eliminated",
+                  "playing"
+                ]
+              },
+              "playoff_average": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "The average match score during playoffs. Year specific. May be null if not relevant for a given year."
               }
-            ]
+            }
           },
-          "status": {
-            "type": "string",
-            "description": "Current competition status for the playoffs.",
-            "enum": [
-              "won",
-              "eliminated",
-              "playing"
-            ]
-          },
-          "playoff_average": {
-            "type": "number",
-            "format": "double",
-            "nullable": true,
-            "description": "The average match score during playoffs. Year specific. May be null if not relevant for a given year."
+          {
+            "type": "null"
           }
-        },
+        ],
         "description": "Playoff status for this team, may be null if the team did not make playoffs, or playoffs have not begun."
       },
       "Event_Ranking": {
@@ -5309,8 +5424,10 @@
                   "description": "Number of matches played by this team."
                 },
                 "qual_average": {
-                  "type": "integer",
-                  "nullable": true,
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
                   "description": "The average match score during qualifications. Year specific. May be null if not relevant for a given year."
                 },
                 "extra_stats": {
@@ -5321,13 +5438,18 @@
                   }
                 },
                 "sort_orders": {
-                  "type": "array",
-                  "nullable": true,
-                  "description": "Additional year-specific information, may be null. See parent `sort_order_info` for details.",
-                  "items": {
-                    "type": "number",
-                    "format": "double"
-                  }
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Additional year-specific information, may be null. See parent `sort_order_info` for details."
                 },
                 "record": {
                   "anyOf": [
@@ -6278,20 +6400,26 @@
             "description": "Event key of the event the match was played at."
           },
           "time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the scheduled match time, as taken from the published schedule.",
             "format": "int64"
           },
           "predicted_time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the TBA predicted match start time.",
             "format": "int64"
           },
           "actual_time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of actual match start time.",
             "format": "int64"
           }
@@ -6368,31 +6496,39 @@
             "description": "Event key of the event the match was played at."
           },
           "time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the scheduled match time, as taken from the published schedule.",
             "format": "int64"
           },
           "actual_time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of actual match start time.",
             "format": "int64"
           },
           "predicted_time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the TBA predicted match start time.",
             "format": "int64"
           },
           "post_result_time": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) when the match result was posted.",
             "format": "int64"
           },
           "score_breakdown": {
-            "oneOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Match_Score_Breakdown_2015"
               },
@@ -6419,9 +6555,11 @@
               },
               {
                 "$ref": "#/components/schemas/Match_Score_Breakdown_2024"
+              },
+              {
+                "type": "null"
               }
             ],
-            "nullable": true,
             "description": "Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null."
           },
           "videos": {
@@ -6503,7 +6641,7 @@
             "items": {
               "type": "number",
               "format": "double",
-              "example": [
+              "examples": [
                 0,
                 0.1,
                 0.2
@@ -6542,7 +6680,9 @@
           "team_key": {
             "type": "string",
             "description": "The TBA team key for the Zebra MotionWorks data.",
-            "example": "frc7332"
+            "examples": [
+              "frc7332"
+            ]
           },
           "xs": {
             "type": "array",
@@ -6550,7 +6690,7 @@
             "items": {
               "type": "number",
               "format": "double",
-              "example": [
+              "examples": [
                 2.73,
                 2.7,
                 null
@@ -6563,7 +6703,7 @@
             "items": {
               "type": "number",
               "format": "double",
-              "example": [
+              "examples": [
                 2.73,
                 2.7,
                 null
@@ -8230,27 +8370,35 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Alliance name, may be null."
           },
           "backup": {
-            "type": "object",
-            "nullable": true,
-            "required": [
-              "in",
-              "out"
-            ],
-            "properties": {
-              "in": {
-                "type": "string",
-                "description": "Team key that was called in as the backup."
+            "anyOf": [
+              {
+                "type": "object",
+                "required": [
+                  "in",
+                  "out"
+                ],
+                "properties": {
+                  "in": {
+                    "type": "string",
+                    "description": "Team key that was called in as the backup."
+                  },
+                  "out": {
+                    "type": "string",
+                    "description": "Team key that was replaced by the backup team."
+                  }
+                }
               },
-              "out": {
-                "type": "string",
-                "description": "Team key that was replaced by the backup team."
+              {
+                "type": "null"
               }
-            },
+            ],
             "description": "Backup team called in, may be null."
           },
           "declines": {
@@ -8349,13 +8497,17 @@
         ],
         "properties": {
           "team_key": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The TBA team key for the team that was given the award. May be null."
           },
           "awardee": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The name of the individual given the award. May be null."
           }
         },
@@ -8514,13 +8666,17 @@
             "description": "Type specific channel information. May be the YouTube stream, or Twitch channel name. In the case of iframe types, contains HTML to embed the stream in an HTML iframe."
           },
           "date": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The date for the webcast in `yyyy-mm-dd` format. May be null."
           },
           "file": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "File identification as may be required for some types. May be null."
           }
         }

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.7",
+    "version": "3.9.9",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -5061,13 +5061,34 @@
         "type": "object",
         "properties": {
           "qual": {
-            "$ref": "#/components/schemas/Team_Event_Status_rank"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Team_Event_Status_rank"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "alliance": {
-            "$ref": "#/components/schemas/Team_Event_Status_alliance"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Team_Event_Status_alliance"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "playoff": {
-            "$ref": "#/components/schemas/Team_Event_Status_playoff"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Team_Event_Status_playoff"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "alliance_status_str": {
             "type": "string",
@@ -5083,10 +5104,12 @@
           },
           "next_match_key": {
             "type": "string",
+            "nullable": true,
             "description": "TBA match key for the next match the team is scheduled to play in at this event, or null."
           },
           "last_match_key": {
             "type": "string",
+            "nullable": true,
             "description": "TBA match key for the last match the team played in at this event, or null."
           }
         }


### PR DESCRIPTION
This doesn't really change much, mostly just preventative maintenance. I only changed things mentioned in here  https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0, which are:

1. Changed `example:` to `examples: []`
2. Removed `nullable: true` in favor of either `types: []` (for non-ref types) or `anyOf: [$ref, null]`

The PWA spec change is only syntactic, no actual type change.

----

edit: temp draft due to git shenanigans