### PR TITLE
Allow for cache clearing to clear API dictionaries

### DIFF
--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -205,7 +205,7 @@ admin_routes.add_url_rule(
     "/cache/<query_class_name>/<cache_key>/delete", view_func=cached_query_delete
 )
 admin_routes.add_url_rule(
-    "/cache/<query_class_name>/purge/<int:db_version>/<int:query_version>",
+    "/cache/<query_class_name>/purge/<db_version>/<int:query_version>",
     view_func=cached_query_purge_version,
 )
 admin_routes.add_url_rule(

--- a/src/backend/web/handlers/admin/cache.py
+++ b/src/backend/web/handlers/admin/cache.py
@@ -90,7 +90,7 @@ def cached_query_detail(query_class_name: str) -> str:
     for item in cached_item_keys:
         key_split = item.string_id().split(":")
         query_version = int(key_split[1])
-        global_version = int(key_split[2])
+        global_version = key_split[2]
         cached_items_by_version[(global_version, query_version)] += 1
 
     template_args = {
@@ -127,7 +127,7 @@ def cached_query_delete(query_class_name: str, cache_key: str) -> Response:
 
 
 def cached_query_purge_version(
-    query_class_name: str, db_version: int, query_version: int
+    query_class_name: str, db_version: str, query_version: int
 ) -> Response:
     query_class = next(
         (
@@ -165,7 +165,7 @@ def cached_query_purge_version(
     for key in cached_item_keys:
         key_split = key.string_id().split(":")
         item_query_version = int(key_split[1])
-        item_db_version = int(key_split[2])
+        item_db_version = key_split[2]
         if query_version == item_query_version and item_db_version == db_version:
             keys_to_delete.add(key)
 

--- a/src/backend/web/templates/admin/cached_query_detail.html
+++ b/src/backend/web/templates/admin/cached_query_detail.html
@@ -28,6 +28,8 @@
 
 <div class="row">
     <h2>Jump To CachedQueryResult</h2>
+    <pre>{{query_class.CACHE_KEY_FORMAT}}</pre>
+    <pre>{{query_class.CACHE_KEY_FORMAT}}:{query_version}:{db_version}</pre>
     <form class="form-inline" method="post">
         <div class="form-group">
             <label for="cache_key">Cache Key: </label>

--- a/src/backend/web/templates/admin/cached_query_info.html
+++ b/src/backend/web/templates/admin/cached_query_info.html
@@ -21,6 +21,10 @@
             <td>Updated</td>
             <td><time datetime="{{ cached_query.updated }}" class="tba-verbose-datetime-utc">{{ cached_query.created|utc_timezone_datetime|strftime("%b. %d, %Y at %I:%M%p") }} UTC</time></td>
         </tr>
+        <tr>
+            <td>Data</td>
+            <td><pre style="white-space: pre-wrap">{{ cached_query.result or cached_query.result_dict|tojson(indent=2) }}</pre></td>
+        </tr>
     </table>
 </div>
 


### PR DESCRIPTION
API dictionaries fail to load with the current cache clearing system. This PR modifies the cache versions to allow for the dictionary cache key versions.

This also surfaces what the cached data is for introspection, and gives some detail about what keys to enter for the inputs when querying cache keys

<img width="1220" alt="Screenshot 2025-03-01 at 11 30 50 AM" src="https://github.com/user-attachments/assets/bf1d8bd7-fa39-489e-a09b-f20c08a61fad" />

<img width="1207" alt="Screenshot 2025-03-01 at 11 22 25 AM" src="https://github.com/user-attachments/assets/e28acc14-2c51-4d7d-8b1e-7988a9e38bac" />

<img width="1205" alt="Screenshot 2025-03-01 at 11 28 43 AM" src="https://github.com/user-attachments/assets/bd931d98-0645-4811-80d2-044231833043" />
