### PR TITLE
[pwa] only include played matches on frontend insight tab

### DIFF
--- a/pwa/app/lib/matchUtils.ts
+++ b/pwa/app/lib/matchUtils.ts
@@ -204,13 +204,11 @@ export function getTeamsUnpenalizedHighScore(
 }
 
 export function getHighScoreMatch(matches: Match[]): Match | undefined {
-  const matchesWithScore = matches.filter((m) => m.alliances.red.score !== -1);
-
-  if (matchesWithScore.length === 0) {
+  if (matches.length === 0) {
     return undefined;
   }
 
-  const scores = matchesWithScore.map((m) => ({
+  const scores = matches.map((m) => ({
     match: m,
     score: Math.max(m.alliances.red.score, m.alliances.blue.score),
   }));

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -370,7 +370,13 @@ export default function EventPage() {
         </TabsContent>
 
         <TabsContent value="insights">
-          <MatchStatsTable matches={sortedMatches} year={event.year} />
+          <MatchStatsTable
+            matches={sortedMatches.filter(
+              (m) =>
+                m.alliances.red.score !== -1 && m.alliances.blue.score !== -1,
+            )}
+            year={event.year}
+          />
           {coprs && Object.keys(coprs).length > 0 && (
             <ComponentsTable coprs={coprs} year={event.year} />
           )}
@@ -536,7 +542,7 @@ function MatchStatsTable({
             ])
             .map((rps) => (rps[0][i] ? 1 : 0) + (rps[1][i] ? 1 : 0))
             .reduce((prev, curr) => prev + curr, 0) /
-          (matches.length * 2),
+          Math.max(1, matches.length * 2),
       ),
     [matches, year],
   );


### PR DESCRIPTION
The RP percentages are wrong because they include unplayed matches. This removes an unnecessary filter from high score calculations as well, now that we are filtering before the data reaches the component.