### PR TITLE
Remove double call in alliance_selection test

### DIFF
--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -184,7 +184,6 @@ class TestTBANSHelper(unittest.TestCase):
             for task in tasks:
                 run_from_task(task)
 
-            TBANSHelper.alliance_selection(self.event)
             # Two calls total - First to the Event, second to frc7332, no call for frc1
             mock_send.assert_called()
             assert len(mock_send.call_args_list) == 2


### PR DESCRIPTION
Just an oversight from https://github.com/the-blue-alliance/the-blue-alliance/commit/bcb8f92ae2b950dac33b71e066802b28dbb23ff7#diff-0ee31cd80d94496fba41420991ecb2d315e73a716cf51d2400bc141ec9251918R180 - the call should've gotten moved before the patch and the call inside the patch should've gotten removed. 