### PR TITLE
Add district-specific insights

### DIFF
--- a/pwa/app/api/tba/@tanstack/react-query.gen.ts
+++ b/pwa/app/api/tba/@tanstack/react-query.gen.ts
@@ -10,6 +10,7 @@ import {
   getDistrictEventsKeys,
   getDistrictEventsSimple,
   getDistrictHistory,
+  getDistrictInsights,
   getDistrictRankings,
   getDistrictTeams,
   getDistrictTeamsKeys,
@@ -91,6 +92,7 @@ import type {
   GetDistrictEventsKeysData,
   GetDistrictEventsSimpleData,
   GetDistrictHistoryData,
+  GetDistrictInsightsData,
   GetDistrictRankingsData,
   GetDistrictTeamsData,
   GetDistrictTeamsKeysData,
@@ -1676,6 +1678,30 @@ export const getDistrictHistoryOptions = (
       return data;
     },
     queryKey: getDistrictHistoryQueryKey(options),
+  });
+};
+
+export const getDistrictInsightsQueryKey = (
+  options: Options<GetDistrictInsightsData>,
+) => createQueryKey('getDistrictInsights', options);
+
+/**
+ * Gets insights for a given district.
+ */
+export const getDistrictInsightsOptions = (
+  options: Options<GetDistrictInsightsData>,
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getDistrictInsights({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getDistrictInsightsQueryKey(options),
   });
 };
 

--- a/pwa/app/api/tba/sdk.gen.ts
+++ b/pwa/app/api/tba/sdk.gen.ts
@@ -27,6 +27,9 @@ import type {
   GetDistrictHistoryData,
   GetDistrictHistoryErrors,
   GetDistrictHistoryResponses,
+  GetDistrictInsightsData,
+  GetDistrictInsightsErrors,
+  GetDistrictInsightsResponses,
   GetDistrictRankingsData,
   GetDistrictRankingsErrors,
   GetDistrictRankingsResponses,
@@ -252,6 +255,7 @@ import {
   zGetDistrictEventsResponse,
   zGetDistrictEventsSimpleResponse,
   zGetDistrictHistoryResponse,
+  zGetDistrictInsightsResponse,
   zGetDistrictRankingsResponse,
   zGetDistrictTeamsKeysResponse,
   zGetDistrictTeamsResponse,
@@ -1949,6 +1953,31 @@ export const getDistrictHistory = <ThrowOnError extends boolean = false>(
       return await zGetDistrictHistoryResponse.parseAsync(data);
     },
     url: '/district/{district_abbreviation}/history',
+    ...options,
+  });
+};
+
+/**
+ * Gets insights for a given district.
+ */
+export const getDistrictInsights = <ThrowOnError extends boolean = false>(
+  options: Options<GetDistrictInsightsData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetDistrictInsightsResponses,
+    GetDistrictInsightsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        name: 'X-TBA-Auth-Key',
+        type: 'apiKey',
+      },
+    ],
+    responseValidator: async (data) => {
+      return await zGetDistrictInsightsResponse.parseAsync(data);
+    },
+    url: '/district/{district_abbreviation}/insights',
     ...options,
   });
 };

--- a/pwa/app/api/tba/types.gen.ts
+++ b/pwa/app/api/tba/types.gen.ts
@@ -2066,6 +2066,46 @@ export type District = {
   year: number;
 };
 
+export type DistrictInsight = {
+  district_data: {
+    /**
+     * Map of year to number of active teams
+     */
+    yearly_active_team_count: {
+      [key: string]: number;
+    };
+    /**
+     * Map of year to number of events
+     */
+    yearly_event_count: {
+      [key: string]: number;
+    };
+    /**
+     * Map of year to list of team keys gained
+     */
+    yearly_gained_teams: {
+      [key: string]: Array<string>;
+    };
+    /**
+     * Map of year to list of team keys lost
+     */
+    yearly_lost_teams: {
+      [key: string]: Array<string>;
+    };
+  };
+  team_data: {
+    district_seasons: number;
+    total_district_points: number;
+    total_pre_dcmp_district_points: number;
+    district_event_wins: number;
+    dcmp_wins: number;
+    team_awards: number;
+    individual_awards: number;
+    quals_record: WltRecord;
+    elims_record: WltRecord;
+  };
+};
+
 /**
  * Rank of a team in a district.
  */
@@ -5438,6 +5478,53 @@ export type GetDistrictHistoryResponses = {
 
 export type GetDistrictHistoryResponse =
   GetDistrictHistoryResponses[keyof GetDistrictHistoryResponses];
+
+export type GetDistrictInsightsData = {
+  body?: never;
+  headers?: {
+    /**
+     * Value of the `ETag` header in the most recently cached response by the client.
+     */
+    'If-None-Match'?: string;
+  };
+  path: {
+    /**
+     * District abbreviation, eg `ne` or `fim`
+     */
+    district_abbreviation: string;
+  };
+  query?: never;
+  url: '/district/{district_abbreviation}/insights';
+};
+
+export type GetDistrictInsightsErrors = {
+  /**
+   * Authorization information is missing or invalid.
+   */
+  401: {
+    /**
+     * Authorization error description.
+     */
+    Error: string;
+  };
+  /**
+   * Not Found
+   */
+  404: unknown;
+};
+
+export type GetDistrictInsightsError =
+  GetDistrictInsightsErrors[keyof GetDistrictInsightsErrors];
+
+export type GetDistrictInsightsResponses = {
+  /**
+   * Successful response
+   */
+  200: DistrictInsight;
+};
+
+export type GetDistrictInsightsResponse =
+  GetDistrictInsightsResponses[keyof GetDistrictInsightsResponses];
 
 export type GetDistrictEventsData = {
   body?: never;

--- a/pwa/app/api/tba/zod.gen.ts
+++ b/pwa/app/api/tba/zod.gen.ts
@@ -1170,6 +1170,26 @@ export const zAward = z.object({
   year: z.number().int(),
 });
 
+export const zDistrictInsight = z.object({
+  district_data: z.object({
+    yearly_active_team_count: z.object({}),
+    yearly_event_count: z.object({}),
+    yearly_gained_teams: z.object({}),
+    yearly_lost_teams: z.object({}),
+  }),
+  team_data: z.object({
+    district_seasons: z.number().int(),
+    total_district_points: z.number().int(),
+    total_pre_dcmp_district_points: z.number().int(),
+    district_event_wins: z.number().int(),
+    dcmp_wins: z.number().int(),
+    team_awards: z.number().int(),
+    individual_awards: z.number().int(),
+    quals_record: zWltRecord,
+    elims_record: zWltRecord,
+  }),
+});
+
 /**
  * Rank of a team in a district.
  */
@@ -2405,6 +2425,21 @@ export const zGetDistrictHistoryParameterDistrictAbbreviation = z.string();
  * Successful response
  */
 export const zGetDistrictHistoryResponse = z.array(zDistrict);
+
+/**
+ * Value of the `ETag` header in the most recently cached response by the client.
+ */
+export const zGetDistrictInsightsParameterIfNoneMatch = z.string();
+
+/**
+ * District abbreviation, eg `ne` or `fim`
+ */
+export const zGetDistrictInsightsParameterDistrictAbbreviation = z.string();
+
+/**
+ * Successful response
+ */
+export const zGetDistrictInsightsResponse = zDistrictInsight;
 
 /**
  * Value of the `ETag` header in the most recently cached response by the client.

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -21,6 +21,7 @@ from backend.api.handlers.district import (
     district_awards,
     district_events,
     district_history,
+    district_insights,
     district_list_year,
     district_rankings,
     district_teams,
@@ -153,6 +154,10 @@ api_v3.add_url_rule(
 api_v3.add_url_rule(
     "/district/<string:district_abbreviation>/dcmp_history",
     view_func=dcmp_history,
+)
+api_v3.add_url_rule(
+    "/district/<string:district_abbreviation>/insights",
+    view_func=district_insights,
 )
 
 # District List

--- a/src/backend/common/consts/insight_type.py
+++ b/src/backend/common/consts/insight_type.py
@@ -8,3 +8,4 @@ class InsightType(StrEnum):
     MATCHES = "matches"
     AWARDS = "awards"
     PREDICTIONS = "predictions"
+    DISTRICTS = "districts"

--- a/src/backend/common/consts/renamed_districts.py
+++ b/src/backend/common/consts/renamed_districts.py
@@ -2,19 +2,28 @@ from typing import Any, Dict, Generator, List
 
 from google.appengine.ext import ndb
 
+from backend.common.models.district import ALL_KNOWN_DISTRICT_ABBREVIATIONS
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey
 
-CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
+OLD_TO_NEW_CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
     # Old to new
     "mar": "fma",
     "nc": "fnc",
     "in": "fin",
     "tx": "fit",
+}
+
+NEW_TO_OLD_CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
     # New to old
     "fma": "mar",
     "fnc": "nc",
     "fin": "in",
     "fit": "tx",
+}
+
+CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
+    **OLD_TO_NEW_CODE_MAP,
+    **NEW_TO_OLD_CODE_MAP,
 }
 
 
@@ -35,6 +44,14 @@ class RenamedDistricts:
             "{}{}".format(year, equiv_code)
             for equiv_code in cls.get_equivalent_codes(code)
         ]
+
+    @classmethod
+    def get_latest_codes(cls) -> List[DistrictAbbreviation]:
+        seen = set()
+        for abbr in ALL_KNOWN_DISTRICT_ABBREVIATIONS:
+            seen.add(OLD_TO_NEW_CODE_MAP.get(abbr, abbr))
+
+        return list(seen)
 
     @classmethod
     @ndb.tasklet

--- a/src/backend/common/helpers/insights_districts_helper.py
+++ b/src/backend/common/helpers/insights_districts_helper.py
@@ -1,0 +1,178 @@
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+from backend.common.consts.alliance_color import AllianceColor
+from backend.common.consts.award_type import AwardType
+from backend.common.consts.comp_level import CompLevel
+from backend.common.consts.event_type import EventType
+from backend.common.models.district import District
+from backend.common.models.event import Event
+from backend.common.models.insight import (
+    DistrictInsightDistrictData,
+    DistrictInsightTeamData,
+)
+from backend.common.models.keys import DistrictAbbreviation, TeamKey, Year
+from backend.common.models.wlt import WLTRecord
+from backend.common.queries.district_query import DistrictHistoryQuery
+from backend.common.queries.event_query import DistrictEventsQuery
+from backend.common.queries.team_query import DistrictTeamsQuery
+
+
+class InsightsDistrictsHelper:
+    @staticmethod
+    def make_insight_team_data(
+        district_abbreviation: DistrictAbbreviation,
+    ) -> Dict[TeamKey, DistrictInsightTeamData]:
+        history: List[District] = DistrictHistoryQuery(district_abbreviation).fetch()
+        years_participated = defaultdict(list)
+        total_district_points = defaultdict(int)
+        total_pre_dcmp_district_points = defaultdict(int)
+        for district in history:
+            if district.year == 2021:
+                continue
+
+            for ranking in district.rankings:
+                if len(ranking["event_points"]) == 0:
+                    continue
+
+                years_participated[ranking["team_key"]].append(district.year)
+                for event_points in ranking["event_points"]:
+                    # Some of them are floats, no idea why
+                    total_district_points[ranking["team_key"]] += int(
+                        event_points["total"]
+                    )
+
+                    if not event_points["district_cmp"]:
+                        total_pre_dcmp_district_points[ranking["team_key"]] += int(
+                            event_points["total"]
+                        )
+
+        district_event_wins = defaultdict(int)
+        dcmp_wins = defaultdict(int)
+        team_awards = defaultdict(int)
+        individual_awards = defaultdict(int)
+        quals_record = defaultdict(lambda: WLTRecord(wins=0, losses=0, ties=0))
+        elims_record = defaultdict(lambda: WLTRecord(wins=0, losses=0, ties=0))
+
+        event_futures = []
+        for district in history:
+            event_futures.append(
+                DistrictEventsQuery(district_key=district.key_name).fetch_async()
+            )
+
+        event_list: List[Event] = []
+        for future in event_futures:
+            partial_event_list = future.get_result()
+            event_list += partial_event_list
+
+        for event in event_list:
+            for award in event.awards:
+                for recipient in award.team_list:
+                    if award.award_type_enum in [
+                        AwardType.WOODIE_FLOWERS,
+                        AwardType.DEANS_LIST,
+                        AwardType.VOLUNTEER,
+                    ]:
+                        individual_awards[recipient.string_id()] += 1
+                    else:
+                        team_awards[recipient.string_id()] += 1
+
+                    if award.award_type_enum == AwardType.WINNER:
+                        if award.event_type_enum == EventType.DISTRICT_CMP:
+                            dcmp_wins[recipient.string_id()] += 1
+                        else:
+                            district_event_wins[recipient.string_id()] += 1
+
+            for match in event.matches:
+                # Most 2015 matches are ties, so just skip them.
+                if match.year == 2015:
+                    continue
+
+                counter_dict = (
+                    quals_record if match.comp_level == CompLevel.QM else elims_record
+                )
+
+                if match.winning_alliance == AllianceColor.RED:
+                    for team in match.alliances[AllianceColor.RED]["teams"]:
+                        counter_dict[team]["wins"] += 1
+                    for team in match.alliances[AllianceColor.BLUE]["teams"]:
+                        counter_dict[team]["losses"] += 1
+                elif match.winning_alliance == AllianceColor.BLUE:
+                    for team in match.alliances[AllianceColor.RED]["teams"]:
+                        counter_dict[team]["losses"] += 1
+                    for team in match.alliances[AllianceColor.BLUE]["teams"]:
+                        counter_dict[team]["wins"] += 1
+                else:
+                    for team in match.alliances[AllianceColor.RED]["teams"]:
+                        counter_dict[team]["ties"] += 1
+                    for team in match.alliances[AllianceColor.BLUE]["teams"]:
+                        counter_dict[team]["ties"] += 1
+
+        return {
+            k: DistrictInsightTeamData(
+                district_seasons=len(years_participated[k]),
+                total_district_points=total_district_points[k],
+                total_pre_dcmp_district_points=total_pre_dcmp_district_points[k],
+                district_event_wins=district_event_wins[k],
+                dcmp_wins=dcmp_wins[k],
+                team_awards=team_awards[k],
+                individual_awards=individual_awards[k],
+                quals_record=quals_record[k],
+                elims_record=elims_record[k],
+            )
+            for k in years_participated.keys()
+        }
+
+    @staticmethod
+    def _make_team_deltas(
+        yearly_teams: Dict[Year, Set[TeamKey]],
+        year_a: Year,
+        year_b: Year,
+    ) -> Tuple[List[TeamKey], List[TeamKey]]:
+        year_a_teams = yearly_teams.get(year_a, set())
+        year_b_teams = yearly_teams.get(year_b, set())
+
+        gained_teams = list(year_b_teams - year_a_teams)
+        lost_teams = list(year_a_teams - year_b_teams)
+
+        return gained_teams, lost_teams
+
+    @staticmethod
+    def make_insight_district_data(
+        district_abbreviation: DistrictAbbreviation,
+    ) -> DistrictInsightDistrictData:
+        history: List[District] = DistrictHistoryQuery(district_abbreviation).fetch()
+
+        yearly_teams = defaultdict(set)
+        yearly_events = {}
+
+        for district in history:
+            district_teams = DistrictTeamsQuery(district_key=district.key_name).fetch()
+
+            for team in district_teams:
+                yearly_teams[district.year].add(team.key_name)
+
+            district_events = DistrictEventsQuery(
+                district_key=district.key_name
+            ).fetch()
+
+            yearly_events[district.year] = len(district_events)
+
+        yearly_gained_teams = {}
+        yearly_lost_teams = {}
+
+        for y in yearly_teams.keys():
+            y_gain, y_loss = InsightsDistrictsHelper._make_team_deltas(
+                yearly_teams, y - 1, y
+            )
+            yearly_gained_teams[y] = y_gain
+            yearly_lost_teams[y] = y_loss
+
+        return DistrictInsightDistrictData(
+            yearly_active_team_count={
+                y: len(teams) for y, teams in yearly_teams.items()
+            },
+            yearly_event_count=yearly_events,
+            yearly_gained_teams=yearly_gained_teams,
+            yearly_lost_teams=yearly_lost_teams,
+        )

--- a/src/backend/common/helpers/insights_helper.py
+++ b/src/backend/common/helpers/insights_helper.py
@@ -15,6 +15,7 @@ from backend.common.consts.event_type import (
     EventType,
     SEASON_EVENT_TYPES,
 )
+from backend.common.consts.renamed_districts import RenamedDistricts
 from backend.common.futures import TypedFuture
 from backend.common.helpers.event_helper import (
     EventHelper,
@@ -22,6 +23,7 @@ from backend.common.helpers.event_helper import (
     PRESEASON_EVENTS_LABEL,
 )
 from backend.common.helpers.event_insights_helper import EventInsightsHelper
+from backend.common.helpers.insights_districts_helper import InsightsDistrictsHelper
 from backend.common.helpers.insights_helper_utils import (
     create_insight,
     sort_counter_dict,
@@ -196,6 +198,30 @@ class InsightsHelper(object):
 
         return [
             create_insight(data, Insight.INSIGHT_NAMES[Insight.MATCH_PREDICTIONS], year)
+        ]
+
+    @classmethod
+    def doDistrictInsights(cls) -> List[Insight]:
+        """
+        Calculate district insights for a given year. Returns a list of Insights.
+        """
+
+        return [
+            create_insight(
+                data=InsightsDistrictsHelper.make_insight_team_data(abbr),
+                name=Insight.INSIGHT_NAMES[Insight.DISTRICT_INSIGHTS_TEAM_DATA],
+                year=0,
+                district_abbreviation=abbr,
+            )
+            for abbr in RenamedDistricts.get_latest_codes()
+        ] + [
+            create_insight(
+                data=InsightsDistrictsHelper.make_insight_district_data(abbr),
+                name=Insight.INSIGHT_NAMES[Insight.DISTRICT_INSIGHT_DISTRICT_DATA],
+                year=0,
+                district_abbreviation=abbr,
+            )
+            for abbr in RenamedDistricts.get_latest_codes()
         ]
 
     @classmethod

--- a/src/backend/common/helpers/insights_helper_utils.py
+++ b/src/backend/common/helpers/insights_helper_utils.py
@@ -102,15 +102,18 @@ def sort_counter_dict(
     return sorted(temp.items(), key=lambda pair: float(pair[0]), reverse=True)
 
 
-def create_insight(data: Any, name: str, year: int) -> Insight:
+def create_insight(
+    data: Any, name: str, year: int, district_abbreviation: Optional[str] = None
+) -> Insight:
     """
     Create Insight object given data, name, and year
     """
     return Insight(
-        id=Insight.render_key_name(year, name),
+        id=Insight.render_key_name(year, name, district_abbreviation),
         name=name,
         year=year,
         data_json=json.dumps(data),
+        district_abbreviation=district_abbreviation,
     )
 
 

--- a/src/backend/common/models/insight.py
+++ b/src/backend/common/models/insight.py
@@ -1,10 +1,17 @@
 import json
-from typing import Dict, List, Literal, Set, TypeAlias, TypedDict
+from typing import Dict, List, Literal, Optional, Set, TypeAlias, TypedDict
 
 from google.appengine.ext import ndb
 
 from backend.common.models.cached_model import CachedModel
-from backend.common.models.keys import EventKey, MatchKey, TeamKey
+from backend.common.models.keys import (
+    DistrictAbbreviation,
+    EventKey,
+    MatchKey,
+    TeamKey,
+    Year,
+)
+from backend.common.models.wlt import WLTRecord
 
 
 LeaderboardKeyType = Literal["team"] | Literal["event"] | Literal["match"]
@@ -62,6 +69,8 @@ class Insight(CachedModel):
     TYPED_LEADERBOARD_MOST_WFFAS = 41
     SUCCESSFUL_EINSTEIN_TEAMUPS = 42
     TYPED_LEADERBOARD_LONGEST_QUALIFYING_EVENT_STREAK = 43
+    DISTRICT_INSIGHTS_TEAM_DATA = 44
+    DISTRICT_INSIGHT_DISTRICT_DATA = 45
     YEAR_SPECIFIC_BY_WEEK = 999
     YEAR_SPECIFIC = 1000
 
@@ -113,6 +122,8 @@ class Insight(CachedModel):
         TYPED_LEADERBOARD_MOST_NON_CHAMPS_IMPACT_WINS: "typed_leaderboard_most_non_champs_impact_wins",
         TYPED_LEADERBOARD_MOST_WFFAS: "typed_leaderboard_most_wffas",
         TYPED_LEADERBOARD_LONGEST_QUALIFYING_EVENT_STREAK: "typed_leaderboard_longest_qualifying_event_streak",
+        DISTRICT_INSIGHTS_TEAM_DATA: "district_insights_team_data",
+        DISTRICT_INSIGHT_DISTRICT_DATA: "district_insights_district_data",
     }
 
     TYPED_LEADERBOARD_KEY_TYPES: Dict[int, LeaderboardKeyType] = {
@@ -149,11 +160,17 @@ class Insight(CachedModel):
         required=True, indexed=False
     )  # JSON dictionary of the data of the insight
 
+    district_abbreviation = ndb.StringProperty(required=False, indexed=True)
+
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
 
     _json_attrs: Set[str] = {
         "data_json",
+    }
+
+    _mutable_attrs: Set[str] = {
+        "district_abbreviation",
     }
 
     def __init__(self, *args, **kw):
@@ -179,14 +196,18 @@ class Insight(CachedModel):
         """
         Returns the string of the key_name of the Insight object before writing it.
         """
-        return self.render_key_name(self.year, self.name)
+        return self.render_key_name(self.year, self.name, self.district_abbreviation)
 
     @classmethod
-    def render_key_name(cls, year, name):
-        if year == 0:
-            return "insights" + "_" + str(name)
-        else:
-            return str(year) + "insights" + "_" + str(name)
+    def render_key_name(
+        cls,
+        year: int,
+        name: str,
+        district_abbreviation: Optional[DistrictAbbreviation] = None,
+    ) -> str:
+        prefix = f"{year}insights" if year != 0 else "insights"
+        suffix = f"_{district_abbreviation}" if district_abbreviation else ""
+        return f"{prefix}_{name}{suffix}"
 
 
 class LeaderboardRanking(TypedDict):
@@ -227,3 +248,22 @@ class NotablesInsight(TypedDict):
     data: NotablesData
     name: str
     year: int
+
+
+class DistrictInsightTeamData(TypedDict):
+    district_seasons: int
+    total_district_points: int
+    total_pre_dcmp_district_points: int
+    district_event_wins: int
+    dcmp_wins: int
+    team_awards: int
+    individual_awards: int
+    quals_record: WLTRecord
+    elims_record: WLTRecord
+
+
+class DistrictInsightDistrictData(TypedDict):
+    yearly_active_team_count: Dict[Year, int]
+    yearly_gained_teams: Dict[Year, List[TeamKey]]
+    yearly_lost_teams: Dict[Year, List[TeamKey]]
+    yearly_event_count: Dict[Year, int]

--- a/src/backend/tasks_cpu/handlers/insights.py
+++ b/src/backend/tasks_cpu/handlers/insights.py
@@ -80,6 +80,8 @@ def do_year_insights(kind: str, year: Year) -> Response:
         insights = InsightsHelper.doAwardInsights(year)
     elif insight_kind == InsightType.PREDICTIONS:
         insights = InsightsHelper.doPredictionInsights(year)
+    elif insight_kind == InsightType.DISTRICTS and year == 0:
+        insights = InsightsHelper.doDistrictInsights()
 
     if insights is not None:
         InsightManipulator.createOrUpdate(insights)
@@ -88,7 +90,9 @@ def do_year_insights(kind: str, year: Year) -> Response:
         "X-Appengine-Taskname" not in request.headers
     ):  # Only write out if not in taskqueue
         return make_response(
-            render_template("math/year_insights_do.html", kind=kind, insights=insights)
+            render_template(
+                "math/year_insights_do.html", kind=kind, insights=insights or []
+            )
         )
 
     return make_response("")

--- a/src/backend/tasks_cpu/templates/math/year_insights_do.html
+++ b/src/backend/tasks_cpu/templates/math/year_insights_do.html
@@ -1,5 +1,5 @@
 <h2>Calculated the following Insights for {{year}} {{kinds}}:</h2>
 {% for insight in insights %}
     <h3>{{insight.name}}</h3>
-    <p>{{insight.data_json}}</p>
+    <code>{{insight.data_json}}</code>
 {% endfor %}

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3991,6 +3991,63 @@
         ]
       }
     },
+    "/district/{district_abbreviation}/insights": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets insights for a given district.",
+        "operationId": "getDistrictInsights",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/District_Insight"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/district/{district_key}/events": {
       "get": {
         "tags": [
@@ -9394,6 +9451,105 @@
             "description": "Year this district participated."
           }
         }
+      },
+      "District_Insight": {
+        "type": "object",
+        "properties": {
+          "district_data": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "yearly_active_team_count": {
+                "type": "object",
+                "description": "Map of year to number of active teams",
+                "additionalProperties": {
+                  "type": "integer"
+                }
+              },
+              "yearly_event_count": {
+                "type": "object",
+                "description": "Map of year to number of events",
+                "additionalProperties": {
+                  "type": "integer"
+                }
+              },
+              "yearly_gained_teams": {
+                "type": "object",
+                "description": "Map of year to list of team keys gained",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "yearly_lost_teams": {
+                "type": "object",
+                "description": "Map of year to list of team keys lost",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "required": [
+              "yearly_active_team_count",
+              "yearly_event_count",
+              "yearly_gained_teams",
+              "yearly_lost_teams"
+            ]
+          },
+          "team_data": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "district_seasons": {
+                "type": "integer"
+              },
+              "total_district_points": {
+                "type": "integer"
+              },
+              "total_pre_dcmp_district_points": {
+                "type": "integer"
+              },
+              "district_event_wins": {
+                "type": "integer"
+              },
+              "dcmp_wins": {
+                "type": "integer"
+              },
+              "team_awards": {
+                "type": "integer"
+              },
+              "individual_awards": {
+                "type": "integer"
+              },
+              "quals_record": {
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              "elims_record": {
+                "$ref": "#/components/schemas/WLT_Record"
+              }
+            },
+            "required": [
+              "district_seasons",
+              "total_district_points",
+              "total_pre_dcmp_district_points",
+              "district_event_wins",
+              "dcmp_wins",
+              "team_awards",
+              "individual_awards",
+              "quals_record",
+              "elims_record"
+            ]
+          }
+        },
+        "required": [
+          "team_data",
+          "district_data"
+        ]
       },
       "District_Ranking": {
         "required": [


### PR DESCRIPTION
Adds district-specific insights.

There are a handful of district-specific spreadsheets floating around that all basically do the same thing - a generic overview of their district's stats, all pulled from TBA and compiled. It would make sense to simply integrate these into TBA; this does that.

Because of json field size constraints, district insights are split into 2 insights: team data and district data. Team info contains team-specific info like average district points earned by a given team. District info contains info like retention, growth, event count, etc.

These are not added to cron here; they will be in a future PR once these insights are known to function on prod.