### PR TITLE
[PWA] Improve event search results

### DIFF
--- a/pwa/app/lib/search/fuzzysortFilterer.ts
+++ b/pwa/app/lib/search/fuzzysortFilterer.ts
@@ -29,6 +29,18 @@ function searchEvents(
     limit,
     keys: ['key', 'name'],
     threshold: 0.5,
+    scoreFn: (r) => {
+      // For current_year events, return score * 2
+      // For current_year-1 events, return score * (2 - 1 / (current_year - 1992))
+      // ...
+      // Down to score * 1
+      const eventYear = Number.parseInt(r.obj.key.slice(0, 4));
+      const currentYear = new Date().getFullYear();
+      const yearDiff = currentYear - eventYear;
+      const denominator = currentYear - 1992;
+
+      return r.score * Math.max(1, 2 - yearDiff / denominator);
+    },
   });
 
   return results.map((result) => result.obj);


### PR DESCRIPTION
This improves the event search results by ordering more recent events first. A reminder that in fuzzysort, a 1.0 score is a perfect match, a 0.5 score is a good match, and a 0.0 score is no match.

Example from documentation: https://github.com/farzher/fuzzysort?tab=readme-ov-file#advanced-usage

Tested locally.