### PR TITLE
Add YT and Twitch icons to GameDay

### DIFF
--- a/src/frontend/gameday2/components/PlatformIcon.js
+++ b/src/frontend/gameday2/components/PlatformIcon.js
@@ -1,0 +1,25 @@
+import React from "react";
+import PropTypes from "prop-types";
+import YouTubeIcon from "./icons/YouTubeIcon";
+import TwitchIcon from "./icons/TwitchIcon";
+
+export default class PlatformIcon extends React.Component {
+  static propTypes = {
+    platform: PropTypes.string.isRequired,
+  };
+
+  static iconStyle = {
+    position: "absolute",
+    top: 0,
+    left: "5px",
+    margin: "12px",
+  };
+
+  render() {
+    if (this.props.platform === "youtube")
+      return <YouTubeIcon style={iconStyle} />;
+    if (this.props.platform === "twitch")
+      return <TwitchIcon style={iconStyle} />;
+    return <></>; // If we don't have a logo for this platform, leave an empty space
+  }
+}

--- a/src/frontend/gameday2/components/PlatformIcon.js
+++ b/src/frontend/gameday2/components/PlatformIcon.js
@@ -8,18 +8,9 @@ export default class PlatformIcon extends React.Component {
     platform: PropTypes.string.isRequired,
   };
 
-  static iconStyle = {
-    position: "absolute",
-    top: 0,
-    left: "5px",
-    margin: "12px",
-  };
-
   render() {
-    if (this.props.platform === "youtube")
-      return <YouTubeIcon style={iconStyle} />;
-    if (this.props.platform === "twitch")
-      return <TwitchIcon style={iconStyle} />;
+    if (this.props.platform === "youtube") return <YouTubeIcon />;
+    if (this.props.platform === "twitch") return <TwitchIcon />;
     return <></>; // If we don't have a logo for this platform, leave an empty space
   }
 }

--- a/src/frontend/gameday2/components/WebcastSelectionDialog.js
+++ b/src/frontend/gameday2/components/WebcastSelectionDialog.js
@@ -49,7 +49,18 @@ export default class WebcastSelectionDialog extends React.Component {
     availableWebcasts.forEach((webcastId) => {
       const webcast = this.props.webcastsById[webcastId];
 
-      let leftIcon = <PlatformIcon platform={webcast.type} />;
+      let leftIcon = (
+        <div
+          className="test12323"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+          }}
+        >
+          <PlatformIcon platform={webcast.type} />
+        </div>
+      );
       let rightIcon = <ActionHelp />;
       let secondaryText = null;
       if (webcast.status === "online") {

--- a/src/frontend/gameday2/components/WebcastSelectionDialog.js
+++ b/src/frontend/gameday2/components/WebcastSelectionDialog.js
@@ -12,6 +12,7 @@ import VideoCam from "material-ui/svg-icons/av/videocam";
 import VideoCamOff from "material-ui/svg-icons/av/videocam-off";
 import WebcastSelectionDialogItem from "./WebcastSelectionDialogItem";
 import { webcastPropType } from "../utils/webcastUtils";
+import PlatformIcon from "./PlatformIcon";
 
 export default class WebcastSelectionDialog extends React.Component {
   static propTypes = {
@@ -48,6 +49,7 @@ export default class WebcastSelectionDialog extends React.Component {
     availableWebcasts.forEach((webcastId) => {
       const webcast = this.props.webcastsById[webcastId];
 
+      let leftIcon = <PlatformIcon platform={webcast.type} />;
       let rightIcon = <ActionHelp />;
       let secondaryText = null;
       if (webcast.status === "online") {
@@ -89,6 +91,7 @@ export default class WebcastSelectionDialog extends React.Component {
             webcast={webcast}
             webcastSelected={this.props.onWebcastSelected}
             secondaryText={secondaryText}
+            leftIcon={leftIcon}
             rightIcon={rightIcon}
           />
         );
@@ -104,6 +107,7 @@ export default class WebcastSelectionDialog extends React.Component {
             webcast={webcast}
             webcastSelected={this.props.onWebcastSelected}
             secondaryText={"The best matches from across FRC"}
+            leftIcon={leftIcon}
             rightIcon={<ActionGrade color={indigo500} />}
           />
         );
@@ -114,6 +118,7 @@ export default class WebcastSelectionDialog extends React.Component {
             webcast={webcast}
             webcastSelected={this.props.onWebcastSelected}
             secondaryText={secondaryText}
+            leftIcon={leftIcon}
             rightIcon={rightIcon}
           />
         );

--- a/src/frontend/gameday2/components/WebcastSelectionDialogItem.js
+++ b/src/frontend/gameday2/components/WebcastSelectionDialogItem.js
@@ -7,6 +7,7 @@ export default class WebcastSelectionDialogItem extends React.Component {
     webcast: PropTypes.object.isRequired,
     webcastSelected: PropTypes.func.isRequired,
     secondaryText: PropTypes.string,
+    leftIcon: PropTypes.element,
     rightIcon: PropTypes.any,
   };
 
@@ -20,7 +21,11 @@ export default class WebcastSelectionDialogItem extends React.Component {
         primaryText={this.props.webcast.name}
         secondaryText={this.props.secondaryText}
         onClick={() => this.handleClick()}
+        leftIcon={this.props.leftIcon}
         rightIcon={this.props.rightIcon}
+        innerDivStyle={{
+          paddingLeft: "50px", // Leave room for the left icon
+        }}
       />
     );
   }

--- a/src/frontend/gameday2/components/icons/TwitchIcon.js
+++ b/src/frontend/gameday2/components/icons/TwitchIcon.js
@@ -1,0 +1,18 @@
+import { SvgIcon } from "material-ui";
+import PropTypes from "prop-types";
+import React from "react";
+
+// Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.
+export default class TwitchIcon extends React.Component {
+  static propTypes = {
+    style: PropTypes.object,
+  };
+
+  render() {
+    return (
+      <SvgIcon viewBox="0 0 512 512" style={this.props.style}>
+        <path d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z" />
+      </SvgIcon>
+    );
+  }
+}

--- a/src/frontend/gameday2/components/icons/YouTubeIcon.js
+++ b/src/frontend/gameday2/components/icons/YouTubeIcon.js
@@ -1,4 +1,5 @@
 import { SvgIcon } from "material-ui";
+import PropTypes from "prop-types";
 import React from "react";
 
 // Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.

--- a/src/frontend/gameday2/components/icons/YouTubeIcon.js
+++ b/src/frontend/gameday2/components/icons/YouTubeIcon.js
@@ -1,0 +1,17 @@
+import { SvgIcon } from "material-ui";
+import React from "react";
+
+// Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.
+export default class YouTubeIcon extends React.Component {
+  static propTypes = {
+    style: PropTypes.object,
+  };
+
+  render() {
+    return (
+      <SvgIcon viewBox="0 0 576 512" style={this.props.style}>
+        <path d="M549.7 124.1c-6.3-23.7-24.8-42.3-48.3-48.6C458.8 64 288 64 288 64S117.2 64 74.6 75.5c-23.5 6.3-42 24.9-48.3 48.6-11.4 42.9-11.4 132.3-11.4 132.3s0 89.4 11.4 132.3c6.3 23.7 24.8 41.5 48.3 47.8C117.2 448 288 448 288 448s170.8 0 213.4-11.5c23.5-6.3 42-24.2 48.3-47.8 11.4-42.9 11.4-132.3 11.4-132.3s0-89.4-11.4-132.3zm-317.5 213.5V175.2l142.7 81.2-142.7 81.2z" />
+      </SvgIcon>
+    );
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds icons for YouTube and Twitch streams to the webcast selector in GameDay. Other live streaming platforms will not show an icon but still be aligned with other streams that do have one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Implements a suggestion [discussed in Slack](https://the-blue-alliance.slack.com/archives/C15SUFL92/p1744167915448729?thread_ts=1744167594.938749&cid=C15SUFL92), this allows users to see at a glance which streaming platform a webcast is using.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using a local version of Firebase. Would definitely appreciate a maintainer taking a good look at this since I had to stub out some of the Twitch/YouTube online status stuff to get it running!

## Screenshots (if appropriate):
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/9c7099f3-5713-4583-b774-41d64c2bbf2b" />
<img width="341" alt="image" src="https://github.com/user-attachments/assets/9bc2ae8f-9c6c-4c9e-ab63-25565c02e72d" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
