### PR TITLE
[PWA] Actually use prettier-plugin-tailwindcss

### DIFF
--- a/pwa/app/components/tba/allianceSelectionTable.tsx
+++ b/pwa/app/components/tba/allianceSelectionTable.tsx
@@ -70,7 +70,7 @@ export default function AllianceSelectionTable(props: {
 
       <Table className="table-fixed">
         <TableHeader>
-          <TableRow className="*:h-8 *:font-bold *:text-center">
+          <TableRow className="*:h-8 *:text-center *:font-bold">
             <TableHead>Alliance</TableHead>
             <TableHead>Captain</TableHead>
             {allianceSize > 1 &&

--- a/pwa/app/components/tba/banner.tsx
+++ b/pwa/app/components/tba/banner.tsx
@@ -42,7 +42,8 @@ export function Banner({
   return (
     <div
       className={cn(
-        'flex h-64 w-40 flex-col items-center justify-between bg-blue-600 px-4 py-6 text-center tracking-tight text-white',
+        `flex h-64 w-40 flex-col items-center justify-between bg-blue-600 px-4 py-6
+        text-center tracking-tight text-white`,
         className,
       )}
     >

--- a/pwa/app/components/tba/cards.tsx
+++ b/pwa/app/components/tba/cards.tsx
@@ -11,8 +11,9 @@ const TitledCard = React.forwardRef<
 >(({ cardTitle, cardSubtitle, className, ...props }, ref) => (
   <div
     className={cn(
-      `flex flex-col justify-center rounded-lg border border-gray-100 px-4 py-6 text-center
-      transition-all duration-300 ease-in-out hover:-translate-y-1 hover:border-gray-200 hover:shadow-md`,
+      `flex flex-col justify-center rounded-lg border border-gray-100 px-4 py-6
+      text-center transition-all duration-300 ease-in-out hover:-translate-y-1
+      hover:border-gray-200 hover:shadow-md`,
       className,
     )}
     {...props}

--- a/pwa/app/components/tba/charts/coprScatterChart.tsx
+++ b/pwa/app/components/tba/charts/coprScatterChart.tsx
@@ -218,7 +218,7 @@ export default function CoprScatterChart({
       </CardContent>
       <div className="flex flex-row justify-around pb-4">
         <div className="flex flex-row items-center">
-          <div className="font-bold pr-4">Y Axis</div>
+          <div className="pr-4 font-bold">Y Axis</div>
           <Select value={selectedYCopr} onValueChange={setSelectedYCopr}>
             <SelectTrigger className="w-auto">
               <SelectValue />
@@ -237,7 +237,7 @@ export default function CoprScatterChart({
         </div>
 
         <div className="flex flex-row items-center">
-          <div className="font-bold pr-4">X Axis</div>
+          <div className="pr-4 font-bold">X Axis</div>
           <Select value={selectedXCopr} onValueChange={setSelectedXCopr}>
             <SelectTrigger className="w-auto">
               <SelectValue />
@@ -273,7 +273,7 @@ const CustomTooltip = ({
     return (
       <div className="flex flex-col rounded-md bg-white shadow-xl">
         <div className="flex flex-col p-4">
-          <div className="text-xl pb-2">{teamKey}</div>
+          <div className="pb-2 text-xl">{teamKey}</div>
           <div className="">
             <div className="flex justify-between gap-4">
               <div>{yCopr}</div>

--- a/pwa/app/components/tba/dataTable.tsx
+++ b/pwa/app/components/tba/dataTable.tsx
@@ -55,7 +55,7 @@ export function DataTable<TData, TValue>({
                         tabIndex={0}
                         className={
                           header.column.getCanSort()
-                            ? 'cursor-pointer select-none text-center'
+                            ? 'cursor-pointer text-center select-none'
                             : ''
                         }
                         onClick={header.column.getToggleSortingHandler()}

--- a/pwa/app/components/tba/leaderboard.tsx
+++ b/pwa/app/components/tba/leaderboard.tsx
@@ -50,7 +50,7 @@ export function Leaderboard({
 
   return (
     <Card className="border-gray-300">
-      <CardHeader className="px-6 pb-1 pt-4">
+      <CardHeader className="px-6 pt-4 pb-1">
         <CardTitle>
           <div className="flex justify-between align-middle">
             <div className="self-center">{displayName}</div>
@@ -143,7 +143,7 @@ function LeaderboardKeyList({
               &nbsp;(and{' '}
               {pluralize(keyVals.length - cutoffSize, 'other', 'others')})
             </TooltipTrigger>
-            <TooltipContent className="max-w-[500px] whitespace-normal break-words text-center">
+            <TooltipContent className="max-w-[500px] text-center break-words whitespace-normal">
               <p>
                 {keyVals.map((k, i) => (
                   <React.Fragment key={k}>

--- a/pwa/app/components/tba/matchResultsTable.tsx
+++ b/pwa/app/components/tba/matchResultsTable.tsx
@@ -207,22 +207,22 @@ function MatchResultsTableGroup({
   const gridStyle = cn(
     // always use these classes:
     'grid items-center justify-items-center',
-    '*:justify-self-stretch *:justify-center',
-    '*:text-center *:p-[5px] *:h-full *:content-center',
+    '*:justify-center *:justify-self-stretch',
+    '*:h-full *:content-center *:p-[5px] *:text-center',
     // use these classes on mobile:
     'grid-rows-2',
     'grid-cols-[calc(1.25em+10px)_8em_1fr_1fr_1fr_1fr]', // 6 columns of these sizes
-    'border-[#000] border-b-[1px]',
-    '*:border-[#ddd] *:border-[1px]',
+    'border-b-[1px] border-[#000]',
+    '*:border-[1px] *:border-[#ddd]',
     // use these on desktop:
     'lg:grid-rows-1',
     'lg:grid-cols-[calc(1.25em+6px*2)_10em_repeat(6,minmax(0,1fr))_0.9fr_0.9fr]',
-    'lg:border-[#ddd] lg:border-b-[1px]',
+    'lg:border-b-[1px] lg:border-[#ddd]',
     'lg:*:border-0 lg:*:border-r-[1px]', // reset the border, then apply one to the right
   );
 
   return (
-    <div className="min-w-[25rem] border-l border-t border-[#ddd] md:min-w-[35rem]">
+    <div className="min-w-[25rem] border-t border-l border-[#ddd] md:min-w-[35rem]">
       <div className={cn(gridStyle, 'bg-[#f0f0f0] font-semibold')}>
         <div className="row-span-2 lg:row-span-1">
           <PlayCircle className="inline" />
@@ -335,7 +335,8 @@ function MatchResultsTableGroup({
             {/* unplayed match */}
             {m.alliances.red.score == -1 && m.alliances.blue.score == -1 && (
               <GridCell
-                className="relative col-start-6 row-span-2 row-start-1 lg:col-span-2 lg:col-start-9 lg:row-span-1"
+                className="relative col-start-6 row-span-2 row-start-1 lg:col-span-2 lg:col-start-9
+                  lg:row-span-1"
                 teamOrScore={'score'}
               >
                 {m.predicted_time && (

--- a/pwa/app/components/tba/nav.tsx
+++ b/pwa/app/components/tba/nav.tsx
@@ -66,24 +66,25 @@ export const DropMenuItem = ({
   return (
     <NavigationMenuItem
       className={cn(
-        `relative flex cursor-default select-none bg-primary items-center rounded-sm
-          text-md outline-hidden transition-colors focus:bg-background
-          focus:text-accent-foreground data-disabled:pointer-events-none
-          data-disabled:opacity-50`,
+        `text-md relative flex cursor-default items-center rounded-sm bg-primary
+        outline-hidden transition-colors select-none focus:bg-background
+        focus:text-accent-foreground data-disabled:pointer-events-none
+        data-disabled:opacity-50`,
         className,
       )}
     >
       <NavigationMenuLink
         className={
           navigationMenuTriggerStyle() +
-          ' cursor-pointer w-full grow hover:no-underline'
+          ' w-full grow cursor-pointer hover:no-underline'
         }
         asChild
       >
         {route ? (
           <Link
             to={route}
-            className="flex grow flex-row flex-wrap content-between items-center justify-start px-2 text-white hover:no-underline"
+            className="flex grow flex-row flex-wrap content-between items-center justify-start px-2
+              text-white hover:no-underline"
           >
             {icon}
             <div className="pl-2 antialiased">{title}</div>
@@ -110,7 +111,7 @@ export const Nav = () => {
             className="size-6 max-w-none"
             alt="The Blue Alliance Logo"
           />
-          <div className="hidden whitespace-nowrap text-xl font-medium tracking-tight	 text-white lg:block">
+          <div className="hidden text-xl font-medium tracking-tight whitespace-nowrap text-white lg:block">
             The Blue Alliance
           </div>
         </Link>
@@ -142,8 +143,8 @@ export const Nav = () => {
               alignOffset={-2}
               align="start"
               className={cn(
-                `mt-6 bg-primary px-1 py-1 w-30 m-0 border-none drop-shadow-lg shadow-l
-                  rounded-md `,
+                `shadow-l m-0 mt-6 w-30 rounded-md border-none bg-primary px-1 py-1
+                drop-shadow-lg`,
               )}
             >
               <DropMenuItem

--- a/pwa/app/components/tba/rankingsTable.tsx
+++ b/pwa/app/components/tba/rankingsTable.tsx
@@ -102,7 +102,7 @@ export default function RankingsTable({
       data={rankings.rankings}
       conditionalRowStyling={(row) =>
         cn({
-          'bg-yellow-100 shadow-inner shadow-yellow-200 font-bold':
+          'bg-yellow-100 font-bold shadow-inner shadow-yellow-200':
             winners.includes(row.original.team_key),
         })
       }

--- a/pwa/app/components/tba/rpDot.tsx
+++ b/pwa/app/components/tba/rpDot.tsx
@@ -23,7 +23,7 @@ function RpDot({
       <Tooltip>
         <TooltipTrigger asChild>
           <svg
-            className={cn('h-[4px] absolute top-[2px] left-[3px] w-[4px]', {
+            className={cn('absolute top-[2px] left-[3px] h-[4px] w-[4px]', {
               'ml-0': rpIndex === 0,
               'ml-[6px]': rpIndex === 1,
               'ml-[12px]': rpIndex === 2,

--- a/pwa/app/components/tba/searchbar.tsx
+++ b/pwa/app/components/tba/searchbar.tsx
@@ -102,7 +102,7 @@ export default function Searchbar() {
 
       <CommandList
         className={cn(
-          'fixed top-14 z-50  w-64 border border-gray-200 bg-white shadow-lg',
+          'fixed top-14 z-50 w-64 border border-gray-200 bg-white shadow-lg',
           {
             hidden: !isOpen,
           },

--- a/pwa/app/components/tba/teamAvatar.tsx
+++ b/pwa/app/components/tba/teamAvatar.tsx
@@ -29,7 +29,7 @@ export default function TeamAvatar({
       <img
         alt="Team Avatar"
         src={`data:image/png;base64, ${media.details.base64Image}`}
-        className={cn('size-12 rounded inline p-1', colorClass)}
+        className={cn('inline size-12 rounded p-1', colorClass)}
       />
     </button>
   );

--- a/pwa/app/components/ui/accordion.tsx
+++ b/pwa/app/components/ui/accordion.tsx
@@ -26,7 +26,8 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
+        `flex flex-1 items-center justify-between py-4 font-medium transition-all
+        hover:underline [&[data-state=open]>svg]:rotate-180`,
         className,
       )}
       {...props}
@@ -44,10 +45,11 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up
+      data-[state=open]:animate-accordion-down"
     {...props}
   >
-    <div className={cn('pb-4 pt-0', className)}>{children}</div>
+    <div className={cn('pt-0 pb-4', className)}>{children}</div>
   </AccordionPrimitive.Content>
 ));
 

--- a/pwa/app/components/ui/avatar.tsx
+++ b/pwa/app/components/ui/avatar.tsx
@@ -40,7 +40,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'bg-muted flex size-full items-center justify-center rounded-full',
+        'flex size-full items-center justify-center rounded-full bg-muted',
         className,
       )}
       {...props}

--- a/pwa/app/components/ui/card.tsx
+++ b/pwa/app/components/ui/card.tsx
@@ -37,7 +37,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      'text-2xl font-medium leading-none tracking-tight',
+      'text-2xl leading-none font-medium tracking-tight',
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/carousel.tsx
+++ b/pwa/app/components/ui/carousel.tsx
@@ -205,7 +205,7 @@ const CarouselPrevious = React.forwardRef<
       className={cn(
         'absolute h-8 w-8 rounded-full',
         orientation === 'horizontal'
-          ? '-left-12 top-1/2 -translate-y-1/2'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
           : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
         className,
       )}
@@ -234,7 +234,7 @@ const CarouselNext = React.forwardRef<
       className={cn(
         'absolute h-8 w-8 rounded-full',
         orientation === 'horizontal'
-          ? '-right-12 top-1/2 -translate-y-1/2'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
           : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
         className,
       )}

--- a/pwa/app/components/ui/chart.tsx
+++ b/pwa/app/components/ui/chart.tsx
@@ -58,7 +58,19 @@ function ChartContainer({
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          `flex aspect-video justify-center text-xs
+          [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground
+          [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50
+          [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border
+          [&_.recharts-dot[stroke='#fff']]:stroke-transparent
+          [&_.recharts-layer]:outline-hidden
+          [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border
+          [&_.recharts-radial-bar-background-sector]:fill-muted
+          [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted
+          [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border
+          [&_.recharts-sector]:outline-hidden
+          [&_.recharts-sector[stroke='#fff']]:stroke-transparent
+          [&_.recharts-surface]:outline-hidden`,
           className,
         )}
         {...props}
@@ -176,7 +188,8 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        'border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
+        `grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50
+        bg-background px-2.5 py-1.5 text-xs shadow-xl`,
         className,
       )}
     >
@@ -191,7 +204,8 @@ function ChartTooltipContent({
             <div
               key={item.dataKey}
               className={cn(
-                '[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5',
+                `flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5
+                [&>svg]:text-muted-foreground`,
                 indicator === 'dot' && 'items-center',
               )}
             >
@@ -236,7 +250,7 @@ function ChartTooltipContent({
                       </span>
                     </div>
                     {item.value && (
-                      <span className="text-foreground font-mono font-medium tabular-nums">
+                      <span className="font-mono font-medium text-foreground tabular-nums">
                         {item.value.toLocaleString()}
                       </span>
                     )}
@@ -286,7 +300,7 @@ function ChartLegendContent({
           <div
             key={item.value}
             className={cn(
-              '[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
+              'flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground',
             )}
           >
             {itemConfig?.icon && !hideIcon ? (

--- a/pwa/app/components/ui/command.tsx
+++ b/pwa/app/components/ui/command.tsx
@@ -13,7 +13,8 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+      `flex h-full w-full flex-col overflow-hidden rounded-md bg-popover
+      text-popover-foreground`,
       className,
     )}
     {...props}
@@ -27,7 +28,13 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
+        <Command
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium
+            [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2
+            [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0
+            [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2
+            [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5"
+        >
           {children}
         </Command>
       </DialogContent>
@@ -45,7 +52,9 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        `flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden
+        placeholder:text-muted-foreground disabled:cursor-not-allowed
+        disabled:opacity-50`,
         className,
       )}
       {...props}
@@ -61,7 +70,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+    className={cn('max-h-[300px] overflow-x-hidden overflow-y-auto', className)}
     {...props}
   />
 ));
@@ -88,7 +97,10 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+      `overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2
+      [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs
+      [&_[cmdk-group-heading]]:font-medium
+      [&_[cmdk-group-heading]]:text-muted-foreground`,
       className,
     )}
     {...props}
@@ -116,7 +128,10 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+      `relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm
+      outline-hidden select-none data-[disabled=true]:pointer-events-none
+      data-[disabled=true]:opacity-50 data-[selected='true']:bg-accent
+      data-[selected=true]:text-accent-foreground`,
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/dialog.tsx
+++ b/pwa/app/components/ui/dialog.tsx
@@ -19,7 +19,9 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      `fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out
+      data-[state=closed]:fade-out-0 data-[state=open]:animate-in
+      data-[state=open]:fade-in-0`,
       className,
     )}
     {...props}
@@ -36,13 +38,26 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        `data-[state=closed]:slide-out-to-left-1/2
+        data-[state=open]:slide-in-from-left-1/2 fixed top-[50%] left-[50%] z-50 grid
+        w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background
+        p-6 shadow-lg duration-200 data-[state=closed]:animate-out
+        data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-[48%]
+        data-[state=closed]:zoom-out-95 data-[state=open]:animate-in
+        data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-[48%]
+        data-[state=open]:zoom-in-95 sm:rounded-lg`,
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute cursor-pointer right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close
+        className="absolute top-4 right-4 cursor-pointer rounded-sm opacity-70
+          ring-offset-background transition-opacity hover:opacity-100 focus:ring-2
+          focus:ring-ring focus:ring-offset-2 focus:outline-hidden
+          disabled:pointer-events-none data-[state=open]:bg-accent
+          data-[state=open]:text-muted-foreground"
+      >
         <X className="size-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -86,7 +101,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-lg leading-none font-semibold tracking-tight',
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/divider.tsx
+++ b/pwa/app/components/ui/divider.tsx
@@ -7,7 +7,10 @@ const Divider = React.forwardRef<
   React.ComponentPropsWithoutRef<'span'>
 >(({ className, children }, ref) => (
   <span className={cn('relative flex justify-center', className)} ref={ref}>
-    <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent bg-gradient-to-r from-transparent via-gray-500 to-transparent opacity-75"></div>
+    <div
+      className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent bg-gradient-to-r
+        from-transparent via-gray-500 to-transparent opacity-75"
+    ></div>
 
     <span className="relative z-10 bg-white px-6">{children}</span>
   </span>

--- a/pwa/app/components/ui/drawer.tsx
+++ b/pwa/app/components/ui/drawer.tsx
@@ -83,7 +83,7 @@ const DrawerTitle = React.forwardRef<
   <DrawerPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-lg leading-none font-semibold tracking-tight',
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/dropdown-menu.tsx
+++ b/pwa/app/components/ui/dropdown-menu.tsx
@@ -25,8 +25,8 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      `flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm
-      outline-hidden focus:bg-accent data-[state=open]:bg-accent`,
+      `flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden
+      select-none focus:bg-accent data-[state=open]:bg-accent`,
       inset && 'pl-8',
       className,
     )}
@@ -47,12 +47,12 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     className={cn(
       `z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1
-      text-popover-foreground shadow-lg data-[state=open]:animate-in
-      data-[state=closed]:animate-out data-[state=closed]:fade-out-0
-      data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95
-      data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2
+      text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2
       data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2
-      data-[side=top]:slide-in-from-bottom-2`,
+      data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out
+      data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95
+      data-[state=open]:animate-in data-[state=open]:fade-in-0
+      data-[state=open]:zoom-in-95`,
       className,
     )}
     {...props}
@@ -71,12 +71,12 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         `z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1
-        text-popover-foreground shadow-md data-[state=open]:animate-in
-        data-[state=closed]:animate-out data-[state=closed]:fade-out-0
-        data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95
-        data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2
+        text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2
         data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2
-        data-[side=top]:slide-in-from-bottom-2`,
+        data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out
+        data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95
+        data-[state=open]:animate-in data-[state=open]:fade-in-0
+        data-[state=open]:zoom-in-95`,
         className,
       )}
       {...props}
@@ -94,8 +94,8 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      `relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5
-      text-sm outline-hidden transition-colors focus:bg-accent
+      `relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm
+      outline-hidden transition-colors select-none focus:bg-accent
       focus:text-accent-foreground data-disabled:pointer-events-none
       data-disabled:opacity-50`,
       inset && 'pl-8',
@@ -113,8 +113,8 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      `relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8
-      pr-2 text-sm outline-hidden transition-colors focus:bg-accent
+      `relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm
+      outline-hidden transition-colors select-none focus:bg-accent
       focus:text-accent-foreground data-disabled:pointer-events-none
       data-disabled:opacity-50`,
       className,
@@ -140,8 +140,8 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      `relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8
-      pr-2 text-sm outline-hidden transition-colors focus:bg-accent
+      `relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm
+      outline-hidden transition-colors select-none focus:bg-accent
       focus:text-accent-foreground data-disabled:pointer-events-none
       data-disabled:opacity-50`,
       className,

--- a/pwa/app/components/ui/input.tsx
+++ b/pwa/app/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          `flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-md
+          `text-md flex h-9 w-full rounded-md border border-input bg-background px-3 py-2
           file:border-0 file:bg-transparent file:text-sm file:font-medium
           placeholder:text-muted-foreground focus-visible:outline-hidden
           disabled:cursor-not-allowed disabled:opacity-50`,

--- a/pwa/app/components/ui/navigation-menu.tsx
+++ b/pwa/app/components/ui/navigation-menu.tsx
@@ -12,7 +12,7 @@ const NavigationMenu = React.forwardRef<
   <NavigationMenuPrimitive.Root
     ref={ref}
     className={cn(
-      'relative z-10 flex container flex-1 items-center justify-center',
+      'relative z-10 container flex flex-1 items-center justify-center',
       className,
     )}
     {...props}
@@ -55,7 +55,8 @@ const NavigationMenuTrigger = React.forwardRef<
   >
     {children}
     <ChevronDown
-      className="relative top-px ml-1 size-3 transition duration-200 group-data-[state=open]:rotate-180"
+      className="relative top-px ml-1 size-3 transition duration-200
+        group-data-[state=open]:rotate-180"
       aria-hidden="true"
     />
   </NavigationMenuPrimitive.Trigger>
@@ -69,12 +70,12 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      `left-0 top-0 w-full data-[motion^=from-]:animate-in
-      data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in
-      data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52
+      `top-0 left-0 w-full data-[motion=from-end]:slide-in-from-right-52
       data-[motion=from-start]:slide-in-from-left-52
       data-[motion=to-end]:slide-out-to-right-52
-      data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto `,
+      data-[motion=to-start]:slide-out-to-left-52 data-[motion^=from-]:animate-in
+      data-[motion^=from-]:fade-in data-[motion^=to-]:animate-out
+      data-[motion^=to-]:fade-out md:absolute md:w-auto`,
       className,
     )}
     {...props}
@@ -88,14 +89,15 @@ const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-  <div className={cn('absolute right-52 top-12 flex justify-center')}>
+  <div className={cn('absolute top-12 right-52 flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        `origin-top-center relative bg-primary mt-1.5
+        `origin-top-center relative mt-1.5
         h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden
-        rounded-md text-popover-foreground shadow-2xl data-[state=open]:animate-in
+        rounded-md bg-primary text-popover-foreground shadow-2xl
         data-[state=closed]:animate-out data-[state=closed]:zoom-out-95
-        data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]`,
+        data-[state=open]:animate-in data-[state=open]:zoom-in-90
+        md:w-[var(--radix-navigation-menu-viewport-width)]`,
         className,
       )}
       ref={ref}
@@ -114,8 +116,8 @@ const NavigationMenuIndicator = React.forwardRef<
     ref={ref}
     className={cn(
       `top-full z-1 flex h-1.5 items-end justify-center overflow-hidden
-      data-[state=visible]:animate-in data-[state=hidden]:animate-out
-      data-[state=hidden]:fade-out data-[state=visible]:fade-in`,
+      data-[state=hidden]:animate-out data-[state=hidden]:fade-out
+      data-[state=visible]:animate-in data-[state=visible]:fade-in`,
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/popover.tsx
+++ b/pwa/app/components/ui/popover.tsx
@@ -18,11 +18,12 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         `z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md
-        outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out
-        data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
-        data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95
-        data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2
-        data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2`,
+        outline-hidden data-[side=bottom]:slide-in-from-top-2
+        data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2
+        data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out
+        data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95
+        data-[state=open]:animate-in data-[state=open]:fade-in-0
+        data-[state=open]:zoom-in-95`,
         className,
       )}
       {...props}

--- a/pwa/app/components/ui/scroll-area.tsx
+++ b/pwa/app/components/ui/scroll-area.tsx
@@ -29,7 +29,7 @@ const ScrollBar = React.forwardRef<
     ref={ref}
     orientation={orientation}
     className={cn(
-      'flex touch-none select-none transition-colors',
+      'flex touch-none transition-colors select-none',
       orientation === 'vertical' &&
         'h-full w-2.5 border-l border-l-transparent p-[1px]',
       orientation === 'horizontal' &&

--- a/pwa/app/components/ui/select.tsx
+++ b/pwa/app/components/ui/select.tsx
@@ -17,7 +17,11 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      `flex h-10 w-full items-center justify-between rounded-md border border-input
+      bg-background px-3 py-2 text-sm ring-offset-background
+      placeholder:text-muted-foreground focus:ring-2 focus:ring-ring
+      focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed
+      disabled:opacity-50 [&>span]:line-clamp-1`,
       className,
     )}
     {...props}
@@ -73,9 +77,16 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[75vh] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        `relative z-50 max-h-[75vh] min-w-[8rem] overflow-hidden rounded-md border
+        bg-popover text-popover-foreground shadow-md
+        data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2
+        data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2
+        data-[state=closed]:animate-out data-[state=closed]:fade-out-0
+        data-[state=closed]:zoom-out-95 data-[state=open]:animate-in
+        data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95`,
         position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          `data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1
+          data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1`,
         className,
       )}
       position={position}
@@ -86,7 +97,8 @@ const SelectContent = React.forwardRef<
         className={cn(
           'p-1',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+            `h-[var(--radix-select-trigger-height)] w-full
+            min-w-[var(--radix-select-trigger-width)]`,
         )}
       >
         {children}
@@ -103,7 +115,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    className={cn('py-1.5 pr-2 pl-8 text-sm font-semibold', className)}
     {...props}
   />
 ));
@@ -116,7 +128,9 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+      `relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-2 pl-8
+      text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground
+      data-disabled:pointer-events-none data-disabled:opacity-50`,
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/tabs.tsx
+++ b/pwa/app/components/ui/tabs.tsx
@@ -28,10 +28,10 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      `inline-flex items-center justify-center whitespace-nowrap rounded-sm px-5 py-1.5
-      text-sm font-medium ring-offset-background transition-all cursor-pointer
-      focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring
-      focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50
+      `inline-flex cursor-pointer items-center justify-center rounded-sm px-5 py-1.5
+      text-sm font-medium whitespace-nowrap ring-offset-background transition-all
+      focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+      focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50
       data-[state=active]:bg-background data-[state=active]:text-foreground
       data-[state=active]:shadow-xs`,
       className,

--- a/pwa/app/components/ui/toc.tsx
+++ b/pwa/app/components/ui/toc.tsx
@@ -61,8 +61,8 @@ const TableOfContentsLink = React.forwardRef<
   <Link
     ref={ref}
     className={cn(
-      'text-foreground hover:text-primary text-sm font-medium transition-colors',
-      isActive ? 'text-foreground font-medium' : 'text-muted-foreground',
+      'text-sm font-medium text-foreground transition-colors hover:text-primary',
+      isActive ? 'font-medium text-foreground' : 'text-muted-foreground',
       className,
     )}
     {...props}

--- a/pwa/app/components/ui/tooltip.tsx
+++ b/pwa/app/components/ui/tooltip.tsx
@@ -17,12 +17,12 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      `z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm
-      text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95
+      `z-50 animate-in overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm
+      text-popover-foreground shadow-md fade-in-0 zoom-in-95
+      data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2
+      data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2
       data-[state=closed]:animate-out data-[state=closed]:fade-out-0
-      data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2
-      data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2
-      data-[side=top]:slide-in-from-bottom-2`,
+      data-[state=closed]:zoom-out-95`,
       className,
     )}
     {...props}

--- a/pwa/app/routes/_index.tsx
+++ b/pwa/app/routes/_index.tsx
@@ -68,11 +68,11 @@ export default function Index() {
 
       {events.length > 0 ? (
         <div>
-          <h1 className="mb-2.5 mt-5 text-4xl">This Week&apos;s Events</h1>
+          <h1 className="mt-5 mb-2.5 text-4xl">This Week&apos;s Events</h1>
           <EventListTable events={events} />
         </div>
       ) : (
-        <h1 className="mb-2.5 mt-5 text-4xl">No Events This Week</h1>
+        <h1 className="mt-5 mb-2.5 text-4xl">No Events This Week</h1>
       )}
 
       <a

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -300,10 +300,7 @@ export default function EventPage() {
         defaultValue={matches.length > 0 ? 'results' : 'teams'}
         className="mt-4"
       >
-        <TabsList
-          className="flex h-auto flex-wrap items-center justify-evenly *:basis-1/2
-            lg:*:basis-1"
-        >
+        <TabsList className="flex h-auto flex-wrap items-center justify-evenly *:basis-1/2 lg:*:basis-1">
           {(matches.length > 0 || (alliances && alliances.length > 0)) && (
             <TabsTrigger value="results">
               <InlineIcon>
@@ -493,7 +490,7 @@ function TeamsTab({ teams, media }: { teams: Team[]; media: Media[] }) {
                       </div>
                     )}
                   </TableCell>
-                  <TableCell className="flex flex-col mt-1">
+                  <TableCell className="mt-1 flex flex-col">
                     <TeamLink teamOrKey={t.key}>{t.team_number}</TeamLink>
                     <div>{t.nickname}</div>
                   </TableCell>
@@ -510,7 +507,7 @@ function TeamsTab({ teams, media }: { teams: Team[]; media: Media[] }) {
                     <TableCell>
                       <Dialog>
                         <DialogTrigger className="align-middle">
-                          <Avatar className="cursor-pointer size-12">
+                          <Avatar className="size-12 cursor-pointer">
                             <AvatarImage src={maybeRobotPic} />
                           </Avatar>
                         </DialogTrigger>

--- a/pwa/app/routes/events.$districtAbbreviation.($year).tsx
+++ b/pwa/app/routes/events.$districtAbbreviation.($year).tsx
@@ -158,7 +158,10 @@ export default function DistrictPage() {
       </h1>
 
       <Tabs defaultValue={'overview'} className="mt-4">
-        <TabsList className="flex h-auto flex-wrap items-center justify-evenly [&>*]:basis-1/2 lg:[&>*]:basis-1">
+        <TabsList
+          className="flex h-auto flex-wrap items-center justify-evenly [&>*]:basis-1/2
+            lg:[&>*]:basis-1"
+        >
           <TabsTrigger value="overview">Overview</TabsTrigger>
           {hasRankings && <TabsTrigger value="rankings">Rankings</TabsTrigger>}
           <TabsTrigger value="events">Events</TabsTrigger>

--- a/pwa/app/routes/team.$teamNumber.($year).tsx
+++ b/pwa/app/routes/team.$teamNumber.($year).tsx
@@ -306,7 +306,7 @@ export default function TeamPage(): React.JSX.Element {
         )}
 
         <div>
-          <Separator className="mb-8 mt-4" />
+          <Separator className="mt-4 mb-8" />
 
           {events.map((e) => (
             <InView
@@ -437,10 +437,9 @@ function StatsSection({
           <div
             // The padding/margins make the separator not actually perfectly centered
             // left-47.5 looks significantly better than left-1/2
-            className={`relative flex flex-wrap before:absolute before:inset-y-0
-          before:left-[47.5%]
-          before:hidden before:w-px before:bg-gray-200 sm:mt-0 lg:before:block
-          *:w-full lg:*:w-1/2`}
+            className={`relative flex flex-wrap *:w-full before:absolute before:inset-y-0
+            before:left-[47.5%] before:hidden before:w-px before:bg-gray-200 sm:mt-0
+            lg:*:w-1/2 lg:before:block`}
           >
             <div className="grid grid-cols-2 items-center gap-y-4">
               <Stat

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -80,6 +80,7 @@
         "postcss": "8.5.3",
         "prettier": "3.5.3",
         "prettier-plugin-classnames": "0.7.7",
+        "prettier-plugin-merge": "0.7.2",
         "prettier-plugin-tailwindcss": "0.6.11",
         "tailwindcss": "4.0.12",
         "typescript": "5.8.2",
@@ -6873,6 +6874,16 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -11220,6 +11231,22 @@
         "prettier-plugin-svelte": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prettier-plugin-merge": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-merge/-/prettier-plugin-merge-0.7.2.tgz",
+      "integrity": "sha512-o/twjBSVjKttfBBz7KWdJxyPjEAoSh1WwkEv02XKWoyifPXVPSifgB597nntEzTo5hN63XnoZQkAdDVnt6WRLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff": "5.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -91,6 +91,7 @@
     "postcss": "8.5.3",
     "prettier": "3.5.3",
     "prettier-plugin-classnames": "0.7.7",
+    "prettier-plugin-merge": "0.7.2",
     "prettier-plugin-tailwindcss": "0.6.11",
     "tailwindcss": "4.0.12",
     "typescript": "5.8.2",

--- a/pwa/prettier.config.js
+++ b/pwa/prettier.config.js
@@ -4,13 +4,15 @@ export default {
   trailingComma: 'all',
   tabWidth: 2,
   plugins: [
+    '@trivago/prettier-plugin-sort-imports',
     'prettier-plugin-tailwindcss',
     'prettier-plugin-classnames',
-    '@trivago/prettier-plugin-sort-imports',
+    'prettier-plugin-merge',
   ],
   tailwindFunctions: ['clsx', 'cn'],
   customFunctions: ['clsx', 'cn'],
   importOrder: ['^@/(.*)$', '^~icons/(.*)$', '^~/(.*)$', '^[./]'],
   importOrderSeparation: true,
   importOrderSortSpecifiers: true,
+  tailwindStylesheet: './app/tailwind.css',
 };


### PR DESCRIPTION
Turns out the `prettier-plugin-tailwindcss` plugin was not being used correctly. Apparently when Prettier has multiple plugins that edit the same file, only the last plugin listed gets applied. `prettier-plugin-merge` fixes this: https://github.com/ony3000/prettier-plugin-merge