### PR TITLE
Add react-router group to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,10 @@ updates:
   labels:
     - PWA
   groups:
-    remix-run:
+    react-router:
       patterns:
-        - "@remix-run/*"
+        - "@react-router/*"
+        - "react-router"
     embla-carousel:
       patterns:
         - "embla-carousel-autoplay"


### PR DESCRIPTION
Replaces remix-run group with react-router group