### PR TITLE
LiveEventPanel/gameday: fix issue where lingering unplayed matches could break sort order

### DIFF
--- a/src/frontend/gameday2/selectors/index.js
+++ b/src/frontend/gameday2/selectors/index.js
@@ -89,6 +89,8 @@ export const getEventMatches = createSelector(
       // if (match.pt) {
       //   time = match.pt
       // }
+      if (!match.c || !match.m || !match.s || !compLevelsPlayOrder[match.c])
+        return 0;
       return compLevelsPlayOrder[match.c] * 100000 + match.m * 100 + match.s;
     }
 

--- a/src/frontend/liveevent/components/LiveEventPanel.js
+++ b/src/frontend/liveevent/components/LiveEventPanel.js
@@ -17,6 +17,8 @@ const compLevelsPlayOrder = {
 };
 
 function playOrder(match) {
+  if (!match.c || !match.m || !match.s || !compLevelsPlayOrder[match.c])
+    return 0;
   return compLevelsPlayOrder[match.c] * 100000 + match.m * 100 + match.s;
 }
 


### PR DESCRIPTION
## Description

2025cur still has f1m3 in Firebase (unsure why - possibly because sf3m2 happened). This is missing the comp_level/set_number/match_number fields (c/s/m in Firebase), so this match's sort order on the frontend gets calculated as `NaN`, which breaks the sorting of everything. Because matches are returned from Firebase in alphabetical order, in practice this means that semifinals end up displayed last.

This does not fix the issue of sf3m2 sorting after sf13m1 (a remnant of the old single-elim bracket) - that is a separate (maaaybe related) issue that likely warrants a bit more discussion.


## How Has This Been Tested?
Local with `2025cur`. Also confirmed no regressions on `2025dal`.


## Screenshots (if appropriate):

Before:

<details>

![image](https://github.com/user-attachments/assets/6626fca9-7e76-4631-801f-82018db2521d)


![image](https://github.com/user-attachments/assets/1d91d482-f1d3-43f4-89a5-3f9414b8f79e)

</details>

After:

<details>

![image](https://github.com/user-attachments/assets/97b17c37-66cb-4a88-8601-0dd9331c485b)

![image](https://github.com/user-attachments/assets/cdf2842e-d4ca-4545-8f5a-d11186be2f1c)


</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
