### PR TITLE
Run safe deferred on own URL

### DIFF
--- a/src/backend/common/helpers/deferred.py
+++ b/src/backend/common/helpers/deferred.py
@@ -7,12 +7,13 @@ from google.appengine.api.apiproxy_stub_map import UserRPC
 from google.appengine.ext.deferred.deferred import (
     _curry_callable,
     _DEFAULT_QUEUE,
-    _DEFAULT_URL,
     _DeferredTaskEntity,
     _TASKQUEUE_HEADERS,
     run,
     run_from_datastore,
 )
+
+_DEFAULT_URL = "/_ah/queue/deferred_encoded"
 
 
 def _serialize(obj: Any, *args, **kwargs) -> bytes:
@@ -42,7 +43,7 @@ def defer_safe(obj: Any, *args, **kwargs) -> UserRPC:
     except taskqueue.TaskTooLargeError:
         key = _DeferredTaskEntity(data=pickled).put()
         pickled = _serialize(run_from_datastore, str(key))
-        task = taskqueue.Task(payload=pickled, **taskargs)
+        task = taskqueue.Task(payload=base64.b64encode(pickled), **taskargs)
         return task.add(queue)
 
 

--- a/src/backend/common/helpers/tests/deferred_test.py
+++ b/src/backend/common/helpers/tests/deferred_test.py
@@ -1,4 +1,5 @@
 import six
+from google.appengine.api import taskqueue
 from google.appengine.ext import testbed
 
 from backend.common.helpers.deferred import defer_safe, run_from_task
@@ -22,7 +23,15 @@ def _fn(*args, **kwargs) -> None:
 def test_enqueue_deferred(
     taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
 ) -> None:
-
     arg = "\0"
+    defer_safe(_fn, arg)
+    _drain_deferred(taskqueue_stub)
+
+
+def test_enqueue_deferred_via_datastore(
+    ndb_stub: testbed.datastore_file_stub.DatastoreFileStub,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+) -> None:
+    arg = "\0" + ("a" * (taskqueue.MAX_TASK_SIZE_BYTES + 1))
     defer_safe(_fn, arg)
     _drain_deferred(taskqueue_stub)


### PR DESCRIPTION
Fixes a bug from https://github.com/the-blue-alliance/the-blue-alliance/pull/7121 that doesn't really repro in tests.

The GAE middleware will slurp up anything with the default deferred URL, so if we want to make requests using a custom payload format, we need to make sure it's run on a distinct URL that can trigger our custom handler.

https://github.com/GoogleCloudPlatform/appengine-python-standard/blob/99f33792c00ecee37ef081d41582c7c4eaa673aa/src/google/appengine/runtime/middlewares.py#L381-L397

Since we already accept a regex:

https://github.com/the-blue-alliance/the-blue-alliance/blob/f05a3db0b0cc05000dae6f8cab0b04158cddc2d1/src/backend/common/deferred/defer_handler.py#L37-L41

anything should do