### PR TITLE
Dispatch webhooks individually. Update ping to have success and valid booleans.

### DIFF
--- a/src/backend/api/handlers/client_api.py
+++ b/src/backend/api/handlers/client_api.py
@@ -150,7 +150,7 @@ def ping_mobile_client(req: PingRequest) -> BaseResponse:
         )
     else:
         client: MobileClient = clients[0]
-        success = TBANSHelper.ping(client)
+        success, valid_client = TBANSHelper.ping(client)
         if success:
             return BaseResponse(code=200, message="Ping sent")
         else:

--- a/src/backend/api/handlers/tests/client_api_ping_test.py
+++ b/src/backend/api/handlers/tests/client_api_ping_test.py
@@ -28,7 +28,7 @@ def test_ping_no_device(api_client: Client, mock_clientapi_auth: User) -> None:
     assert resp["code"] == 404
 
 
-def test_ping_clinet(api_client: Client, mock_clientapi_auth: User, ndb_stub) -> None:
+def test_ping_client(api_client: Client, mock_clientapi_auth: User, ndb_stub) -> None:
     MobileClient(
         parent=mock_clientapi_auth.account_key,
         user_id=str(mock_clientapi_auth.uid),
@@ -39,7 +39,7 @@ def test_ping_clinet(api_client: Client, mock_clientapi_auth: User, ndb_stub) ->
     ).put()
 
     with patch.object(TBANSHelper, "ping") as mock_ping:
-        mock_ping.return_value = True
+        mock_ping.return_value = (True, True)
         req = PingRequest(
             mobile_id="abc123",
         )
@@ -48,7 +48,7 @@ def test_ping_clinet(api_client: Client, mock_clientapi_auth: User, ndb_stub) ->
     assert resp["code"] == 200
 
 
-def test_ping_clinet_fails(
+def test_ping_client_fails(
     api_client: Client, mock_clientapi_auth: User, ndb_stub
 ) -> None:
     MobileClient(
@@ -61,7 +61,7 @@ def test_ping_clinet_fails(
     ).put()
 
     with patch.object(TBANSHelper, "ping") as mock_ping:
-        mock_ping.return_value = False
+        mock_ping.return_value = (False, False)
         req = PingRequest(
             mobile_id="abc123",
         )

--- a/src/backend/common/models/notifications/requests/tests/webhook_request_test.py
+++ b/src/backend/common/models/notifications/requests/tests/webhook_request_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, patch
 
 import pytest
 from google.appengine.api import urlfetch

--- a/src/backend/common/models/notifications/requests/webhook_request.py
+++ b/src/backend/common/models/notifications/requests/webhook_request.py
@@ -1,6 +1,6 @@
 import json
 
-import requests
+from google.appengine.api import urlfetch
 
 from backend.common.models.notifications.requests.request import Request
 
@@ -34,7 +34,7 @@ class WebhookRequest(Request):
             str(self.notification), self.url
         )
 
-    def send(self) -> bool:
+    def send(self) -> tuple[bool, bool]:
         """Attempt to send the notification."""
         # Build the request
         headers = {
@@ -49,19 +49,18 @@ class WebhookRequest(Request):
 
         # TODO: Consider more useful way to surface error messages
         # https://github.com/the-blue-alliance/the-blue-alliance/issues/2576
-        valid_url = True
+        success, valid_url = True, True
 
         try:
-            response = requests.post(self.url, data=payload, headers=headers)
-            if response.status_code == requests.codes.ok:
-                self.defer_track_notification(1)
-            elif response.status_code == 404:
+            response = urlfetch.fetch(
+                self.url, payload=payload, method=urlfetch.POST, headers=headers
+            )
+            if response.status_code != 200:
                 valid_url = False
-        except Exception:
-            # logging.error(f"Failed to send webhook request: {e}")
-            pass
+        except:
+            success = False
 
-        return valid_url
+        return success, valid_url
 
     def _json_string(self) -> str:
         """JSON dict representation of an WebhookRequest object.

--- a/src/backend/common/models/notifications/requests/webhook_request.py
+++ b/src/backend/common/models/notifications/requests/webhook_request.py
@@ -57,7 +57,7 @@ class WebhookRequest(Request):
             )
             if response.status_code != 200:
                 valid_url = False
-        except:
+        except Exception:
             success = False
 
         return success, valid_url

--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -545,7 +545,7 @@ def ping():
 
     from backend.common.helpers.tbans_helper import TBANSHelper
 
-    success = TBANSHelper.ping(client)
+    success, valid_url = TBANSHelper.ping(client)
     if success:
         session["ping_sent"] = "1"
     else:

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -625,7 +625,9 @@ def test_mytba(
     assert context["year"] == mock_year
 
 
-@pytest.mark.parametrize("ping_sent, expected", [(True, "1"), (False, "0")])
+@pytest.mark.parametrize(
+    "ping_sent, expected", [((True, True), "1"), ((False, True), "0")]
+)
 def test_ping_client(
     ping_sent,
     expected,
@@ -677,7 +679,9 @@ def test_ping_not_our_client(
     )
     c1.put()
 
-    with web_client, patch.object(TBANSHelper, "ping", return_value=True) as mock_ping:
+    with web_client, patch.object(
+        TBANSHelper, "ping", return_value=(True, True)
+    ) as mock_ping:
         response = web_client.post(
             "/account/ping", data={"mobile_client_id": c1.key.id()}
         )

--- a/src/backend/web/templates/apidocs_webhooks.html
+++ b/src/backend/web/templates/apidocs_webhooks.html
@@ -47,6 +47,8 @@
       <h2 id="request">Request Structure</h2>
         <p>Each request will contain a payload of JSON data containing information about the event that has been pushed to you. Each request will contain a <code>message_type</code> and <code>message_data</code> field. The <code>message_type</code> field can be used to determine the data being sent. The <code>message_data</code> is the data specific to the message being sent. Details of each type of supported event is below.</p>
         <p>Each request also contains a <code>X-TBA-HMAC</code> header that you can use to validate requests on your client. The header will contain a hash of a secret key that is set by the server when you create the webhook concatenated with the payload string. This is caculated using <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.198-1.pdf">NIST's HMAC algorithm</a>, using SHA256. You can see <a href="https://github.com/the-blue-alliance/the-blue-alliance/blob/7443c5bbfc817e9faa1b084aa9d5de267a45e785/src/backend/common/models/notifications/requests/webhook_request.py#L99" target="_blank">in the code</a> where this is calculated.
+      <h2 id="details">Implementation Details</h2>
+        <p>Each POST request has a timeout of 10s from TBA's servers. Not responding within this timeframe will be considered a failed request.</p>
 
       <h2 id="configuration">Configuration</h2>
         <p>Webhooks are tied to your TBA Account - you can create them from your <a href="/account">account overview</a>. You will have to enter a URL that will receive the pushed notification. You also have to enter a secret key used to secure requests - we recommend using a long randomly generated string. When you receive a webhook, TBA will send a HTTP POST request to the URL you have entered, so make sure you're listening. Not responding or returning an error code may cause your webhook to be deleted.</p>
@@ -637,7 +639,7 @@ $( document ).ready(function() {
             else if (data.responseJSON && data.responseJSON.Error) responseText = data.responseJSON.Error;
             else if (data.status === 401) responseText = 'Please log in before sending test notifications.';
             else responseText = 'Something went horribly wrong. Refresh the page and try again.';
-            
+
             $(this.form).find('.webhook-alert')
                 .addClass(data === 'ok' ? 'alert-success' : 'alert-danger')
                 .css('display', 'block')


### PR DESCRIPTION
Two changes here -

First one is part of the arc of work to increase reliability of our webhooks. No idea why, but I was treating webhooks similarly to FCM clients where we'd pass an array and process them all in one go. This obviously doesn't scale if we're trying to process data to all our webhooks within a single 30s GAE request. This now breaks each webhook request into it's own task. The urlfetch (moved back to urlfetch from requests - possibly to tie into the ndb context in the future for all this work - we'll see) has a default timeout of 10s. This has been updated in the webhook docs.

Second - the `ping` endpoint now has two response values - a `success` (did we throw an error) and a `valid` (which covers whatever our logic will be for a valid/invalid response). A single boolean doesn't work here - we can't treat timeouts the same that we treat non-200 responses.