### PR TITLE
Fix broken sitevar creation flow

### DIFF
--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -281,6 +281,9 @@ admin_routes.add_url_rule(
     "/sitevar/edit/<sitevar_key>", view_func=sitevar_edit, methods=["GET"]
 )
 admin_routes.add_url_rule(
+    "/sitevar/edit", view_func=sitevar_edit_post, methods=["POST"]
+)
+admin_routes.add_url_rule(
     "/sitevar/edit/<sitevar_key>", view_func=sitevar_edit_post, methods=["POST"]
 )
 admin_routes.add_url_rule("/gameday", methods=["GET"], view_func=gameday_dashboard)

--- a/src/backend/web/handlers/admin/sitevars.py
+++ b/src/backend/web/handlers/admin/sitevars.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from flask import redirect, request, url_for
 from werkzeug.wrappers import Response
 
@@ -28,7 +30,7 @@ def sitevar_edit(sitevar_key: str) -> str:
     return render_template("admin/sitevar_edit.html", template_values)
 
 
-def sitevar_edit_post(sitevar_key: str) -> Response:
+def sitevar_edit_post(sitevar_key: Optional[str] = None) -> Response:
     # note, we don't use sitevar_key
 
     sitevar = Sitevar(

--- a/src/backend/web/templates/admin/sitevar_create.html
+++ b/src/backend/web/templates/admin/sitevar_create.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<form action="/admin/sitevar/edit/" method="post">
+<form action="/admin/sitevar/edit" method="post">
     <legend>Create new Sitevar</legend>
     <table class="table table-striped table-hover table-condensed">
         <tr>
@@ -21,6 +21,7 @@
         </tr>
     </table>
 
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-thumbs-up"></span> Create Sitevar</button>
     <a href="/admin/sitevars" class="btn btn-default"><span class="glyphicon glyphicon-thumbs-down"></span> Cancel Create</a>
 </form>


### PR DESCRIPTION
Sitevar creation via the admin panel wasn't working - probably just due to something with the upgrade to py3, since it was still even missing a csrf token. This PR updates that flow to work again.