### PR TITLE
Patch threading not to throw an error from upstream Google Cloud Logging exception

### DIFF
--- a/src/backend/common/logging.py
+++ b/src/backend/common/logging.py
@@ -6,6 +6,20 @@ from backend.common.environment import Environment
 
 
 def configure_logging() -> None:
+    # See https://github.com/GoogleChrome/chromium-dashboard/issues/3197
+    import threading
+
+    # Patch treading library to work-around bug with Google Cloud Logging.
+    original_delete = threading.Thread._delete  # type: ignore
+
+    def safe_delete(self):
+        try:
+            original_delete(self)
+        except KeyError:
+            pass
+
+    threading.Thread._delete = safe_delete  # type: ignore
+
     if Environment.is_prod() and not Environment.is_unit_test():
         # Setting this up only needs to be done in prod to ensure logs are grouped properly with the request.
         client = google.cloud.logging.Client()


### PR DESCRIPTION
Tested this on a local instance and this fixed the threading errors. Should be good until we get a new version of Google Cloud Logging.