### PR TITLE
[pwa] fix div escaping its parent

### DIFF
--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -415,7 +415,7 @@ function TeamsTab({
               })()}
             </Card>
           </CredenzaTrigger>
-          <CredenzaContent>
+          <CredenzaContent className="md:max-w-[80%] 2xl:max-w-[50%]">
             <CredenzaHeader>
               <CredenzaTitle>
                 <TeamLink teamOrKey={t.key}>
@@ -428,7 +428,7 @@ function TeamsTab({
               </CredenzaDescription>
             </CredenzaHeader>
             <CredenzaBody>
-              <ScrollArea className="h-[70vh] md:h-auto">
+              <ScrollArea className="h-[70vh]">
                 <MatchResultsTable
                   team={t}
                   matches={matches.filter(


### PR DESCRIPTION
prev:

![image](https://github.com/user-attachments/assets/a575f41c-7477-4334-919e-b82876d5f120)

new:

![image](https://github.com/user-attachments/assets/659ae190-fcad-4949-8d8c-142c2f25c3ac)
