### PR TITLE
[PWA] overhaul teams tab to add avatars and be more compact

### DIFF
--- a/pwa/app/components/tba/teamAvatar.tsx
+++ b/pwa/app/components/tba/teamAvatar.tsx
@@ -5,8 +5,10 @@ import { cn } from '~/lib/utils';
 
 export default function TeamAvatar({
   media,
+  className,
 }: {
   media: Media;
+  className?: string;
 }): React.JSX.Element {
   const [colorClass, setColorClass] = useState('bg-first-avatar-blue');
 
@@ -23,7 +25,7 @@ export default function TeamAvatar({
   };
 
   return (
-    <button className="mr-3" onClick={handler} onKeyDown={handler}>
+    <button onClick={handler} onKeyDown={handler} className={className}>
       <img
         alt="Team Avatar"
         src={`data:image/png;base64, ${media.details.base64Image}`}

--- a/pwa/app/components/tba/teamPageTeamInfo.tsx
+++ b/pwa/app/components/tba/teamPageTeamInfo.tsx
@@ -40,7 +40,7 @@ export default function TeamPageTeamInfo({
     <>
       <div>
         <h1 className="mb-2.5 text-4xl">
-          {maybeAvatar && <TeamAvatar media={maybeAvatar} />}
+          {maybeAvatar && <TeamAvatar media={maybeAvatar} className="mr-3" />}
           Team {team.team_number} - {team.nickname}
         </h1>
         <InlineIcon>

--- a/pwa/app/components/ui/avatar.tsx
+++ b/pwa/app/components/ui/avatar.tsx
@@ -1,0 +1,51 @@
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import * as React from 'react';
+
+import { cn } from '~/lib/utils';
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        'relative flex size-8 shrink-0 overflow-hidden rounded-md',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('aspect-square size-full', className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'bg-muted flex size-full items-center justify-center rounded-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/pwa/app/components/ui/dialog.tsx
+++ b/pwa/app/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute cursor-pointer right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="size-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/pwa/app/lib/utils.test.ts
+++ b/pwa/app/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   median,
   removeNonNumeric,
   slugify,
+  splitIntoNChunks,
 } from './utils';
 
 describe.concurrent('removeNonNumeric', () => {
@@ -37,5 +38,14 @@ describe.concurrent('camelCaseToHumanReadable', () => {
     );
     expect(camelCaseToHumanReadable('totalPoints')).toEqual('Total Points');
     expect(camelCaseToHumanReadable('rp')).toEqual('Rp');
+  });
+});
+
+describe.concurrent('splitIntoNChunks', () => {
+  test('basic', () => {
+    expect(splitIntoNChunks([1, 2, 3, 4, 5], 2)).toEqual([
+      [1, 2, 3],
+      [4, 5],
+    ]);
   });
 });

--- a/pwa/app/lib/utils.tsx
+++ b/pwa/app/lib/utils.tsx
@@ -186,6 +186,12 @@ export const USA_STATE_ABBREVIATION_TO_FULL = new Map<string, string>([
   ['WY', 'Wyoming'],
 ]);
 
+export const STATE_TO_ABBREVIATION = new Map<string, string>(
+  Array.from(USA_STATE_ABBREVIATION_TO_FULL.entries()).map(
+    ([abbr, fullName]) => [fullName, abbr],
+  ),
+);
+
 // https://stackoverflow.com/a/70806192
 export function median(arr: number[]): number | undefined {
   if (!arr.length) {
@@ -202,4 +208,31 @@ export function camelCaseToHumanReadable(camelCaseStr: string): string {
   const withSpaces = camelCaseStr.replace(/([A-Z])/g, ' $1');
   // Capitalize the first letter and return the result
   return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+}
+
+export function splitIntoNChunks<T>(array: T[], numChunks: number): T[][] {
+  if (array.length === 0) {
+    return [];
+  }
+
+  const actualNumChunks = Math.min(numChunks, array.length);
+
+  // Calculate the base size of each chunk
+  const chunkSize = Math.floor(array.length / actualNumChunks);
+
+  // Calculate how many chunks need an extra element
+  const remainder = array.length % actualNumChunks;
+
+  const result: T[][] = [];
+  let currentIndex = 0;
+
+  for (let i = 0; i < actualNumChunks; i++) {
+    // Determine if this chunk needs an extra element
+    const currentChunkSize = i < remainder ? chunkSize + 1 : chunkSize;
+
+    result.push(array.slice(currentIndex, currentIndex + currentChunkSize));
+    currentIndex += currentChunkSize;
+  }
+
+  return result;
 }

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -18,7 +18,6 @@ import MdiVideo from '~icons/mdi/video';
 
 import {
   Award,
-  Event,
   EventCopRs,
   Match,
   Media,
@@ -36,9 +35,11 @@ import AllianceSelectionTable from '~/components/tba/allianceSelectionTable';
 import AwardRecipientLink from '~/components/tba/awardRecipientLink';
 import { DataTable } from '~/components/tba/dataTable';
 import InlineIcon from '~/components/tba/inlineIcon';
-import { TeamLink } from '~/components/tba/links';
+import { LocationLink, TeamLink } from '~/components/tba/links';
 import MatchResultsTable from '~/components/tba/matchResultsTable';
 import RankingsTable from '~/components/tba/rankingsTable';
+import TeamAvatar from '~/components/tba/teamAvatar';
+import { Avatar, AvatarImage } from '~/components/ui/avatar';
 import { Badge } from '~/components/ui/badge';
 import {
   Card,
@@ -48,17 +49,13 @@ import {
   CardTitle,
 } from '~/components/ui/card';
 import {
-  Credenza,
-  CredenzaBody,
-  CredenzaClose,
-  CredenzaContent,
-  CredenzaDescription,
-  CredenzaFooter,
-  CredenzaHeader,
-  CredenzaTitle,
-  CredenzaTrigger,
-} from '~/components/ui/credenza';
-import { ScrollArea } from '~/components/ui/scroll-area';
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog';
 import {
   Select,
   SelectContent,
@@ -66,7 +63,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select';
-import { Table, TableBody, TableCell, TableRow } from '~/components/ui/table';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { sortAwardsComparator } from '~/lib/awardUtils';
 import {
@@ -85,7 +89,12 @@ import {
   getBonusRankingPoints,
 } from '~/lib/rankingPoints';
 import { sortTeamKeysComparator, sortTeamsComparator } from '~/lib/teamUtils';
-import { camelCaseToHumanReadable } from '~/lib/utils';
+import {
+  STATE_TO_ABBREVIATION,
+  camelCaseToHumanReadable,
+  cn,
+  splitIntoNChunks,
+} from '~/lib/utils';
 
 import { Route } from '.react-router/types/app/routes/+types/event.$eventKey';
 
@@ -361,12 +370,7 @@ export default function EventPage() {
         </TabsContent>
 
         <TabsContent value="teams">
-          <TeamsTab
-            teams={teams}
-            matches={sortedMatches}
-            event={event}
-            media={teamMedia}
-          />
+          <TeamsTab teams={teams} media={teamMedia} />
         </TabsContent>
 
         <TabsContent value="insights">
@@ -421,84 +425,96 @@ function AwardsTab({ awards }: { awards: Award[] }) {
   );
 }
 
-function TeamsTab({
-  teams,
-  matches,
-  event,
-  media,
-}: {
-  teams: Team[];
-  matches: Match[];
-  event: Event;
-  media: Media[];
-}) {
+function TeamsTab({ teams, media }: { teams: Team[]; media: Media[] }) {
   teams.sort(sortTeamsComparator);
 
-  // todo
-  // 1. add hover effects
-  // 2. split out CredenzaTrigger, so the same UI (Body) can be triggered by different UI elements
-  return (
-    <div className="md:columns-2">
-      {teams.map((t) => (
-        <Credenza key={t.key}>
-          <CredenzaTrigger asChild>
-            <Card className="content-visibility-auto my-0 mb-1 flex h-[150px] cursor-pointer items-center gap-4 rounded-lg bg-background p-4">
-              <div className="grid flex-1 gap-1">
-                <div className="font-medium">
-                  {t.team_number} - {t.nickname}
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  {t.city}, {t.state_prov}, {t.country}
-                </div>
-              </div>
-              {(() => {
-                const maybeImage = getTeamPreferredRobotPicMedium(
-                  media.filter((m) => m.team_keys.includes(t.key)),
-                );
+  const teamChunks = splitIntoNChunks(teams, 2);
 
-                return maybeImage === undefined ? null : (
-                  <img
-                    src={maybeImage}
-                    alt={`${t.team_number}'s robot`}
-                    className="h-full w-1/3 rounded-lg border-2 border-neutral-300 object-cover"
-                    loading="lazy"
-                  />
-                );
-              })()}
-            </Card>
-          </CredenzaTrigger>
-          <CredenzaContent className="md:max-w-[80%] 2xl:max-w-[50%]">
-            <CredenzaHeader>
-              <CredenzaTitle>
-                <TeamLink teamOrKey={t.key}>
-                  {t.team_number} - {t.nickname}
-                </TeamLink>{' '}
-                at {event.short_name}
-              </CredenzaTitle>
-              <CredenzaDescription>
-                From {t.city}, {t.state_prov}, {t.country}
-              </CredenzaDescription>
-            </CredenzaHeader>
-            <CredenzaBody>
-              <ScrollArea className="h-[70vh]">
-                <MatchResultsTable
-                  team={t}
-                  matches={matches.filter(
-                    (m) =>
-                      m.alliances.blue.team_keys.includes(t.key) ||
-                      m.alliances.red.team_keys.includes(t.key),
+  return (
+    <div className="flex flex-row flex-wrap md:flex-nowrap">
+      {teamChunks.map((chunk, idx) => (
+        <Table key={`chunk-${idx}`}>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[60px] text-center">Avatar</TableHead>
+              <TableHead className="w-[30ch]">Team</TableHead>
+              <TableHead>Location</TableHead>
+              <TableHead>Pic</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {chunk.map((t) => {
+              const teamMedia = media.filter((m) =>
+                m.team_keys.includes(t.key),
+              );
+
+              const maybeAvatar = teamMedia.find((m) => m.type === 'avatar');
+              const maybeRobotPic = getTeamPreferredRobotPicMedium(teamMedia);
+
+              const abbreviatedStateProv =
+                STATE_TO_ABBREVIATION.get(t.state_prov ?? '') ?? t.state_prov;
+
+              const teamLocation = `${t.city}, ${abbreviatedStateProv}, ${t.country}`;
+
+              return (
+                <TableRow key={t.key}>
+                  <TableCell
+                    className={cn({
+                      'h-[61px]': maybeAvatar === undefined,
+                    })}
+                  >
+                    {maybeAvatar && (
+                      <div className="flex h-full w-full items-center justify-center">
+                        <TeamAvatar media={maybeAvatar} />
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="flex flex-col mt-1">
+                    <TeamLink teamOrKey={t.key}>{t.team_number}</TeamLink>
+                    <div>{t.nickname}</div>
+                  </TableCell>
+                  <TableCell className={'text-xs'}>
+                    <LocationLink
+                      city={t.city ?? ''}
+                      state_prov={t.state_prov ?? ''}
+                      country={t.country ?? ''}
+                    >
+                      {teamLocation}
+                    </LocationLink>
+                  </TableCell>
+                  {maybeRobotPic && (
+                    <TableCell>
+                      <Dialog>
+                        <DialogTrigger className="align-middle">
+                          <Avatar className="cursor-pointer size-12">
+                            <AvatarImage src={maybeRobotPic} />
+                          </Avatar>
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>
+                              <TeamLink teamOrKey={t.key}>
+                                Team {t.team_number} - {t.nickname}
+                              </TeamLink>
+                            </DialogTitle>
+                            <DialogDescription>
+                              <img
+                                src={maybeRobotPic}
+                                alt=""
+                                className="max-h-[80vh] w-3xl rounded-lg object-cover"
+                                loading="lazy"
+                              />
+                            </DialogDescription>
+                          </DialogHeader>
+                        </DialogContent>
+                      </Dialog>
+                    </TableCell>
                   )}
-                  event={event}
-                />
-              </ScrollArea>
-            </CredenzaBody>
-            <CredenzaFooter>
-              <CredenzaClose asChild>
-                <button>Close</button>
-              </CredenzaClose>
-            </CredenzaFooter>
-          </CredenzaContent>
-        </Credenza>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
       ))}
     </div>
   );

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@oazapfts/runtime": "1.0.4",
         "@radix-ui/react-accordion": "1.2.3",
+        "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "1.1.6",
         "@radix-ui/react-dropdown-menu": "2.1.6",
         "@radix-ui/react-navigation-menu": "1.2.5",
@@ -2361,6 +2362,32 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.3.tgz",
+      "integrity": "sha512-Paen00T4P8L8gd9bNsRMw7Cbaz85oxiv+hzomsRZgFm2byltPFDtfcoqlWJ8GyZlIBWgLssJlzLCnKU0G0302g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@oazapfts/runtime": "1.0.4",
     "@radix-ui/react-accordion": "1.2.3",
+    "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "1.1.6",
     "@radix-ui/react-dropdown-menu": "2.1.6",
     "@radix-ui/react-navigation-menu": "1.2.5",


### PR DESCRIPTION
This gets rid of the team-schedule popup for now. I believe a better UX is:

1. When clicking on a team in the teams tab, you are brought to the team page
2. When clicking on a team in the schedule tab, you are given a dialog of the team's schedule

This PR is a step towards that. Still need to implement the dialog on the schedule.

![image](https://github.com/user-attachments/assets/778f7b47-3a77-4ab4-861c-827f76d83578)
