### PR TITLE
Resolve CMP division overrides in truted API

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -8,6 +8,7 @@ from backend.api.client_api_types import VoidRequest
 from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
 from backend.common.auth import current_user
 from backend.common.consts.auth_type import AuthType
+from backend.common.consts.event_code_exceptions import EventCodeExceptions
 from backend.common.consts.renamed_districts import RenamedDistricts
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.district import District
@@ -131,6 +132,7 @@ def validate_keys(func):
 
             event_future = None
             if event_key:
+                event_key = EventCodeExceptions.resolve(event_key)
                 event_future = Event.get_by_id_async(event_key)
 
             match_future = None

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -24,6 +24,7 @@ from backend.api.handlers.decorators import require_write_auth, validate_keys
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.common.consts.alliance_color import ALLIANCE_COLORS, AllianceColor
 from backend.common.consts.auth_type import AuthType
+from backend.common.consts.event_code_exceptions import EventCodeExceptions
 from backend.common.consts.media_type import MediaType
 from backend.common.futures import TypedFuture
 from backend.common.helpers.deferred import defer_safe
@@ -52,6 +53,7 @@ from backend.common.models.zebra_motionworks import ZebraMotionWorks
 @require_write_auth({AuthType.EVENT_TEAMS})
 @validate_keys
 def update_teams(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     team_key_names = JSONTeamListParser.parse(request.data)
     team_keys = [ndb.Key(Team, key_name) for key_name in team_key_names]
 
@@ -89,6 +91,7 @@ def update_teams(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.MATCH_VIDEO})
 @validate_keys
 def add_match_video(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     match_key_to_video = JSONMatchVideoParser.parse(event_key, request.data)
     match_keys = [ndb.Key(Match, k) for k in match_key_to_video.keys()]
     match_futures: List[TypedFuture[Match]] = ndb.get_multi_async(match_keys)
@@ -122,6 +125,7 @@ def add_match_video(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_INFO})
 @validate_keys
 def update_event_info(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     parsed_info = JSONEventInfoParser.parse(request.data)
     event: Event = none_throws(Event.get_by_id(event_key))
 
@@ -150,6 +154,7 @@ def update_event_info(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_ALLIANCES})
 @validate_keys
 def update_event_alliances(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     alliance_selections = JSONAllianceSelectionsParser.parse(request.data)
     event: Event = none_throws(Event.get_by_id(event_key))
 
@@ -167,6 +172,7 @@ def update_event_alliances(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_AWARDS})
 @validate_keys
 def update_event_awards(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     awards = JSONAwardsParser.parse(request.data, event_key)
     event: Event = none_throws(Event.get_by_id(event_key))
 
@@ -201,6 +207,7 @@ def update_event_awards(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_MATCHES})
 @validate_keys
 def update_event_matches(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     event: Event = none_throws(Event.get_by_id(event_key))
     parsed_matches = JSONMatchesParser.parse(request.data, event.year)
 
@@ -248,6 +255,7 @@ def update_event_matches(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_MATCHES})
 @validate_keys
 def delete_event_matches(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     keys_to_delete: Set[ndb.Key] = set()
     try:
         match_keys = safe_json.loads(request.data, List[str])
@@ -275,6 +283,7 @@ def delete_event_matches(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_MATCHES})
 @validate_keys
 def delete_all_event_matches(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     if request.data.decode() != event_key:
         return make_response(
             profiled_jsonify(
@@ -296,6 +305,7 @@ def delete_all_event_matches(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.EVENT_RANKINGS})
 @validate_keys
 def update_event_rankings(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     event: Event = none_throws(Event.get_by_id(event_key))
     rankings = JSONRankingsParser.parse(event.year, request.data)
 
@@ -314,6 +324,7 @@ def update_event_rankings(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.MATCH_VIDEO})
 @validate_keys
 def add_event_media(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     event: Event = none_throws(Event.get_by_id(event_key))
 
     video_list = safe_json.loads(request.data, List[str])
@@ -339,6 +350,7 @@ def add_event_media(event_key: EventKey) -> Response:
 @require_write_auth({AuthType.ZEBRA_MOTIONWORKS})
 @validate_keys
 def add_match_zebra_motionworks_info(event_key: EventKey) -> Response:
+    event_key = EventCodeExceptions.resolve(event_key)
     to_put: List[ZebraMotionWorks] = []
     for zebra_data in JSONZebraMotionWorksParser.parse(request.data):
         match_key = zebra_data["key"]

--- a/src/backend/api/trusted_api_auth_helper.py
+++ b/src/backend/api/trusted_api_auth_helper.py
@@ -9,6 +9,7 @@ from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.common.auth import current_user
 from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.auth_type import AuthType, WRITE_TYPE_NAMES
+from backend.common.consts.event_code_exceptions import EventCodeExceptions
 from backend.common.consts.event_type import EventType
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.event import Event
@@ -28,6 +29,7 @@ class TrustedApiAuthHelper:
     def do_trusted_api_auth(
         cls, event_key: EventKey, required_auth_types: Set[AuthType]
     ) -> None:
+        event_key = EventCodeExceptions.resolve(event_key)
         event = Event.get_by_id(event_key)
         if not event:
             abort(

--- a/src/backend/common/consts/event_code_exceptions.py
+++ b/src/backend/common/consts/event_code_exceptions.py
@@ -1,0 +1,43 @@
+from backend.common.models.keys import EventKey
+
+# event_key (code, short_name)
+EVENT_CODE_EXCEPTIONS = {
+    "archimedes": ("arc", "Archimedes"),
+    "arpky": ("arc", "Archimedes"),
+    "carson": ("cars", "Carson"),
+    "carver": ("carv", "Carver"),
+    "curie": ("cur", "Curie"),
+    "cpra": ("cur", "Curie"),
+    "daly": ("dal", "Daly"),
+    "dcmp": ("dal", "Daly"),
+    "darwin": ("dar", "Darwin"),
+    "galileo": ("gal", "Galileo"),
+    "gcmp": ("gal", "Galileo"),
+    "hopper": ("hop", "Hopper"),
+    "hcmp": ("hop", "Hopper"),
+    "jcmp": ("joh", "Johnson"),
+    "mpcia": ("mil", "Milstein"),
+    "newton": ("new", "Newton"),
+    "npfcmp": ("new", "Newton"),
+    "roebling": ("roe", "Roebling"),
+    "tesla": ("tes", "Tesla"),
+    "turing": ("tur", "Turing"),
+    "johnson": ("joh", "Johnson"),
+    "milstein": ("mil", "Milstein"),
+    # For Einstein, format with the name "Einstein" or "FIRST Championship" or whatever
+    "cmp": ("cmp", "{}"),
+    "cmpmi": ("cmpmi", "{} (Detroit)"),
+    "cmpmo": ("cmpmo", "{} (St. Louis)"),
+    "cmptx": ("cmptx", "{} (Houston)"),
+}
+
+
+class EventCodeExceptions:
+
+    @staticmethod
+    def resolve(event_key: EventKey) -> EventKey:
+        year, event_code = (event_key[:4], event_key[4:])
+        if event_code in EVENT_CODE_EXCEPTIONS:
+            return f"{year}{EVENT_CODE_EXCEPTIONS[event_code][0]}"
+
+        return event_key

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -10,7 +10,11 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.consts import event_type
-from backend.common.consts.event_type import CMP_EVENT_TYPES, EventType, SEASON_EVENT_TYPES
+from backend.common.consts.event_type import (
+    CMP_EVENT_TYPES,
+    EventType,
+    SEASON_EVENT_TYPES,
+)
 from backend.common.consts.playoff_type import PlayoffType
 from backend.common.futures import TypedFuture
 from backend.common.memcache_models.webcast_online_status_memcache import (

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from google.appengine.ext import ndb
 
+from backend.common.consts.event_code_exceptions import EVENT_CODE_EXCEPTIONS
 from backend.common.consts.event_type import EventType
 from backend.common.consts.playoff_type import PlayoffType
 from backend.common.helpers.event_short_name_helper import EventShortNameHelper
@@ -50,37 +51,6 @@ class FMSAPIEventListParser(ParserJSON[Tuple[List[Event], List[District]]]):
 
     NON_OFFICIAL_EVENT_TYPES = ["offseason"]
 
-    # event_key (code, short_name)
-    EVENT_CODE_EXCEPTIONS = {
-        "archimedes": ("arc", "Archimedes"),
-        "arpky": ("arc", "Archimedes"),
-        "carson": ("cars", "Carson"),
-        "carver": ("carv", "Carver"),
-        "curie": ("cur", "Curie"),
-        "cpra": ("cur", "Curie"),
-        "daly": ("dal", "Daly"),
-        "dcmp": ("dal", "Daly"),
-        "darwin": ("dar", "Darwin"),
-        "galileo": ("gal", "Galileo"),
-        "gcmp": ("gal", "Galileo"),
-        "hopper": ("hop", "Hopper"),
-        "hcmp": ("hop", "Hopper"),
-        "jcmp": ("joh", "Johnson"),
-        "mpcia": ("mil", "Milstein"),
-        "newton": ("new", "Newton"),
-        "npfcmp": ("new", "Newton"),
-        "roebling": ("roe", "Roebling"),
-        "tesla": ("tes", "Tesla"),
-        "turing": ("tur", "Turing"),
-        "johnson": ("joh", "Johnson"),
-        "milstein": ("mil", "Milstein"),
-        # For Einstein, format with the name "Einstein" or "FIRST Championship" or whatever
-        "cmp": ("cmp", "{}"),
-        "cmpmi": ("cmpmi", "{} (Detroit)"),
-        "cmpmo": ("cmpmo", "{} (St. Louis)"),
-        "cmptx": ("cmptx", "{} (Houston)"),
-    }
-
     EINSTEIN_SHORT_NAME_DEFAULT = "Einstein"
     EINSTEIN_NAME_DEFAULT = "Einstein Field"
     EINSTEIN_CODES = {"cmp", "cmpmi", "cmpmo", "cmptx"}
@@ -93,7 +63,7 @@ class FMSAPIEventListParser(ParserJSON[Tuple[List[Event], List[District]]]):
         # Even though 2022/2023 Einstein is listed as "cmptx", we don't want it to say "(Houston)".
         if season >= 2022 and code == "cmptx":
             return (code, "{}")
-        return self.EVENT_CODE_EXCEPTIONS[code]
+        return EVENT_CODE_EXCEPTIONS[code]
 
     def get_playoff_type(self, year, alliance_count):
         playoff_type = None
@@ -172,7 +142,7 @@ class FMSAPIEventListParser(ParserJSON[Tuple[List[Event], List[District]]]):
             # TODO read timezone from API
 
             # Special cases for champs
-            if code in self.EVENT_CODE_EXCEPTIONS:
+            if code in EVENT_CODE_EXCEPTIONS:
                 code, short_name = self.get_code_and_short_name(self.season, code)
 
                 # FIRST indicates CMP registration before divisions are assigned by adding all teams


### PR DESCRIPTION
This will take away an annual headache we have to do; this will allow FIRST to post videos using the full division name keys (which match frc-events) and not need to maintain their own list of overrides.