### PR TITLE
fix typed_tasklet type hints

### DIFF
--- a/src/backend/common/helpers/firebase_pusher.py
+++ b/src/backend/common/helpers/firebase_pusher.py
@@ -295,9 +295,9 @@ class FirebasePusher:
 
     @classmethod
     @typed_toplevel
-    def _update_live_events_helper(cls) -> Generator[Any, Any, Dict[EventKey, Dict]]:
+    def _update_live_events_helper(cls) -> Generator[Any, Any, Dict[EventKey, Event]]:
         week_events = EventHelper.week_events()
-        events_by_key: Dict[EventKey, Dict] = {}
+        events_by_key: Dict[EventKey, Event] = {}
         live_events: List[Event] = []
         webcast_status_futures: List[TypedFuture[None]] = []
         for event in week_events:

--- a/src/backend/common/tasklets.py
+++ b/src/backend/common/tasklets.py
@@ -1,23 +1,22 @@
-from typing import Callable, cast, Generator, Iterable, TypeVar, Union
+from typing import Any, Callable, cast, Generator, Iterable, ParamSpec, TypeVar, Union
 
 from google.appengine.ext import ndb
-from pyre_extensions import ParameterSpecification
 
 from backend.common.futures import TypedFuture
 
-TParams = ParameterSpecification("TParams")
+TParams = ParamSpec("TParams")
 TReturn = TypeVar("TReturn")
 
 
 def typed_tasklet(
     f: Callable[
-        TParams, Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]
+        TParams, Union[TReturn, Iterable[TReturn], Generator[Any, Any, TReturn]]
     ],
 ) -> Callable[TParams, TypedFuture[TReturn]]:
     @ndb.tasklet
     def inner(
         *args: TParams.args, **kwargs: TParams.kwargs
-    ) -> Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]:
+    ) -> Union[TReturn, Iterable[TReturn], Generator[Any, Any, TReturn]]:
         return f(*args, **kwargs)
 
     return cast(Callable[TParams, TypedFuture[TReturn]], inner)
@@ -25,13 +24,13 @@ def typed_tasklet(
 
 def typed_toplevel(
     f: Callable[
-        TParams, Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]
+        TParams, Union[TReturn, Iterable[TReturn], Generator[Any, Any, TReturn]]
     ],
 ) -> Callable[TParams, TReturn]:
     @ndb.toplevel
     def inner(
         *args: TParams.args, **kwargs: TParams.kwargs
-    ) -> Union[TReturn, Iterable[TReturn], Generator[TReturn, None, None]]:
+    ) -> Union[TReturn, Iterable[TReturn], Generator[Any, Any, TReturn]]:
         return f(*args, **kwargs)
 
     return cast(Callable[TParams, TReturn], inner)


### PR DESCRIPTION
This updates the `typed_tasklet` decorator to use modern python's `ParamSpec` (instead of the original experimental pyre one), and fixes some bugs along the way