### PR TITLE
Fix cOPRs for L2-L4 coral

### DIFF
--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -144,22 +144,13 @@ MANUAL_COMPONENTS = {
             + match.score_breakdown[color].get("teleopReef", {}).get("trough", 0)
         ),
         "L2 Coral Count": lambda match, color: (
-            match.score_breakdown[color].get("autoReef", {}).get("tba_botRowCount", 0)
-            + match.score_breakdown[color]
-            .get("teleopReef", {})
-            .get("tba_botRowCount", 0)
+            match.score_breakdown[color].get("teleopReef", {}).get("tba_botRowCount", 0)
         ),
         "L3 Coral Count": lambda match, color: (
-            match.score_breakdown[color].get("autoReef", {}).get("tba_midRowCount", 0)
-            + match.score_breakdown[color]
-            .get("teleopReef", {})
-            .get("tba_midRowCount", 0)
+            match.score_breakdown[color].get("teleopReef", {}).get("tba_midRowCount", 0)
         ),
         "L4 Coral Count": lambda match, color: (
-            match.score_breakdown[color].get("autoReef", {}).get("tba_topRowCount", 0)
-            + match.score_breakdown[color]
-            .get("teleopReef", {})
-            .get("tba_topRowCount", 0)
+            match.score_breakdown[color].get("teleopReef", {}).get("tba_topRowCount", 0)
         ),
         "Total Coral Count": lambda match, color: sum(
             [


### PR DESCRIPTION
https://www.chiefdelphi.com/t/2025-high-scores/492943/14?u=jtrv

The `tba_<level>RowCount` teleop fields are based on the state at the end of the match. Here is an example score breakdown from `2025isde1_f1m1`:

```
                     'red': {'adjustPoints': 0,
                             'algaePoints': 12,
                             'autoBonusAchieved': False,
                             'autoCoralCount': 6,
                             'autoCoralPoints': 42,
                             'autoLineRobot1': 'Yes',
                             'autoLineRobot2': 'Yes',
                             'autoLineRobot3': 'Yes',
                             'autoMobilityPoints': 9,
                             'autoPoints': 51,
                             'autoReef': {'botRow': {'nodeA': False,
                                                     'nodeB': False,
                                                     'nodeC': False,
                                                     'nodeD': False,
                                                     'nodeE': False,
                                                     'nodeF': False,
                                                     'nodeG': False,
                                                     'nodeH': False,
                                                     'nodeI': False,
                                                     'nodeJ': False,
                                                     'nodeK': False,
                                                     'nodeL': False},
                                          'midRow': {'nodeA': False,
                                                     'nodeB': False,
                                                     'nodeC': False,
                                                     'nodeD': False,
                                                     'nodeE': False,
                                                     'nodeF': False,
                                                     'nodeG': False,
                                                     'nodeH': False,
                                                     'nodeI': False,
                                                     'nodeJ': False,
                                                     'nodeK': False,
                                                     'nodeL': False},
                                          'tba_botRowCount': 0,
                                          'tba_midRowCount': 0,
                                          'tba_topRowCount': 6,
                                          'topRow': {'nodeA': False,
                                                     'nodeB': False,
                                                     'nodeC': True,
                                                     'nodeD': True,
                                                     'nodeE': True,
                                                     'nodeF': False,
                                                     'nodeG': False,
                                                     'nodeH': False,
                                                     'nodeI': True,
                                                     'nodeJ': False,
                                                     'nodeK': True,
                                                     'nodeL': True},
                                          'trough': 0},
                             'bargeBonusAchieved': False,
                             'coopertitionCriteriaMet': False,
                             'coralBonusAchieved': False,
                             'endGameBargePoints': 26,
                             'endGameRobot1': 'Parked',
                             'endGameRobot2': 'DeepCage',
                             'endGameRobot3': 'DeepCage',
                             'foulCount': 0,
                             'foulPoints': 6,
                             'g206Penalty': False,
                             'g408Penalty': False,
                             'g424Penalty': False,
                             'netAlgaeCount': 3,
                             'rp': 0,
                             'techFoulCount': 0,
                             'teleopCoralCount': 31,
                             'teleopCoralPoints': 116,
                             'teleopPoints': 154,
                             'teleopReef': {'botRow': {'nodeA': True,
                                                       'nodeB': True,
                                                       'nodeC': True,
                                                       'nodeD': True,
                                                       'nodeE': True,
                                                       'nodeF': True,
                                                       'nodeG': True,
                                                       'nodeH': True,
                                                       'nodeI': True,
                                                       'nodeJ': True,
                                                       'nodeK': True,
                                                       'nodeL': True},
                                            'midRow': {'nodeA': True,
                                                       'nodeB': True,
                                                       'nodeC': True,
                                                       'nodeD': True,
                                                       'nodeE': True,
                                                       'nodeF': True,
                                                       'nodeG': True,
                                                       'nodeH': True,
                                                       'nodeI': True,
                                                       'nodeJ': True,
                                                       'nodeK': True,
                                                       'nodeL': True},
                                            'tba_botRowCount': 12,
                                            'tba_midRowCount': 12,
                                            'tba_topRowCount': 12,
                                            'topRow': {'nodeA': True,
                                                       'nodeB': True,
                                                       'nodeC': True,
                                                       'nodeD': True,
                                                       'nodeE': True,
                                                       'nodeF': True,
                                                       'nodeG': True,
                                                       'nodeH': True,
                                                       'nodeI': True,
                                                       'nodeJ': True,
                                                       'nodeK': True,
                                                       'nodeL': True},
                                            'trough': 1},
                             'totalPoints': 211,
                             'wallAlgaeCount': 0}},
```

You can see that `sb['red']['autoReef']['tba_topRowCount']` equals 6, showing they scored 6 in auto. You can also see that `sb['red']['teleopReef']['tba_topRowCount']` is 12, as all 12 pegs were full at the end of teleop. The code as is will count 12 + 6 for total scored, when in reality it's just 12.

The trough is not like this.