### PR TITLE
Fix double alliances in alliances table. Only show alliances table if we have non-empty alliances

### DIFF
--- a/pwa/README.md
+++ b/pwa/README.md
@@ -13,6 +13,7 @@ npm i
 Make sure you have your TBA APIv3 Read Key set in `.env`:
 
 ```sh
+$ cp default.env .env
 VITE_TBA_API_READ_KEY="myKey"
 ```
 

--- a/pwa/app/components/tba/allianceSelectionTable.tsx
+++ b/pwa/app/components/tba/allianceSelectionTable.tsx
@@ -73,9 +73,6 @@ export default function AllianceSelectionTable(props: {
           <TableRow className="*:h-8 *:font-bold">
             <TableHead>Alliance</TableHead>
             <TableHead>Captain</TableHead>
-            {[...Array(allianceSize - 1).keys()].map((i) => (
-              <TableHead key={i}>Pick {i + 1}</TableHead>
-            ))}
             {allianceSize > 1 &&
               [...Array(allianceSize - 1).keys()].map((i) => (
                 <TableHead key={i}>Pick {i + 1}</TableHead>

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -287,7 +287,7 @@ export default function EventPage() {
             <div className="basis-full lg:basis-1/2">{leftSideMatches}</div>
 
             <div className="basis-full lg:basis-1/2">
-              {alliances && (
+              {alliances && alliances.length > 0 && (
                 <AllianceSelectionTable
                   alliances={alliances}
                   year={event.year}


### PR DESCRIPTION
I think I bork'd this when merging https://github.com/the-blue-alliance/the-blue-alliance/pull/6623

This PR fixes the alliances table showing double headers, as well as only shows the alliances table if we have some non-empty alliances array

## Before

<img width="1290" alt="Screenshot 2025-03-01 at 12 20 19 PM" src="https://github.com/user-attachments/assets/463d8b08-62a7-4423-9bcd-62f106759826" />

<img width="1280" alt="Screenshot 2025-03-01 at 12 20 40 PM" src="https://github.com/user-attachments/assets/2910cf10-a7d8-4f33-b787-a640dac02964" />

## After

<img width="1306" alt="Screenshot 2025-03-01 at 12 20 10 PM" src="https://github.com/user-attachments/assets/16ca0850-b4fa-46d1-93bd-13dfc301368b" />

<img width="1276" alt="Screenshot 2025-03-01 at 12 20 04 PM" src="https://github.com/user-attachments/assets/94cce343-c729-486e-aaa0-d72dd8d6af9f" />