### PR TITLE
Fix 2025 ranking point statistics

### DIFF
--- a/src/backend/common/helpers/event_insights_helper.py
+++ b/src/backend/common/helpers/event_insights_helper.py
@@ -65,6 +65,7 @@ class EventInsightsHelper:
         coral_rp_count = 0
         coopertition_count = 0
         six_rp_count = 0
+        nine_rp_count = 0
 
         total_scores = 0
         total_win_margins = 0
@@ -113,18 +114,13 @@ class EventInsightsHelper:
             if blue_sb["coopertitionCriteriaMet"]:
                 coopertition_count += 1
 
-            if (
-                red_sb["autoBonusAchieved"]
-                and red_sb["bargeBonusAchieved"]
-                and red_sb["coralBonusAchieved"]
-            ):
+            red_all_rp = red_sb["autoBonusAchieved"] and red_sb["bargeBonusAchieved"] and red_sb["coralBonusAchieved"]
+            blue_all_rp = blue_sb["autoBonusAchieved"] and blue_sb["bargeBonusAchieved"] and blue_sb["coralBonusAchieved"]
+
+            if (red_score > blue_score and red_all_rp) or (blue_score > red_score and blue_all_rp):
                 six_rp_count += 1
-            if (
-                blue_sb["autoBonusAchieved"]
-                and blue_sb["bargeBonusAchieved"]
-                and blue_sb["coralBonusAchieved"]
-            ):
-                six_rp_count += 1
+                if (red_all_rp and blue_all_rp):
+                    nine_rp_count += 1
 
             total_scores += red_score + blue_score
             total_win_margins += win_score - min(red_score, blue_score)
@@ -156,8 +152,13 @@ class EventInsightsHelper:
             ],
             "six_rp_count": [
                 six_rp_count,
-                finished_matches * 2,
-                100.0 * six_rp_count / (finished_matches * 2),
+                finished_matches,
+                100.0 * six_rp_count / finished_matches,
+            ],
+            "nine_rp_count": [
+                nine_rp_count,
+                finished_matches,
+                100.0 * nine_rp_count / finished_matches,
             ],
             "average_score": total_scores / (finished_matches * 2),
             "average_win_margin": total_win_margins / finished_matches,

--- a/src/backend/web/templates/event_partials/event_insights_2025.html
+++ b/src/backend/web/templates/event_partials/event_insights_2025.html
@@ -47,6 +47,13 @@
           <td>{{event_insights.six_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.six_rp_count[2])}}%</td>
         </tr>
+
+        <tr>
+          <td>9 RP</td>
+          <td>{{event_insights.nine_rp_count[0]}}</td>
+          <td>{{event_insights.nine_rp_count[1]}}</td>
+          <td>{{'%0.2f' | format(event_insights.nine_rp_count[2])}}%</td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION

## Description
Corrects the 6RP statistic to count only for the winning alliance, adds a 9RP statistic to show the number of matches where all 9RP were achieved

## Motivation and Context
Resolves #7441

## How Has This Been Tested?
Local TBA instance with 2025pncmp data. 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/f03c6808-30da-40c8-a89d-bb4d1fa5e001)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
