### PR TITLE
Add nav bar padding; Fixes #7225

### DIFF
--- a/subtrees/bootstrap/less/navs.less
+++ b/subtrees/bootstrap/less/navs.less
@@ -84,6 +84,7 @@
     > a {
       margin-right: 2px;
       line-height: @line-height-base;
+      height: (@line-height-base * 2em) + (@padding-base-vertical * 2) + 2px;
       border: 1px solid transparent;
       border-radius: @border-radius-base @border-radius-base 0 0;
       &:hover {


### PR DESCRIPTION
## Description
Moves the bottom border to account for two lines. Uses line height x2 + a border.

## Motivation and Context
The new "Champs Qual Points" tab spans two lines and the border doesn't like right (see #7225).

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4aad47ac-272f-43b2-b38a-ba689a19beb4)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
