### PR TITLE
Clean up webcast status fetching

### DIFF
--- a/src/backend/common/cache/cache_if.py
+++ b/src/backend/common/cache/cache_if.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import abc
 from typing import Any, Dict, List, Optional, TypedDict
 
+from backend.common.futures import TypedFuture
+
 """
 A shim for the Legacy GAE memcache module
 
@@ -37,6 +39,11 @@ class CacheIf(abc.ABC):
         Returns:
         True if set.  False on error.
         """
+
+    @abc.abstractmethod
+    def set_async(
+        self, key: bytes, value: Any, time: Optional[int] = None
+    ) -> TypedFuture[bool]: ...
 
     @abc.abstractmethod
     def set_multi(
@@ -76,6 +83,9 @@ class CacheIf(abc.ABC):
         Returns:
         The value of the key, if found in memcache, else None.
         """
+
+    @abc.abstractmethod
+    def get_async(self, key: bytes) -> TypedFuture[Optional[Any]]: ...
 
     @abc.abstractmethod
     def get_multi(

--- a/src/backend/common/cache/noop_cache.py
+++ b/src/backend/common/cache/noop_cache.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from backend.common.cache.cache_if import CacheIf, CacheStats
+from backend.common.futures import InstantFuture, TypedFuture
 
 
 class NoopCache(CacheIf):
@@ -16,6 +17,11 @@ class NoopCache(CacheIf):
     def set(self, key: bytes, value: Any, time: Optional[int] = None) -> bool:
         return True
 
+    def set_async(
+        self, key: bytes, value: Any, time: Optional[int] = None
+    ) -> TypedFuture[bool]:
+        return InstantFuture(True)  # pyre-ignore[7]
+
     def set_multi(
         self,
         mapping: Dict[bytes, Any],
@@ -27,6 +33,10 @@ class NoopCache(CacheIf):
     def get(self, key: bytes) -> Optional[Any]:
         self.miss_count += 1
         return None
+
+    def get_async(self, key: bytes) -> Optional[Any]:
+        self.miss_count += 1
+        return InstantFuture(None)
 
     def get_multi(
         self,

--- a/src/backend/common/cache/tests/test_gae_builtin_cache.py
+++ b/src/backend/common/cache/tests/test_gae_builtin_cache.py
@@ -11,11 +11,16 @@ def mc(memcache_stub) -> memcache.Client:
 
 @pytest.fixture
 def cache(mc: memcache.Client) -> AppEngineBuiltinCache:
-    return AppEngineBuiltinCache(memcache)
+    return AppEngineBuiltinCache(mc)
 
 
 def test_set(mc: memcache.Client, cache: AppEngineBuiltinCache) -> None:
     assert cache.set(b"foo", "bar") is True
+    assert mc.get(b"foo") == "bar"
+
+
+def test_set_async(mc: memcache.Client, cache: AppEngineBuiltinCache) -> None:
+    assert cache.set_async(b"foo", "bar").get_result() is True
     assert mc.get(b"foo") == "bar"
 
 
@@ -27,6 +32,11 @@ def test_set_multi(mc: memcache.Client, cache: AppEngineBuiltinCache) -> None:
 def test_get(mc: memcache.Client, cache: AppEngineBuiltinCache) -> None:
     mc.set(b"foo", "bar")
     assert cache.get(b"foo") == "bar"
+
+
+def test_get_async(mc: memcache.Client, cache: AppEngineBuiltinCache) -> None:
+    mc.set(b"foo", "bar")
+    assert cache.get_async(b"foo").get_result() == "bar"
 
 
 def test_get_multi(mc: memcache.Client, cache: AppEngineBuiltinCache) -> None:

--- a/src/backend/common/helpers/tests/webcast_online_helper_test.py
+++ b/src/backend/common/helpers/tests/webcast_online_helper_test.py
@@ -3,12 +3,14 @@ from urllib.parse import urlparse
 
 import pytest
 
-from google.appengine.api import memcache
 from google.appengine.ext import testbed
 
 from backend.common.consts.webcast_status import WebcastStatus
 from backend.common.consts.webcast_type import WebcastType
 from backend.common.helpers.webcast_online_helper import WebcastOnlineHelper
+from backend.common.memcache_models.webcast_online_status_memcache import (
+    WebcastOnlineStatusMemcache,
+)
 from backend.common.models.webcast import Webcast
 from backend.common.sitevars.google_api_secret import GoogleApiSecret
 from backend.common.sitevars.twitch_secrets import TwitchSecrets
@@ -135,7 +137,7 @@ def test_add_online_status_not_in_cache() -> None:
     assert webcast.get("viewer_count") is None
 
     # Check we write the updated dict back to cache
-    cache_data = memcache.Client().get("webcast_status:html5:test_stream.m4v:None")
+    cache_data = WebcastOnlineStatusMemcache(webcast).get()
     assert webcast == cache_data
 
 
@@ -151,9 +153,8 @@ def test_add_online_status_in_cache() -> None:
         stream_title="A Stream",
         viewer_count=1337,
     )
-    memcache.Client().set(
-        "webcast_status:html5:test_stream.m4v:None", webcast_with_status
-    )
+
+    WebcastOnlineStatusMemcache(webcast).put(webcast_with_status)
 
     WebcastOnlineHelper.add_online_status([webcast])
     assert webcast == webcast_with_status

--- a/src/backend/common/memcache_models/memcache_model.py
+++ b/src/backend/common/memcache_models/memcache_model.py
@@ -1,8 +1,10 @@
 import abc
 from datetime import timedelta
-from typing import Generic, Optional, TypeVar
+from typing import Any, Generator, Generic, Optional, TypeVar
 
+from backend.common.futures import TypedFuture
 from backend.common.memcache import MemcacheClient
+from backend.common.tasklets import typed_tasklet
 
 DT = TypeVar("DT")
 
@@ -21,11 +23,27 @@ class MemcacheModel(abc.ABC, Generic[DT]):
     @abc.abstractmethod
     def ttl(self) -> timedelta: ...
 
-    def put(self, val: DT) -> None:
+    def put(self, val: DT) -> bool:
+        return self.put_async(val).get_result()
+
+    @typed_tasklet  # pyre-ignore[56]
+    def _put_async(self, val: DT) -> Generator[Any, Any, bool]:
         mc_key = self.key()
         ttl_seconds = self.ttl().seconds
-        self.mc_client.set(mc_key, val, ttl_seconds)
+        res = yield self.mc_client.set_async(mc_key, val, ttl_seconds)
+        return res
+
+    def put_async(self, val: DT) -> TypedFuture[bool]:
+        return self._put_async(val)
 
     def get(self) -> Optional[DT]:
+        return self.get_async().get_result()
+
+    @typed_tasklet  # pyre-ignore[56]
+    def _get_async(self) -> Generator[Any, Any, DT]:
         mc_key = self.key()
-        return self.mc_client.get(mc_key)
+        ret = yield self.mc_client.get_async(mc_key)
+        return ret
+
+    def get_async(self) -> TypedFuture[DT]:
+        return self._get_async()

--- a/src/backend/common/memcache_models/webcast_online_status_memcache.py
+++ b/src/backend/common/memcache_models/webcast_online_status_memcache.py
@@ -1,0 +1,19 @@
+from datetime import timedelta
+
+from backend.common.memcache_models.memcache_model import MemcacheModel
+from backend.common.models.webcast import Webcast
+
+
+class WebcastOnlineStatusMemcache(MemcacheModel[Webcast]):
+
+    def __init__(self, webcast: Webcast) -> None:
+        super().__init__()
+        self.type = webcast["type"]
+        self.channel = webcast.get("channel")
+        self.file = webcast.get("file")
+
+    def key(self) -> bytes:
+        return f"webcast_status:{self.type}:{self.channel}:{self.file}".encode()
+
+    def ttl(self) -> timedelta:
+        return timedelta(minutes=5)

--- a/src/backend/tasks_io/handlers/live_events.py
+++ b/src/backend/tasks_io/handlers/live_events.py
@@ -17,6 +17,7 @@ from backend.common.helpers.match_time_prediction_helper import (
 )
 from backend.common.helpers.playoff_advancement_helper import PlayoffAdvancementHelper
 from backend.common.helpers.season_helper import SeasonHelper
+from backend.common.helpers.webcast_online_helper import WebcastOnlineHelper
 from backend.common.manipulators.event_details_manipulator import (
     EventDetailsManipulator,
 )
@@ -281,6 +282,16 @@ def update_match_time_predictions(event_key: EventKey) -> str:
     # Clear API Response cache
     # ApiStatusController.clear_cache_if_needed(old_status, new_status)
     return ""
+
+
+@blueprint.route("/tasks/do/update_webcast_online_status/<event_key>")
+def update_event_webcast_status(event_key: EventKey) -> Response:
+    event = Event.get_by_id(event_key)
+    if not event:
+        abort(404)
+
+    WebcastOnlineHelper.add_online_status(event.webcast)
+    return make_response(f"Updated event webcasts: {event.webcast}")
 
 
 @blueprint.route("/tasks/do/update_firebase_event/<event_key>")

--- a/src/backend/web/handlers/admin/authkeys.py
+++ b/src/backend/web/handlers/admin/authkeys.py
@@ -35,7 +35,8 @@ def authkeys_get() -> str:
         "android_client_id": clientIds.get("android", ""),
         "ios_client_id": clientIds.get("ios", ""),
         "gcm_key": gcm_serverKey.get("gcm_key", ""),
-        "twitch_secret": twitch_secrets.get("client_id", ""),
+        "twitch_client_id": twitch_secrets.get("client_id", ""),
+        "twitch_secret": twitch_secrets.get("client_secret", ""),
         "livestream_secret": livestream_secrets.get("api_key", ""),
         "instagram_secret": instagram_secrets.get("api_key", ""),
         "nexus_secret": nexus_secrets.get("api_secret", ""),
@@ -53,7 +54,8 @@ def authkeys_post() -> Response:
     android_client_id = request.form.get("android_client_id", "")
     ios_client_id = request.form.get("ios_client_id", "")
     gcm_key = request.form.get("gcm_key", "")
-    twitch_client_id = request.form.get("twitch_secret", "")
+    twitch_client_id = request.form.get("twitch_client_id", "")
+    twitch_secret = request.form.get("twitch_secret", "")
     livestream_key = request.form.get("livestream_secret", "")
     instagram_key = request.form.get("instagram_secret", "")
     apiv3_key = request.form.get("apiv3_key", "")
@@ -75,6 +77,7 @@ def authkeys_post() -> Response:
 
     twitch_secrets = TwitchSecrets.get()
     twitch_secrets["client_id"] = twitch_client_id
+    twitch_secrets["client_secret"] = twitch_secret
     TwitchSecrets.put(twitch_secrets)
 
     LivestreamSecrets.put({"api_key": livestream_key})

--- a/src/backend/web/handlers/admin/event.py
+++ b/src/backend/web/handlers/admin/event.py
@@ -30,6 +30,9 @@ from backend.common.manipulators.event_details_manipulator import (
 from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
 from backend.common.manipulators.match_manipulator import MatchManipulator
+from backend.common.memcache_models.webcast_online_status_memcache import (
+    WebcastOnlineStatusMemcache,
+)
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.district import District
 from backend.common.models.event import Event
@@ -127,6 +130,11 @@ def event_detail(event_key: EventKey) -> str:
             DistrictPointTiebreakersSortingHelper.sorted_points(points)
         )
 
+    webcast_online_status = [
+        WebcastOnlineStatusMemcache(webcast).get() for webcast in event.webcast
+    ]
+    webcast_online_status = [w for w in webcast_online_status if w is not None]
+
     template_values = {
         "event": event,
         "medias": event_medias.get_result(),
@@ -157,6 +165,7 @@ def event_detail(event_key: EventKey) -> str:
         "deleted_count": request.args.get("deleted"),
         "district_points_sorted": district_points_sorted,
         "regional_champs_pool_points_sorted": regional_champs_pool_points_sorted,
+        "webcast_online_status": webcast_online_status,
     }
 
     return render_template("admin/event_details.html", template_values)

--- a/src/backend/web/handlers/admin/tests/authkeys_test.py
+++ b/src/backend/web/handlers/admin/tests/authkeys_test.py
@@ -24,6 +24,7 @@ def test_update_authkeys(login_gae_admin, web_client: Client) -> None:
         "android_client_id": "android_client_id",
         "ios_client_id": "ios_client_id",
         "gcm_key": "gcm_key",
+        "twitch_client_id": "twitch_client_id",
         "twitch_secret": "twitch_secret",
         "livestream_secret": "livestream_secret",
     }
@@ -48,7 +49,8 @@ def test_update_authkeys(login_gae_admin, web_client: Client) -> None:
         "android_client_id": clientIds.get("android", ""),
         "ios_client_id": clientIds.get("ios", ""),
         "gcm_key": gcm_serverKey.get("gcm_key", ""),
-        "twitch_secret": twitch_secrets.get("client_id", ""),
+        "twitch_secret": twitch_secrets.get("client_secret", ""),
+        "twitch_client_id": twitch_secrets.get("client_id", ""),
         "livestream_secret": livestream_secrets.get("api_key", ""),
     }
     assert data == check_data

--- a/src/backend/web/templates/admin/authkeys.html
+++ b/src/backend/web/templates/admin/authkeys.html
@@ -30,7 +30,8 @@
   <tr><td>iOS Client ID</td><td><input name="ios_client_id" value="{{ios_client_id}}" class="form-control"/></td></tr>
 
   <tr><th>Twitch</th></tr>
-  <tr><td>Client ID</td><td><input name="twitch_secret" value="{{twitch_secret}}" class="form-control"/></td></tr>
+  <tr><td>Client ID</td><td><input name="twitch_client_id" value="{{twitch_client_id}}" class="form-control"/></td></tr>
+  <tr><td>Secret</td><td><input name="twitch_secret" value="{{twitch_secret}}" class="form-control"/></td></tr>
 
   <tr><th>Livestream</th></tr>
   <tr><td>API Key</td><td><input name="livestream_secret" value="{{livestream_secret}}" class="form-control"/></td></tr>

--- a/src/backend/web/templates/admin/event_details.html
+++ b/src/backend/web/templates/admin/event_details.html
@@ -436,6 +436,31 @@
       <p>No webcasts found</p>
       {% endfor %}
     </ul>
+    <h2>Webcast Online Status</h2>
+    <a href="/tasks/do/update_webcast_online_status/{{event.key_name}}"><button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> Refresh Online Status</button></a>
+    {% if webcast_online_status %}
+    <p>Fetched from memcache:</p>
+    <table class="table">
+      <tr>
+        <th>Type</th>
+        <th>Channel</th>
+        <th>Status</th>
+        <th>Stream Title</th>
+        <th>Viewer Count</th>
+      </tr>
+      {% for webcast in webcast_online_status %}
+        <tr>
+          <td>{{webcast.type}}</td>
+          <td>{{webcast.channel}}</td>
+          <td>{{webcast.status.value}}</td>
+          <td>{{webcast.stream_title}}</td>
+          <td>{{webcast.viewer_count}}</td>
+        </tr>
+      {% endfor %}
+    </table>
+    {% else %}
+      <p>No online webcast data found</p>
+    {% endif %}
     {% include "suggestions/partials/webcast_add_instructions_partial.html" %}
     <form action="/admin/event/add_webcast/{{event.key_name}}" method="post">
       {% include "suggestions/partials/webcast_add_form_partial.html" %}


### PR DESCRIPTION
A series of things I noticed while working in this code:
 - move the webcast status to be backed by a `MemcacheModel`, to leverage the abstraction here
 - support async get/set in `MemcacheModel`
 - clean up the async-ificatoin of all the webcast status fetching, which should hopefully increase the parallelism here
 - show webast online status from memcache in the admin panel + a way to refresh it (since it has a pretty short TTL)