### PR TITLE
Implement basic regional advancement tiebreakers

### DIFF
--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -3,7 +3,17 @@ import logging
 import math
 from collections import defaultdict
 from datetime import timedelta
-from typing import cast, DefaultDict, Dict, List, Set, Tuple, TypedDict, Union
+from typing import (
+    cast,
+    DefaultDict,
+    Dict,
+    List,
+    MutableSequence,
+    Set,
+    Tuple,
+    TypedDict,
+    Union,
+)
 
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
@@ -40,7 +50,7 @@ class DistrictRankingTeamTotal(TypedDict):
 
     event_points: List[Tuple[Event, TeamAtEventDistrictPoints]]
     point_total: int
-    tiebreakers: List[int]
+    tiebreakers: MutableSequence[int]
     qual_scores: List[int]
     rookie_bonus: int
     other_bonus: int


### PR DESCRIPTION
This will do the ones based on event points.

While investigating this, it actually looks like our district point tiebreakres have been wrong for ages (we look at highest _qual_ match, while the manual says _any_ match for like the last decade). I will clean this up separately (and also backport this named tuple type hinting setup to make it more robust as well)