### PR TITLE
update youtube playist parser for double elim keys

### DIFF
--- a/src/backend/common/helpers/tests/youtube_video_helper_test.py
+++ b/src/backend/common/helpers/tests/youtube_video_helper_test.py
@@ -180,6 +180,7 @@ def test_parse_id_from_url() -> None:
         ("2020ctwat Q4", "qm4"),
         ("CTWAT QM4", "qm4"),
         ("2020ctwat sf1m2", "sf1m2"),
+        ("2020ctwat sf10m1", "sf10m1"),
         ("2020ctwat QF2M3", "qf2m3"),
         ("CTWAT F1M3", "f1m3"),
         ("asdf", ""),

--- a/src/backend/common/helpers/youtube_video_helper.py
+++ b/src/backend/common/helpers/youtube_video_helper.py
@@ -72,7 +72,9 @@ class YouTubeVideoHelper(object):
             return f"qm{qual_match.group(2)}"
 
         elim_match = re.search(
-            r"[^\w\d]*(ef\dm\d|qf\dm\d|sf\dm\d|f\dm\d).*", video_title, re.IGNORECASE
+            r"[^\w\d]*(ef\d+m\d+|qf\d+m\d+|sf\d+m\d+|f\d+m\d+).*",
+            video_title,
+            re.IGNORECASE,
         )
         if elim_match is not None:
             return elim_match.group(1).lower()


### PR DESCRIPTION
this was never updated to support `sf\d\dm\d` formats