### PR TITLE
Add longest qualifying event win streak insight

### DIFF
--- a/src/backend/common/helpers/insights_leaderboard_team_helper.py
+++ b/src/backend/common/helpers/insights_leaderboard_team_helper.py
@@ -27,6 +27,7 @@ class InsightsLeaderboardTeamHelper:
                 InsightsLeaderboardTeamHelper._longest_einstein_streak,
                 InsightsLeaderboardTeamHelper._most_non_champs_impact_wins,
                 InsightsLeaderboardTeamHelper._most_wffas,
+                InsightsLeaderboardTeamHelper._longest_qualifying_event_streak,
             ],
         )
 
@@ -214,5 +215,42 @@ class InsightsLeaderboardTeamHelper:
         return make_leaderboard_from_dict_counts(
             longest_streaks,
             Insight.TYPED_LEADERBOARD_LONGEST_EINSTEIN_STREAK,
+            arguments.year,
+        )
+
+    @staticmethod
+    def _longest_qualifying_event_streak(
+        arguments: LeaderboardInsightArguments,
+    ) -> Optional[Insight]:
+        if arguments.year != 0:
+            return None
+
+        arguments.events.sort(key=lambda e: e.start_date)
+
+        active_streaks = defaultdict(int)
+        longest_streaks = defaultdict(int)
+
+        for event in arguments.events:
+            if event.event_type_enum not in [EventType.DISTRICT, EventType.REGIONAL]:
+                continue
+
+            winners = set()
+            for award in event.awards:
+                if award.award_type_enum == AwardType.WINNER:
+                    for team_key in award.team_list:
+                        active_streaks[team_key.string_id()] += 1
+                        longest_streaks[team_key.string_id()] = max(
+                            longest_streaks[team_key.string_id()],
+                            active_streaks[team_key.string_id()],
+                        )
+                        winners.add(team_key.string_id())
+
+            for team in event.teams:
+                if team.key_name not in winners and active_streaks[team.key_name] > 0:
+                    active_streaks[team.key_name] = 0
+
+        return make_leaderboard_from_dict_counts(
+            {k: v for k, v in longest_streaks.items() if v > 1},
+            Insight.TYPED_LEADERBOARD_LONGEST_QUALIFYING_EVENT_STREAK,
             arguments.year,
         )

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -61,6 +61,7 @@ class Insight(CachedModel):
     TYPED_LEADERBOARD_MOST_NON_CHAMPS_IMPACT_WINS = 40
     TYPED_LEADERBOARD_MOST_WFFAS = 41
     SUCCESSFUL_EINSTEIN_TEAMUPS = 42
+    TYPED_LEADERBOARD_LONGEST_QUALIFYING_EVENT_STREAK = 43
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -111,6 +112,7 @@ class Insight(CachedModel):
         TYPED_NOTABLES_CMP_FINALS_APPEARANCES: "notables_cmp_finals_appearances",
         TYPED_LEADERBOARD_MOST_NON_CHAMPS_IMPACT_WINS: "typed_leaderboard_most_non_champs_impact_wins",
         TYPED_LEADERBOARD_MOST_WFFAS: "typed_leaderboard_most_wffas",
+        TYPED_LEADERBOARD_LONGEST_QUALIFYING_EVENT_STREAK: "typed_leaderboard_longest_qualifying_event_streak",
     }
 
     TYPED_LEADERBOARD_KEY_TYPES: Dict[int, LeaderboardKeyType] = {
@@ -127,6 +129,7 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_LONGEST_EINSTEIN_STREAK: "team",
         TYPED_LEADERBOARD_MOST_NON_CHAMPS_IMPACT_WINS: "team",
         TYPED_LEADERBOARD_MOST_WFFAS: "team",
+        TYPED_LEADERBOARD_LONGEST_QUALIFYING_EVENT_STREAK: "team",
     }
 
     NOTABLE_INSIGHTS = {


### PR DESCRIPTION
Adds longest qualifying event win streak insight. Qualifying events are districts or regionals.  It excludes DCMP and CMP.