### PR TITLE
Only spin up one instance of a service for dev_appserver

### DIFF
--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -96,6 +96,7 @@ dev_appserver.py \
     --runtime_python_path=/usr/bin/python3 \
     --admin_host=0.0.0.0 \
     --host=0.0.0.0 \
+    --max_module_instances=1 \
     --runtime="$runtime_version" \
     --application="$application" \
     "${env[@]}" \


### PR DESCRIPTION
This is mostly a QOL thing for me working in the container. When dev_appserver spins up multiple instances of web, sometimes I get logs and sometimes I don't. Working locally - we only really need one instance.