### PR TITLE
Add game name information to avatars page. Add avatars docs to season runbook

### DIFF
--- a/docs/Maintainers/New-Season.md
+++ b/docs/Maintainers/New-Season.md
@@ -60,7 +60,9 @@ Once the game is announced, the landing page type should be changed to `Build Se
 
 ### Avatars
 
-TODO
+At some point during the build season avatar submissions will open. This is generally accompanied by a blog post from FIRST letting teams know submissions are open, and guiding teams on how to submit their avatars. We should add a link to this blog post from the [avatars page](https://github.com/rbgk/the-blue-alliance/blob/py3/src/backend/web/templates/avatars.html) at the top. See an [example PR from 2025](https://github.com/the-blue-alliance/the-blue-alliance/pull/7060).
+
+Optionally, the build season landing page `build_handler_show_avatars` property can be swapped to true. However, the avatars page attempts to load ALL team avatars in one go, which causes a 500 due to our request going OOM. This is a neat little page to look at, but we might not want to advertise it until optimizations have been made.
 
 ## Pre-First Event
 

--- a/src/backend/web/templates/avatars.html
+++ b/src/backend/web/templates/avatars.html
@@ -21,7 +21,7 @@
           </ul>
         </div>
 
-        <span style="vertical-align: middle">{% if year == 2018 %}<i>FIRST POWER UP</i>{% elif year == 2019 %}<i>DESTINATION: DEEP SPACE</i>{% elif year == 2020 %}<i>INFINITE RECHARGE</i>{% elif year == 2022 %}<i>RAPID REACT</i>{% endif %} Avatars</span>
+        <span style="vertical-align: middle">{% if year == 2018 %}<i>FIRST POWER UP</i>{% elif year == 2019 %}<i>DESTINATION: DEEP SPACE</i>{% elif year == 2020 %}<i>INFINITE RECHARGE</i>{% elif year == 2022 %}<i>RAPID REACT</i>{% elif year == 2023 %}<i>CHARGED UP</i>{% elif year == 2024 %}<i>CRESCENDO</i>{% elif year == 2025 %}<i>REEFSCAPE</i>{% endif %} Avatars</span>
       </h1>
 
       <p>For more information about submitting avatars, please read the official FRC <a href="{% if year == 2018 %}https://www.firstinspires.org/robotics/frc/blog/team-avatar-submission-system{% elif year == 2019 %}https://www.firstinspires.org/robotics/frc/blog/2019-team-avatars-reprise{% elif year == 2020 %}https://www.firstinspires.org/robotics/frc/blog/2020-team-avatars{% elif year == 2022 %}https://www.firstinspires.org/robotics/frc/blog/2022-team-avatars-return-for-2022{% elif year == 2023 %}https://www.firstinspires.org/robotics/frc/blog/2023-2023-team-avatars{% elif year == 2024 %}https://www.firstinspires.org/robotics/frc/blog/2024-2024-team-avatars{% elif year == 2025 %}https://community.firstinspires.org/2025-team-avatars{% endif %}" target="_blank" rel="noopener noreferrer">blog post</a>.</p>


### PR DESCRIPTION
We really ought to have some year <-> game name dictionary somewhere to do this dynamically. But until then - adds the few missing game names from recent years and adds docs letting people what to do for avatars during the build season.