### PR TITLE
Fix Firebase Auth setup to require less messing with locally

### DIFF
--- a/docs/Deployment/GAE-Firebase-Setup.md
+++ b/docs/Deployment/GAE-Firebase-Setup.md
@@ -35,6 +35,8 @@ $ gcloud auth application-default login
 
 The [`push.yml` GitHub Action](https://github.com/the-blue-alliance/the-blue-alliance/blob/py3/.github/workflows/push.yml) contains the commands CI uses to deploy to production and can be used as a reference.
 
+TODO: Add notes about setting up a `src/env_variables.yaml` before deploying with a Flask secret key.
+
 1. Deploy the default service and any other necessary services for testing.
 
 ```bash

--- a/src/backend/web/static/javascript/tba_js/tba_auth.js
+++ b/src/backend/web/static/javascript/tba_js/tba_auth.js
@@ -1,3 +1,6 @@
+const auth = firebase.auth();
+auth.setPersistence(firebase.auth.Auth.Persistence.NONE);
+
 function signInWithGoogle(csrfToken) {
   var provider = new firebase.auth.GoogleAuthProvider();
   provider.addScope("email");

--- a/src/backend/web/static/javascript/tba_js/tba_firebase.js
+++ b/src/backend/web/static/javascript/tba_js/tba_firebase.js
@@ -9,8 +9,3 @@ var config = {
   appId: firebaseAppId
 };
 firebase.initializeApp(config);
-
-const perf = firebase.performance();
-
-const auth = firebase.auth();
-auth.setPersistence(firebase.auth.Auth.Persistence.NONE);

--- a/src/backend/web/static/javascript/tba_js/tba_keys_template.js
+++ b/src/backend/web/static/javascript/tba_js/tba_keys_template.js
@@ -1,6 +1,6 @@
 // Fill this out and rename to tba_keys.js
 var firebaseApiKey = "fake-api-key";
-var firebaseAuthDomain = "";
+var firebaseAuthDomain = "demo-test";
 var firebaseDatabaseURL = "";
 var firebaseProjectId = "demo-test";
 var firebaseStorageBucket = "";

--- a/src/backend/web/templates/account_login_required.html
+++ b/src/backend/web/templates/account_login_required.html
@@ -8,9 +8,8 @@
 <script src="//gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
 <script src="/py3_javascript/tba_combined_js.firebase.min.js"></script>
 <script>
-  // Setup auth emulator host if passed
-  if ({{ auth_emulator_host|tojson }}) {
-    auth.useEmulator("http://" + {{ auth_emulator_host|tojson }});
+  if (is_local()) {
+    auth.useEmulator("http://" + {{auth_emulator_host|tojson}});
   }
 </script>
 {% endblock %}

--- a/src/backend/web/templates/account_login_required.html
+++ b/src/backend/web/templates/account_login_required.html
@@ -8,8 +8,9 @@
 <script src="//gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
 <script src="/py3_javascript/tba_combined_js.firebase.min.js"></script>
 <script>
-  if ({{ auth_emulator_host | tojson }}) {
-    auth.useEmulator("http://" + {{ auth_emulator_host | tojson }});
+  // Setup auth emulator host if passed
+  if ({{ auth_emulator_host|tojson }}) {
+    auth.useEmulator("http://" + {{ auth_emulator_host|tojson }});
   }
 </script>
 {% endblock %}

--- a/src/backend/web/templates/account_login_required.html
+++ b/src/backend/web/templates/account_login_required.html
@@ -8,8 +8,8 @@
 <script src="//gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
 <script src="/py3_javascript/tba_combined_js.firebase.min.js"></script>
 <script>
-  if (is_local()) {
-    auth.useEmulator("http://" + {{auth_emulator_host|tojson}});
+  if ({{ auth_emulator_host | tojson }}) {
+    auth.useEmulator("http://" + {{ auth_emulator_host | tojson }});
   }
 </script>
 {% endblock %}

--- a/src/backend/web/templates/admin/base.html
+++ b/src/backend/web/templates/admin/base.html
@@ -16,7 +16,6 @@
 
     <!-- Le javascript
     ================================================== -->
-    <script src="https://www.gstatic.com/firebasejs/3.6.9/firebase.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js"></script>

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -194,6 +194,7 @@
 {% endblock %}
 
 {% block inline_javascript %}{% endblock %}
+
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -195,7 +195,12 @@
 {% endblock %}
 
 {% block inline_javascript %}{% endblock %}
-
+<script>
+  if (!is_local()) {
+    // Not running on localhost - assumes prod keys
+    const perf = firebase.performance();
+  }
+</script>
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -177,7 +177,6 @@
 {% endblock %}
 
 <script src="//gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
-<script src="//gstatic.com/firebasejs/8.10.0/firebase-performance.js"></script>
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js"></script>
@@ -195,12 +194,6 @@
 {% endblock %}
 
 {% block inline_javascript %}{% endblock %}
-<script>
-  if (!is_local()) {
-    // Not running on localhost - assumes prod keys
-    const perf = firebase.performance();
-  }
-</script>
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
@@ -228,6 +221,21 @@ ga('send', 'pageview');
 </script>
 
 {% block ganalytics_timer %}{% endblock %}
+
+<script>
+  (function (sa, fbc) {
+    function load(f, c) {
+      var a = document.createElement('script');
+      a.async = 1; a.src = f; var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(a, s);
+    } load(sa);
+    window.addEventListener('load', function () { firebase.initializeApp(fbc).performance() });
+  })('https://www.gstatic.com/firebasejs/8.10.0/firebase-performance-standalone.js', {
+    apiKey: "AIzaSyDBlFwtAgb2i7hMCQ5vBv44UEKVsA543hs",
+    projectId: "tbatv-prod-hrd",
+    appId: "1:836511118694:web:02272aa0400554c7"
+  });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Figured out some of the wonkiness with getting Firebase Auth setup locally. The user emulator should work out of the box now.

Additionally - moves our Firebase performance call back to the standalone (for now) because our performance was only getting setup on our login page (where we pull in the Firebase JS). Reverts https://github.com/the-blue-alliance/the-blue-alliance/pull/3237