### PR TITLE
[pwa] center table headers on alliance selection table

### DIFF
--- a/pwa/app/components/tba/allianceSelectionTable.tsx
+++ b/pwa/app/components/tba/allianceSelectionTable.tsx
@@ -70,7 +70,7 @@ export default function AllianceSelectionTable(props: {
 
       <Table className="table-fixed">
         <TableHeader>
-          <TableRow className="*:h-8 *:font-bold">
+          <TableRow className="*:h-8 *:font-bold *:text-center">
             <TableHead>Alliance</TableHead>
             <TableHead>Captain</TableHead>
             {allianceSize > 1 &&


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/644c7152-f173-44f9-8391-f6d4a5a761c1)

after:

![image](https://github.com/user-attachments/assets/9f076cd7-c166-4f3b-a8f0-9f8a1328586c)
