### PR TITLE
[nexus] Patch queue status into firebase outside of Match Manipulator

### DIFF
--- a/src/backend/common/helpers/tests/firebase_pusher_test.py
+++ b/src/backend/common/helpers/tests/firebase_pusher_test.py
@@ -12,19 +12,12 @@ from google.appengine.ext import ndb, testbed
 from pyre_extensions import none_throws
 
 from backend.common.consts.event_type import EventType
-from backend.common.consts.nexus_match_status import NexusMatchStatus
 from backend.common.consts.webcast_status import WebcastStatus
 from backend.common.consts.webcast_type import WebcastType
 from backend.common.helpers.deferred import run_from_task
 from backend.common.helpers.firebase_pusher import FirebasePusher
 from backend.common.models.district import District
 from backend.common.models.event import Event
-from backend.common.models.event_queue_status import (
-    EventQueueStatus,
-    NexusCurrentlyQueueing,
-    NexusMatch,
-    NexusMatchTiming,
-)
 from backend.common.models.match import Match
 from backend.common.models.webcast import Webcast
 from backend.common.sitevars.forced_live_events import ForcedLiveEvents
@@ -322,7 +315,7 @@ def test_update_match(
         match_number=1,
     )
 
-    FirebasePusher.update_match(match, set(), nexus_status=None)
+    FirebasePusher.update_match(match, set())
     drain_deferred(taskqueue_stub)
 
     expected = {
@@ -353,7 +346,7 @@ def test_update_match_skips_pre_2017(
         match_number=1,
     )
 
-    FirebasePusher.update_match(match, set(), nexus_status=None)
+    FirebasePusher.update_match(match, set())
     drain_deferred(taskqueue_stub)
 
     with pytest.raises(firebase_exceptions.NotFoundError):
@@ -373,7 +366,7 @@ def test_update_match_merges_predicted_time(
         match_number=1,
     )
 
-    FirebasePusher.update_match(match, set(), nexus_status=None)
+    FirebasePusher.update_match(match, set())
     drain_deferred(taskqueue_stub)
 
     # Make a change to the alliance dict, so that the test will fail we it not for the hack
@@ -381,7 +374,7 @@ def test_update_match_merges_predicted_time(
     match.predicted_time = predicted_time
     match.alliances_json = """{"blue": {"score": -1, "teams": ["frc3464", "frc20", "frc1073"]}, "red": {"score": -1, "teams": ["frc69", "frc571", "frc176"]}}"""
     match._alliances = None
-    FirebasePusher.update_match(match, {"predicted_time"}, nexus_status=None)
+    FirebasePusher.update_match(match, {"predicted_time"})
     drain_deferred(taskqueue_stub)
 
     expected = {
@@ -395,60 +388,6 @@ def test_update_match_merges_predicted_time(
         "t": None,
         "pt": predicted_time.timestamp(),
         "w": "red",
-    }
-    assert FirebasePusher._get_reference("e/2018ct/m/qm1").get() == expected
-
-
-def test_update_match_merges_nexus_status(
-    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
-) -> None:
-    match = Match(
-        id="2018ct_qm1",
-        alliances_json="""{"blue": {"score": 57, "teams": ["frc3464", "frc20", "frc1073"]}, "red": {"score": 74, "teams": ["frc69", "frc571", "frc176"]}}""",
-        comp_level="qm",
-        event=ndb.Key(Event, "2018ct"),
-        year=2018,
-        set_number=1,
-        match_number=1,
-    )
-
-    FirebasePusher.update_match(match, set(), nexus_status=None)
-    drain_deferred(taskqueue_stub)
-
-    nexus_status = EventQueueStatus(
-        data_as_of_ms=0,
-        now_queueing=NexusCurrentlyQueueing(
-            match_key="2018ct_qm1",
-            match_name="Quals 1",
-        ),
-        matches={
-            "2018ct_qm1": NexusMatch(
-                label="Quals 1",
-                status=NexusMatchStatus.NOW_QUEUING,
-                played=False,
-                times=NexusMatchTiming(
-                    estimated_queue_time_ms=None,
-                    estimated_start_time_ms=None,
-                ),
-            ),
-        },
-    )
-
-    FirebasePusher.update_match(match, set(), nexus_status=nexus_status)
-    drain_deferred(taskqueue_stub)
-
-    expected = {
-        "c": "qm",
-        "s": 1,
-        "m": 1,
-        "r": 74,
-        "rt": ["frc69", "frc571", "frc176"],
-        "b": 57,
-        "bt": ["frc3464", "frc20", "frc1073"],
-        "t": None,
-        "pt": None,
-        "w": "red",
-        "q": "Now queuing",
     }
     assert FirebasePusher._get_reference("e/2018ct/m/qm1").get() == expected
 

--- a/src/backend/common/manipulators/match_manipulator.py
+++ b/src/backend/common/manipulators/match_manipulator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Set, TYPE_CHECKING
+from typing import List, Set, TYPE_CHECKING
 
 from google.appengine.api import taskqueue
 from pyre_extensions import none_throws
@@ -11,11 +11,7 @@ from backend.common.helpers.firebase_pusher import FirebasePusher
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.helpers.tbans_helper import TBANSHelper
 from backend.common.manipulators.manipulator_base import ManipulatorBase, TUpdatedModel
-from backend.common.memcache_models.event_nexus_queue_status_memcache import (
-    EventNexusQueueStatusMemcache,
-)
 from backend.common.models.cached_model import TAffectedReferences
-from backend.common.models.event_queue_status import EventQueueStatus
 from backend.common.models.keys import EventKey
 from backend.common.models.match import Match
 
@@ -67,20 +63,9 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
     affected_stats_event_keys: Set[EventKey] = set()
     affected_stats_events: List[Event] = []
 
-    all_affected_event_keys: Set[EventKey] = {
-        none_throws(m.model.event.string_id())
-        for m in updated_models
-        if m.model.event.string_id() is not None
-    }
-    event_nexus_status = {
-        ek: EventNexusQueueStatusMemcache(ek).get() for ek in all_affected_event_keys
-    }
-
     for updated_model in updated_models:
         event_key: EventKey = none_throws(updated_model.model.event.string_id())
-        MatchPostUpdateHooks.firebase_update(
-            updated_model, event_nexus_status.get(event_key)
-        )
+        MatchPostUpdateHooks.firebase_update(updated_model)
 
         # Only attrs that affect stats
         if (
@@ -193,14 +178,12 @@ class MatchPostUpdateHooks:
     """
 
     @staticmethod
-    def firebase_update(
-        model: TUpdatedModel[Match], nexus_status: Optional[EventQueueStatus]
-    ) -> None:
+    def firebase_update(model: TUpdatedModel[Match]) -> None:
         """
         Enqueue firebase push
         """
         try:
-            FirebasePusher.update_match(model.model, model.updated_attrs, nexus_status)
+            FirebasePusher.update_match(model.model, model.updated_attrs)
         except Exception:
             logging.exception("Firebase update_match failed!")
 

--- a/src/backend/common/manipulators/tests/match_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/match_manipulator_test.py
@@ -196,7 +196,7 @@ def test_updateHook(mock_firebase, ndb_context, taskqueue_stub) -> None:
     for task in tasks:
         run_from_task(task)
 
-    mock_firebase.assert_called_once_with(test_match, set(), None)
+    mock_firebase.assert_called_once_with(test_match, set())
 
 
 @mock.patch.object(FirebasePusher, "update_match")

--- a/src/backend/tasks_io/handlers/live_events.py
+++ b/src/backend/tasks_io/handlers/live_events.py
@@ -21,9 +21,6 @@ from backend.common.manipulators.event_details_manipulator import (
     EventDetailsManipulator,
 )
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
-from backend.common.memcache_models.event_nexus_queue_status_memcache import (
-    EventNexusQueueStatusMemcache,
-)
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.event_playoff_advancement import EventPlayoffAdvancement
@@ -303,11 +300,8 @@ def update_firebase_matches(event_key: EventKey) -> Response:
         abort(404)
 
     event.prep_matches()
-    nexus_data_model = EventNexusQueueStatusMemcache(event_key).get()
 
     for match in event.matches:
-        FirebasePusher.update_match(
-            match, updated_attrs=set(), nexus_status=nexus_data_model
-        )
+        FirebasePusher.update_match(match, updated_attrs=set())
 
     return make_response("")


### PR DESCRIPTION
This didn't make sense to hang off of `MatchManipulator`, because the two data sources are updated independently. Instead, use Firebase's ability to merge specific dict keys and update it as part of the nexus fetch