### PR TITLE
Move backend-tasks-b2 to py3-tasks-io

### DIFF
--- a/src/dispatch.yaml
+++ b/src/dispatch.yaml
@@ -19,7 +19,7 @@ dispatch:
     service: py3-tasks-io
 
   - url: "*/backend-tasks-b2/*"
-    service: py3-tasks-cpu
+    service: py3-tasks-io
 
   - url: "*/*"
     service: py3-web


### PR DESCRIPTION
We are encountering a lot of timeouts on backend-tasks-b2:

![image](https://github.com/user-attachments/assets/964360b1-56ab-4cce-a0fe-8a32bd94d60e)

@fangeugene:

>i think the problem is that the py3-tasks-cpu service doesn't autoscale (it's pinned to one instance) so if it's handling something already, any incoming request times out.




