### PR TITLE
Show correct foul points for red/blue for 2025 breakdowns

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2025.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2025.html
@@ -342,11 +342,11 @@
     {% if "foulCount" in match.score_breakdown.red %}
     <tr>
         <td class="red" colspan="2">
-            {{fouls(match.score_breakdown.blue)}}
+            {{fouls(match.score_breakdown.red)}}
         </td>
         <td>Fouls / Tech Fouls</td>
         <td class="blue" colspan="2">
-            {{fouls(match.score_breakdown.red)}}
+            {{fouls(match.score_breakdown.blue)}}
         </td>
     </tr>
     {% endif %}


### PR DESCRIPTION
<img width="607" alt="Screenshot 2025-02-26 at 6 55 18 PM" src="https://github.com/user-attachments/assets/04e62e8b-9055-430f-9a44-fa825b809f96" />

Fixes https://github.com/the-blue-alliance/the-blue-alliance/issues/7155