### PR TITLE
Hook up 'clear cache' admin panel button

### DIFF
--- a/src/backend/common/manipulators/manipulator_base.py
+++ b/src/backend/common/manipulators/manipulator_base.py
@@ -152,6 +152,22 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
             self._run_post_delete_hook(models)
         self._clearCache(models)
 
+    @overload
+    @classmethod
+    def clearCache(cls, models: TModel) -> None: ...
+
+    @overload
+    @classmethod
+    def clearCache(cls, models: List[TModel]) -> None: ...
+
+    @classmethod
+    def clearCache(cls, models) -> None:
+        models = list(filter(None, listify(models)))
+        for model in models:
+            model._dirty = True
+            cls._computeAndSaveAffectedReferences(model)
+        cls._clearCache(models)
+
     """
     findOrSpawn will take either a singular model or a list of models and merge them
     with the (optionally present) existing versions

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -25,6 +25,7 @@ from backend.web.handlers.admin.cache import (
     cached_query_key_lookup_post,
     cached_query_list,
     cached_query_purge_version,
+    clear_model_cache,
 )
 from backend.web.handlers.admin.districts import (
     district_create,
@@ -208,6 +209,10 @@ admin_routes.add_url_rule(
 admin_routes.add_url_rule(
     "/cache/<query_class_name>/purge/<db_version>/<int:query_version>",
     view_func=cached_query_purge_version,
+)
+admin_routes.add_url_rule(
+    "/cache/clear/<model_type>/<model_key>",
+    view_func=clear_model_cache,
 )
 admin_routes.add_url_rule(
     "/districts", view_func=district_list, defaults={"year": None}

--- a/src/backend/web/templates/admin/event_details.html
+++ b/src/backend/web/templates/admin/event_details.html
@@ -11,21 +11,8 @@
     Edit</a>
   <a href="/event/{{event.key_name}}" class="btn btn-default"><span class="glyphicon glyphicon-eye-open"></span> View on
     TBA</a>
-  <button class="btn btn-danger" form="event_cache_clear"><span class="glyphicon glyphicon-trash"></span> Clear
-    Cache</button>
+  <a href="/admin/cache/clear/event/{{event.key_name}}" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Clear Cache</a>
 </div>
-
-<form action="/admin/memcache" method="post" id="event_cache_clear">
-  <input name="event_key" value="{{event.key_name}}" type="hidden" />
-  <input name="return_url" value="/admin/event/{{ event.key_name }}" type="hidden" />
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-</form>
-
-{% if flushed %}
-<div class="row">
-  <p>Cleared cache keys {{ flushed }}</p>
-</div>
-{% endif %}
 
 <hr/>
 

--- a/src/backend/web/templates/admin/match_details.html
+++ b/src/backend/web/templates/admin/match_details.html
@@ -9,6 +9,7 @@
 <div class="btn-group">
     <a href="/match/{{match.key_name}}" class="btn btn-default"><span class="glyphicon glyphicon-eye-open"></span> View on TBA</a>
     <a href="/admin/match/edit/{{match.key_name}}" class="btn btn-primary"><span class="glyphicon glyphicon-edit"></span> Edit</a>
+    <a href="/admin/cache/clear/match/{{match.key_name}}" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Clear Cache</a>
 </div>
 
 <hr/>

--- a/src/backend/web/templates/admin/team_details.html
+++ b/src/backend/web/templates/admin/team_details.html
@@ -10,6 +10,7 @@
     <a href="/team/{{ team.team_number }}" class="btn btn-default"><span class="glyphicon glyphicon-eye-open"></span> View on TBA</a>
     <a href="/backend-tasks/get/team_details/{{ team.key.string_id() }}" class="btn btn-default"><span class="glyphicon glyphicon-refresh"></span> Refresh from FIRST</a>
     <a href="/backend-tasks/do/team_blacklist_website/{{ team.key.string_id() }}" class="btn btn-danger"><span class="glyphicon glyphicon-remove"></span> Blacklist website</a>
+    <a href="/admin/cache/clear/team/{{team.key_name}}" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Clear Cache</a>
 </div>
 <hr>
 


### PR DESCRIPTION
This makes the "clear cache" button on the admin panel do something again :stuck_out_tongue: 

Mainly, it'll defer through the model manipulator to get the necessary affected DB queries and delete those