### PR TITLE
show queue status from nexus in upcoming match table

### DIFF
--- a/src/frontend/liveevent/components/UpcomingMatchesTable.js
+++ b/src/frontend/liveevent/components/UpcomingMatchesTable.js
@@ -31,10 +31,12 @@ class UpcomingMatchesTable extends React.PureComponent {
     const matchRows = [];
     this.props.matches.forEach((match) => {
       let etaStr = "?";
+      let queueString = match.q;
+
       if (this.state.currentTime && match.pt) {
         const etaMin = (match.pt - this.state.currentTime) / 60;
         if (etaMin < 2) {
-          etaStr = "<2 min";
+          etaStr = queueString ? queueString : "<2 min";
         } else if (etaMin > 120) {
           etaStr = `~${Math.round(etaMin / 60)} h`;
         } else {


### PR DESCRIPTION
If a match is predicted to happen immanently, and we have queuing status from nexus, display that

eg:

![image](https://github.com/user-attachments/assets/b2ebf4a3-2bf9-417c-9ac3-725cf2e7e0a3)
