### PR TITLE
Add additional URL formats to YouTube webcast parser

### DIFF
--- a/src/backend/api/handlers/tests/update_event_info_test.py
+++ b/src/backend/api/handlers/tests/update_event_info_test.py
@@ -96,7 +96,7 @@ def test_update_event_info(
         "first_event_code": "abc123",
         "playoff_type": int(PlayoffType.ROUND_ROBIN_6_TEAM),
         "webcasts": [
-            {"url": "https://youtu.be/abc123"},
+            {"url": "https://youtu.be/abc12312312"},
             {"type": "youtube", "channel": "cde456", "date": "2024-01-03"},
         ],
         "remap_teams": {
@@ -126,7 +126,7 @@ def test_update_event_info(
 
     webcast = webcasts[0]
     assert webcast["type"] == "youtube"
-    assert webcast["channel"] == "abc123"
+    assert webcast["channel"] == "abc12312312"
     assert "date" not in webcast
 
     webcast = webcasts[1]

--- a/src/backend/common/helpers/tests/webcast_helper_test.py
+++ b/src/backend/common/helpers/tests/webcast_helper_test.py
@@ -1,0 +1,38 @@
+import pytest
+
+from backend.common.helpers.webcast_helper import (
+    WebcastParser,
+)
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik",
+        "http://www.youtube.com/watch?v=1v8_2dW7Kik",
+        "http://youtu.be/1v8_2dW7Kik",
+        "https://youtu.be/1v8_2dW7Kik",
+        "https://youtube.com/live/1v8_2dW7Kik",
+        "http://youtube.com/live/1v8_2dW7Kik",
+        "https://youtube.com/live/1v8_2dW7Kik?si=randomstring",
+        "https://www.youtube.com/live/1v8_2dW7Kik?si=randomstring",
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik&t=21",
+        "https://youtu.be/1v8_2dW7Kik?t=21",
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik&feature=youtu.be",
+        "https://youtu.be/1v8_2dW7Kik?feature=youtu.be",
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik&feature=youtu.be&t=11850",
+        "https://youtu.be/1v8_2dW7Kik?feature=youtu.be&t=11850",
+        # Bunch of inconsistent (partially outdated) formats
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik#t=11850",
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik#t=1h",
+        "https://youtu.be/1v8_2dW7Kik#t=11850",
+        "https://youtu.be/1v8_2dW7Kik#t=1h",
+        "https://youtu.be/1v8_2dW7Kik?t=3h17m30s",
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik&t=3h17m30s"
+    ],
+)
+def test_youtube_webcast_dict_from_url(url: str) -> None:
+    parser = WebcastParser()
+    assert (
+        parser.webcast_dict_from_url(url).channel
+        == "1v8_2dW7Kik"
+    )

--- a/src/backend/common/helpers/tests/webcast_helper_test.py
+++ b/src/backend/common/helpers/tests/webcast_helper_test.py
@@ -31,8 +31,8 @@ from backend.common.helpers.webcast_helper import (
     ],
 )
 def test_youtube_webcast_dict_from_url(url: str) -> None:
-    parser = WebcastParser()
+    webcast = WebcastParser.webcast_dict_from_url(url)
     assert (
-        parser.webcast_dict_from_url(url).channel
-        == "1v8_2dW7Kik"
+        webcast is not None and
+        webcast.channel == "1v8_2dW7Kik"
     )

--- a/src/backend/common/helpers/tests/webcast_helper_test.py
+++ b/src/backend/common/helpers/tests/webcast_helper_test.py
@@ -4,6 +4,7 @@ from backend.common.helpers.webcast_helper import (
     WebcastParser,
 )
 
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -27,12 +28,12 @@ from backend.common.helpers.webcast_helper import (
         "https://youtu.be/1v8_2dW7Kik#t=11850",
         "https://youtu.be/1v8_2dW7Kik#t=1h",
         "https://youtu.be/1v8_2dW7Kik?t=3h17m30s",
-        "https://www.youtube.com/watch?v=1v8_2dW7Kik&t=3h17m30s"
+        "https://www.youtube.com/watch?v=1v8_2dW7Kik&t=3h17m30s",
     ],
 )
 def test_youtube_webcast_dict_from_url(url: str) -> None:
     webcast = WebcastParser.webcast_dict_from_url(url)
     assert (
         webcast is not None and
-        webcast.channel == "1v8_2dW7Kik"
+        webcast["channel"] == "1v8_2dW7Kik"
     )

--- a/src/backend/common/helpers/tests/webcast_helper_test.py
+++ b/src/backend/common/helpers/tests/webcast_helper_test.py
@@ -33,7 +33,4 @@ from backend.common.helpers.webcast_helper import (
 )
 def test_youtube_webcast_dict_from_url(url: str) -> None:
     webcast = WebcastParser.webcast_dict_from_url(url)
-    assert (
-        webcast is not None and
-        webcast["channel"] == "1v8_2dW7Kik"
-    )
+    assert webcast is not None and webcast["channel"] == "1v8_2dW7Kik"

--- a/src/backend/common/helpers/webcast_helper.py
+++ b/src/backend/common/helpers/webcast_helper.py
@@ -105,7 +105,7 @@ class WebcastParser:
     def _parse_youtube_channel(cls, url: str) -> Optional[str]:
         youtube_id = None
         # youtu.be/video-id or youtube.com/live/video-id
-        regex1 = re.match(r".*(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]*)", url)
+        regex1 = re.match(r"(?:https?:\/\/)?(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})", url)
         if regex1 is not None:
             youtube_id = regex1.group(1)
         else:

--- a/src/backend/common/helpers/webcast_helper.py
+++ b/src/backend/common/helpers/webcast_helper.py
@@ -105,7 +105,7 @@ class WebcastParser:
     def _parse_youtube_channel(cls, url: str) -> Optional[str]:
         youtube_id = None
         # youtu.be/video-id or youtube.com/live/video-id
-        regex1 = re.match(r"(?:https?:\/\/)?(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})", url)
+        regex1 = re.match(r"(?:https?:\/\/)?(?:www.)?(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})", url)
         if regex1 is not None:
             youtube_id = regex1.group(1)
         else:

--- a/src/backend/common/helpers/webcast_helper.py
+++ b/src/backend/common/helpers/webcast_helper.py
@@ -105,12 +105,12 @@ class WebcastParser:
     def _parse_youtube_channel(cls, url: str) -> Optional[str]:
         youtube_id = None
         # youtu.be/video-id or youtube.com/live/video-id
-        regex1 = re.match(r".*(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]*)", url)
+        regex1 = re.match(r".*(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})", url)
         if regex1 is not None:
             youtube_id = regex1.group(1)
         else:
             # youtube.com/watch?v=video-id
-            regex2 = re.match(r".*v=([a-zA-Z0-9_-]*)", url)
+            regex2 = re.match(r".*v=([a-zA-Z0-9_-]{11})", url)
             if regex2 is not None:
                 youtube_id = regex2.group(1)
 

--- a/src/backend/common/helpers/webcast_helper.py
+++ b/src/backend/common/helpers/webcast_helper.py
@@ -104,10 +104,12 @@ class WebcastParser:
     @classmethod
     def _parse_youtube_channel(cls, url: str) -> Optional[str]:
         youtube_id = None
-        regex1 = re.match(r".*youtu\.be\/(.*)", url)
+        # youtu.be/video-id or youtube.com/live/video-id
+        regex1 = re.match(r".*(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]*)", url)
         if regex1 is not None:
             youtube_id = regex1.group(1)
         else:
+            # youtube.com/watch?v=video-id
             regex2 = re.match(r".*v=([a-zA-Z0-9_-]*)", url)
             if regex2 is not None:
                 youtube_id = regex2.group(1)

--- a/src/backend/common/helpers/webcast_helper.py
+++ b/src/backend/common/helpers/webcast_helper.py
@@ -105,7 +105,10 @@ class WebcastParser:
     def _parse_youtube_channel(cls, url: str) -> Optional[str]:
         youtube_id = None
         # youtu.be/video-id or youtube.com/live/video-id
-        regex1 = re.match(r"(?:https?:\/\/)?(?:www.)?(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})", url)
+        regex1 = re.match(
+            r"(?:https?:\/\/)?(?:www.)?(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})",
+            url,
+        )
         if regex1 is not None:
             youtube_id = regex1.group(1)
         else:

--- a/src/backend/common/helpers/webcast_helper.py
+++ b/src/backend/common/helpers/webcast_helper.py
@@ -105,12 +105,12 @@ class WebcastParser:
     def _parse_youtube_channel(cls, url: str) -> Optional[str]:
         youtube_id = None
         # youtu.be/video-id or youtube.com/live/video-id
-        regex1 = re.match(r".*(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]{11})", url)
+        regex1 = re.match(r".*(?:youtu\.be|youtube.com\/live)\/([a-zA-Z0-9_-]*)", url)
         if regex1 is not None:
             youtube_id = regex1.group(1)
         else:
             # youtube.com/watch?v=video-id
-            regex2 = re.match(r".*v=([a-zA-Z0-9_-]{11})", url)
+            regex2 = re.match(r".*v=([a-zA-Z0-9_-]*)", url)
             if regex2 is not None:
                 youtube_id = regex2.group(1)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the regex for parsing YouTube webcasts to support the alternative `https://youtube.com/live/video-id?si=tracking-id` URL

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is the format that YouTube gives you when you share a livestream, currently to add a YouTube webcast you have to modify the URL to match one of the expected formats

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with regexr

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
