### PR TITLE
Replace deprecated FCM send

### DIFF
--- a/src/backend/common/models/notifications/requests/fcm_request.py
+++ b/src/backend/common/models/notifications/requests/fcm_request.py
@@ -55,7 +55,7 @@ class FCMRequest(Request):
         Returns:
             messaging.BatchResponse - Batch response object for the messages sent.
         """
-        response = messaging.send_multicast(self._fcm_message(), app=self._app)
+        response = messaging.send_each_for_multicast(self._fcm_message(), app=self._app)
         if response.success_count > 0:
             self.defer_track_notification(response.success_count)
         return response

--- a/src/backend/common/models/notifications/requests/tests/fcm_request_test.py
+++ b/src/backend/common/models/notifications/requests/tests/fcm_request_test.py
@@ -57,7 +57,7 @@ def test_send(fcm_app):
     )
     request = FCMRequest(fcm_app, notification=MockNotification(), tokens=["abc"])
     with patch.object(
-        messaging, "send_multicast", return_value=batch_response
+        messaging, "send_each_for_multicast", return_value=batch_response
     ) as mock_send, patch.object(request, "defer_track_notification") as mock_track:
         response = request.send()
     mock_send.assert_called_once()
@@ -71,7 +71,7 @@ def test_send_failed(fcm_app):
         fcm_app, notification=MockNotification(), tokens=["abc", "def"]
     )
     with patch.object(
-        messaging, "send_multicast", return_value=batch_response
+        messaging, "send_each_for_multicast", return_value=batch_response
     ) as mock_send, patch.object(request, "defer_track_notification") as mock_track:
         response = request.send()
     mock_send.assert_called_once()
@@ -90,7 +90,7 @@ def test_send_failed_partial(fcm_app):
         fcm_app, notification=MockNotification(), tokens=["abc", "def"]
     )
     with patch.object(
-        messaging, "send_multicast", return_value=batch_response
+        messaging, "send_each_for_multicast", return_value=batch_response
     ) as mock_send, patch.object(request, "defer_track_notification") as mock_track:
         response = request.send()
     mock_send.assert_called_once()


### PR DESCRIPTION
We're getting 404's from using the deprecated batch APIs for FCM (see https://github.com/firebase/firebase-admin-python/issues/849)

This PR updates our calls to the deprecated `send_multicast` to calling `send_each_for_multicast`, which should be a drop in replacement.