### PR TITLE
Adds `tba_botRowCount`, `tba_midRowCount`, `tba_topRowCount` to `autoReef` and `teleopReef` for `red`/`blue` 2025 match breakdowns

### DIFF
--- a/src/backend/common/models/tests/match_test.py
+++ b/src/backend/common/models/tests/match_test.py
@@ -5,6 +5,7 @@ from typing import Optional
 import pytest
 from freezegun import freeze_time
 from google.appengine.ext import ndb
+from pyre_extensions.refinement import none_throws
 
 from backend.common.consts import comp_level
 from backend.common.consts.alliance_color import AllianceColor
@@ -22,7 +23,7 @@ def get_base_elim_match(**kwargs) -> Match:
         comp_level=CompLevel.SF,
         set_number=1,
         match_number=2,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -34,7 +35,7 @@ def get_base_finals_match(**kwargs) -> Match:
         comp_level=CompLevel.F,
         set_number=1,
         match_number=3,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -46,7 +47,7 @@ def get_base_qual_match(**kwargs) -> Match:
         comp_level=CompLevel.QM,
         set_number=1,
         match_number=20,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -415,3 +416,294 @@ def test_youtube_videos_formatted_no_timestamp() -> None:
     # Test that nothing is changed if there is no timestamp
     match = Match(youtube_videos=["TqY324xLU4s"])
     assert match.youtube_videos_formatted == ["TqY324xLU4s"]
+
+
+def test_score_breakdown_lazy_load_none() -> None:
+    match = Match(id="2025miket_qm1", year=2025)
+    assert match.score_breakdown is None
+
+
+def test_score_breakdown_lazy_load_invalid() -> None:
+    match = Match(id="2025miket_qm1", year=2025, score_breakdown_json="")
+    assert match.score_breakdown is None
+
+
+def test_score_breakdown_lazy_load_json_missing_colors() -> None:
+    # Setup alliances for Match.has_been_played
+    alliance_dict = {
+        AllianceColor.RED: MatchAlliance(
+            teams=["frc1", "frc2", "frc3"], score=-1, dqs=[], surrogates=[]
+        ),
+        AllianceColor.BLUE: MatchAlliance(
+            teams=["frc4", "frc5", "frc6"], score=-1, dqs=[], surrogates=[]
+        ),
+    }
+    score_breakdown = {}
+    match = Match(
+        id="2025miket_qm1",
+        year=2025,
+        alliances_json=json.dumps(alliance_dict),
+        score_breakdown_json=json.dumps(score_breakdown),
+    )
+    assert match.score_breakdown is None
+    assert match._score_breakdown is None
+
+
+def test_score_breakdown_lazy_load_json() -> None:
+    # Setup alliances for Match.has_been_played
+    alliance_dict = {
+        AllianceColor.RED: MatchAlliance(
+            teams=["frc1", "frc2", "frc3"], score=-1, dqs=[], surrogates=[]
+        ),
+        AllianceColor.BLUE: MatchAlliance(
+            teams=["frc4", "frc5", "frc6"], score=-1, dqs=[], surrogates=[]
+        ),
+    }
+    score_breakdown = {AllianceColor.RED: {}, AllianceColor.BLUE: {}}
+    match = Match(
+        id="2025miket_qm1",
+        year=2025,
+        alliances_json=json.dumps(alliance_dict),
+        score_breakdown_json=json.dumps(score_breakdown),
+    )
+    # Order here is important - first checks our empty case, second inits, third checks init
+    assert match._score_breakdown is None
+    assert match.score_breakdown == score_breakdown
+    assert match._score_breakdown == score_breakdown
+
+
+def test_score_breakdown_2025_tba_fields() -> None:
+    # Setup alliances for Match.has_been_played
+    # Scores need to be not -1
+    alliance_dict = {
+        AllianceColor.RED: MatchAlliance(
+            teams=["frc1", "frc2", "frc3"], score=1, dqs=[], surrogates=[]
+        ),
+        AllianceColor.BLUE: MatchAlliance(
+            teams=["frc4", "frc5", "frc6"], score=2, dqs=[], surrogates=[]
+        ),
+    }
+    # Forgive me -
+    score_breakdown = {
+        AllianceColor.RED: {
+            "autoReef": {
+                "botRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "midRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "topRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "trough": 0,
+            },
+            "teleopReef": {
+                "botRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "midRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "topRow": {
+                    "nodeA": True,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+            },
+        },
+        AllianceColor.BLUE: {
+            "autoReef": {
+                "botRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "midRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "topRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": False,
+                    "nodeD": False,
+                    "nodeE": False,
+                    "nodeF": True,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": True,
+                },
+            },
+            "teleopReef": {
+                "botRow": {
+                    "nodeA": False,
+                    "nodeB": False,
+                    "nodeC": True,
+                    "nodeD": True,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": False,
+                    "nodeL": False,
+                },
+                "midRow": {
+                    "nodeA": True,
+                    "nodeB": True,
+                    "nodeC": True,
+                    "nodeD": True,
+                    "nodeE": False,
+                    "nodeF": False,
+                    "nodeG": False,
+                    "nodeH": False,
+                    "nodeI": False,
+                    "nodeJ": False,
+                    "nodeK": True,
+                    "nodeL": True,
+                },
+                "topRow": {
+                    "nodeA": False,
+                    "nodeB": True,
+                    "nodeC": True,
+                    "nodeD": True,
+                    "nodeE": True,
+                    "nodeF": True,
+                    "nodeG": True,
+                    "nodeH": True,
+                    "nodeI": True,
+                    "nodeJ": True,
+                    "nodeK": True,
+                    "nodeL": True,
+                },
+            },
+        },
+    }
+    expected = {
+        AllianceColor.RED: {
+            "autoReef": {
+                "tba_botRowCount": 0,
+                "tba_midRowCount": 0,
+                "tba_topRowCount": 0,
+            },
+            "teleopReef": {
+                "tba_botRowCount": 0,
+                "tba_midRowCount": 0,
+                "tba_topRowCount": 1,
+            },
+        },
+        AllianceColor.BLUE: {
+            "autoReef": {
+                "tba_botRowCount": 0,
+                "tba_midRowCount": 0,
+                "tba_topRowCount": 2,
+            },
+            "teleopReef": {
+                "tba_botRowCount": 2,
+                "tba_midRowCount": 6,
+                "tba_topRowCount": 11,
+            },
+        },
+    }
+    match = Match(
+        id="2025miket_qm1",
+        year=2025,
+        alliances_json=json.dumps(alliance_dict),
+        score_breakdown_json=json.dumps(score_breakdown),
+    )
+    computed_score_breakdown = none_throws(match.score_breakdown)
+    for color in expected:
+        for peroid in expected[color]:
+            for tba_key in expected[color][peroid]:
+                expected_value = expected[color][peroid][tba_key]
+                actual_value = computed_score_breakdown[color][peroid][tba_key]
+                assert_string = f"{color}/{peroid}/{tba_key} expected {expected_value} got {actual_value}"
+                assert expected_value == actual_value, assert_string

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.10",
+    "version": "3.9.11",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -8357,6 +8357,18 @@
               },
               "trough": {
                 "type": "integer"
+              },
+              "tba_botRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the botRow object."
+              },
+              "tba_midRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the midRow object."
+              },
+              "tba_topRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the topRow object."
               }
             }
           },
@@ -8558,6 +8570,18 @@
               },
               "trough": {
                 "type": "integer"
+              },
+              "tba_botRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the botRow object."
+              },
+              "tba_midRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the midRow object."
+              },
+              "tba_topRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the topRow object."
               }
             }
           },


### PR DESCRIPTION
Also adds tests for some of the match breakdown logic