### PR TITLE
Fix Invalid RegionalPoolTeam property

### DIFF
--- a/src/backend/common/tasklets.py
+++ b/src/backend/common/tasklets.py
@@ -12,7 +12,7 @@ TReturn = TypeVar("TReturn")
 def typed_tasklet(
     f: Callable[
         TParams, Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]
-    ]
+    ],
 ) -> Callable[TParams, TypedFuture[TReturn]]:
     @ndb.tasklet
     def inner(

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -40,7 +40,6 @@ from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import DistrictKey, EventKey, TeamKey, Year
-from backend.common.models.regional_pool_advancement import RegionalPoolAdvancement
 from backend.common.models.regional_pool_team import RegionalPoolTeam
 from backend.common.models.robot import Robot
 from backend.common.models.team import Team
@@ -405,14 +404,6 @@ def event_details(event_key: EventKey) -> Response:
                 id=RegionalPoolTeam.render_key_name(event.year, team.key_name),
                 year=event.year,
                 team=team.key,
-                advancemnet=(
-                    RegionalPoolAdvancement(
-                        cmp=True,
-                    )
-                    if event.event_type_enum
-                    in {EventType.CMP_DIVISION, EventType.CMP_FINALS}
-                    else None
-                ),
             )
             regional_pool_teams.append(regional_pool_team)
 


### PR DESCRIPTION
doh

```
 AttributeError: type object 'RegionalPoolTeam' has no attribute 'advancemnet'
at ._set_attributes ( /layers/google.python.pip/pip/lib/python3.12/site-packages/google/appengine/ext/ndb/model.py:3078 )
at .__init__ ( /layers/google.python.pip/pip/lib/python3.12/site-packages/google/appengine/ext/ndb/model.py:3026 )
at .__init__ ( /workspace/backend/common/models/cached_model.py:41 )
at .__init__ ( /workspace/backend/common/models/regional_pool_team.py:27 )
at .event_details ( /workspace/backend/tasks_io/handlers/frc_api.py:404 )
at .dispatch_request ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:902 )
at .full_dispatch_request ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:917 )
at .full_dispatch_request ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:919 )
at .wsgi_app ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:1511 ) 
```