### PR TITLE
Fix Regional --> CMP Advancement Calculation

### DIFF
--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -85,7 +85,6 @@ def event_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAndQuery]
     for year in years:
         queries.append(event_query.EventListQuery(year))
         queries.append(event_query.RegionalEventsQuery(year))
-        queries.append(event_query.ChampionshipEventsAndDivisionsInYearQuery(year))
 
     for event_district_key in event_district_keys:
         queries.append(event_query.DistrictEventsQuery(event_district_key.id()))

--- a/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
+++ b/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
@@ -185,8 +185,6 @@ class TestDatabaseCacheClearer(unittest.TestCase):
             event_query.EventDivisionsQuery("2015cafoo").cache_key,
             event_query.RegionalEventsQuery(2014).cache_key,
             event_query.RegionalEventsQuery(2015).cache_key,
-            event_query.ChampionshipEventsAndDivisionsInYearQuery(2014).cache_key,
-            event_query.ChampionshipEventsAndDivisionsInYearQuery(2015).cache_key,
         }
 
     def test_event_details_updated(self) -> None:
@@ -422,7 +420,6 @@ class TestDatabaseCacheClearer(unittest.TestCase):
             event_query.TeamYearEventTeamsQuery("frc125", 2016).cache_key,
             event_query.EventDivisionsQuery("2016necmp").cache_key,
             event_query.RegionalEventsQuery(2016).cache_key,
-            event_query.ChampionshipEventsAndDivisionsInYearQuery(2016).cache_key,
         }
 
     def test_renamed_district_updated(self) -> None:

--- a/src/backend/common/models/regional_pool_advancement.py
+++ b/src/backend/common/models/regional_pool_advancement.py
@@ -1,10 +1,11 @@
-from typing import Dict, TypedDict
+from typing import Dict, NotRequired, TypedDict
 
-from backend.common.models.keys import TeamKey
+from backend.common.models.keys import EventKey, TeamKey
 
 
 class TeamRegionalPoolAdvancement(TypedDict):
     cmp: bool
+    cmp_event: NotRequired[EventKey]
 
 
 RegionalPoolAdvancement = Dict[TeamKey, TeamRegionalPoolAdvancement]

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -3,7 +3,6 @@ from typing import Any, Generator, List, Optional
 from google.appengine.ext import ndb
 
 from backend.common.consts.event_type import (
-    CMP_EVENT_TYPES,
     EventType,
     SEASON_EVENT_TYPES,
 )
@@ -95,25 +94,6 @@ class DistrictChampsInYearQuery(CachedDatabaseQuery[List[Event], List[EventDict]
     def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
         all_cmp_event_keys = yield Event.query(
             Event.year == year, Event.event_type_enum == EventType.DISTRICT_CMP
-        ).fetch_async(keys_only=True)
-        events = yield ndb.get_multi_async(all_cmp_event_keys)
-        return list(events)
-
-
-class ChampionshipEventsAndDivisionsInYearQuery(
-    CachedDatabaseQuery[List[Event], List[EventDict]]
-):
-    CACHE_VERSION = 0
-    CACHE_KEY_FORMAT = "championship_events_and_divisions_{year}"
-    DICT_CONVERTER = EventConverter
-
-    def __init__(self, year: Year) -> None:
-        super().__init__(year=year)
-
-    @typed_tasklet
-    def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
-        all_cmp_event_keys = yield Event.query(
-            Event.year == year, Event.event_type_enum.IN(CMP_EVENT_TYPES)
         ).fetch_async(keys_only=True)
         events = yield ndb.get_multi_async(all_cmp_event_keys)
         return list(events)

--- a/src/backend/web/templates/admin/regional_champs_pool_list.html
+++ b/src/backend/web/templates/admin/regional_champs_pool_list.html
@@ -64,11 +64,13 @@
                 <tr>
                     <th>Team</th>
                     <th>Qualified for CMP</th>
+                    <th>Qualifying Event</th>
                 </tr>
                 {% for team_key, advancement in (pool_model.advancement or {}).items() %}
                     <tr>
                         <td><a href="/admin/team/{{team_key}}">{{team_key}}</a></td>
                         <td>{% if advancement.cmp %}<span class="glyphicon glyphicon-ok"></span>{% endif %}</td>
+                        <td>{% if advancement.cmp_event %}<a href="/admin/event/{{advancement.cmp_event}}">{{advancement.cmp_event}}</a>{% else %}--{% endif %}</td>
                     </tr>
                 {% else %}
                     <tr><td>No advancement found</td></tr>


### PR DESCRIPTION
We need to compute this entirely when we fetch team registration. We also need to store/update the event from which we're considering the team "qualified", so we can ignore updates to other events. That way we don't clobber the advancement after fetching teams for a regional.