### PR TITLE
Fix leaderboards OOMing

### DIFF
--- a/src/backend/common/helpers/insights_helper_utils.py
+++ b/src/backend/common/helpers/insights_helper_utils.py
@@ -1,7 +1,7 @@
 import json
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple
+from typing import Any, Callable, DefaultDict, Dict, Generator, List, Optional, Tuple
 
 from backend.common.consts.event_type import SEASON_EVENT_TYPES
 from backend.common.helpers.season_helper import SeasonHelper
@@ -23,71 +23,53 @@ CounterDictType = DefaultDict[Any, int] | DefaultDict[Any, float] | Dict[Any, in
 
 @dataclass
 class LeaderboardInsightArguments:
-    matches: List[Match]
     events: List[Event]
-    awards: List[Award]
     year: int
 
+    def matches(self) -> Generator[Match, None, None]:
+        """
+        It's not feasible to store every match in memory, so create a reusable generator
+        that yields one match at a time given a list of events.
+        """
+        for event in self.events:
+            for match in event.matches:
+                yield match
 
-def make_leaderboard_args() -> List[LeaderboardInsightArguments]:
+    def awards(self) -> Generator[Award, None, None]:
+        """
+        It's not feasible to store every award in memory, so create a reusable generator
+        that yields one award at a time given a list of events.
+        """
+        for event in self.events:
+            for award in event.awards:
+                yield award
+
+
+def make_leaderboard_args(year: Year) -> LeaderboardInsightArguments:
     all_events: List[Event] = []
 
-    event_futures = []
-    for year in SeasonHelper.get_valid_years():
-        event_futures.append(EventListQuery(year=year).fetch_async())
-
-    for future in event_futures:
-        all_events.extend(future.get_result())
+    if year == 0:
+        for yr in SeasonHelper.get_valid_years():
+            all_events.extend(EventListQuery(year=yr).fetch())
+    else:
+        all_events.extend(EventListQuery(year=year).fetch())
 
     all_events = [e for e in all_events if e.event_type_enum in SEASON_EVENT_TYPES]
-
-    args_list: List[LeaderboardInsightArguments] = []
-    all_matches: List[Match] = []
-    all_awards: List[Award] = []
-
-    # Build per-year args
-    for year in SeasonHelper.get_valid_years():
-        year_events = [e for e in all_events if e.year == year]
-        year_matches = [m for e in year_events for m in e.matches]
-        year_awards = [a for e in year_events for a in e.awards]
-
-        all_awards.extend(year_awards)
-        all_matches.extend(year_matches)
-        args_list.append(
-            LeaderboardInsightArguments(
-                matches=year_matches,
-                events=year_events,
-                awards=year_awards,
-                year=year,
-            )
-        )
-
-    # Build overall args
-    args_list.append(
-        LeaderboardInsightArguments(
-            matches=all_matches, events=all_events, awards=all_awards, year=0
-        )
+    return LeaderboardInsightArguments(
+        events=all_events,
+        year=year,
     )
-
-    # todo(tervay): add more args groups, e.g. by district
-
-    return args_list
 
 
 def make_insights_from_functions(
     year: Year, fns: List[Callable[[LeaderboardInsightArguments], Optional[Insight]]]
 ) -> List[Insight]:
-    args_list = make_leaderboard_args()
+    args = make_leaderboard_args(year=year)
 
     insights: List[Insight] = []
-    for args in args_list:
-        # Only compute overall and the given year
-        if args.year not in [0, year]:
-            continue
-
-        for fn in fns:
-            if maybe_insight := fn(args):
-                insights.append(maybe_insight)
+    for fn in fns:
+        if maybe_insight := fn(args):
+            insights.append(maybe_insight)
 
     return insights
 

--- a/src/backend/common/helpers/insights_leaderboard_event_helper.py
+++ b/src/backend/common/helpers/insights_leaderboard_event_helper.py
@@ -29,7 +29,7 @@ class InsightsLeaderboardEventHelper:
     ) -> Optional[Insight]:
         clean_scores = defaultdict(list)
 
-        for match in arguments.matches:
+        for match in arguments.matches():
             if match.has_been_played:
                 redScore = int(match.alliances[AllianceColor.RED]["score"])
                 blueScore = int(match.alliances[AllianceColor.BLUE]["score"])

--- a/src/backend/common/helpers/insights_leaderboard_match_helper.py
+++ b/src/backend/common/helpers/insights_leaderboard_match_helper.py
@@ -30,19 +30,18 @@ class InsightsLeaderboardMatchHelper:
     ) -> Optional[Insight]:
         clean_scores = defaultdict(int)
 
-        for match in arguments.matches:
+        for match in arguments.matches():
             if match.has_been_played:
                 redScore = int(match.alliances[AllianceColor.RED]["score"])
                 blueScore = int(match.alliances[AllianceColor.BLUE]["score"])
 
-                if match.year >= 2016:
-                    if match.score_breakdown:
-                        redScore -= none_throws(match.score_breakdown)[
-                            AllianceColor.RED
-                        ].get("foulPoints", 0)
-                        blueScore -= none_throws(match.score_breakdown)[
-                            AllianceColor.BLUE
-                        ].get("foulPoints", 0)
+                if match.year >= 2016 and match.score_breakdown is not None:
+                    redScore -= none_throws(match.score_breakdown)[
+                        AllianceColor.RED
+                    ].get("foulPoints", 0)
+                    blueScore -= none_throws(match.score_breakdown)[
+                        AllianceColor.BLUE
+                    ].get("foulPoints", 0)
 
                 clean_scores[match.key.id()] = max(redScore, blueScore)
 
@@ -58,19 +57,18 @@ class InsightsLeaderboardMatchHelper:
     ) -> Optional[Insight]:
         clean_scores = defaultdict(int)
 
-        for match in arguments.matches:
+        for match in arguments.matches():
             if match.has_been_played:
                 redScore = int(match.alliances[AllianceColor.RED]["score"])
                 blueScore = int(match.alliances[AllianceColor.BLUE]["score"])
 
-                if match.year >= 2016:
-                    if match.score_breakdown:
-                        redScore -= none_throws(match.score_breakdown)[
-                            AllianceColor.RED
-                        ].get("foulPoints", 0)
-                        blueScore -= none_throws(match.score_breakdown)[
-                            AllianceColor.BLUE
-                        ].get("foulPoints", 0)
+                if match.year >= 2016 and match.score_breakdown is not None:
+                    redScore -= none_throws(match.score_breakdown)[
+                        AllianceColor.RED
+                    ].get("foulPoints", 0)
+                    blueScore -= none_throws(match.score_breakdown)[
+                        AllianceColor.BLUE
+                    ].get("foulPoints", 0)
 
                 clean_scores[match.key.id()] = redScore + blueScore
 
@@ -89,8 +87,8 @@ class InsightsLeaderboardMatchHelper:
 
         coral_scores = defaultdict(int)
 
-        for match in arguments.matches:
-            if match.has_been_played:
+        for match in arguments.matches():
+            if match.has_been_played and match.score_breakdown is not None:
                 red_coral = (
                     none_throws(match.score_breakdown)[AllianceColor.RED][
                         "teleopCoralCount"

--- a/src/backend/common/helpers/insights_leaderboard_team_helper.py
+++ b/src/backend/common/helpers/insights_leaderboard_team_helper.py
@@ -30,7 +30,7 @@ class InsightsLeaderboardTeamHelper:
     def _most_blue_banners(arguments: LeaderboardInsightArguments) -> Optional[Insight]:
         count = defaultdict(int)
 
-        for award in arguments.awards:
+        for award in arguments.awards():
             if award.award_type_enum in BLUE_BANNER_AWARDS and award.count_banner:
                 for team_key in award.team_list:
                     count[team_key.id()] += 1
@@ -43,7 +43,7 @@ class InsightsLeaderboardTeamHelper:
     def _most_awards(arguments: LeaderboardInsightArguments) -> Optional[Insight]:
         count = defaultdict(int)
 
-        for award in arguments.awards:
+        for award in arguments.awards():
             if award.award_type_enum == AwardType.WILDCARD:
                 continue
 
@@ -60,7 +60,7 @@ class InsightsLeaderboardTeamHelper:
     ) -> Optional[Insight]:
         count = defaultdict(int)
 
-        for award in arguments.awards:
+        for award in arguments.awards():
             if (
                 award.award_type_enum == AwardType.WINNER
                 and award.event_type_enum in NON_CMP_EVENT_TYPES
@@ -78,7 +78,7 @@ class InsightsLeaderboardTeamHelper:
     ) -> Optional[Insight]:
         count = defaultdict(int)
 
-        for match in arguments.matches:
+        for match in arguments.matches():
             if match.has_been_played:
                 for team_key in match.team_keys:
                     count[team_key.id()] += 1
@@ -93,12 +93,13 @@ class InsightsLeaderboardTeamHelper:
     ) -> Optional[Insight]:
         played_at = defaultdict(set)
 
-        for match in arguments.matches:
+        for match in arguments.matches():
             if match.has_been_played:
                 for team_key in match.team_keys:
                     played_at[team_key.id()].add(match.event_key_name)
 
         counts = {tk: len(events) for tk, events in played_at.items()}
+
         return make_leaderboard_from_dict_counts(
             counts, Insight.TYPED_LEADERBOARD_MOST_EVENTS_PLAYED_AT, arguments.year
         )
@@ -109,7 +110,7 @@ class InsightsLeaderboardTeamHelper:
     ) -> Optional[Insight]:
         seen_teams = defaultdict(set)
 
-        for match in arguments.matches:
+        for match in arguments.matches():
             if match.has_been_played:
                 for a in match.team_key_names:
                     for b in match.team_key_names:

--- a/src/backend/common/helpers/insights_notable_helper.py
+++ b/src/backend/common/helpers/insights_notable_helper.py
@@ -54,7 +54,7 @@ class InsightsNotableHelper:
         insight_type: InsightEnumId,
     ) -> Insight:
         team_context_map: Dict[TeamKey, List[EventKey]] = {}
-        for award in arguments.awards:
+        for award in arguments.awards():
             if (
                 award.event_type_enum == event_type
                 and award.award_type_enum == award_type
@@ -111,7 +111,7 @@ class InsightsNotableHelper:
         arguments: LeaderboardInsightArguments,
     ) -> Insight:
         team_context_map: Dict[TeamKey, List[EventKey]] = {}
-        for award in arguments.awards:
+        for award in arguments.awards():
             if (
                 award.event_type_enum == EventType.CMP_DIVISION
                 and award.award_type_enum in [AwardType.WINNER, AwardType.FINALIST]

--- a/src/backend/common/helpers/tests/insights_helper_utils_test.py
+++ b/src/backend/common/helpers/tests/insights_helper_utils_test.py
@@ -88,21 +88,17 @@ def test_make_args_has_no_offseasons(ndb_stub, test_data_importer):
     test_data_importer.import_event(__file__, "data/2019nyny.json")
     test_data_importer.import_match_list(__file__, "data/2019nyny_matches.json")
 
-    args = make_leaderboard_args()
-    args_2019 = [a for a in args if a.year == 2019]
-
-    assert len(args_2019) == 1
-
+    args = make_leaderboard_args(year=2019)
     mttd_2019_matches = [
-        m for m in args_2019[0].matches if m.key.id().startswith("2019mttd")
+        m
+        for m in args.matches()
+        if m.key.id().startswith("2019mttd")
     ]
 
     assert len(mttd_2019_matches) == 0
 
 
-def test_make_insights_from_fns_only_computes_overall_and_year(
-    ndb_stub, test_data_importer
-):
+def test_make_insights_from_fns_only_computes_year(ndb_stub, test_data_importer):
     test_data_importer.import_event(__file__, "data/2025isde1.json")
     test_data_importer.import_match_list(__file__, "data/2025isde1_matches.json")
     test_data_importer.import_event(__file__, "data/2019nyny.json")
@@ -112,9 +108,7 @@ def test_make_insights_from_fns_only_computes_overall_and_year(
         2019,
         [
             lambda _: create_insight(data={}, name="test_2019", year=2019),
-            lambda _: create_insight(data={}, name="test_overall", year=0),
         ],
     )
 
-    # If it created all the insights, there'd be 2 * len(valid_years)
-    assert len(insights) == 4
+    assert len(insights) == 1

--- a/src/backend/common/helpers/tests/insights_leaderboard_event_helper_test.py
+++ b/src/backend/common/helpers/tests/insights_leaderboard_event_helper_test.py
@@ -14,12 +14,7 @@ def test_highest_median_score(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardEventHelper._highest_median_score(
         LeaderboardInsightArguments(
-            matches=(
-                Event.get_by_id("2022on305").matches
-                + Event.get_by_id("2022on306").matches
-            ),
             events=[Event.get_by_id("2022on305"), Event.get_by_id("2022on306")],
-            awards=[],
             year=2022,
         )
     )

--- a/src/backend/common/helpers/tests/insights_leaderboard_match_helper_test.py
+++ b/src/backend/common/helpers/tests/insights_leaderboard_match_helper_test.py
@@ -12,9 +12,7 @@ def test_highest_clean_score(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardMatchHelper._highest_match_clean_score(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2019nyny").matches,
             events=[Event.get_by_id("2019nyny")],
-            awards=[],
             year=2019,
         )
     )
@@ -36,9 +34,7 @@ def test_highest_clean_combined_score(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardMatchHelper._highest_match_clean_combined_score(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2019nyny").matches,
             events=[Event.get_by_id("2019nyny")],
-            awards=[],
             year=2019,
         )
     )
@@ -60,9 +56,7 @@ def test_2025_most_coral_scored(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardMatchHelper._2025_most_coral_scored(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2025isde1").matches,
             events=[Event.get_by_id("2025isde1")],
-            awards=[],
             year=2025,
         )
     )
@@ -79,21 +73,17 @@ def test_2025_most_coral_scored(ndb_stub, test_data_importer):
     assert insight.data["key_type"] == "match"
 
 
-def test_only_overall_and_year_are_computed(ndb_stub, test_data_importer):
+def test_only_year_are_computed(ndb_stub, test_data_importer):
     test_data_importer.import_event(__file__, "data/2025isde1.json")
     test_data_importer.import_match_list(__file__, "data/2025isde1_matches.json")
     test_data_importer.import_event(__file__, "data/2019nyny.json")
     test_data_importer.import_match_list(__file__, "data/2019nyny_matches.json")
 
     insights = InsightsLeaderboardMatchHelper.make_insights(2025)
-    assert len(insights) == 5
+    assert len(insights) == 3
 
-    overall_insights = [i for i in insights if i.year == 0]
     insights_2025 = [i for i in insights if i.year == 2025]
-
-    assert len(overall_insights) == 2
     assert len(insights_2025) == 3
-    assert len(overall_insights) + len(insights_2025) == len(insights)
 
 
 def test_only_official_events_are_included(ndb_stub, test_data_importer):
@@ -110,18 +100,7 @@ def test_only_official_events_are_included(ndb_stub, test_data_importer):
         == Insight.INSIGHT_NAMES[Insight.TYPED_LEADERBOARD_HIGHEST_MATCH_CLEAN_SCORE]
     ]
 
-    clean_score_overall = next(i for i in clean_score_insights if i.year == 0)
     clean_score_2019 = next(i for i in clean_score_insights if i.year == 2019)
-
-    assert clean_score_overall is not None
-    assert clean_score_overall.year == 0
-    assert clean_score_overall.data["rankings"][:5] == [
-        {"keys": ["2019nyny_f1m1", "2019nyny_qf1m1"], "value": 91},
-        {"keys": ["2019nyny_qf1m2"], "value": 89},
-        {"keys": ["2019nyny_sf1m1"], "value": 83},
-        {"keys": ["2019nyny_f1m2", "2019nyny_qm57"], "value": 77},
-        {"keys": ["2019nyny_qm15"], "value": 76},
-    ]
 
     assert clean_score_2019 is not None
     assert clean_score_2019.year == 2019

--- a/src/backend/common/helpers/tests/insights_leaderboard_team_helper_test.py
+++ b/src/backend/common/helpers/tests/insights_leaderboard_team_helper_test.py
@@ -15,11 +15,7 @@ def test_most_blue_banners(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardTeamHelper._most_blue_banners(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2019nyny").matches
-            + Event.get_by_id("2024nytr").matches,
             events=[Event.get_by_id("2019nyny"), Event.get_by_id("2024nytr")],
-            awards=Event.get_by_id("2019nyny").awards
-            + Event.get_by_id("2024nytr").awards,
             year=0,
         )
     )
@@ -54,11 +50,7 @@ def test_most_awards(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardTeamHelper._most_awards(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2019nyny").matches
-            + Event.get_by_id("2024nytr").matches,
             events=[Event.get_by_id("2019nyny"), Event.get_by_id("2024nytr")],
-            awards=Event.get_by_id("2019nyny").awards
-            + Event.get_by_id("2024nytr").awards,
             year=0,
         )
     )
@@ -99,21 +91,11 @@ def test_most_non_champs_event_wins(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardTeamHelper._most_non_champs_event_wins(
         LeaderboardInsightArguments(
-            matches=(
-                Event.get_by_id("2019nyny").matches
-                + Event.get_by_id("2024nytr").matches
-                + Event.get_by_id("2024mil").matches
-            ),
             events=[
                 Event.get_by_id("2019nyny"),
                 Event.get_by_id("2024nytr"),
                 Event.get_by_id("2024mil"),
             ],
-            awards=(
-                Event.get_by_id("2019nyny").awards
-                + Event.get_by_id("2024nytr").awards
-                + Event.get_by_id("2024mil").awards
-            ),
             year=2024,
         )
     )
@@ -132,9 +114,7 @@ def test_most_matches_played(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardTeamHelper._most_matches_played(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2019nyny").matches,
             events=[Event.get_by_id("2019nyny")],
-            awards=[],
             year=2019,
         )
     )
@@ -162,12 +142,7 @@ def test_most_events_played_at(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardTeamHelper._most_events_played_at(
         LeaderboardInsightArguments(
-            matches=(
-                Event.get_by_id("2019nyny").matches
-                + Event.get_by_id("2024nytr").matches
-            ),
             events=[Event.get_by_id("2019nyny"), Event.get_by_id("2024nytr")],
-            awards=[],
             year=0,
         )
     )
@@ -186,9 +161,7 @@ def test_most_unique_teams_played_with_or_against(ndb_stub, test_data_importer):
 
     insight = InsightsLeaderboardTeamHelper._most_unique_teams_played_with_or_against(
         LeaderboardInsightArguments(
-            matches=Event.get_by_id("2019nyny").matches,
             events=[Event.get_by_id("2019nyny")],
-            awards=[],
             year=2019,
         )
     )
@@ -220,14 +193,10 @@ def test_only_overall_and_year_are_computed(ndb_stub, test_data_importer):
     test_data_importer.import_match_list(__file__, "data/2019nyny_matches.json")
 
     insights = InsightsLeaderboardTeamHelper.make_insights(2025)
-    assert len(insights) == 12
+    assert len(insights) == 6
 
-    overall_insights = [i for i in insights if i.year == 0]
     insights_2025 = [i for i in insights if i.year == 2025]
-
-    assert len(overall_insights) == 6
     assert len(insights_2025) == 6
-    assert len(overall_insights) + len(insights_2025) == len(insights)
 
 
 def test_only_official_events_are_included(ndb_stub, test_data_importer):
@@ -244,21 +213,7 @@ def test_only_official_events_are_included(ndb_stub, test_data_importer):
         == Insight.INSIGHT_NAMES[Insight.TYPED_LEADERBOARD_MOST_MATCHES_PLAYED]
     ]
 
-    most_matches_overall = next(i for i in most_matches_played_insights if i.year == 0)
     most_matches_2019 = next(i for i in most_matches_played_insights if i.year == 2019)
-
-    assert most_matches_overall is not None
-    assert most_matches_overall.year == 0
-    assert most_matches_overall.data["rankings"][:5] == [
-        {"keys": ["frc1155", "frc2869"], "value": 17},
-        {"keys": ["frc4122"], "value": 16},
-        {"keys": ["frc694", "frc1796", "frc2265"], "value": 15},
-        {
-            "keys": ["frc333", "frc334", "frc354", "frc1880", "frc2579", "frc3419"],
-            "value": 14,
-        },
-        {"keys": ["frc2344"], "value": 13},
-    ]
 
     assert most_matches_2019 is not None
     assert most_matches_2019.year == 2019

--- a/src/backend/common/helpers/tests/insights_notable_helper_test.py
+++ b/src/backend/common/helpers/tests/insights_notable_helper_test.py
@@ -81,9 +81,7 @@ def setup(ndb_stub):
 def test_notables_hall_of_fame(ndb_stub):
     insight = InsightsNotableHelper._calculate_notables_hall_of_fame(
         LeaderboardInsightArguments(
-            matches=[],
             events=[Event.get_by_id("2024cmptx")],
-            awards=[Award.get_by_id("2024cmptx_1"), Award.get_by_id("2024cmptx_2")],
             year=2024,
         )
     )
@@ -97,9 +95,7 @@ def test_notables_hall_of_fame(ndb_stub):
 def test_notables_world_champions(ndb_stub):
     insight = InsightsNotableHelper._calculate_notables_world_champions(
         LeaderboardInsightArguments(
-            matches=[],
             events=[Event.get_by_id("2024cmptx")],
-            awards=[Award.get_by_id("2024cmptx_1"), Award.get_by_id("2024cmptx_2")],
             year=2024,
         )
     )
@@ -113,18 +109,10 @@ def test_notables_world_champions(ndb_stub):
 def test_notables_division_winners(ndb_stub):
     insight = InsightsNotableHelper._calculate_notables_division_winners(
         LeaderboardInsightArguments(
-            matches=[],
             events=[
                 Event.get_by_id("2024cmptx"),
                 Event.get_by_id("2024new"),
                 Event.get_by_id("2024mil"),
-            ],
-            awards=[
-                Award.get_by_id("2024cmptx_1"),
-                Award.get_by_id("2024cmptx_2"),
-                Award.get_by_id("2024new_1"),
-                Award.get_by_id("2024mil_1"),
-                Award.get_by_id("2024mil_2"),
             ],
             year=2024,
         )
@@ -140,18 +128,10 @@ def test_notables_division_winners(ndb_stub):
 def test_notables_division_finals_appearances(ndb_stub):
     insight = InsightsNotableHelper._calculate_notables_division_finals_appearances(
         LeaderboardInsightArguments(
-            matches=[],
             events=[
                 Event.get_by_id("2024cmptx"),
                 Event.get_by_id("2024new"),
                 Event.get_by_id("2024mil"),
-            ],
-            awards=[
-                Award.get_by_id("2024cmptx_1"),
-                Award.get_by_id("2024cmptx_2"),
-                Award.get_by_id("2024new_1"),
-                Award.get_by_id("2024mil_1"),
-                Award.get_by_id("2024mil_2"),
             ],
             year=2024,
         )

--- a/src/backend/tasks_cpu/handlers/insights.py
+++ b/src/backend/tasks_cpu/handlers/insights.py
@@ -148,6 +148,13 @@ def enqueue_all_leaderboard_insights(kind: LeaderboardKeyType) -> Response:
             queue_name="run-in-order",
         )
 
+    taskqueue.add(
+        url=url_for("insights.do_leaderboard_year_insights", kind=kind, year=0),
+        method="GET",
+        target="py3-tasks-cpu",
+        queue_name="run-in-order",
+    )
+
     return make_response(f"enqueued {escape(kind)} leaderboard insights for all years")
 
 
@@ -176,6 +183,13 @@ def enqueue_all_notables_insights() -> Response:
             target="py3-tasks-cpu",
             queue_name="run-in-order",
         )
+
+    taskqueue.add(
+        url=url_for("insights.do_notables_year_insights", year=0),
+        method="GET",
+        target="py3-tasks-cpu",
+        queue_name="run-in-order",
+    )
 
     return make_response("enqueued all notable insights")
 


### PR DESCRIPTION
Previously leaderboard calculations would store all matches `len(valid_years)` times, since for each one it was calculating the given year and also overall. Now, overall is a separate year (0) and matches are retrieved via generator given a list of events, rather than stored in `arguments`.