### PR TITLE
[nexus] Use predicted times where available 

### DIFF
--- a/src/backend/common/helpers/tests/match_time_prediction_helper_test.py
+++ b/src/backend/common/helpers/tests/match_time_prediction_helper_test.py
@@ -49,7 +49,7 @@ def test_predict_times(
         played = matches[:i]
         unplayed = matches[i:]
         MatchTimePredictionHelper.predict_future_matches(
-            "2019nyny", played, unplayed, timezone, False
+            "2019nyny", played, unplayed, timezone, False, None
         )
 
         _mark_match_played(matches, original_matches, i)

--- a/src/backend/web/handlers/admin/event.py
+++ b/src/backend/web/handlers/admin/event.py
@@ -30,6 +30,9 @@ from backend.common.manipulators.event_details_manipulator import (
 from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
 from backend.common.manipulators.match_manipulator import MatchManipulator
+from backend.common.memcache_models.event_nexus_queue_status_memcache import (
+    EventNexusQueueStatusMemcache,
+)
 from backend.common.memcache_models.webcast_online_status_memcache import (
     WebcastOnlineStatusMemcache,
 )
@@ -135,6 +138,8 @@ def event_detail(event_key: EventKey) -> str:
     ]
     webcast_online_status = [w for w in webcast_online_status if w is not None]
 
+    nexus_queue_status = EventNexusQueueStatusMemcache(event.key_name).get()
+
     template_values = {
         "event": event,
         "medias": event_medias.get_result(),
@@ -166,6 +171,7 @@ def event_detail(event_key: EventKey) -> str:
         "district_points_sorted": district_points_sorted,
         "regional_champs_pool_points_sorted": regional_champs_pool_points_sorted,
         "webcast_online_status": webcast_online_status,
+        "nexus_queue_status": nexus_queue_status,
     }
 
     return render_template("admin/event_details.html", template_values)

--- a/src/backend/web/jinja2_filters.py
+++ b/src/backend/web/jinja2_filters.py
@@ -59,6 +59,12 @@ def limit_prob(prob: float) -> int:
     return int(round(prob))
 
 
+def from_ms_timestamp(timestamp: Optional[int]) -> Optional[datetime]:
+    if timestamp is None:
+        return None
+    return datetime.fromtimestamp(timestamp / 1000)
+
+
 def strftime(dt: datetime, formatstr: str) -> str:
     """
     Uses Python's strftime with some tweaks
@@ -162,6 +168,7 @@ _filters = {
     "sort_by": sort_by,
     "get_item": get_item,
     "pprint_json": pprint_json,
+    "from_ms_timestamp": from_ms_timestamp,
 }
 
 

--- a/src/backend/web/templates/admin/event_details.html
+++ b/src/backend/web/templates/admin/event_details.html
@@ -647,6 +647,7 @@
         <th>Match Key</th>
         <th>Scheduled Time</th>
         <th>Predicted Time</th>
+        {% if event.within_a_day %}<th>Nexus Predicted Time</th>{%endif%}
         <th>Actual Time</th>
         <th>Post Result Time</th>
         <th>Alliances JSON</th>
@@ -659,9 +660,20 @@
             datetime="{{match.time.isoformat()}}+00:00">{{match.time|strftime("%a %I:%M%p UTC")}}</time>{% endif %}
         </td>
         <td>{% if match.predicted_time %}<time class="tba-match-time-utc"
-            datetime="{{match.predicted_time.isoformat()}}+00:00">{{match.time|strftime("%a %I:%M%p UTC")}}</time>{%
+            datetime="{{match.predicted_time.isoformat()}}+00:00">{{match.predicted_time|strftime("%a %I:%M%p UTC")}}</time>{%
           endif %}
           {% if match.prediction_error_str %}<br>({{ match.prediction_error_str}}){% endif %}</td>
+        {% if event.within_a_day %}
+        <td>
+          {% if nexus_queue_status and match.key_name in nexus_queue_status.matches %}
+            {% with nexus_time = nexus_queue_status.matches.get(match.key_name).times.estimated_start_time_ms|from_ms_timestamp %}
+              {% if nexus_time %}
+                <time class="tba-match-time-utc" datetime="{{nexus_time.isoformat()}}+00:00">{{nexus_time|strftime("%a %I:%M%p UTC")}}</time>
+              {% endif %}
+            {% endwith %}
+          {% endif %}
+        </td>
+        {% endif %}
         <td>{% if match.actual_time %}<time class="tba-match-time-utc"
             datetime="{{match.actual_time.isoformat()}}+00:00">{{match.time|strftime("%a %I:%M%p UTC")}}</time>{%
           endif %}


### PR DESCRIPTION
In situations where we have an estimated match start time from nexus, use that as the match "predicted time". This should help minimize confusion with different sources showing conflicting information.

If the data isn't available, or is stale, then we can fall back to the existing time predictions.