### PR TITLE
Fix media details in api spec

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -1956,6 +1956,9 @@ export type Media = {
    */
   details?:
     | {
+        [key: string]: unknown;
+      }
+    | {
         base64Image: string;
       }
     | {

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -1140,6 +1140,7 @@ export const zMedia = z.object({
   foreign_key: z.string(),
   details: z
     .union([
+      z.object({}),
       z.object({
         base64Image: z.string(),
       }),

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -9261,6 +9261,10 @@
             "description": "If required, a JSON dict of additional media information.",
             "oneOf": [
               {
+                "type": "object",
+                "properties": {}
+              },
+              {
                 "properties": {
                   "base64Image": {
                     "type": "string"


### PR DESCRIPTION
Apparently on social media, `details` can also just be an empty object (`{}`)