### PR TITLE
Fix PWA linting on CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -331,6 +331,10 @@ jobs:
         working-directory: pwa
         run: npm ci
 
+      - name: Generate react-router types
+        working-directory: pwa
+        run: npm run typecheck
+
       - name: Run generate-api.sh
         working-directory: ./pwa
         run: ./generate-api.sh


### PR DESCRIPTION
Linting is erroring on API regeneration because it can't find the (not generated) react router types