### PR TITLE
Move gcloud deploy off beta deploy. Add app_engine_apis flag to default.yaml

### DIFF
--- a/ops/deploy/deploy_module.sh
+++ b/ops/deploy/deploy_module.sh
@@ -3,8 +3,4 @@ set -e
 
 SERVICE=$1
 
-# We need gcloud beta to set up the VPC connector
-gcloud components install beta
-
-# Actualy run the deploy
-gcloud beta app deploy "$SERVICE" --version 1 --quiet
+gcloud app deploy "$SERVICE" --version 1 --quiet

--- a/src/default.yaml
+++ b/src/default.yaml
@@ -1,4 +1,5 @@
 runtime: python312
+app_engine_apis: true
 entrypoint: gunicorn -b :$PORT backend.default.main:app
 
 instance_class: F1


### PR DESCRIPTION
A few small app engine deployment fixes while I'm looking at them