### PR TITLE
More strongly type district ranking tiebreakers

### DIFF
--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -8,7 +8,8 @@ from typing import (
     DefaultDict,
     Dict,
     List,
-    MutableSequence,
+    NamedTuple,
+    Sequence,
     Set,
     Tuple,
     TypedDict,
@@ -50,10 +51,18 @@ class DistrictRankingTeamTotal(TypedDict):
 
     event_points: List[Tuple[Event, TeamAtEventDistrictPoints]]
     point_total: int
-    tiebreakers: MutableSequence[int]
+    tiebreakers: Sequence[int]
     qual_scores: List[int]
     rookie_bonus: int
     other_bonus: int
+
+
+class DistrictRankingTiebreakers(NamedTuple):
+    total_playoff_points: int
+    best_playoff_points: int
+    total_alliance_points: int
+    best_alliance_points: int
+    total_qual_points: int
 
 
 class DistrictHelper:
@@ -213,7 +222,13 @@ class DistrictHelper:
                 event_points=[],
                 point_total=0,
                 rookie_bonus=0,
-                tiebreakers=5 * [0],
+                tiebreakers=DistrictRankingTiebreakers(
+                    total_playoff_points=0,
+                    best_playoff_points=0,
+                    total_alliance_points=0,
+                    best_alliance_points=0,
+                    total_qual_points=0,
+                ),
                 qual_scores=[],
                 other_bonus=0,
             )
@@ -231,46 +246,49 @@ class DistrictHelper:
                         or event.event_type_enum == EventType.DISTRICT_CMP
                         or event.event_type_enum == EventType.DISTRICT_CMP_DIVISION
                     ):
+                        tiebreakers = DistrictRankingTiebreakers(
+                            *team_totals[team_key]["tiebreakers"]
+                        )
+
                         if team_key in event_district_points["points"]:
-                            team_totals[team_key]["event_points"].append(
-                                (event, event_district_points["points"][team_key])
+                            team_event_points: TeamAtEventDistrictPoints = (
+                                event_district_points["points"][team_key]
                             )
-                            team_totals[team_key][
-                                "point_total"
-                            ] += event_district_points["points"][team_key]["total"]
+                            team_totals[team_key]["event_points"].append(
+                                (event, team_event_points)
+                            )
+                            team_totals[team_key]["point_total"] += team_event_points[
+                                "total"
+                            ]
 
                             # add tiebreakers in order
-                            team_totals[team_key]["tiebreakers"][
-                                0
-                            ] += event_district_points["points"][team_key][
-                                "elim_points"
-                            ]
-                            team_totals[team_key]["tiebreakers"][1] = max(
-                                event_district_points["points"][team_key][
-                                    "elim_points"
-                                ],
-                                team_totals[team_key]["tiebreakers"][1],
+                            tiebreakers = DistrictRankingTiebreakers(
+                                total_playoff_points=(
+                                    tiebreakers.total_playoff_points
+                                    + team_event_points["elim_points"]
+                                ),
+                                best_playoff_points=max(
+                                    tiebreakers.best_playoff_points,
+                                    team_event_points["elim_points"],
+                                ),
+                                total_alliance_points=(
+                                    tiebreakers.total_alliance_points
+                                    + team_event_points["alliance_points"]
+                                ),
+                                best_alliance_points=max(
+                                    tiebreakers.best_alliance_points,
+                                    team_event_points["alliance_points"],
+                                ),
+                                total_qual_points=(
+                                    tiebreakers.total_qual_points
+                                    + team_event_points["qual_points"]
+                                ),
                             )
-                            team_totals[team_key]["tiebreakers"][
-                                2
-                            ] += event_district_points["points"][team_key][
-                                "alliance_points"
-                            ]
-                            team_totals[team_key]["tiebreakers"][3] = max(
-                                event_district_points["points"][team_key][
-                                    "alliance_points"
-                                ],
-                                team_totals[team_key]["tiebreakers"][3],
-                            )
+                            team_totals[team_key]["tiebreakers"] = tiebreakers
 
                         if (
                             team_key in event_district_points["tiebreakers"]
                         ):  # add more tiebreakers
-                            team_totals[team_key]["tiebreakers"][
-                                4
-                            ] += event_district_points["tiebreakers"][team_key][
-                                "qual_wins"
-                            ]
                             team_totals[team_key]["qual_scores"] = heapq.nlargest(
                                 3,
                                 [
@@ -325,12 +343,8 @@ class DistrictHelper:
                 team_totals.items(),
                 key=lambda item: [
                     -item[1]["point_total"],
-                    -item[1]["tiebreakers"][0],
-                    -item[1]["tiebreakers"][1],
-                    -item[1]["tiebreakers"][2],
-                    -item[1]["tiebreakers"][3],
-                    -item[1]["tiebreakers"][4],
                 ]
+                + [-t for t in item[1]["tiebreakers"]]
                 + [-score for score in item[1]["qual_scores"]],
             )
         )

--- a/src/backend/common/helpers/regional_champs_pool_helper.py
+++ b/src/backend/common/helpers/regional_champs_pool_helper.py
@@ -1,6 +1,6 @@
 import logging
-from collections import defaultdict, namedtuple
-from typing import DefaultDict, Dict, List, Set, Union
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, NamedTuple, Set, Union
 
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
@@ -22,14 +22,10 @@ from backend.common.models.keys import EventKey, TeamKey, Year
 from backend.common.models.team import Team
 
 
-RegionalChampsPoolTiebreakers = namedtuple(
-    "RegionalChampsPoolTiebreakers",
-    [
-        "best_playoff_points",
-        "best_alliance_points",
-        "best_qual_points",
-    ],
-)
+class RegionalChampsPoolTiebreakers(NamedTuple):
+    best_playoff_points: int
+    best_alliance_points: int
+    best_qual_points: int
 
 
 class RegionalChampsPoolHelper(DistrictHelper):
@@ -122,12 +118,10 @@ class RegionalChampsPoolHelper(DistrictHelper):
                 event_points=[],
                 point_total=0,
                 rookie_bonus=0,
-                tiebreakers=list(
-                    RegionalChampsPoolTiebreakers(
-                        best_playoff_points=0,
-                        best_alliance_points=0,
-                        best_qual_points=0,
-                    )
+                tiebreakers=RegionalChampsPoolTiebreakers(
+                    best_playoff_points=0,
+                    best_alliance_points=0,
+                    best_qual_points=0,
                 ),
                 qual_scores=[],
                 other_bonus=0,
@@ -177,7 +171,7 @@ class RegionalChampsPoolHelper(DistrictHelper):
 
                 # TODO: this does not yet track "best match score" tiebreakers
 
-                team_totals[team_key]["tiebreakers"] = list(tiebreakers)
+                team_totals[team_key]["tiebreakers"] = tiebreakers
 
         valid_team_keys: Set[TeamKey] = set()
         if isinstance(teams, ndb.tasklets.Future):

--- a/src/backend/common/helpers/tests/district_helper_test.py
+++ b/src/backend/common/helpers/tests/district_helper_test.py
@@ -3,7 +3,10 @@ import json
 import pytest
 from pyre_extensions import none_throws
 
-from backend.common.helpers.district_helper import DistrictHelper
+from backend.common.helpers.district_helper import (
+    DistrictHelper,
+    DistrictRankingTiebreakers,
+)
 from backend.common.models.event import Event
 from backend.common.models.keys import Year
 from backend.common.models.team import Team
@@ -98,7 +101,7 @@ def test_calculate_multi_event_rankings(setup_full_event) -> None:
         "qual_scores": [85, 71, 69],
         "rookie_bonus": 0,
         "other_bonus": 0,
-        "tiebreakers": [30, 30, 16, 16, 0],
+        "tiebreakers": DistrictRankingTiebreakers(*[30, 30, 16, 16, 19]),
     }
     assert rankings["frc4362"] == {
         "event_points": [
@@ -127,7 +130,7 @@ def test_calculate_multi_event_rankings(setup_full_event) -> None:
         "qual_scores": [104, 97, 93],
         "rookie_bonus": 0,
         "other_bonus": 0,
-        "tiebreakers": [150, 90, 42, 42, 0],
+        "tiebreakers": DistrictRankingTiebreakers(*[150, 90, 42, 42, 60]),
     }
 
 
@@ -174,7 +177,7 @@ def test_2022_back_to_back_single_day_bonus(setup_full_event) -> None:
         "qual_scores": [93, 82, 82],
         "rookie_bonus": 0,
         "other_bonus": 2,
-        "tiebreakers": [40, 20, 32, 16, 0],
+        "tiebreakers": DistrictRankingTiebreakers(*[40, 20, 32, 16, 44]),
     }
     assert rankings["frc610"] == {
         "event_points": [
@@ -193,7 +196,7 @@ def test_2022_back_to_back_single_day_bonus(setup_full_event) -> None:
         "qual_scores": [52, 41, 40],
         "rookie_bonus": 0,
         "other_bonus": 0,
-        "tiebreakers": [20, 20, 16, 16, 0],
+        "tiebreakers": DistrictRankingTiebreakers(*[20, 20, 16, 16, 18]),
     }
     assert rankings["frc1241"] == {
         "event_points": [
@@ -212,7 +215,7 @@ def test_2022_back_to_back_single_day_bonus(setup_full_event) -> None:
         "qual_scores": [67, 56, 45],
         "rookie_bonus": 0,
         "other_bonus": 0,
-        "tiebreakers": [10, 10, 14, 14, 0],
+        "tiebreakers": DistrictRankingTiebreakers(*[10, 10, 14, 14, 12]),
     }
 
 

--- a/src/backend/web/templates/admin/district_details.html
+++ b/src/backend/web/templates/admin/district_details.html
@@ -39,6 +39,7 @@
         <h2>Tasks</h2>
         <div class="btn-group">
           <a href="/backend-tasks/get/district_rankings/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Details from FIRST</a>
+          <a href="/tasks/math/do/district_rankings_calc/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-stats"></span> Recompute Rankings</a>
         </div>
     </div>
     <div class="tab-pane" id="events">
@@ -76,7 +77,7 @@
                     <td><a href="/admin/team/{{rank.team_key[3:]}}">{{rank.team_key}}</a></td>
                     <td>{{rank.point_total}}</td>
                     <td>{{rank.rookie_bonus}}</td>
-                    <td><pre>{{rank.event_points}}</pre></td>
+                    <td><pre>{% if rank.event_points %}{{rank.event_points|pprint_json}}{%endif%}</pre></td>
                 </tr>
             {% else %}
                 <tr><td>No district rankings found</td></tr>


### PR DESCRIPTION
This updates district rankings to use a similar typing scheme as the regional one; which allows us to use a `NamedTuple` instead of direct indexing "magic" bits into a list.

This also cleans up a bug where we were tracking qual wins, instead of qual performance district points.