### PR TITLE
[PWA] fix event/insights 500 on old, pre-RP events

### DIFF
--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -526,7 +526,7 @@ function MatchStatsTable({
 
   const rpPercentages = useMemo(
     () =>
-      range(0, RANKING_POINT_LABELS[year].length).map(
+      range(0, (RANKING_POINT_LABELS[year] ?? []).length).map(
         (i) =>
           matches
             .filter((m) => m.score_breakdown !== null)


### PR DESCRIPTION
old events (pre RPs) 500 on the insights tab due to missing RP names