### PR TITLE
Implement sorting for regional champs pool

### DIFF
--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -246,11 +246,11 @@ class DistrictHelper:
                         or event.event_type_enum == EventType.DISTRICT_CMP
                         or event.event_type_enum == EventType.DISTRICT_CMP_DIVISION
                     ):
-                        tiebreakers = DistrictRankingTiebreakers(
-                            *team_totals[team_key]["tiebreakers"]
-                        )
-
                         if team_key in event_district_points["points"]:
+                            tiebreakers = DistrictRankingTiebreakers(
+                                *team_totals[team_key]["tiebreakers"]
+                            )
+
                             team_event_points: TeamAtEventDistrictPoints = (
                                 event_district_points["points"][team_key]
                             )

--- a/src/backend/common/helpers/district_point_tiebreakers_sorting_helper.py
+++ b/src/backend/common/helpers/district_point_tiebreakers_sorting_helper.py
@@ -1,0 +1,30 @@
+from typing import List, Tuple
+
+from backend.common.models.event_district_points import (
+    EventDistrictPoints,
+    TeamAtEventDistrictPoints,
+)
+from backend.common.models.keys import TeamKey
+
+
+class DistrictPointTiebreakersSortingHelper:
+
+    @classmethod
+    def sorted_points(
+        cls, event_points: EventDistrictPoints
+    ) -> List[Tuple[TeamKey, TeamAtEventDistrictPoints]]:
+        return sorted(
+            event_points["points"].items(),
+            key=lambda team_and_points: [
+                -team_and_points[1]["total"],
+                -team_and_points[1]["elim_points"],
+                -team_and_points[1]["alliance_points"],
+                -team_and_points[1]["qual_points"],
+            ]
+            + [
+                -score
+                for score in event_points["tiebreakers"]
+                .get(team_and_points[0], {})
+                .get("highest_qual_scores", [])
+            ],
+        )

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -16,6 +16,9 @@ from backend.common.consts.event_type import EventType
 from backend.common.decorators import cached_public
 from backend.common.flask_cache import make_cached_response
 from backend.common.helpers.award_helper import AwardHelper
+from backend.common.helpers.district_point_tiebreakers_sorting_helper import (
+    DistrictPointTiebreakersSortingHelper,
+)
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.media_helper import MediaHelper
@@ -199,10 +202,9 @@ def event_detail(event_key: EventKey) -> Response:
     playoff_template = PlayoffAdvancementHelper.playoff_template(event)
 
     district_points_sorted = None
-    if event.district_key and event.district_points:
-        district_points_sorted = sorted(
-            none_throws(event.district_points)["points"].items(),
-            key=lambda team_and_points: -team_and_points[1]["total"],
+    if event.district_key and (points := event.district_points):
+        district_points_sorted = DistrictPointTiebreakersSortingHelper.sorted_points(
+            points
         )
 
     is_regional_cmp_pool_eligible = (
@@ -211,9 +213,8 @@ def event_detail(event_key: EventKey) -> Response:
     )
     regional_champs_pool_points_sorted = None
     if is_regional_cmp_pool_eligible and (points := event.regional_champs_pool_points):
-        regional_champs_pool_points_sorted = sorted(
-            none_throws(points["points"].items()),
-            key=lambda team_and_points: -team_and_points[1]["total"],
+        regional_champs_pool_points_sorted = (
+            DistrictPointTiebreakersSortingHelper.sorted_points(points)
         )
 
     event_insights = event.details.insights if event.details else None

--- a/src/backend/web/templates/admin/event_details.html
+++ b/src/backend/web/templates/admin/event_details.html
@@ -675,7 +675,7 @@
   </div>
 
   <div class="tab-pane" id="district-points">
-    {% if event.details.regional_champs_pool_points %}
+    {% if regional_champs_pool_points_sorted %}
       <h2>Regional Championship Pool Points</h2>
       <table class="table table-striped table-hover table-condensed">
         <tr>
@@ -686,7 +686,7 @@
           <th>Award Points</th>
           <th>Total Points</th>
         </tr>
-        {% for team_key, points in event.details.regional_champs_pool_points.points.items() %}
+        {% for team_key, points in regional_champs_pool_points_sorted %}
           <tr>
             <td><a href="/team/{{team_key[3:]}}">{{team_key[3:]}}</a></td>
             <td>{{points.qual_points}}</td>
@@ -699,7 +699,7 @@
       </table>
     {% endif %}
 
-    {% if event.details.district_points %}
+    {% if district_points_sorted %}
       <h2>District Points</h2>
       <i>These may or may not be relevant, TBA always calculates district points</i>
       <table class="table table-striped table-hover table-condensed">
@@ -711,7 +711,7 @@
           <th>Award Points</th>
           <th>Total Points</th>
         </tr>
-        {% for team_key, points in event.details.district_points.points.items() %}
+        {% for team_key, points in district_points_sorted %}
           <tr>
             <td><a href="/team/{{team_key[3:]}}">{{team_key[3:]}}</a></td>
             <td>{{points.qual_points}}</td>


### PR DESCRIPTION
This implements most of the sorting (and also makes sure the UI takes tiebreakers into account as well).

This still isn't perfect, because we are still looking at the highest _qual_ match as the bottom tiebreakers (instead of _all_ matches). But untangling this is going to be a bit tricky to do safely with historical data being written differently, so leave it for now.