### PR TITLE
Add new DCMP event/awards history endpoint

### DIFF
--- a/pwa/app/api/v3.ts
+++ b/pwa/app/api/v3.ts
@@ -4088,6 +4088,47 @@ export function getDistrictAdvancement(
   });
 }
 /**
+ * Gets a list of DCMP events and awards for the given district abbreviation.
+ */
+export function getDistrictDcmpHistory(
+  {
+    ifNoneMatch,
+    districtAbbreviation,
+  }: {
+    ifNoneMatch?: string;
+    districtAbbreviation: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          awards?: Award[];
+          event?: Event;
+        }[];
+      }
+    | {
+        status: 304;
+      }
+    | {
+        status: 401;
+        data: {
+          /** Authorization error description. */
+          Error: string;
+        };
+      }
+    | {
+        status: 404;
+      }
+  >(`/district/${encodeURIComponent(districtAbbreviation)}/dcmp_history`, {
+    ...opts,
+    headers: oazapfts.mergeHeaders(opts?.headers, {
+      'If-None-Match': ifNoneMatch,
+    }),
+  });
+}
+/**
  * Gets information about per-team advancement to the FIRST Championship.
  */
 export function getRegionalAdvancement(

--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -11,6 +11,7 @@ from backend.api.handlers.helpers.model_properties import (
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.consts.event_type import EventType
 from backend.common.decorators import cached_public
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey
 from backend.common.queries.award_query import EventAwardsQuery
@@ -138,3 +139,54 @@ def district_advancement(district_key: DistrictKey) -> Response:
 
     district = DistrictQuery(district_key=district_key).fetch()
     return profiled_jsonify(district.advancement)
+
+
+@api_authenticated
+@cached_public
+def dcmp_history(district_abbreviation: DistrictAbbreviation) -> Response:
+    """
+    Returns DCMP awards/events for a given DistrictAbbreviation
+    """
+    track_call_after_response("district/dcmp_history", district_abbreviation)
+
+    districts = DistrictAbbreviationQuery(
+        abbreviation=district_abbreviation
+    ).fetch_dict(ApiMajorVersion.API_V3)
+
+    dcmp_event_futures = []
+    for district in districts:
+        dcmp_event_futures.append(
+            DistrictEventsQuery(district_key=district["key"]).fetch_dict_async(
+                ApiMajorVersion.API_V3
+            )
+        )
+
+    dcmp_events = {}
+    for future in dcmp_event_futures:
+        result = future.get_result()
+        for event in result:
+            if event["event_type"] in [
+                EventType.DISTRICT_CMP,
+                EventType.DISTRICT_CMP_DIVISION,
+            ]:
+                dcmp_events[event["key"]] = event
+
+    dcmp_award_futures = {}
+    for event_key in dcmp_events:
+        dcmp_award_futures[event_key] = EventAwardsQuery(
+            event_key=event_key
+        ).fetch_dict_async(ApiMajorVersion.API_V3)
+
+    dcmp_awards = {}
+    for event_key, future in dcmp_award_futures.items():
+        dcmp_awards[event_key] = future.get_result()
+
+    ret = [
+        {
+            "event": dcmp_events[event_key],
+            "awards": dcmp_awards[event_key],
+        }
+        for event_key in dcmp_events
+    ]
+
+    return profiled_jsonify(ret)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -16,6 +16,7 @@ from backend.api.handlers.client_api import (
     update_model_preferences,
 )
 from backend.api.handlers.district import (
+    dcmp_history,
     district_advancement,
     district_awards,
     district_events,
@@ -148,6 +149,10 @@ api_v3.add_url_rule(
 )
 api_v3.add_url_rule(
     "/district/<string:district_key>/advancement", view_func=district_advancement
+)
+api_v3.add_url_rule(
+    "/district/<string:district_abbreviation>/dcmp_history",
+    view_func=dcmp_history,
 )
 
 # District List

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -4573,6 +4573,77 @@
         ]
       }
     },
+    "/district/{district_abbreviation}/dcmp_history": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets a list of DCMP events and awards for the given district abbreviation.",
+        "operationId": "getDistrictDCMPHistory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "awards": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/Award"
+                        }
+                      },
+                      "event": {
+                        "$ref": "#/components/schemas/Event"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/regional_advancement/{year}": {
       "get": {
         "tags": [


### PR DESCRIPTION
This is useful for an upcoming PWA page and saves a great deal of unnecessary requests when trying to get a historical view of DCMP.

Returns an array of objects, where each object has an event and an array of awards. Each object represents a DCMP event or DCMP division.