### PR TITLE
Change delete auth button to be named Delete Auth (not Delete Event)

### DIFF
--- a/src/backend/web/templates/admin/api_delete_auth.html
+++ b/src/backend/web/templates/admin/api_delete_auth.html
@@ -10,7 +10,7 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <a href="/admin/api_auth/manage" class="btn btn-default btn-lg"><span class="glyphicon glyphicon-ban-circle"></span> Cancel Delete</a>
 
-    <button type="submit" class="btn btn-danger btn-small pull-right"><span class="glyphicon glyphicon-trash"></span> Delete Event</button>
+    <button type="submit" class="btn btn-danger btn-small pull-right"><span class="glyphicon glyphicon-trash"></span> Delete Auth</button>
 </form>
 
 {% endblock %}


### PR DESCRIPTION
Got VERY scared when I clicked this button

## Before

<img width="940" alt="Screenshot 2025-03-01 at 1 26 49 PM" src="https://github.com/user-attachments/assets/eda1cd81-1fc7-44a6-bee0-660ef3a6df99" />

## After

<img width="968" alt="Screenshot 2025-03-01 at 1 25 31 PM" src="https://github.com/user-attachments/assets/5c0fcd9b-ce2b-44dd-83ea-fbaff29bf83f" />
