### PR TITLE
Add robots.txt to pwa

### DIFF
--- a/pwa/public/robots.txt
+++ b/pwa/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
We're getting a lot of 500s on the backend from robots crawling the PWA pages. Going to add a `robots.txt` for now in order to disallow crawling these pages until we've got them fixed up.