### PR TITLE
Add webcast date field to eventwizard2 UI

### DIFF
--- a/src/frontend/eventwizard/components/infoTab/AddRemoveWebcast.js
+++ b/src/frontend/eventwizard/components/infoTab/AddRemoveWebcast.js
@@ -8,20 +8,29 @@ class AddRemoveWebcast extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      nextWebcastToAdd: "",
+      newWebcastUrl: "",
+      newWebcastDate: "",
     };
 
-    this.onNextWebcastChange = this.onNextWebcastChange.bind(this);
+    this.onNewWebcastUrlChange = this.onNewWebcastUrlChange.bind(this);
+    this.onNewWebcastDateChange = this.onNewWebcastDateChange.bind(this);
     this.onAddWebcastClick = this.onAddWebcastClick.bind(this);
   }
 
-  onNextWebcastChange(event) {
-    this.setState({ nextWebcastToAdd: event.target.value });
+  onNewWebcastUrlChange(event) {
+    this.setState({ newWebcastUrl: event.target.value });
+  }
+
+  onNewWebcastDateChange(event) {
+    this.setState({ newWebcastDate: event.target.value });
   }
 
   onAddWebcastClick() {
-    this.props.addWebcast(this.state.nextWebcastToAdd);
-    this.setState({ nextWebcastToAdd: "" });
+    this.props.addWebcast(this.state.newWebcastUrl, this.state.newWebcastDate);
+    this.setState({
+      newWebcastUrl: "",
+      newWebcastDate: "",
+    });
   }
 
   render() {
@@ -45,21 +54,33 @@ class AddRemoveWebcast extends Component {
         <div className="col-sm-10" id="webcast_list">
           {webcastList}
 
-          <input
-            type="text"
-            id="webcast_url"
-            placeholder="https://youtu.be/abc123"
-            disabled={this.props.eventInfo === null}
-            onChange={this.onNextWebcastChange}
-            value={this.state.nextWebcastToAdd}
-          />
-          <button
-            className="btn btn-info"
-            onClick={this.onAddWebcastClick}
-            disabled={this.props.eventInfo === null}
-          >
-            Add Webcast
-          </button>
+          <div style={{ display: "flex", gap: "0.5em" }}>
+            <input
+              type="text"
+              className="form-control"
+              id="webcast_url"
+              placeholder="https://youtu.be/abc123"
+              disabled={this.props.eventInfo === null}
+              onChange={this.onNewWebcastUrlChange}
+              value={this.state.newWebcastUrl}
+            />
+            <input
+              type="text"
+              className="form-control"
+              id="webcast_date"
+              placeholder="2025-03-02 (optional)"
+              disabled={this.props.eventInfo === null}
+              onChange={this.onNewWebcastDateChange}
+              value={this.state.newWebcastDate}
+            />
+            <button
+              className="btn btn-info"
+              onClick={this.onAddWebcastClick}
+              disabled={this.props.eventInfo === null}
+            >
+              Add Webcast
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/src/frontend/eventwizard/components/infoTab/EventInfoTab.js
+++ b/src/frontend/eventwizard/components/infoTab/EventInfoTab.js
@@ -75,13 +75,14 @@ class EventInfoTab extends Component {
       .then((data) => this.setState({ eventInfo: data, status: "" }));
   }
 
-  addWebcast(webcastUrl) {
+  addWebcast(webcastUrl, webcastDate) {
     const currentInfo = this.state.eventInfo;
     if (currentInfo !== null) {
       currentInfo.webcasts.push({
         type: "",
         channel: "",
         url: webcastUrl,
+        date: webcastDate ? webcastDate : null,
       });
       this.setState({ eventInfo: currentInfo });
     }

--- a/src/frontend/eventwizard/components/infoTab/EventInfoTab.js
+++ b/src/frontend/eventwizard/components/infoTab/EventInfoTab.js
@@ -82,7 +82,7 @@ class EventInfoTab extends Component {
         type: "",
         channel: "",
         url: webcastUrl,
-        date: webcastDate ? webcastDate : null,
+        date: webcastDate ? webcastDate : undefined,
       });
       this.setState({ eventInfo: currentInfo });
     }

--- a/src/frontend/eventwizard/components/infoTab/WebcastItem.js
+++ b/src/frontend/eventwizard/components/infoTab/WebcastItem.js
@@ -21,6 +21,10 @@ class WebcastItem extends Component {
       item = `${this.props.webcast.type} - ${this.props.webcast.channel}`;
     }
 
+    if (this.props.webcast.date) {
+      item += ` (${this.props.webcast.date})`;
+    }
+
     return (
       <p>
         {item} &nbsp;

--- a/src/frontend/eventwizard/constants/ApiWebcast.js
+++ b/src/frontend/eventwizard/constants/ApiWebcast.js
@@ -4,6 +4,7 @@ const WEBCAST_SHAPE = {
   type: PropTypes.string.isRequired,
   channel: PropTypes.string.isRequired,
   file: PropTypes.string,
+  date: PropTypes.string,
   url: PropTypes.string,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds an optional field to the event info tab of eventwizard2 to allow for specifying a date for a webcast.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is to support a subset of FIRST in Michigan events, who have streams which are only active on certain days. This functionality was already available in the trusted API, but not surfaced in the event wizard.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In local environment, adding and removing webcasts via the event wizard both with and without dates, confirming changes are as expected by using the read API. Local environment is set up using the docker compose method.

Node tests and lints have been run locally and passed.

## Screenshots (if appropriate):
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/e0ba5ea5-3abd-4a91-a555-91db0a2a1aee" />

<img width="805" alt="image" src="https://github.com/user-attachments/assets/89a99f33-9a78-461f-af82-961210acc6c7" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
