### PR TITLE
Remove sending to Android via legacy data payload flow

### DIFF
--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -19,10 +19,6 @@ FCM_CLIENTS: Set[ClientType] = {
     ClientType.WEB,
 }
 
-FCM_LEGACY_CLIENTS: Set[ClientType] = {
-    ClientType.OS_ANDROID,
-}
-
 
 NAMES: Dict[ClientType, str] = {
     ClientType.OS_ANDROID: "Android",

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -336,7 +336,7 @@ class TestTBANSHelper(unittest.TestCase):
             # Make sure our taskqueue tasks execute what we expect
             with patch.object(TBANSHelper, "_send_fcm") as mock_send_fcm:
                 deferred.run(tasks[0].payload)
-                mock_send_fcm.assert_called_once_with([client], ANY, False)
+                mock_send_fcm.assert_called_once_with([client], ANY)
                 # Make sure the notification is a BroadcastNotification
                 notification = mock_send_fcm.call_args[0][1]
                 assert isinstance(notification, BroadcastNotification)
@@ -1036,7 +1036,7 @@ class TestTBANSHelper(unittest.TestCase):
         # Make sure our taskqueue tasks execute what we expect
         with patch.object(TBANSHelper, "_send_fcm") as mock_send_fcm:
             deferred.run(tasks[0].payload)
-            mock_send_fcm.assert_called_once_with([client], ANY, False)
+            mock_send_fcm.assert_called_once_with([client], ANY)
 
     def test_defer_webhook(self):
         client = MobileClient(
@@ -1096,7 +1096,7 @@ class TestTBANSHelper(unittest.TestCase):
             autospec=True,
         ) as mock_init:
             TBANSHelper._send_fcm(clients, MockNotification())
-            mock_init.assert_called_once_with(ANY, ANY, expected, False)
+            mock_init.assert_called_once_with(ANY, ANY, expected)
 
     def test_send_fcm_filter_from_notification(self):
         clients = [
@@ -1410,7 +1410,7 @@ class TestTBANSHelper(unittest.TestCase):
                 "logging.error"
             ):
                 # call_time = time.time()
-                TBANSHelper._send_fcm([client], MockNotification(), False, i)
+                TBANSHelper._send_fcm([client], MockNotification(), i)
 
                 # NOTE: Removed in https://github.com/the-blue-alliance/the-blue-alliance/pull/4620
                 # Check that we queue'd for a retry with the proper countdown time

--- a/src/backend/common/models/notifications/requests/fcm_request.py
+++ b/src/backend/common/models/notifications/requests/fcm_request.py
@@ -1,13 +1,6 @@
-import json
-
 from firebase_admin import messaging
-from googleapiclient import (
-    _helpers,
-)  # Fix positional argument warnings - can remove once we upgrade to firebase-admin=4.0.0
 
 from backend.common.models.notifications.requests.request import Request
-
-_helpers.positional_parameters_enforcement = _helpers.POSITIONAL_IGNORE
 
 
 MAXIMUM_TOKENS = 500


### PR DESCRIPTION
Android notifications are too large currently by passing in the entire webhook data payload. This removes the legacy data payload flow (and thus sending to Android devices for now)
Mostly a revert of https://github.com/the-blue-alliance/the-blue-alliance/pull/4311

Tests will fail to begin with, I didn't get all the removal of the expected calls with the True/False flag for legacy payloads I imagine