### PR TITLE
Ingest Event Queue Status / Predicted Times from Nexus

### DIFF
--- a/src/backend/common/consts/nexus_match_status.py
+++ b/src/backend/common/consts/nexus_match_status.py
@@ -1,8 +1,22 @@
-from backend.common.consts.string_enum import StrEnum
+import enum
 
 
-class NexusMatchStatus(StrEnum):
-    QUEUEING_SOON = "Queuing soon"
-    NOW_QUEUEING = "Now queuing"
-    ON_DECK = "On deck"
-    ON_FIELD = "On field"
+@enum.unique
+class NexusMatchStatus(enum.IntEnum):
+    QUEUING_SOON = 1
+    NOW_QUEUING = 2
+    ON_DECK = 3
+    ON_FIELD = 4
+
+    @classmethod
+    def from_string(cls, name: str) -> "NexusMatchStatus":
+        match name:
+            case "Queuing soon":
+                return cls.QUEUING_SOON
+            case "Now queuing":
+                return cls.NOW_QUEUING
+            case "On deck":
+                return cls.ON_DECK
+            case "On field":
+                return cls.ON_FIELD
+        raise ValueError(f"Unknown value for NexusMatchStatus: {name}")

--- a/src/backend/common/consts/nexus_match_status.py
+++ b/src/backend/common/consts/nexus_match_status.py
@@ -1,0 +1,8 @@
+from backend.common.consts.string_enum import StrEnum
+
+
+class NexusMatchStatus(StrEnum):
+    QUEUEING_SOON = "Queuing soon"
+    NOW_QUEUEING = "Now queuing"
+    ON_DECK = "On deck"
+    ON_FIELD = "On field"

--- a/src/backend/common/consts/nexus_match_status.py
+++ b/src/backend/common/consts/nexus_match_status.py
@@ -20,3 +20,16 @@ class NexusMatchStatus(enum.IntEnum):
             case "On field":
                 return cls.ON_FIELD
         raise ValueError(f"Unknown value for NexusMatchStatus: {name}")
+
+    def to_string(self) -> str:
+        match self:
+            case self.QUEUING_SOON:
+                return "Queuing soon"
+            case self.NOW_QUEUING:
+                return "Now queuing"
+            case self.ON_DECK:
+                return "On deck"
+            case self.ON_FIELD:
+                return "On field"
+
+        raise ValueError(f"Unknown value for NexusMatchStatus: {self}")

--- a/src/backend/common/helpers/firebase_pusher.py
+++ b/src/backend/common/helpers/firebase_pusher.py
@@ -8,7 +8,9 @@ from backend.common.firebase import app as get_firebase_app
 from backend.common.helpers.deferred import defer_safe
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.webcast_online_helper import WebcastOnlineHelper
-from backend.common.memcache_models.event_nexus_queue_status_memcache import EventNexusQueueStatusMemcache
+from backend.common.memcache_models.event_nexus_queue_status_memcache import (
+    EventNexusQueueStatusMemcache,
+)
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey
 from backend.common.models.match import Match

--- a/src/backend/common/helpers/webcast_online_helper.py
+++ b/src/backend/common/helpers/webcast_online_helper.py
@@ -18,7 +18,7 @@ class WebcastOnlineHelper:
     @classmethod
     @typed_toplevel
     def add_online_status(cls, webcasts: List[Webcast]) -> Generator[Any, Any, None]:
-        yield (cls.add_online_status_async(webcast) for webcast in webcasts)
+        yield tuple(cls.add_online_status_async(webcast) for webcast in webcasts)
 
     @classmethod
     @typed_tasklet

--- a/src/backend/common/manipulators/tests/match_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/match_manipulator_test.py
@@ -196,7 +196,7 @@ def test_updateHook(mock_firebase, ndb_context, taskqueue_stub) -> None:
     for task in tasks:
         run_from_task(task)
 
-    mock_firebase.assert_called_once_with(test_match, set())
+    mock_firebase.assert_called_once_with(test_match, set(), None)
 
 
 @mock.patch.object(FirebasePusher, "update_match")

--- a/src/backend/common/memcache_models/event_nexus_queue_status_memcache.py
+++ b/src/backend/common/memcache_models/event_nexus_queue_status_memcache.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+
+from backend.common.memcache_models.memcache_model import MemcacheModel
+from backend.common.models.event_queue_status import EventQueueStatus
+from backend.common.models.keys import EventKey
+
+
+class EventNexusQueueStatusMemcache(MemcacheModel[EventQueueStatus]):
+
+    def __init__(self, event_key: EventKey) -> None:
+        super().__init__()
+        self.event_key = event_key
+
+    def key(self) -> bytes:
+        return f"nexus_queue_status_{self.event_key}".encode()
+
+    def ttl(self) -> timedelta:
+        return timedelta(minutes=5)

--- a/src/backend/common/memcache_models/memcache_model.py
+++ b/src/backend/common/memcache_models/memcache_model.py
@@ -1,0 +1,31 @@
+import abc
+from datetime import timedelta
+from typing import Generic, Optional, TypeVar
+
+from backend.common.memcache import MemcacheClient
+
+DT = TypeVar("DT")
+
+
+class MemcacheModel(abc.ABC, Generic[DT]):
+    """
+    This is an abstraction around data we write/read from memcache
+    """
+
+    def __init__(self) -> None:
+        self.mc_client = MemcacheClient.get()
+
+    @abc.abstractmethod
+    def key(self) -> bytes: ...
+
+    @abc.abstractmethod
+    def ttl(self) -> timedelta: ...
+
+    def put(self, val: DT) -> None:
+        mc_key = self.key()
+        ttl_seconds = self.ttl().seconds
+        self.mc_client.set(mc_key, val, ttl_seconds)
+
+    def get(self) -> Optional[DT]:
+        mc_key = self.key()
+        return self.mc_client.get(mc_key)

--- a/src/backend/common/models/event_queue_status.py
+++ b/src/backend/common/models/event_queue_status.py
@@ -1,0 +1,27 @@
+from typing import Dict, Optional, TypedDict
+
+from backend.common.consts.nexus_match_status import NexusMatchStatus
+from backend.common.models.keys import MatchKey
+
+
+class NexusCurrentlyQueueing(TypedDict):
+    match_key: MatchKey
+    match_name: str
+
+
+class NexusMatchTiming(TypedDict):
+    estimated_queue_time_ms: int
+    estimated_start_time_ms: int
+
+
+class NexusMatch(TypedDict):
+    label: str
+    status: NexusMatchStatus
+    played: bool
+    times: NexusMatchTiming
+
+
+class EventQueueStatus(TypedDict):
+    data_as_of_ms: int
+    now_queueing: Optional[NexusCurrentlyQueueing]
+    matches: Dict[MatchKey, NexusMatch]

--- a/src/backend/common/models/event_queue_status.py
+++ b/src/backend/common/models/event_queue_status.py
@@ -10,8 +10,8 @@ class NexusCurrentlyQueueing(TypedDict):
 
 
 class NexusMatchTiming(TypedDict):
-    estimated_queue_time_ms: int
-    estimated_start_time_ms: int
+    estimated_queue_time_ms: Optional[int]
+    estimated_start_time_ms: Optional[int]
 
 
 class NexusMatch(TypedDict):

--- a/src/backend/common/tasklets.py
+++ b/src/backend/common/tasklets.py
@@ -21,3 +21,17 @@ def typed_tasklet(
         return f(*args, **kwargs)
 
     return cast(Callable[TParams, TypedFuture[TReturn]], inner)
+
+
+def typed_toplevel(
+    f: Callable[
+        TParams, Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]
+    ],
+) -> Callable[TParams, TReturn]:
+    @ndb.toplevel
+    def inner(
+        *args: TParams.args, **kwargs: TParams.kwargs
+    ) -> Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]:
+        return f(*args, **kwargs)
+
+    return cast(Callable[TParams, TReturn], inner)

--- a/src/backend/tasks_io/datafeeds/datafeed_nexus.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_nexus.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any, Dict, Generator, Optional
 
+from backend.common.models.event import Event
+from backend.common.models.event_queue_status import EventQueueStatus
 from backend.common.models.event_team_pit_location import EventTeamPitLocation
 from backend.common.models.keys import EventKey, TeamKey
 from backend.common.profiler import Span
@@ -9,6 +11,9 @@ from backend.common.urlfetch import URLFetchResult
 from backend.tasks_io.datafeeds.nexus_api import NexusAPI
 from backend.tasks_io.datafeeds.parsers.nexus_api.pit_location_parser import (
     NexusAPIPitLocationParser,
+)
+from backend.tasks_io.datafeeds.parsers.nexus_api.queue_status_parser import (
+    NexusAPIQueueStatusParser,
 )
 from backend.tasks_io.datafeeds.parsers.parser_base import ParserBase, TParsedResponse
 
@@ -23,6 +28,13 @@ class DatafeedNexus:
     ) -> Generator[Any, Any, Optional[Dict[TeamKey, EventTeamPitLocation]]]:
         response = yield self.api.pit_locations(event_key)
         return self._parse(response, NexusAPIPitLocationParser())
+
+    @typed_tasklet
+    def get_event_queue_status(
+        self, event: Event,
+    ) -> Generator[Any, Any, Optional[EventQueueStatus]]:
+        response = yield self.api.queue_status(event.key_name)
+        return self._parse(response, NexusAPIQueueStatusParser(event))
 
     def _parse(
         self, response: URLFetchResult, parser: ParserBase[TParsedResponse]

--- a/src/backend/tasks_io/datafeeds/datafeed_nexus.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_nexus.py
@@ -31,7 +31,8 @@ class DatafeedNexus:
 
     @typed_tasklet
     def get_event_queue_status(
-        self, event: Event,
+        self,
+        event: Event,
     ) -> Generator[Any, Any, Optional[EventQueueStatus]]:
         response = yield self.api.queue_status(event.key_name)
         return self._parse(response, NexusAPIQueueStatusParser(event))

--- a/src/backend/tasks_io/datafeeds/nexus_api.py
+++ b/src/backend/tasks_io/datafeeds/nexus_api.py
@@ -28,6 +28,10 @@ class NexusAPI:
         endpoint = f"/event/{event_key}/pits"
         return self._get(endpoint)
 
+    def queue_status(self, event_key: EventKey) -> TypedFuture[URLFetchResult]:
+        endpoint = f"/event/{event_key}"
+        return self._get(endpoint)
+
     @typed_tasklet
     def _get(
         self, endpoint: str, version: str = "v1"

--- a/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
@@ -48,7 +48,7 @@ class NexusAPIQueueStatusParser(ParserBase[Optional[EventQueueStatus]]):
 
             matches[match_key] = NexusMatch(
                 label=api_match["label"],
-                status=NexusMatchStatus(api_match["status"]),
+                status=NexusMatchStatus.from_string(api_match["status"]),
                 played=match.has_been_played,
                 times=NexusMatchTiming(
                     estimated_queue_time_ms=api_match["times"]["estimatedQueueTime"],

--- a/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
@@ -20,7 +20,9 @@ from backend.tasks_io.datafeeds.parsers.parser_base import ParserBase
 
 class NexusAPIQueueStatusParser(ParserBase[Optional[EventQueueStatus]]):
 
-    MATCH_LABEL_PATTERN: re.Pattern = re.compile(r"(Practice|Qualification|Qualification|Playoff|Final) (\d+)( Replay)?")
+    MATCH_LABEL_PATTERN: re.Pattern = re.compile(
+        r"(Practice|Qualification|Qualification|Playoff|Final) (\d+)( Replay)?"
+    )
 
     def __init__(self, event: Event) -> None:
         super().__init__()

--- a/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
@@ -1,0 +1,94 @@
+import logging
+import re
+from typing import Dict, Optional
+
+from pyre_extensions import JSON
+
+from backend.common.consts.nexus_match_status import NexusMatchStatus
+from backend.common.helpers.playoff_type_helper import PlayoffTypeHelper
+from backend.common.models.event import Event
+from backend.common.models.event_queue_status import (
+    EventQueueStatus,
+    NexusCurrentlyQueueing,
+    NexusMatch,
+    NexusMatchTiming,
+)
+from backend.common.models.keys import MatchKey
+from backend.common.models.match import Match
+from backend.tasks_io.datafeeds.parsers.parser_base import ParserBase
+
+
+class NexusAPIQueueStatusParser(ParserBase[Optional[EventQueueStatus]]):
+
+    MATCH_LABEL_PATTERN: re.Pattern = re.compile(r"(Practice|Qualification|Qualification|Playoff|Final) (\d+)( Replay)?")
+
+    def __init__(self, event: Event) -> None:
+        super().__init__()
+        self.event = event
+        self.matches = event.matches
+
+    def parse(self, response: JSON) -> Optional[EventQueueStatus]:
+        if not isinstance(response, dict):
+            return None
+
+        nexus_matches = response.get("matches")
+        if not isinstance(nexus_matches, list):
+            return None
+
+        now_queueing_match_key: Optional[MatchKey] = None
+        matches: Dict[MatchKey, NexusMatch] = {}
+        for api_match in nexus_matches:
+            match_key = self._parse_match_description(api_match["label"])
+            if not match_key:
+                continue
+
+            match = next((m for m in self.matches if match_key == m.key_name), None)
+            if not match:
+                continue
+
+            matches[match_key] = NexusMatch(
+                label=api_match["label"],
+                status=NexusMatchStatus(api_match["status"]),
+                played=match.has_been_played,
+                times=NexusMatchTiming(
+                    estimated_queue_time_ms=api_match["times"]["estimatedQueueTime"],
+                    estimated_start_time_ms=api_match["times"]["estimatedStartTime"],
+                ),
+            )
+            if response.get("nowQueuing") == api_match["label"]:
+                now_queueing_match_key = match_key
+
+        return EventQueueStatus(
+            data_as_of_ms=int(response["dataAsOfTime"]),
+            now_queueing=(
+                NexusCurrentlyQueueing(
+                    match_key=now_queueing_match_key,
+                    match_name=str(response["nowQueuing"]),
+                )
+                if now_queueing_match_key
+                else None
+            ),
+            matches=matches,
+        )
+
+    def _parse_match_description(self, description: str) -> Optional[MatchKey]:
+        re_match = self.MATCH_LABEL_PATTERN.match(description)
+        if not re_match:
+            logging.warning(f"Unable to parse nexus match label: {description}")
+            return None
+
+        level = re_match.group(1)
+        level_number = int(re_match.group(2))
+        if level == "Practice":
+            # Practice matches aren't currently supported
+            return None
+
+        comp_level = PlayoffTypeHelper.get_comp_level(
+            self.event.playoff_type, level, level_number
+        )
+        set_number, match_number = PlayoffTypeHelper.get_set_match_number(
+            self.event.playoff_type, comp_level, level_number
+        )
+        return Match.render_key_name(
+            self.event.key_name, comp_level.value, set_number, match_number
+        )

--- a/src/backend/tasks_io/handlers/nexus_api.py
+++ b/src/backend/tasks_io/handlers/nexus_api.py
@@ -101,9 +101,8 @@ def event_queue_status(event_key: EventKey) -> Response:
     event_queue_status_future = nexus_df.get_event_queue_status(event)
 
     event_queue_status = event_queue_status_future.get_result()
-    status_data = json.dumps(event_queue_status)
 
     memcache = MemcacheClient.get()
     memcache_key = f"nexus_queue_status:{event_key}".encode()
-    memcache.set(memcache_key, status_data, 60 * 5)
-    return make_response(f"Fetched nexus queue data:\n{status_data}")
+    memcache.set(memcache_key, event_queue_status, 60 * 5)
+    return make_response(f"Fetched nexus queue data:\n{json.dumps(event_queue_status)}")

--- a/src/backend/tasks_io/handlers/nexus_api.py
+++ b/src/backend/tasks_io/handlers/nexus_api.py
@@ -88,6 +88,27 @@ def event_pit_locations(event_key: EventKey) -> Response:
     return make_response("")
 
 
+@blueprint.route("/tasks/enqueue/nexus_queue_status/now")
+def current_event_queue_status() -> Response:
+    events = EventHelper.events_within_a_day()
+    for event in events:
+        taskqueue.add(
+            queue_name="datafeed",
+            target="py3-tasks-io",
+            url=url_for("nexus_api.event_queue_status", event_key=event.key_name),
+            method="GET",
+        )
+
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return make_response(
+            f"Enqueued queue updates for {[e.key_name for e in events]}"
+        )
+
+    return make_response("")
+
+
 @blueprint.route("/tasks/get/nexus_queue_status/<event_key>")
 def event_queue_status(event_key: EventKey) -> Response:
     if not Event.validate_key_name(event_key):

--- a/src/backend/tasks_io/handlers/nexus_api.py
+++ b/src/backend/tasks_io/handlers/nexus_api.py
@@ -7,7 +7,7 @@ from google.appengine.api import taskqueue
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
-from backend.common.memcache import MemcacheClient
+from backend.common.memcache_models.event_nexus_queue_status_memcache import EventNexusQueueStatusMemcache
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, Year
 from backend.common.queries.event_query import EventListQuery
@@ -102,7 +102,7 @@ def event_queue_status(event_key: EventKey) -> Response:
 
     event_queue_status = event_queue_status_future.get_result()
 
-    memcache = MemcacheClient.get()
-    memcache_key = f"nexus_queue_status:{event_key}".encode()
-    memcache.set(memcache_key, event_queue_status, 60 * 5)
+    mc_model = EventNexusQueueStatusMemcache(event.key_name)
+    mc_model.put(event_queue_status)
+
     return make_response(f"Fetched nexus queue data:\n{json.dumps(event_queue_status)}")

--- a/src/backend/tasks_io/handlers/nexus_api.py
+++ b/src/backend/tasks_io/handlers/nexus_api.py
@@ -7,7 +7,9 @@ from google.appengine.api import taskqueue
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
-from backend.common.memcache_models.event_nexus_queue_status_memcache import EventNexusQueueStatusMemcache
+from backend.common.memcache_models.event_nexus_queue_status_memcache import (
+    EventNexusQueueStatusMemcache,
+)
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, Year
 from backend.common.queries.event_query import EventListQuery

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -33,6 +33,10 @@ cron:
   url: /tasks/enqueue/nexus_pit_locations/now
   schedule: every 1 hours
 
+- description: Nexus queue status current events
+  url: /tasks/enqueue/nexus_queue_status/now
+  schedule: every 1 minutes
+
 - description: Nexus pit locations for all season events
   url: /tasks/enqueue/nexus_pit_locations/current_year
   schedule: every day 02:00


### PR DESCRIPTION
This will add a cronjob that fetches the queue data from nexus.

We also get it updated in firebase, in both the live event status, and the per-match objects.

![image](https://github.com/user-attachments/assets/adfcb907-99e4-40b9-8992-e98fc61ee336)

![image](https://github.com/user-attachments/assets/bc5d7c17-6f21-492e-b6cc-a6b289a34d39)
