### PR TITLE
Update pwa dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,10 +41,13 @@ updates:
     radix-ui:
       patterns:
         - "@radix-ui/*"
-    vitest:
+    vite:
       patterns:
+        - "vite"
+        - "vite-tsconfig-paths"
         - "vitest"
         - "@vitest/coverage-v8"
+        - "@julr/vite-plugin-validate-env"
     linting:
       patterns:
         - "@eslint/*"
@@ -59,6 +62,23 @@ updates:
         - "globals"
         - "typescript-eslint"
         - "@typescript-eslint/*"
+        - "prettier"
+        - "prettier-plugin-classnames"
+        - "prettier-plugin-merge"
+        - "prettier-plugin-tailwindcss"
+    sentry:
+      patterns:
+        - "@sentry/*"
+    tailwind:
+      patterns:
+        - "@tailwindcss/*"
+        - "tailwindcss"
+        - "tailwind-merge"
+    icons:
+      patterns:
+        - "@iconify/json"
+        - "lucide-react"
+        - "unplugin-icons"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Should reduce the number of separate dependabot PRs we get and also reduce some merge conflicts by updating things together.