### PR TITLE
Calculate regional champs advancement in datafeed

### DIFF
--- a/src/backend/common/models/regional_champs_pool.py
+++ b/src/backend/common/models/regional_champs_pool.py
@@ -23,7 +23,7 @@ class RegionalChampsPool(CachedModel):
     rankings: List[RegionalPoolRanking] = ndb.JsonProperty()
 
     # Dict of team key -> advancement data
-    advancement: RegionalPoolAdvancement = ndb.JsonProperty()  # pyre-ignore[8]
+    advancement: RegionalPoolAdvancement = ndb.JsonProperty()
 
     _mutable_attrs: Set[str] = {
         "rankings",

--- a/src/backend/common/models/regional_pool_advancement.py
+++ b/src/backend/common/models/regional_pool_advancement.py
@@ -1,5 +1,10 @@
-from typing import TypedDict
+from typing import Dict, TypedDict
+
+from backend.common.models.keys import TeamKey
 
 
-class RegionalPoolAdvancement(TypedDict):
+class TeamRegionalPoolAdvancement(TypedDict):
     cmp: bool
+
+
+RegionalPoolAdvancement = Dict[TeamKey, TeamRegionalPoolAdvancement]


### PR DESCRIPTION
This will set the "qualified for CMP" flag when we get a confirmed `EventTeam` back for a CMP division/finals event