### PR TITLE
Add links to event public agendas

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -10,7 +10,7 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.consts import event_type
-from backend.common.consts.event_type import EventType
+from backend.common.consts.event_type import EventType, SEASON_EVENT_TYPES
 from backend.common.consts.playoff_type import PlayoffType
 from backend.common.futures import TypedFuture
 from backend.common.models.alliance import EventAlliance
@@ -699,6 +699,13 @@ class Event(CachedModel):
             return "/gameday/{}".format(self.key_name)
         else:
             return None
+
+    @property
+    def public_agenda_url(self) -> Optional[str]:
+        if self.event_type_enum not in SEASON_EVENT_TYPES:
+            return None
+
+        return f"http://firstinspires.org/sites/default/files/uploads/frc/{self.year}-events/{self.year}_{self.event_short.upper()}_Agenda.pdf"
 
     @property
     def hashtag(self) -> str:

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -426,3 +426,14 @@ def event_rss(event_key: EventKey) -> Response:
     response.headers["content-type"] = "application/xml; charset=UTF-8"
 
     return response
+
+
+def event_agenda(event_key: EventKey) -> Response:
+    if (
+        not Event.validate_key_name(event_key)
+        or not (event := Event.get_by_id(event_key))
+        or not (agenda_url := event.public_agenda_url)
+    ):
+        abort(404)
+
+    return redirect(agenda_url)

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -26,6 +26,7 @@ from backend.web.handlers.district import district_detail, regional_detail
 from backend.web.handlers.embed import avatar_png, instagram_oembed
 from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.event import (
+    event_agenda,
     event_detail,
     event_insights,
     event_list,
@@ -95,6 +96,7 @@ app.add_url_rule("/gameday/<alias>", view_func=gameday_redirect)
 app.add_url_rule("/gameday", view_func=gameday)
 
 app.add_url_rule("/event/<event_key>", view_func=event_detail)
+app.add_url_rule("/event/<event_key>/agenda", view_func=event_agenda)
 app.add_url_rule("/event/<event_key>/feed", view_func=event_rss)
 app.add_url_rule("/event/<event_key>/insights", view_func=event_insights)
 app.add_url_rule("/events/<int:year>", view_func=event_list)

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -66,6 +66,7 @@
           <span class="glyphicon glyphicon-circle-arrow-right"></span> Winners advance to the <a href="/event/{{ parent_event.key_name }}">{{ parent_event.name }}</a><br />
         {% endif %}
         {{ em.showEventDates(event) }}
+        {% if event.public_agenda_url and (event.within_a_day or event.future) %}<br><span class="glyphicon glyphicon-paperclip"></span> <a href="{{event.public_agenda_url}}" target="_blank" rel="noopener noreferrer">Public Agenda</a>{% endif %}
         {% if event.location or event.venue_address_safe %}
           <br><span class="glyphicon glyphicon-map-marker"></span>
           <span itemprop="location">


### PR DESCRIPTION
This one is a little selfish, but getting links to event agendas is always kinda annoying. This adds a link to the event page for current + future events, and also adds `/event/<event key>/agenda` as a redirect helper.