### PR TITLE
[apidocs] Include reference of remap_teams in trusted event info

### DIFF
--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -20,7 +20,7 @@
           "Event Details"
         ],
         "summary": "Update top-level properties for the event",
-        "description": "An endpoint to overwrite certain event fields",
+        "description": "An endpoint to overwrite certain event fields. All fields are optional, set only the ones you wish to update",
         "operationId": "updateEventInfo",
         "parameters": [
           {
@@ -544,6 +544,16 @@
                   "example": "https://youtu.be/abc123"
                 }
               }
+            }
+          },
+          "remap_teams": {
+            "type": "object",
+            "description": "A mapping of temp key --> remapped key (including B team keys)",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": {
+              "frc1337": "frc337B"
             }
           }
         }


### PR DESCRIPTION
I [realized today](https://www.chiefdelphi.com/t/tba-unable-to-generate-event-write-tokens-or-email-support/484964/17?u=plnyyanks) we were missing this :stuck_out_tongue: 

![image](https://github.com/user-attachments/assets/b0e0df1b-6638-43b7-844f-7a00f93de3fa)
