### PR TITLE
Add insight delete task endpoint

### DIFF
--- a/src/backend/tasks_cpu/handlers/insights.py
+++ b/src/backend/tasks_cpu/handlers/insights.py
@@ -280,3 +280,15 @@ def enqueue_all_insights_of_kind(kind: str) -> Response:
         )
 
     return make_response("")
+
+
+@blueprint.route("/backend-tasks-b2/math/do/insights/delete/<name>")
+def do_insights_delete(name: str) -> Response:
+    """
+    Deletes an insight from the datastore.
+    """
+
+    old_insight_keys = Insight.query(Insight.name == name).fetch(keys_only=True)
+    InsightManipulator.delete_keys(old_insight_keys)
+
+    return make_response("")


### PR DESCRIPTION
Adds an endpoint that can be used to delete insights, as currently there's no way to do it besides going into GAE console and manually doing it.

This does it by name, so all years attached to a name will be deleted.