### PR TITLE
Fix coral and barge RP dots in 2025 match breakdowns overlapping

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2025.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2025.html
@@ -392,7 +392,7 @@
         </svg>
         {% endif %}
         {% if match.score_breakdown.red.bargeBonusAchieved %}
-        <svg class="top-left-dot-2" rel="tooltip" title="Barge Bonus">
+        <svg class="top-left-dot-3" rel="tooltip" title="Barge Bonus">
           <circle cx="2" cy="2" r="2"/>
         </svg>
         {% endif %}
@@ -411,7 +411,7 @@
         </svg>
         {% endif %}
         {% if match.score_breakdown.blue.bargeBonusAchieved %}
-        <svg class="top-left-dot-2" rel="tooltip" title="Barge Bonus">
+        <svg class="top-left-dot-3" rel="tooltip" title="Barge Bonus">
             <circle cx="2" cy="2" r="2" />
         </svg>
         {% endif %}


### PR DESCRIPTION
<img width="655" alt="Screenshot 2025-02-26 at 6 40 09 PM" src="https://github.com/user-attachments/assets/f7063366-5309-4f90-9a0f-b4ebd2c8f6f3" />
