### PR TITLE
Show pit location in team info pane

### DIFF
--- a/src/backend/web/templates/team_history.html
+++ b/src/backend/web/templates/team_history.html
@@ -93,6 +93,17 @@
 </div>
 {% endblock %}
 
+{% block footer_content %}
+{% if years and years|min >= 2015 %}
+<div class="text-left col-sm-9 col-lg-10 col-sm-offset-3 col-lg-offset-2" style="margin-bottom: 2rem;">
+  <p><span class="glyphicon glyphicon-info-sign"></span> Data provided by the <a href="https://frc-events.firstinspires.org/services/API" target="_blank" rel="noopener noreferrer"><em>FIRST</em><sup>®</sup> Events API</a></p>
+  {% if current_event_pit_location %}
+    <p><img style="width:12px; height:12px; vertical-align: baseline;" src="/images/nexus_logo.png" alt="nexus logo"> Pit Locations provided by the <a href="https://frc.nexus/en/api" target="_blank" rel="noopener noreferrer">Nexus API</a></p>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock %}
+
 {% block inline_javascript %}
 {% if team.team_number == 148 %}
 <script>

--- a/src/backend/web/templates/team_partials/team_info.html
+++ b/src/backend/web/templates/team_partials/team_info.html
@@ -66,6 +66,9 @@
       {% else %}
         No upcoming matches.
       {% endif %}
+      {% if current_event_pit_location %}
+        <img style="width:12px; height:12px; vertical-align: baseline;" src="/images/nexus_logo.png" alt="nexus logo"> Pit Location: <a href="https://frc.nexus/en/event/{{current_event.key_name}}/team/{{team.team_number}}/map" target="_blank" rel="noopener noreferrer">{{current_event_pit_location}}</a>
+      {% endif %}
       </div>
     </div>
   {% else %}


### PR DESCRIPTION
This way, if a team is competing at multiple events, it's easier to see at a quick glance on the page

![image](https://github.com/user-attachments/assets/3d4d4ed7-d39a-4689-9884-005ed2b5d241)
