### PR TITLE
Implement 2025+ Regional to CMP Advancement

### DIFF
--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -271,11 +271,22 @@ def districtteam_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAn
 def regionalpoolteam_updated(
     affected_refs: TAffectedReferences,
 ) -> List[TCacheKeyAndQuery]:
-    # team_keys = _filter(affected_refs["team"])
-    # years = _filter(affected_refs["year"])
+    years = _filter(affected_refs["year"])
 
     queries: List[CachedDatabaseQuery] = []
-    # TODO
+    for year in years:
+        queries.append(team_query.RegionalTeamsQuery(year))
+    return _queries_to_cache_keys_and_queries(queries)
+
+
+def regional_champs_pool_updated(
+    affected_refs: TAffectedReferences,
+) -> List[TCacheKeyAndQuery]:
+    years = _filter(affected_refs["year"])
+
+    queries: List[CachedDatabaseQuery] = []
+    for year in years:
+        queries.append(team_query.RegionalTeamsQuery(year))
     return _queries_to_cache_keys_and_queries(queries)
 
 

--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -268,6 +268,17 @@ def districtteam_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAn
     return _queries_to_cache_keys_and_queries(queries)
 
 
+def regionalpoolteam_updated(
+    affected_refs: TAffectedReferences,
+) -> List[TCacheKeyAndQuery]:
+    # team_keys = _filter(affected_refs["team"])
+    # years = _filter(affected_refs["year"])
+
+    queries: List[CachedDatabaseQuery] = []
+    # TODO
+    return _queries_to_cache_keys_and_queries(queries)
+
+
 def district_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]:
     years = _filter(affected_refs["year"])
     district_abbrevs = _filter(affected_refs["abbreviation"])

--- a/src/backend/common/consts/district_point_values.py
+++ b/src/backend/common/consts/district_point_values.py
@@ -176,3 +176,9 @@ class DistrictPointValues:
             AwardType.WEBSITE,
         ],
     }
+
+    REGIONAL_AWARD_VALUES = {
+        AwardType.CHAIRMANS: 45,
+        AwardType.ENGINEERING_INSPIRATION: 28,
+        AwardType.ROOKIE_ALL_STAR: 8,
+    }

--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -394,7 +394,6 @@ class DistrictHelper:
 
             winning_alliance = cast(AllianceColor, match.winning_alliance)
 
-            # Get alliance numbers
             winning_alliance_number = cls._get_alliance_number_from_teams(
                 alliance_selections,
                 match.alliances[winning_alliance]["teams"],

--- a/src/backend/common/helpers/regional_champs_pool_helper.py
+++ b/src/backend/common/helpers/regional_champs_pool_helper.py
@@ -124,7 +124,9 @@ class RegionalChampsPoolHelper(DistrictHelper):
             if event_regional_points is None:
                 continue
 
-            for team_key in set(event_regional_points["points"].keys()).union(set(event_regional_points["tiebreakers"].keys())):
+            for team_key in set(event_regional_points["points"].keys()).union(
+                set(event_regional_points["tiebreakers"].keys())
+            ):
                 team_attendance[team_key].append(event.key_name)
                 if len(team_attendance[team_key]) > 2:
                     continue
@@ -133,7 +135,9 @@ class RegionalChampsPoolHelper(DistrictHelper):
                     team_totals[team_key]["event_points"].append(
                         (event, event_regional_points["points"][team_key])
                     )
-                    team_totals[team_key]["point_total"] += event_regional_points["points"][team_key]["total"]
+                    team_totals[team_key]["point_total"] += event_regional_points[
+                        "points"
+                    ][team_key]["total"]
 
                     # Add tiebreakers in order
                     # TODO: implement tiebreakers
@@ -163,7 +167,7 @@ class RegionalChampsPoolHelper(DistrictHelper):
                     # -item[1]["tiebreakers"][2],
                     # -item[1]["tiebreakers"][3],
                     # -item[1]["tiebreakers"][4],
-                ]
+                ],
                 # + [-score for score in item[1]["qual_scores"]],
             )
         )

--- a/src/backend/common/helpers/regional_champs_pool_helper.py
+++ b/src/backend/common/helpers/regional_champs_pool_helper.py
@@ -1,0 +1,173 @@
+import logging
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, Set, Union
+
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+
+from backend.common.consts.award_type import NON_JUDGED_NON_TEAM_AWARDS
+from backend.common.consts.district_point_values import DistrictPointValues
+from backend.common.futures import TypedFuture
+from backend.common.helpers.district_helper import (
+    DistrictHelper,
+    DistrictRankingTeamTotal,
+)
+from backend.common.models.event import Event
+from backend.common.models.event_district_points import (
+    EventDistrictPoints,
+    TeamAtEventDistrictPoints,
+    TeamAtEventDistrictPointTiebreakers,
+)
+from backend.common.models.keys import EventKey, TeamKey, Year
+from backend.common.models.team import Team
+
+
+class RegionalChampsPoolHelper(DistrictHelper):
+
+    @classmethod
+    def calculate_event_points(cls, event: Event) -> EventDistrictPoints:
+        event.get_awards_async()
+        event.get_matches_async()
+
+        district_points: EventDistrictPoints = {
+            "points": defaultdict(
+                lambda: TeamAtEventDistrictPoints(
+                    qual_points=0,
+                    elim_points=0,
+                    alliance_points=0,
+                    award_points=0,
+                    total=0,
+                ),
+            ),
+            "tiebreakers": defaultdict(
+                lambda: TeamAtEventDistrictPointTiebreakers(
+                    # for tiebreaker stats that can't be calculated with 'points'
+                    qual_wins=0,
+                    highest_qual_scores=[],
+                )
+            ),
+        }
+
+        # match points
+        cls._calc_rank_based_match_points(
+            event, district_points, event.matches, POINTS_MULTIPLIER=1
+        )
+
+        # alliance points
+        if event.alliance_selections:
+            selection_points = cls._alliance_selections_to_points(
+                event, multiplier=1, alliance_selections=event.alliance_selections
+            )
+            for team, points in selection_points.items():
+                district_points["points"][team]["alliance_points"] += points
+        else:
+            logging.info(
+                "Event {} has no alliance selection regional pool points!".format(
+                    event.key.id()
+                )
+            )
+
+        # award points
+        for award in event.awards:
+            point_value = 0
+            if award.award_type_enum not in NON_JUDGED_NON_TEAM_AWARDS:
+                if award.award_type_enum in DistrictPointValues.REGIONAL_AWARD_VALUES:
+                    point_value = DistrictPointValues.REGIONAL_AWARD_VALUES.get(
+                        award.award_type_enum
+                    )
+                else:
+                    point_value = DistrictPointValues.OTHER_AWARD_DEFAULT
+
+            # Add award points to all teams who won
+            if point_value:
+                for team in award.team_list:
+                    team_key = none_throws(team.string_id())
+                    district_points["points"][team_key]["award_points"] += point_value
+
+        for team, point_breakdown in district_points["points"].items():
+            total_points = sum(
+                [
+                    point_breakdown["qual_points"],
+                    point_breakdown["elim_points"],
+                    point_breakdown["alliance_points"],
+                    point_breakdown["award_points"],
+                ]
+            )
+            district_points["points"][team]["total"] += total_points
+
+        return district_points
+
+    @classmethod
+    def calculate_rankings(
+        cls,
+        events: List[Event],
+        teams: Union[List[Team], TypedFuture[List[Team]]],
+        year: Year,
+    ) -> Dict[TeamKey, DistrictRankingTeamTotal]:
+        # aggregate points from first two regional events
+        events_by_key: Dict[EventKey, Event] = {}
+        team_attendance: DefaultDict[TeamKey, List[EventKey]] = defaultdict(list)
+        team_totals: Dict[TeamKey, DistrictRankingTeamTotal] = defaultdict(
+            lambda: DistrictRankingTeamTotal(
+                event_points=[],
+                point_total=0,
+                rookie_bonus=0,
+                tiebreakers=5 * [0],
+                qual_scores=[],
+                other_bonus=0,
+            )
+        )
+
+        for event in events:
+            events_by_key[event.key_name] = event
+            event_regional_points = event.regional_champs_pool_points
+            if event_regional_points is None:
+                continue
+
+            for team_key in set(event_regional_points["points"].keys()).union(set(event_regional_points["tiebreakers"].keys())):
+                team_attendance[team_key].append(event.key_name)
+                if len(team_attendance[team_key]) > 2:
+                    continue
+
+                if team_key in event_regional_points["points"]:
+                    team_totals[team_key]["event_points"].append(
+                        (event, event_regional_points["points"][team_key])
+                    )
+                    team_totals[team_key]["point_total"] += event_regional_points["points"][team_key]["total"]
+
+                    # Add tiebreakers in order
+                    # TODO: implement tiebreakers
+
+        valid_team_keys: Set[TeamKey] = set()
+        if isinstance(teams, ndb.tasklets.Future):
+            teams = teams.get_result()
+
+        for team in teams:
+            if isinstance(teams, ndb.tasklets.Future):
+                team = team.get_result()
+            bonus = cls._get_rookie_bonus(year, team.rookie_year)
+
+            team_totals[team.key_name]["rookie_bonus"] = bonus
+            team_totals[team.key_name]["point_total"] += bonus
+
+            valid_team_keys.add(team.key_name)
+
+        team_totals = dict(
+            sorted(
+                team_totals.items(),
+                key=lambda item: [
+                    -item[1]["point_total"],
+                    # TODO: also sort by tiebreakers
+                    # -item[1]["tiebreakers"][0],
+                    # -item[1]["tiebreakers"][1],
+                    # -item[1]["tiebreakers"][2],
+                    # -item[1]["tiebreakers"][3],
+                    # -item[1]["tiebreakers"][4],
+                ]
+                # + [-score for score in item[1]["qual_scores"]],
+            )
+        )
+
+        return dict(
+            filter(lambda item: item[0] in valid_team_keys, team_totals.items())
+        )

--- a/src/backend/common/helpers/season_helper.py
+++ b/src/backend/common/helpers/season_helper.py
@@ -15,6 +15,7 @@ class SeasonHelper(object):
 
     MIN_YEAR: Year = 1992
     MIN_DISTRICT_YEAR: Year = 2009
+    MIN_REGIONAL_CMP_POOL_YEAR: Year = 2025
 
     @staticmethod
     def get_max_year() -> Year:
@@ -35,6 +36,11 @@ class SeasonHelper(object):
     def get_valid_district_years(cls) -> Sequence[Year]:
         max_year = cls.get_max_year()
         return range(cls.MIN_DISTRICT_YEAR, max_year + 1)
+
+    @classmethod
+    def get_valid_regional_pool_years(cls) -> Sequence[Year]:
+        max_year = cls.get_max_year()
+        return range(cls.MIN_REGIONAL_CMP_POOL_YEAR, max_year + 1)
 
     @staticmethod
     def effective_season_year(date=datetime.now()) -> Year:

--- a/src/backend/common/manipulators/regional_champs_pool_manipulator.py
+++ b/src/backend/common/manipulators/regional_champs_pool_manipulator.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
+from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
+from backend.common.models.regional_champs_pool import RegionalChampsPool
+
+
+class RegionalChampsPoolManipulator(ManipulatorBase[RegionalChampsPool]):
+
+    @classmethod
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.regional_champs_pool_updated(affected_refs)
+
+    @classmethod
+    def updateMerge(
+        cls,
+        new_model: RegionalChampsPool,
+        old_model: RegionalChampsPool,
+        auto_union: bool = True,
+    ) -> RegionalChampsPool:
+        cls._update_attrs(new_model, old_model, auto_union)
+        return old_model

--- a/src/backend/common/manipulators/regional_pool_team_manipulator.py
+++ b/src/backend/common/manipulators/regional_pool_team_manipulator.py
@@ -1,0 +1,28 @@
+from typing import List
+
+from backend.common.cache_clearing import get_affected_queries
+from backend.common.manipulators.manipulator_base import ManipulatorBase
+from backend.common.models.cached_model import TAffectedReferences
+from backend.common.models.regional_pool_team import RegionalPoolTeam
+
+
+class RegionalPoolTeamManipulator(ManipulatorBase[RegionalPoolTeam]):
+    """
+    handle RegionalPoolTeam writes
+    """
+
+    @classmethod
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[get_affected_queries.TCacheKeyAndQuery]:
+        return get_affected_queries.regionalpoolteam_updated(affected_refs)
+
+    @classmethod
+    def updateMerge(
+        cls,
+        new_model: RegionalPoolTeam,
+        old_model: RegionalPoolTeam,
+        auto_union: bool = True,
+    ):
+        cls._update_attrs(new_model, old_model, auto_union)
+        return old_model

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -239,6 +239,13 @@ class Event(CachedModel):
             return self.details.district_points
 
     @property
+    def regional_champs_pool_points(self) -> Optional[EventDistrictPoints]:
+        if self.event_type_enum != EventType.REGIONAL or self.details is None:
+            return None
+
+        return self.details.regional_champs_pool_points
+
+    @property
     def playoff_advancement(self) -> Optional[TPlayoffAdvancement]:
         if self.details is None:
             return None

--- a/src/backend/common/models/event_details.py
+++ b/src/backend/common/models/event_details.py
@@ -35,6 +35,9 @@ class EventDetails(CachedModel):
         ndb.JsonProperty()
     )  # Formatted as: [{'picks': [captain, pick1, pick2, 'frc123', ...], 'declines':[decline1, decline2, ...] }, {'picks': [], 'declines': []}, ... ]
     district_points: EventDistrictPoints = cast(EventDistrictPoints, ndb.JsonProperty())
+    regional_champs_pool_points: EventDistrictPoints = cast(
+        EventDistrictPoints, ndb.JsonProperty()
+    )
     matchstats: EventMatchstats = cast(
         EventMatchstats, ndb.JsonProperty()
     )  # for OPR, DPR, CCWM, etc.
@@ -61,6 +64,7 @@ class EventDetails(CachedModel):
         "rankings",
         "rankings2",
         "playoff_advancement",
+        "regional_champs_pool_points",
     }
 
     def __init__(self, *args, **kw):

--- a/src/backend/common/models/keys.py
+++ b/src/backend/common/models/keys.py
@@ -12,6 +12,7 @@ EventTeamKey = str
 DistrictKey = str
 DistrictAbbreviation = str
 DistrictTeamKey = str
+RegionalPoolTeamKey = str
 MatchKey = str
 AwardKey = str
 MediaKey = str

--- a/src/backend/common/models/keys.py
+++ b/src/backend/common/models/keys.py
@@ -12,6 +12,7 @@ EventTeamKey = str
 DistrictKey = str
 DistrictAbbreviation = str
 DistrictTeamKey = str
+RegionalChampsPoolKey = str
 RegionalPoolTeamKey = str
 MatchKey = str
 AwardKey = str

--- a/src/backend/common/models/regional_champs_pool.py
+++ b/src/backend/common/models/regional_champs_pool.py
@@ -1,0 +1,56 @@
+from typing import List, Optional
+
+from google.appengine.ext import ndb
+
+from backend.common.helpers.season_helper import SeasonHelper
+from backend.common.models.cached_model import CachedModel
+from backend.common.models.keys import RegionalChampsPoolKey, Year
+from backend.common.models.regional_pool_advancement import RegionalPoolAdvancement
+from backend.common.models.regional_pool_ranking import RegionalPoolRanking
+
+
+class RegionalChampsPool(CachedModel):
+    """
+    One instance of Championship qualification by way of the
+    regional pool (2025+)
+    """
+
+    year: Year = ndb.IntegerProperty()
+
+    created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
+    updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
+
+    rankings: List[RegionalPoolRanking] = ndb.JsonProperty()
+
+    # Dict of team key -> advancement data
+    advancement: RegionalPoolAdvancement = ndb.JsonProperty()  # pyre-ignore[8]
+
+    def __init__(self, *args, **kw) -> None:
+        self._affected_references = {
+            "year": set(),
+        }
+        super(RegionalChampsPool, self).__init__(*args, **kw)
+
+    @property
+    def key_name(self) -> RegionalChampsPoolKey:
+        return f"{self.year}"
+
+    @classmethod
+    def get_for_year(cls, year: Year) -> Optional["RegionalChampsPool"]:
+        if year not in SeasonHelper.get_valid_regional_pool_years():
+            return None
+
+        return cls.get_by_id(cls.render_key_name(year))
+
+    @classmethod
+    def validate_key_name(cls, key: str) -> bool:
+        try:
+            year = int(key)
+            return year in SeasonHelper.get_valid_regional_pool_years()
+        except ValueError:
+            return False
+
+    @classmethod
+    def render_key_name(cls, year: Year) -> RegionalChampsPoolKey:
+        # Simply a stringified year
+        return f"{year}"

--- a/src/backend/common/models/regional_pool_advancement.py
+++ b/src/backend/common/models/regional_pool_advancement.py
@@ -1,0 +1,5 @@
+from typing import TypedDict
+
+
+class RegionalPoolAdvancement(TypedDict):
+    cmp: bool

--- a/src/backend/common/models/regional_pool_ranking.py
+++ b/src/backend/common/models/regional_pool_ranking.py
@@ -1,0 +1,9 @@
+from typing import List, TypedDict
+
+from backend.common.models.event_district_points import TeamAtEventDistrictPoints
+
+
+class RegionalPoolRanking(TypedDict):
+    point_total: int
+    rookie_bonus: int
+    event_points: List[TeamAtEventDistrictPoints]

--- a/src/backend/common/models/regional_pool_ranking.py
+++ b/src/backend/common/models/regional_pool_ranking.py
@@ -1,9 +1,12 @@
 from typing import List, TypedDict
 
 from backend.common.models.event_district_points import TeamAtEventDistrictPoints
+from backend.common.models.keys import TeamKey
 
 
 class RegionalPoolRanking(TypedDict):
+    rank: int
+    team_key: TeamKey
     point_total: int
     rookie_bonus: int
     event_points: List[TeamAtEventDistrictPoints]

--- a/src/backend/common/models/regional_pool_team.py
+++ b/src/backend/common/models/regional_pool_team.py
@@ -1,8 +1,12 @@
+from typing import Set
+
 from google.appengine.ext import ndb
 
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.cached_model import CachedModel
 from backend.common.models.keys import RegionalPoolTeamKey, TeamKey, Year
+from backend.common.models.regional_pool_advancement import RegionalPoolAdvancement
+from backend.common.models.regional_pool_ranking import RegionalPoolRanking
 from backend.common.models.team import Team
 
 
@@ -19,6 +23,16 @@ class RegionalPoolTeam(CachedModel):
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
+
+    total_points = ndb.IntegerProperty()  # For query ordering
+    earned_points: RegionalPoolRanking = ndb.JsonProperty()  # pyre-ignore[8]
+    advancemnet: RegionalPoolAdvancement = ndb.JsonProperty()  # pyre-ignore[8]
+
+    _mutable_attrs: Set[str] = {
+        "total_points",
+        "earned_points",
+        "advancement",
+    }
 
     def __init__(self, *args, **kw) -> None:
         self._affected_references = {

--- a/src/backend/common/models/regional_pool_team.py
+++ b/src/backend/common/models/regional_pool_team.py
@@ -1,0 +1,48 @@
+from google.appengine.ext import ndb
+
+from backend.common.helpers.season_helper import SeasonHelper
+from backend.common.models.cached_model import CachedModel
+from backend.common.models.keys import RegionalPoolTeamKey, TeamKey, Year
+from backend.common.models.team import Team
+
+
+class RegionalPoolTeam(CachedModel):
+    """
+    RegionalPoolTeam represents a team that competed in regionals in a season
+    (and is eligible for Championship via the regional pool)
+
+    Think of it as the regional equivalent of DistrictTeam
+    """
+
+    team = ndb.KeyProperty(kind=Team)
+    year: Year = ndb.IntegerProperty()
+
+    created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
+    updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
+
+    def __init__(self, *args, **kw) -> None:
+        self._affected_references = {
+            "team": set(),
+            "year": set(),
+        }
+        super(RegionalPoolTeam, self).__init__(*args, **kw)
+
+    @property
+    def key_name(self) -> RegionalPoolTeamKey:
+        return self.render_key_name(self.year, self.team.id())
+
+    @staticmethod
+    def validate_key_name(cls, key: str) -> bool:
+        split = key.split("_")
+        try:
+            return (
+                len(split) == 2
+                and int(split[0]) in SeasonHelper.get_valid_regional_pool_years()
+                and Team.validate_key_name(split[1])
+            )
+        except ValueError:
+            return False
+
+    @staticmethod
+    def render_key_name(year: Year, team_key: TeamKey) -> str:
+        return f"{year}_{team_key}"

--- a/src/backend/common/models/regional_pool_team.py
+++ b/src/backend/common/models/regional_pool_team.py
@@ -1,12 +1,8 @@
-from typing import Set
-
 from google.appengine.ext import ndb
 
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.cached_model import CachedModel
 from backend.common.models.keys import RegionalPoolTeamKey, TeamKey, Year
-from backend.common.models.regional_pool_advancement import RegionalPoolAdvancement
-from backend.common.models.regional_pool_ranking import RegionalPoolRanking
 from backend.common.models.team import Team
 
 
@@ -24,19 +20,8 @@ class RegionalPoolTeam(CachedModel):
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
 
-    total_points = ndb.IntegerProperty()  # For query ordering
-    earned_points: RegionalPoolRanking = ndb.JsonProperty()  # pyre-ignore[8]
-    advancemnet: RegionalPoolAdvancement = ndb.JsonProperty()  # pyre-ignore[8]
-
-    _mutable_attrs: Set[str] = {
-        "total_points",
-        "earned_points",
-        "advancement",
-    }
-
     def __init__(self, *args, **kw) -> None:
         self._affected_references = {
-            "team": set(),
             "year": set(),
         }
         super(RegionalPoolTeam, self).__init__(*args, **kw)

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -501,7 +501,7 @@ def event_details(event_key: EventKey) -> Response:
     template_values = {
         "event": event,
         "event_teams": event_teams,
-        "district_teams": district_teams,
+        "district_teams": listify(district_teams),
         "regional_pool_teams": regional_pool_teams,
     }
 

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -40,6 +40,7 @@ from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import DistrictKey, EventKey, TeamKey, Year
+from backend.common.models.regional_pool_advancement import RegionalPoolAdvancement
 from backend.common.models.regional_pool_team import RegionalPoolTeam
 from backend.common.models.robot import Robot
 from backend.common.models.team import Team
@@ -395,7 +396,8 @@ def event_details(event_key: EventKey) -> Response:
 
         if (
             event.year in SeasonHelper.get_valid_regional_pool_years()
-            and event.event_type_enum == EventType.REGIONAL
+            and event.event_type_enum
+            in {EventType.REGIONAL, EventType.CMP_DIVISION, EventType.CMP_FINALS}
             and team is not None
             and district_team is None
         ):
@@ -403,6 +405,14 @@ def event_details(event_key: EventKey) -> Response:
                 id=RegionalPoolTeam.render_key_name(event.year, team.key_name),
                 year=event.year,
                 team=team.key,
+                advancemnet=(
+                    RegionalPoolAdvancement(
+                        cmp=True,
+                    )
+                    if event.event_type_enum
+                    in {EventType.CMP_DIVISION, EventType.CMP_FINALS}
+                    else None
+                ),
             )
             regional_pool_teams.append(regional_pool_team)
 

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -9,6 +9,7 @@ from google.appengine.ext import ndb
 from markupsafe import Markup
 from pyre_extensions import none_throws
 
+from backend.common.consts.event_type import EventType
 from backend.common.environment import Environment
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.event_remapteams_helper import EventRemapTeamsHelper
@@ -28,6 +29,9 @@ from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
 from backend.common.manipulators.match_manipulator import MatchManipulator
 from backend.common.manipulators.media_manipulator import MediaManipulator
+from backend.common.manipulators.regional_pool_team_manipulator import (
+    RegionalPoolTeamManipulator,
+)
 from backend.common.manipulators.robot_manipulator import RobotManipulator
 from backend.common.manipulators.team_manipulator import TeamManipulator
 from backend.common.models.district import District
@@ -36,6 +40,7 @@ from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import DistrictKey, EventKey, TeamKey, Year
+from backend.common.models.regional_pool_team import RegionalPoolTeam
 from backend.common.models.robot import Robot
 from backend.common.models.team import Team
 from backend.common.sitevars.apistatus import ApiStatus
@@ -120,12 +125,32 @@ def team_details(team_key: TeamKey) -> Response:
     fms_details = fms_df.get_team_details(year, team_key).get_result()
 
     team, district_team, robot = fms_details or (None, None, None)
+    regional_pool_team: Optional[RegionalPoolTeam] = None
 
     if team:
         team = TeamManipulator.createOrUpdate(team)
 
     if district_team:
         district_team = DistrictTeamManipulator.createOrUpdate(district_team)
+
+        if year in SeasonHelper.get_valid_regional_pool_years():
+            regional_pool_key = ndb.Key(
+                RegionalPoolTeam,
+                RegionalPoolTeam.render_key_name(year, team_key),
+            )
+            RegionalPoolTeamManipulator.delete_keys([regional_pool_key])
+
+    if (
+        year in SeasonHelper.get_valid_regional_pool_years()
+        and team
+        and not district_team
+    ):
+        regional_pool_team = RegionalPoolTeam(
+            id=RegionalPoolTeam.render_key_name(year, team.key_name),
+            year=year,
+            team=team.key,
+        )
+        RegionalPoolTeamManipulator.createOrUpdate(regional_pool_team)
 
     # Clean up junk district teams
     # https://www.facebook.com/groups/moardata/permalink/1310068625680096/
@@ -163,6 +188,7 @@ def team_details(team_key: TeamKey) -> Response:
         "success": team is not None,
         "robot": robot,
         "district_team": district_team,
+        "regional_pool_team": regional_pool_team,
     }
 
     if (
@@ -355,6 +381,7 @@ def event_details(event_key: EventKey) -> Response:
     models = event_teams_future.get_result()
     teams: List[Team] = []
     district_teams: List[DistrictTeam] = []
+    regional_pool_teams: List[RegionalPoolTeam] = []
     robots: List[Robot] = []
     for group in models:
         # models is a list of tuples (team, districtTeam, robot)
@@ -365,6 +392,19 @@ def event_details(event_key: EventKey) -> Response:
         district_team = group[1]
         if isinstance(district_team, DistrictTeam):
             district_teams.append(district_team)
+
+        if (
+            event.year in SeasonHelper.get_valid_regional_pool_years()
+            and event.event_type_enum == EventType.REGIONAL
+            and team is not None
+            and district_team is None
+        ):
+            regional_pool_team = RegionalPoolTeam(
+                id=RegionalPoolTeam.render_key_name(event.year, team.key_name),
+                year=event.year,
+                team=team.key,
+            )
+            regional_pool_teams.append(regional_pool_team)
 
         robot = group[2]
         if isinstance(robot, Robot):
@@ -378,6 +418,9 @@ def event_details(event_key: EventKey) -> Response:
 
     district_teams = DistrictTeamManipulator.createOrUpdate(district_teams)
     robots = RobotManipulator.createOrUpdate(robots)
+    regional_pool_teams = RegionalPoolTeamManipulator.createOrUpdate(
+        regional_pool_teams
+    )
 
     if not teams:
         # No teams found registered for this event
@@ -448,6 +491,8 @@ def event_details(event_key: EventKey) -> Response:
     template_values = {
         "event": event,
         "event_teams": event_teams,
+        "district_teams": district_teams,
+        "regional_pool_teams": regional_pool_teams,
     }
 
     if (

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -172,8 +172,7 @@ def regional_event_champs_pool_points_calc(event_key: EventKey) -> Response:
 
     if event.event_type_enum == EventType.REGIONAL:
         taskqueue.add(
-            url=url_for("match.regional_champs_pool_rankings_calc"),
-            year=event.year,
+            url=url_for("math.regional_champs_pool_rankings_calc", year=event.year),
             method="GET",
             target="py3-tasks-io",
             queue_name="default",
@@ -280,7 +279,7 @@ def district_rankings_calc(district_key: DistrictKey) -> Response:
     return make_response("")
 
 
-@blueprint.route("/tasks/math/do/regional_champs_pool_rankings_calc/<year:int>")
+@blueprint.route("/tasks/math/do/regional_champs_pool_rankings_calc/<int:year>")
 def regional_champs_pool_rankings_calc(year: Year) -> Response:
     regional_pool = RegionalChampsPool.get_for_year(year)
     if not regional_pool:

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -8,7 +8,7 @@ from google.appengine.ext import ndb
 from werkzeug.wrappers import Response
 
 from backend.common.consts.event_type import EventType, SEASON_EVENT_TYPES
-from backend.common.futures import TypedFuture
+from backend.common.futures import InstantFuture, TypedFuture
 from backend.common.helpers.district_helper import DistrictHelper
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.event_insights_helper import EventInsightsHelper
@@ -17,21 +17,31 @@ from backend.common.helpers.listify import listify
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.matchstats_helper import MatchstatsHelper
 from backend.common.helpers.prediction_helper import PredictionHelper
+from backend.common.helpers.regional_champs_pool_helper import RegionalChampsPoolHelper
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.manipulators.district_manipulator import DistrictManipulator
 from backend.common.manipulators.event_details_manipulator import (
     EventDetailsManipulator,
 )
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
+from backend.common.manipulators.regional_champs_pool_manipulator import (
+    RegionalChampsPoolManipulator,
+)
 from backend.common.models.district import District
 from backend.common.models.district_ranking import DistrictRanking
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.keys import DistrictKey, EventKey, Year
+from backend.common.models.regional_champs_pool import RegionalChampsPool
+from backend.common.models.regional_pool_ranking import RegionalPoolRanking
 from backend.common.models.team import Team
 from backend.common.queries.district_query import DistrictsInYearQuery
-from backend.common.queries.event_query import DistrictEventsQuery, EventListQuery
-from backend.common.queries.team_query import DistrictTeamsQuery
+from backend.common.queries.event_query import (
+    DistrictEventsQuery,
+    EventListQuery,
+    RegionalEventsQuery,
+)
+from backend.common.queries.team_query import DistrictTeamsQuery, RegionalTeamsQuery
 
 
 blueprint = Blueprint("math", __name__)
@@ -46,13 +56,41 @@ def enqueue_event_district_points_calc(year: Optional[Year]) -> Response:
     if year is None:
         year = SeasonHelper.get_current_season()
 
-    event_keys: List[ndb.Key] = Event.query(
-        Event.year == year, Event.event_type_enum.IN(SEASON_EVENT_TYPES)
-    ).fetch(None, keys_only=True)
-    for event_key in event_keys:
+    if year in SeasonHelper.get_valid_regional_pool_years():
+        district_point_types = SEASON_EVENT_TYPES - {EventType.REGIONAL}
+        regional_point_types = {EventType.REGIONAL}
+    else:
+        district_point_types = SEASON_EVENT_TYPES
+        regional_point_types = {}
+
+    district_event_keys_future: TypedFuture[List[ndb.Key]] = Event.query(
+        Event.year == year, Event.event_type_enum.IN(district_point_types)
+    ).fetch_async(None, keys_only=True)
+    regional_event_keys_future: TypedFuture[List[ndb.Key]] = (
+        Event.query(
+            Event.year == year, Event.event_type_enum.IN(regional_point_types)
+        ).fetch_async(None, keys_only=True)
+        if regional_point_types
+        else InstantFuture(result=[])
+    )
+
+    district_event_keys = district_event_keys_future.get_result()
+    for event_key in district_event_keys:
         taskqueue.add(
             url=url_for(
                 "math.event_district_points_calc", event_key=event_key.string_id()
+            ),
+            method="GET",
+            target="py3-tasks-io",
+            queue_name="default",
+        )
+
+    regional_event_keys = regional_event_keys_future.get_result()
+    for event_key in regional_event_keys:
+        taskqueue.add(
+            url=url_for(
+                "math.regional_event_champs_pool_points_calc",
+                event_key=event_key.string_id(),
             ),
             method="GET",
             target="py3-tasks-io",
@@ -63,7 +101,10 @@ def enqueue_event_district_points_calc(year: Optional[Year]) -> Response:
         "X-Appengine-Taskname" not in request.headers
     ):  # Only write out if not in taskqueue
         return make_response(
-            "Enqueued for: {}".format([event_key.id() for event_key in event_keys])
+            "Enqueued for districts: {}\nEnqueued for regionals: {}".format(
+                [event_key.id() for event_key in district_event_keys],
+                [event_key.id() for event_key in regional_event_keys],
+            )
         )
 
     return make_response("")
@@ -106,6 +147,43 @@ def event_district_points_calc(event_key: EventKey) -> Response:
         "X-Appengine-Taskname" not in request.headers
     ):  # Only write out if not in taskqueue
         return make_response(json.dumps(district_points, sort_keys=True, indent=2))
+
+    return make_response("")
+
+
+@blueprint.route("/tasks/math/do/regional_champs_pool_points_calc/<event_key>")
+def regional_event_champs_pool_points_calc(event_key: EventKey) -> Response:
+    """
+    Calculates regional CMP pool advancement points for an event (2025+)
+    """
+
+    event = Event.get_by_id(event_key)
+    if not event:
+        abort(404)
+
+    if event.year not in SeasonHelper.get_valid_regional_pool_years():
+        return make_response("")
+
+    regional_pool_points = RegionalChampsPoolHelper.calculate_event_points(event)
+    event_details = EventDetails(
+        id=event_key, regional_champs_pool_points=regional_pool_points
+    )
+    EventDetailsManipulator.createOrUpdate(event_details)
+
+    if event.event_type_enum == EventType.REGIONAL:
+        taskqueue.add(
+            url=url_for("match.regional_champs_pool_rankings_calc"),
+            year=event.year,
+            method="GET",
+            target="py3-tasks-io",
+            queue_name="default",
+            # TODO: ^ new queue with a rate limit
+        )
+
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return make_response(json.dumps(regional_pool_points, sort_keys=True, indent=2))
 
     return make_response("")
 
@@ -198,6 +276,53 @@ def district_rankings_calc(district_key: DistrictKey) -> Response:
     ):  # Only write out if not in taskqueue
         return make_response(
             f"Finished calculating rankings for: {district_key}:\n{rankings}"
+        )
+    return make_response("")
+
+
+@blueprint.route("/tasks/math/do/regional_champs_pool_rankings_calc/<year:int>")
+def regional_champs_pool_rankings_calc(year: Year) -> Response:
+    regional_pool = RegionalChampsPool.get_for_year(year)
+    if not regional_pool:
+        return make_response(f"Regional champs pool not found for year {year}", 404)
+
+    events_future: TypedFuture[List[Event]] = RegionalEventsQuery(year).fetch_async()
+    teams_future: TypedFuture[List[Team]] = RegionalTeamsQuery(year).fetch_async()
+
+    events = events_future.get_result()
+    for event in events:
+        event.prep_details
+
+    events = EventHelper.sorted_events(events)
+    team_totals = RegionalChampsPoolHelper.calculate_rankings(
+        events, teams_future, year
+    )
+
+    rankings: List[RegionalPoolRanking] = []
+    current_rank = 1
+    for key, points in team_totals.items():
+        point_detail = RegionalPoolRanking(
+            rank=current_rank,
+            team_key=key,
+            event_points=[],
+            rookie_bonus=points.get("rookie_bonus", 0),
+            point_total=points["point_total"],
+        )
+        for event, event_points in points["event_points"]:
+            event_points["event_key"] = event.key_name
+            point_detail["event_points"].append(event_points)
+
+        rankings.append(point_detail)
+        current_rank += 1
+
+    if rankings:
+        regional_pool.rankings = rankings
+        RegionalChampsPoolManipulator.createOrUpdate(regional_pool)
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return make_response(
+            f"Finished calculating regional pool rankings for: {year}:\n{rankings}"
         )
     return make_response("")
 

--- a/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
+++ b/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
@@ -27,7 +27,7 @@ def test_enqueue_no_events(
 ) -> None:
     resp = tasks_client.get("/tasks/math/enqueue/district_points_calc/2020")
     assert resp.status_code == 200
-    assert resp.data == b"Enqueued for: []"
+    assert resp.data == b"Enqueued for districts: []\nEnqueued for regionals: []"
 
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
     assert len(tasks) == 0

--- a/src/backend/tasks_io/templates/datafeeds/usfirst_event_details_get.html
+++ b/src/backend/tasks_io/templates/datafeeds/usfirst_event_details_get.html
@@ -18,5 +18,9 @@
     <li>Ends on: {{event.end_date}}</li>
     <li>Website: {{event.website}}</li>
     <li>Playoff type: {{event.playoff_type}}</li>
-    <li>Teams: {{event_teams|length}} registered - {% for event_team in event_teams %}{{event_team.team.id}} {% endfor %}</li>
+    <li>Teams: {{event_teams|length}} registered - {% for event_team in event_teams %}{{event_team.team.id()}} {% endfor %}</li>
 </ul>
+
+<h3>Other Models</h3>
+<p><b>DistrictTeams:</b> {% for dt in district_teams %}{{dt.key.string_id()}} {%endfor%}</p>
+<p><b>RegionalPoolTeams:</b> {% for rpt in regional_pool_teams %}{{rpt.key.string_id()}} {%endfor%}</p>

--- a/src/backend/tasks_io/templates/datafeeds/usfirst_team_details_get.html
+++ b/src/backend/tasks_io/templates/datafeeds/usfirst_team_details_get.html
@@ -15,6 +15,7 @@
         <li>Website: {{team.website}}</li>
         <li>Robot: {{robot}}</li>
         <li>DistrictTeam: {{district_team}}</li>
+        <li>RegionalPoolTeam: {{regional_pool_team}}</li>
     </ul>
     {% else %}
     <div>

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -22,6 +22,7 @@ from backend.web.handlers.admin.districts import (
     district_create,
     district_delete,
     district_delete_post,
+    district_details,
     district_edit,
     district_edit_post,
     district_list,
@@ -185,6 +186,7 @@ admin_routes.add_url_rule(
     "/districts", view_func=district_list, defaults={"year": None}
 )
 admin_routes.add_url_rule("/districts/<int:year>", view_func=district_list)
+admin_routes.add_url_rule("/district/<district_key>", view_func=district_details)
 admin_routes.add_url_rule("/district/create", view_func=district_create)
 admin_routes.add_url_rule(
     "/district/delete/<district_key>", methods=["GET"], view_func=district_delete

--- a/src/backend/web/handlers/admin/districts.py
+++ b/src/backend/web/handlers/admin/districts.py
@@ -11,6 +11,7 @@ from backend.common.manipulators.district_team_manipulator import (
 )
 from backend.common.models.district import District
 from backend.common.models.district_team import DistrictTeam
+from backend.common.models.event import Event
 from backend.common.models.keys import DistrictKey, Year
 from backend.web.profiled_render import render_template
 
@@ -27,6 +28,16 @@ def district_list(year: Optional[Year]) -> str:
     }
 
     return render_template("admin/district_list.html", template_values)
+
+
+def district_details(district_key: DistrictKey) -> str:
+    district = District.get_by_id(district_key)
+    if not district:
+        abort(404)
+
+    events = Event.query(Event.district_key == district.key).fetch_async()
+    template_values = {"district": district, "events": events.get_result()}
+    return render_template("admin/district_details.html", template_values)
 
 
 def district_edit(district_key: DistrictKey) -> str:

--- a/src/backend/web/handlers/admin/team.py
+++ b/src/backend/web/handlers/admin/team.py
@@ -9,6 +9,7 @@ from backend.common.manipulators.team_manipulator import TeamManipulator
 from backend.common.models.district_team import DistrictTeam
 from backend.common.models.event_team import EventTeam
 from backend.common.models.media import Media
+from backend.common.models.regional_pool_team import RegionalPoolTeam
 from backend.common.models.robot import Robot
 from backend.common.models.team import Team
 from backend.common.queries.team_query import TeamParticipationQuery
@@ -61,6 +62,9 @@ def team_detail(team_number: int) -> str:
     team_medias = Media.query(Media.references == team.key).fetch(500)
     robots = Robot.query(Robot.team == team.key).fetch()
     district_teams = DistrictTeam.query(DistrictTeam.team == team.key).fetch()
+    regional_pool_teams = RegionalPoolTeam.query(
+        RegionalPoolTeam.team == team.key
+    ).fetch()
     years_participated = sorted(TeamParticipationQuery(team.key_name).fetch())
 
     team_medias_by_year = defaultdict(list)
@@ -84,6 +88,7 @@ def team_detail(team_number: int) -> str:
         "team_social_media": team_social_media,
         "robots": robots,
         "district_teams": district_teams,
+        "regional_pool_teams": regional_pool_teams,
         "years_participated": years_participated,
     }
 

--- a/src/backend/web/templates/admin/district_details.html
+++ b/src/backend/web/templates/admin/district_details.html
@@ -1,0 +1,88 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{district.key_name}}{% endblock %}
+
+{% block content %}
+<h1>{{district.year}} {{district.display_name}} District</h1>
+<div class="btn-group">
+  <a href="/admin/district/edit/{{district.key_name}}" class="btn btn-primary"><span class="glyphicon glyphicon-edit"></span>
+    Edit</a>
+  <a href="/events/{{district.abbreviation}}/{{district.year}}" class="btn btn-default"><span class="glyphicon glyphicon-eye-open"></span> View on
+    TBA</a>
+</div>
+<hr/>
+
+<div class="row">
+  <div class="col-sm-12">
+    <ul class="nav nav-tabs nav-justified">
+      <li class="active"><a href="#info" data-toggle="tab">Info</a></li>
+      <li><a href="#events" data-toggle="tab">Events</a></li>
+      <li><a href="#rankings" data-toggle="tab">Rankings</a></li>
+      <li><a href="#advancement" data-toggle="tab">Advancement</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="tab-content">
+    <div class="tab-pane active" id="info">
+        <table class="table table-striped table-hover">
+            <tr>
+                <td>Display Name</td>
+                <td>{{ district.display_name }}</td>
+            </tr>
+            <tr>
+                <td>Elasticsearch Name</td>
+                <td> {{district.elasticsearch_name }}</td>
+            </tr>
+        </table>
+
+        <h2>Tasks</h2>
+        <div class="btn-group">
+          <a href="/backend-tasks/get/district_rankings/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Details from FIRST</a>
+        </div>
+    </div>
+    <div class="tab-pane" id="events">
+        <table class="table table-striped table-hover">
+            <tr>
+                <th>Event</th>
+                <th>Has Points</th>
+                <th></th>
+            </tr>
+            {% for event in events %}
+                <tr>
+                    <td><a href="/admin/event/{{event.key_name}}">{{event.name}}</a></td>
+                    <td>
+                        {% if event.details.district_points and event.details.district_points.points %}<span class="glyphicon glyphicon-ok"><span>{% endif %}
+                    </td>
+                    <td>
+                        <a href="/tasks/math/do/district_points_calc/{{event.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-tasks"></span> Compute District Points</a>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
+    <div class="tab-pane" id="rankings">
+        <table class="table table-striped table-hover">
+            <tr>
+                <th>Rank</th>
+                <th>Team</th>
+                <th>Point Total</th>
+                <th>Rookie Bonus</th>
+                <th>Event Points</th>
+            </tr>
+            {% for rank in district.rankings or []%}
+                <tr>
+                    <td>{{rank.rank}}</td>
+                    <td><a href="/admin/team/{{rank.team_key[3:]}}">{{rank.team_key}}</a></td>
+                    <td>{{rank.point_total}}</td>
+                    <td>{{rank.rookie_bonus}}</td>
+                    <td><pre>{{rank.event_points}}</pre></td>
+                </tr>
+            {% else %}
+                <tr><td>No district rankings found</td></tr>
+            {% endfor %}
+        </table>
+    </div>
+</div>
+
+{% endblock %}

--- a/src/backend/web/templates/admin/district_list.html
+++ b/src/backend/web/templates/admin/district_list.html
@@ -32,7 +32,7 @@
 
     {% for district in districts %}
     <tr>
-        <td><a href="/admin/district/edit/{{district.key_name}}">{{ district.key_name }}</a></td>
+        <td><a href="/admin/district/{{district.key_name}}">{{ district.key_name }}</a></td>
         <td>{{ district.year }}</td>
         <td>{{ district.abbreviation }}</td>
         <td>{{ district.display_name }}</td>

--- a/src/backend/web/templates/admin/event_details.html
+++ b/src/backend/web/templates/admin/event_details.html
@@ -42,6 +42,7 @@
       <li><a href="#advancement" data-toggle="tab">Playoff Advancement</a></li>
       <li><a href="#awards" data-toggle="tab">Awards</a></li>
       <li><a href="#matches" data-toggle="tab">Matches</a></li>
+      <li><a href="#district-points" data-toggle="tab">District Points</a></li>
       <li><a href="#media" data-toggle="tab">Media</a></li>
     </ul>
   </div>
@@ -669,6 +670,56 @@
       </p>
 
     </form>
+  </div>
+
+  <div class="tab-pane" id="district-points">
+    {% if event.details.regional_champs_pool_points %}
+      <h2>Regional Championship Pool Points</h2>
+      <table class="table table-striped table-hover table-condensed">
+        <tr>
+          <th>Team</th>
+          <th>Qual Points</th>
+          <th>Elim Points</th>
+          <th>Alliance Points</th>
+          <th>Award Points</th>
+          <th>Total Points</th>
+        </tr>
+        {% for team_key, points in event.details.regional_champs_pool_points.points.items() %}
+          <tr>
+            <td><a href="/team/{{team_key[3:]}}">{{team_key[3:]}}</a></td>
+            <td>{{points.qual_points}}</td>
+            <td>{{points.elim_points}}</td>
+            <td>{{points.alliance_points}}</td>
+            <td>{{points.award_points}}</td>
+            <td>{{points.total}}</td>
+          </tr>
+        {% endfor %}
+      </table>
+
+    {% elif event.details.district_points %}
+      <h2>District Points</h2>
+      <i>These may or may not be relevant, TBA always calculates district points</i>
+      <table class="table table-striped table-hover table-condensed">
+        <tr>
+          <th>Team</th>
+          <th>Qual Points</th>
+          <th>Elim Points</th>
+          <th>Alliance Points</th>
+          <th>Award Points</th>
+          <th>Total Points</th>
+        </tr>
+        {% for team_key, points in event.details.district_points.points.items() %}
+          <tr>
+            <td><a href="/team/{{team_key[3:]}}">{{team_key[3:]}}</a></td>
+            <td>{{points.qual_points}}</td>
+            <td>{{points.elim_points}}</td>
+            <td>{{points.alliance_points}}</td>
+            <td>{{points.award_points}}</td>
+            <td>{{points.total}}</td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% endif %}
   </div>
 
   <div class="tab-pane" id="media">

--- a/src/backend/web/templates/admin/team_details.html
+++ b/src/backend/web/templates/admin/team_details.html
@@ -101,6 +101,15 @@
             {% endfor %}
         </td>
     </tr>
+    <tr>
+        <td>Regional Pool Participation</td>
+        <td>
+            {% for rp_team in regional_pool_teams %}
+                {{ rp_team.key.string_id() }}
+                {% if not loop.last %}, {% endif %}
+            {% endfor %}
+        </td>
+    </tr>
 </table>
 
 <p>Teams are currently uneditable. They are updated via FRC API scraping.</p>


### PR DESCRIPTION
This is new for this year!

We now need to track the leaderboard in the "regional pool" (where points are similar, but not exactly equivalent to district points). 

We will implement this with an analogue of the `DistrictTeam` model for regional teams.

This PR contains a few commits:
 - introduce the models / manipulator plumbing
 - update the API datafeed to write a `RegionalPoolTeam` when we do not have a district team (we are assuming that event team not in a district is a regional team) + display them naively in the admin panel / datafeed output
 - the annual rankings are stored in the `RegionalPool` model 
 - update the "calculate district points" hooks to trigger regional points for relevant events

Still TODO:
 - implement the differing tiebreakers
 - add API endpoint for regional pool rankings/etc
 - no pages to display the data yet (either in regular interface or admin panel)