### PR TITLE
Reduce size of regional pool db quueries

### DIFF
--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -103,8 +103,8 @@ class DistrictTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
         return list(teams)
 
 
-class RegionalTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
-    CACHE_VERSION = 1
+class RegionalTeamsQuery(CachedDatabaseQuery[List[ndb.Key], List[str]]):
+    CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "regional_teams_{year}"
     DICT_CONVERTER = TeamConverter
 
@@ -112,13 +112,12 @@ class RegionalTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
         super().__init__(year=year)
 
     @typed_tasklet
-    def _query_async(self, year: Year) -> Generator[Any, Any, List[Team]]:
+    def _query_async(self, year: Year) -> Generator[Any, Any, List[ndb.Key]]:
         regional_teams = yield RegionalPoolTeam.query(
             RegionalPoolTeam.year == year
         ).fetch_async()
         team_keys = map(lambda t: t.team, regional_teams)
-        teams = yield ndb.get_multi_async(team_keys)
-        return list(teams)
+        return list(team_keys)
 
 
 class EventTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):


### PR DESCRIPTION
For the list of regional pool teams, store the keys, not the full team models (since I think this was too large).

Also filter out entries where the teams have no points.

Fixes https://github.com/the-blue-alliance/the-blue-alliance/issues/7220