### PR TITLE
Add APIv3 endpoint for regional champs pool points

### DIFF
--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -108,6 +108,30 @@ def event_detail(event_key: EventKey, detail_type: str) -> Response:
 @api_authenticated
 @validate_keys
 @cached_public
+def event_advancement_points(event_key: EventKey) -> Response:
+    """
+    Returns details about one event, specified by |event_key| and |detail_type|.
+    """
+    track_call_after_response("event/advancement_points", event_key)
+
+    event_details = EventDetailsQuery(event_key=event_key).fetch_dict(
+        ApiMajorVersion.API_V3
+    )
+    if event_details is None:
+        return profiled_jsonify(None)
+
+    # This is a hybrid merging of regiona/district points
+    if regional_champs_pool_points := event_details.get("regional_champs_pool_points"):
+        return profiled_jsonify(regional_champs_pool_points)
+    elif district_points := event_details.get("district_points"):
+        return profiled_jsonify(district_points)
+    else:
+        return profiled_jsonify(None)
+
+
+@api_authenticated
+@validate_keys
+@cached_public
 def event_teams(
     event_key: EventKey, model_type: Optional[ModelType] = None
 ) -> Response:

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -26,6 +26,7 @@ from backend.api.handlers.district import (
 from backend.api.handlers.error import handle_404
 from backend.api.handlers.event import (
     event,
+    event_advancement_points,
     event_awards,
     event_detail,
     event_list_all,
@@ -93,7 +94,7 @@ class ModelTypeConverter(BaseConverter):
 
 
 class EventDetailTypeConverter(BaseConverter):
-    regex = r"alliances|district_points|insights|oprs|coprs|predictions|rankings"
+    regex = r"alliances|district_points|insights|oprs|coprs|predictions|rankings|regional_champs_pool_points"
 
 
 configure_logging()
@@ -152,6 +153,10 @@ api_v3.add_url_rule(
 api_v3.add_url_rule(
     "/event/<string:event_key>/<event_detail_type:detail_type>",
     view_func=event_detail,
+)
+api_v3.add_url_rule(
+    "/event/<string:event_key>/advancement_points",
+    view_func=event_advancement_points,
 )
 api_v3.add_url_rule("/event/<string:event_key>/teams", view_func=event_teams)
 api_v3.add_url_rule(

--- a/src/backend/common/queries/dict_converters/event_details_converter.py
+++ b/src/backend/common/queries/dict_converters/event_details_converter.py
@@ -57,6 +57,9 @@ class EventDetailsConverter(ConverterBase):
         event_details_dict = {
             "alliances": event_details.alliance_selections if event_details else [],
             "district_points": event_details.district_points if event_details else {},
+            "regional_champs_pool_points": (
+                event_details.regional_champs_pool_points if event_details else {}
+            ),
             "insights": (
                 event_details.insights if event_details else {"qual": {}, "playoff": {}}
             ),

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -2844,8 +2844,132 @@
           "event",
           "district"
         ],
-        "description": "Gets a list of team rankings for the Event.",
+        "description": "Gets a list of district points for the Event. These are always calculated, regardless of event type, and may/may not be actually useful.",
         "operationId": "getEventDistrictPoints",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_District_Points"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/regional_champs_pool_points": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "For 2025+ Regional events, this will return points towards the Championship qualification pool.",
+        "operationId": "getRegionalChampsPoolPoints",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_District_Points"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/advancement_points": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Depending on the type of event (district/regional), this will return either district points or regional CMP points",
+        "operationId": "getEventAdvancementPoints",
         "parameters": [
           {
             "$ref": "#/components/parameters/If-None-Match"


### PR DESCRIPTION
This adds an API endpoint, shaped the same as the district point one, for regional CMP pool points. There is also a "hybrid" endpoint, for `advancement_points`, which will return either district points or the regional points, whichever is applicable for that event.