### PR TITLE
Add PWA API regeneration CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -284,16 +284,47 @@ jobs:
       - name: Install Dependencies
         working-directory: pwa
         run: npm ci
-      
+
       - name: Install Playwright Browsers
         working-directory: pwa
         run: npx playwright install --with-deps chromium
-      
+
       - name: Run Playwright tests
         working-directory: pwa
         run: npx playwright test
         env:
           VITE_TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
+
+  check-pwa-api:
+    name: "[pwa] Check API regeneration"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.16.0"
+
+      - name: Install Dependencies
+        working-directory: pwa
+        run: npm ci
+
+      - name: Run generate-api.sh
+        working-directory: ./pwa
+        run: ./generate-api.sh
+
+      - name: Detect changes in pwa/app/api
+        run: |
+          CHANGED_FILES=$(git diff --name-only pwa/app/api)
+          if [[ -n "$CHANGED_FILES" ]]; then
+            echo "::error title=API Mismatch::Files changed in pwa/app/api:"
+            echo "$CHANGED_FILES"
+            exit 1
+          else
+            echo "No changes detected in pwa/app/api."
+          fi
 
   bash-lint:
     name: "[bash] Lint"


### PR DESCRIPTION
Fails if the PWA API needs to be regenerated

Example failure: https://github.com/the-blue-alliance/the-blue-alliance/actions/runs/15469172612/job/43548776238?pr=7781

Example success: https://github.com/the-blue-alliance/the-blue-alliance/actions/runs/15469256923/job/43549064131?pr=7781