### PR TITLE
Mark APIv3 Event.timezone as nullable. Rename District_List to District

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -1,6 +1,6 @@
 /**
  * The Blue Alliance API v3
- * 3.9.15
+ * 3.9.16
  * DO NOT MODIFY - This file has been generated using oazapfts.
  * See https://www.npmjs.com/package/oazapfts
  */
@@ -90,7 +90,7 @@ export type TeamSimple = {
   /** Country of team derived from parsing the address registered with FIRST. */
   country: string | null;
 };
-export type DistrictList = {
+export type District = {
   /** The short identifier for the district. */
   abbreviation: string;
   /** The long name for the district. */
@@ -131,7 +131,7 @@ export type Event = {
   event_code: string;
   /** Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py#L2 */
   event_type: EventType;
-  district: DistrictList | null;
+  district: District | null;
   /** City, town, village, etc. the event is located in. */
   city: string | null;
   /** State or Province the event is located in. */
@@ -165,7 +165,7 @@ export type Event = {
   /** Name of the location at the address for the event, eg. Blue Alliance High School. */
   location_name: string | null;
   /** Timezone name. */
-  timezone: string;
+  timezone: string | null;
   /** The event's website, if any. */
   website: string | null;
   /** The FIRST internal Event ID, used to link to the event on the FRC webpage. */
@@ -223,7 +223,7 @@ export type EventSimple = {
   event_code: string;
   /** Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py#L2 */
   event_type: EventType;
-  district: DistrictList | null;
+  district: District | null;
   /** City, town, village, etc. the event is located in. */
   city: string | null;
   /** State or Province the event is located in. */
@@ -1664,7 +1664,7 @@ export function getTeamDistricts(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: DistrictList[];
+        data: District[];
       }
     | {
         status: 304;
@@ -3683,7 +3683,7 @@ export function getDistrictsByYear(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: DistrictList[];
+        data: District[];
       }
     | {
         status: 304;
@@ -3721,7 +3721,7 @@ export function getDistrictHistory(
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: DistrictList[];
+        data: District[];
       }
     | {
         status: 304;

--- a/pwa/app/lib/utils.tsx
+++ b/pwa/app/lib/utils.tsx
@@ -50,13 +50,13 @@ export async function parseParamsForYearElseDefault(
 export function timestampsAreOnDifferentDays(
   timestamp1: number,
   timestamp2: number,
-  timezone: string,
+  timezone: string | null,
 ): boolean {
   const date1 = new Date(timestamp1 * 1000);
   const date2 = new Date(timestamp2 * 1000);
 
   const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: timezone,
+    timeZone: timezone ?? 'UTC',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',

--- a/pwa/generate-api.sh
+++ b/pwa/generate-api.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
+set -e
+
+# Generate the TypeScript API client
 npx oazapfts ../src/backend/web/static/swagger/api_v3.json --argumentStyle=object > app/api/v3.ts
-sed -i 's/award_type: number/award_type: AwardType/g' app/api/v3.ts
-sed -i 's/event_type: number/event_type: EventType/g' app/api/v3.ts
-sed -i '1i\
-import { AwardType } from '"'"'~/lib/api/AwardType'"'"';\
-import { EventType } from '"'"'~/lib/api/EventType'"'"';' app/api/v3.ts
+
+# Define a function to run sed in Docker
+docker_sed() {
+  docker run --rm -v "$PWD":/work -w /work alpine sed -i "$@"
+}
+
+# Replace types using Dockerized sed
+docker_sed 's/award_type: number/award_type: AwardType/g' app/api/v3.ts
+docker_sed 's/event_type: number/event_type: EventType/g' app/api/v3.ts
+
+# Add imports to the top of the file
+docker run --rm -v "$PWD":/work -w /work alpine sh -c \
+  "sed -i '1i\
+import { AwardType } from \"~/lib/api/AwardType\";\
+import { EventType } from \"~/lib/api/EventType\";' app/api/v3.ts"
+
+# Format the resulting file
 npm run format:fix

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.9.15",
+    "version": "3.9.16",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -746,7 +746,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/District_List"
+                    "$ref": "#/components/schemas/District"
                   }
                 }
               }
@@ -3921,7 +3921,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/District_List"
+                    "$ref": "#/components/schemas/District"
                   }
                 }
               }
@@ -3981,7 +3981,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/District_List"
+                    "$ref": "#/components/schemas/District"
                   }
                 }
               }
@@ -5149,7 +5149,7 @@
           "district": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/District_List"
+                "$ref": "#/components/schemas/District"
               },
               {
                 "type": "null"
@@ -5241,7 +5241,7 @@
           "district": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/District_List"
+                "$ref": "#/components/schemas/District"
               },
               {
                 "type": "null"
@@ -5331,6 +5331,7 @@
           },
           "timezone": {
             "type": "string",
+            "nullable": true,
             "description": "Timezone name."
           },
           "website": {
@@ -9215,7 +9216,7 @@
         },
         "description": "An `Award_Recipient` object represents the team and/or person who received an award at an event."
       },
-      "District_List": {
+      "District": {
         "required": [
           "abbreviation",
           "display_name",


### PR DESCRIPTION
Not all events have timezone information. Additionally, the District model is named `District_List` which is a little wonky.