### PR TITLE
[PWA] Add react query, client-side load awards

### DIFF
--- a/pwa/app/lib/utils.tsx
+++ b/pwa/app/lib/utils.tsx
@@ -236,3 +236,33 @@ export function splitIntoNChunks<T>(array: T[], numChunks: number): T[][] {
 
   return result;
 }
+
+// Reduces boilerplate when using react-query and API functions.
+// Makes it so you don't have to call <response>.data.data, just <response>.data.
+export async function queryFromAPI<T>(
+  apiPromise: Promise<
+    | {
+        status: 200;
+        data: T;
+      }
+    | {
+        status: 304;
+      }
+    | {
+        status: 401;
+        data: {
+          Error: string;
+        };
+      }
+    | {
+        status: 404;
+      }
+  >,
+): Promise<T> {
+  const resp = await apiPromise;
+  if (resp.status === 200) {
+    return Promise.resolve(resp.data);
+  }
+
+  return Promise.reject(new Error(resp.status.toString()));
+}

--- a/pwa/app/root.tsx
+++ b/pwa/app/root.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   Links,
   Meta,
@@ -53,6 +54,8 @@ api.defaults.headers = {
 //   }
 //   return response;
 // };
+
+const queryClient = new QueryClient();
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
@@ -236,7 +239,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Nav />
         <div className="container mx-auto px-4 pt-14 text-sm">
           <div vaul-drawer-wrapper="" className="bg-background">
-            {children}
+            <QueryClientProvider client={queryClient}>
+              {children}
+            </QueryClientProvider>
           </div>
         </div>
         <ScrollRestoration />

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -24,6 +24,7 @@
         "@react-router/node": "7.3.0",
         "@sentry/profiling-node": "9.5.0",
         "@sentry/react-router": "9.5.0",
+        "@tanstack/react-query": "5.67.3",
         "@tanstack/react-table": "8.21.2",
         "@types/lodash-es": "4.17.12",
         "class-variance-authority": "0.7.1",
@@ -5350,6 +5351,32 @@
         "lightningcss": "1.29.2",
         "postcss": "^8.4.41",
         "tailwindcss": "4.0.13"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.67.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.3.tgz",
+      "integrity": "sha512-pq76ObpjcaspAW4OmCbpXLF6BCZP2Zr/J5ztnyizXhSlNe7fIUp0QKZsd0JMkw9aDa+vxDX/OY7N+hjNY/dCGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.67.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.3.tgz",
+      "integrity": "sha512-u/n2HsQeH1vpZIOzB/w2lqKlXUDUKo6BxTdGXSMvNzIq5MHYFckRMVuFABp+QB7RN8LFXWV6X1/oSkuDq+MPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.67.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -35,6 +35,7 @@
     "@react-router/node": "7.3.0",
     "@sentry/profiling-node": "9.5.0",
     "@sentry/react-router": "9.5.0",
+    "@tanstack/react-query": "5.67.3",
     "@tanstack/react-table": "8.21.2",
     "@types/lodash-es": "4.17.12",
     "class-variance-authority": "0.7.1",


### PR DESCRIPTION
Adds client-side requests for data to the event page via react-query. The `shouldPreviewXYZ` fields are to minimize how often the UI "jumps" around when something is rendered. The only jumping that occurs as a result of this PR is offseason pages with awards (e.g. 2024cc), and the team count badge going from `-` to `40` (or whatever the team count is).