### PR TITLE
Schedules award scrapes more frequently on the last day of events

### DIFF
--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -811,10 +811,14 @@ def event_matches(event_key: EventKey) -> Response:
 # @blueprint.route("/awards/<int:from backend.common.helpers.listify import delistify, listifyyear>")
 # TODO: Drop support for this "now" and just use an empty year
 @blueprint.route("/tasks/enqueue/fmsapi_awards/now", defaults={"year": None})
+@blueprint.route("/tasks/enqueue/fmsapi_awards/last_day_only", defaults={"year": None, "when": "last_day_only"})
 @blueprint.route("/tasks/enqueue/fmsapi_awards/<int:year>")
-def awards_year(year: Optional[int]) -> Response:
+def awards_year(year: Optional[int], when: Optional[str] = None) -> Response:
     events: List[Event]
-    if year is None:
+    if when == "last_day_only":
+        events = EventHelper.events_within_a_day()
+        events = list(filter(lambda e: e.official and e.ends_today, events))
+    elif year is None:
         events = EventHelper.events_within_a_day()
         events = list(filter(lambda e: e.official, events))
     else:

--- a/src/backend/tasks_io/handlers/tests/frc_api_awards_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_awards_test.py
@@ -16,11 +16,12 @@ from backend.common.models.event_team import EventTeam
 from backend.common.models.team import Team
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
+
 def create_event(
     official: bool,
     end_date: Optional[datetime.datetime] = None,
     remap_teams: Optional[Dict[str, str]] = None,
-) -> None:
+) -> Event:
     e = Event(
         id="2019casj",
         year=2019,
@@ -33,6 +34,7 @@ def create_event(
     )
     e.put()
     return e
+
 
 def test_enqueue_bad_when(tasks_client: Client) -> None:
     create_event(official=True)
@@ -81,6 +83,7 @@ def test_enqueue_current_official_only(
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
     assert len(tasks) == 0
 
+
 @freeze_time("2019-04-01")
 def test_enqueue_last_day_only(
     tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
@@ -98,6 +101,7 @@ def test_enqueue_last_day_only(
         t.url for t in tasks
     ]
 
+
 @freeze_time("2019-04-01")
 def test_enqueue_last_day_only_false(
     tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
@@ -109,6 +113,7 @@ def test_enqueue_last_day_only_false(
 
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
     assert len(tasks) == 0
+
 
 @freeze_time("2019-04-01")
 def test_enqueue_last_day_only_skips_unofficial(

--- a/src/backend/tasks_io/handlers/tests/frc_api_awards_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_awards_test.py
@@ -16,21 +16,23 @@ from backend.common.models.event_team import EventTeam
 from backend.common.models.team import Team
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
-
-def create_event(official: bool, remap_teams: Optional[Dict[str, str]] = None) -> Event:
+def create_event(
+    official: bool,
+    end_date: Optional[datetime.datetime] = None,
+    remap_teams: Optional[Dict[str, str]] = None,
+) -> None:
     e = Event(
         id="2019casj",
         year=2019,
         event_short="casj",
-        start_date=datetime.datetime(2019, 4, 1),
-        end_date=datetime.datetime(2019, 4, 3),
         event_type_enum=EventType.REGIONAL,
+        start_date=datetime.datetime(2019, 4, 1),
+        end_date=end_date or datetime.datetime(2019, 4, 3),
         official=official,
         remap_teams=remap_teams,
     )
     e.put()
     return e
-
 
 def test_enqueue_bad_when(tasks_client: Client) -> None:
     create_event(official=True)
@@ -75,6 +77,47 @@ def test_enqueue_current_official_only(
     resp = tasks_client.get("/tasks/enqueue/fmsapi_awards/now")
     assert resp.status_code == 200
     assert resp.data != ""
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
+    assert len(tasks) == 0
+
+@freeze_time("2019-04-01")
+def test_enqueue_last_day_only(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    create_event(official=True, end_date=datetime.datetime(2019, 4, 1))
+    resp = tasks_client.get("/tasks/enqueue/fmsapi_awards/last_day_only")
+    assert resp.status_code == 200
+    assert len(resp.data) > 0
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
+    assert len(tasks) == 1
+
+    expected_keys = ["2019casj"]
+    assert [f"/tasks/get/fmsapi_awards/{k}" for k in expected_keys] == [
+        t.url for t in tasks
+    ]
+
+@freeze_time("2019-04-01")
+def test_enqueue_last_day_only_false(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    create_event(official=True, end_date=datetime.datetime(2019, 4, 3))
+    resp = tasks_client.get("/tasks/enqueue/fmsapi_awards/last_day_only")
+    assert resp.status_code == 200
+    assert len(resp.data) > 0
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
+    assert len(tasks) == 0
+
+@freeze_time("2019-04-01")
+def test_enqueue_last_day_only_skips_unofficial(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    create_event(official=False, end_date=datetime.datetime(2019, 4, 1))
+    resp = tasks_client.get("/tasks/enqueue/fmsapi_awards/last_day_only")
+    assert resp.status_code == 200
+    assert len(resp.data) > 0
 
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
     assert len(tasks) == 0

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -29,6 +29,10 @@ cron:
   url: /tasks/enqueue/fmsapi_awards/now
   schedule: every 1 hours
 
+- description: FIRST award scraping for current events on their last day
+  url: /tasks/enqueue/fmsapi_awards/last_day_only
+  schedule: every 10 minutes
+
 - description: Nexus pit locations for current events
   url: /tasks/enqueue/nexus_pit_locations/now
   schedule: every 1 hours

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -31,7 +31,7 @@ cron:
 
 - description: FIRST award scraping for current events on their last day
   url: /tasks/enqueue/fmsapi_awards/last_day_only
-  schedule: every 10 minutes
+  schedule: every 5 minutes
 
 - description: Nexus pit locations for current events
   url: /tasks/enqueue/nexus_pit_locations/now


### PR DESCRIPTION
## Description
Instead of waiting an hour before looking for awards, this PR fetches them every 10 minutes only on the last day of an event.

## Motivation and Context
For FRCLocks.com we'd like to get award information from the TBA API sooner. It currently can take up to an hour after awards are updated for them to appear. This means that teams who want to see if they qualify for the district championship can't see that until well after an event is over and they are on their way home.

This year we've also seen some events upload certain awards while the playoffs are still progressing, and we'd like to see those reflected on API sooner too.

## How Has This Been Tested?
The unit tests here are based off of the ones for getting alliance selection data on the day of the event.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
