### PR TITLE
Updates short names for 2025 DCMP divisions

### DIFF
--- a/src/backend/common/helpers/event_short_name_helper.py
+++ b/src/backend/common/helpers/event_short_name_helper.py
@@ -60,6 +60,8 @@ class EventShortNameHelper:
                 "".join(item[0].upper() for item in event_name.split()),
                 division_name,
             )
+            # Remove "presented by"
+            short_name = short_name.split("presented by")[0].strip()
             return short_name
 
         all_district_codes = cls._get_all_district_codes()

--- a/src/backend/common/helpers/tests/event_short_name_helper_test.py
+++ b/src/backend/common/helpers/tests/event_short_name_helper_test.py
@@ -982,6 +982,13 @@ def test_event_get_short_name():
         == "NEDC - MEIR"
     )
     assert (
+        EventShortNameHelper.get_short_name(
+            "New England FIRST District Championship - Ballard Division presented by Altair",
+            event_type=EventType.DISTRICT_CMP_DIVISION,
+        )
+        == "NEDC - Ballard"
+    )
+    assert (
         EventShortNameHelper.get_short_name("FIRST Indiana State Championship")
         == "Indiana"
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the "presented by" is in the short name for New England DCMP Divisions.

## Motivation and Context
This makes the short names match how they look for other years, and aligns removing the "presented by" text like is done for regionals or other events.

## How Has This Been Tested?
A unit test was added for this case

## Screenshots (if appropriate):
This is how it looks right now:
<img width="142" alt="Screenshot 2025-04-01 at 7 15 06 PM" src="https://github.com/user-attachments/assets/cfc43433-5231-449f-9bc4-2fe1ebabae02" />

And this is how it looked in 2024:
<img width="152" alt="Screenshot 2025-04-01 at 7 15 13 PM" src="https://github.com/user-attachments/assets/bd03ea40-6ea4-428e-ab63-bcd86be232a4" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
