### PR TITLE
Update runtime version to python312 in dev_appserver launch

### DIFF
--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -89,7 +89,7 @@ fi
 
 # dev_appserver doesn't support the python311 runtime yet
 # but will still point at the local system python3 binary
-runtime_version="python310"
+runtime_version="python312"
 
 set -x
 dev_appserver.py \


### PR DESCRIPTION
Just bumping this - the `python312` seems like it picks up the proper Python runtime now

<img width="1548" alt="Screenshot 2025-02-17 at 2 21 06 PM" src="https://github.com/user-attachments/assets/0d135766-9fad-494e-bfad-1910570ae4ee" />
