### PR TITLE
Separate enqueue/do handlers for CPU tasks

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -315,7 +315,6 @@ jobs:
             echo "No changes detected in pwa/app/api."
           fi
 
-
   bash-lint:
     name: "[bash] Lint"
     runs-on: ubuntu-22.04
@@ -704,6 +703,9 @@ jobs:
       - name: Deploy
         if: steps.changes.outputs.tasks-cpu == 'true'
         run: ./ops/deploy/deploy_module.sh src/tasks_cpu.yaml
+      - name: Deploy Enqueue
+        if: steps.changes.outputs.tasks-cpu == 'true'
+        run: ./ops/deploy/deploy_module.sh src/tasks_cpu_enqueue.yaml
   deploy-pwa:
     name: Deploy PWA Service
     runs-on: ubuntu-22.04

--- a/ops/dev/vagrant/dev_appserver.sh
+++ b/ops/dev/vagrant/dev_appserver.sh
@@ -110,4 +110,4 @@ dev_appserver.py \
     --env_var SAVE_FRC_API_RESPONSE="$save_frc_api_response" \
     --dev_appserver_log_level="$log_level" \
     --enable_task_running yes \
-    src/default.yaml src/web.yaml src/api.yaml src/tasks_io.yaml src/tasks_cpu.yaml src/dispatch.yaml
+    src/default.yaml src/web.yaml src/api.yaml src/tasks_io.yaml src/tasks_cpu_enqueue.yaml src/tasks_cpu.yaml src/dispatch.yaml

--- a/ops/test_vagrant_startup.py
+++ b/ops/test_vagrant_startup.py
@@ -7,7 +7,14 @@ import time
 import requests
 
 TIME_LIMIT = 10 * 60  # seconds
-MODULE_NAMES = {"default", "py3-web", "py3-api", "py3-tasks-io", "py3-tasks-cpu"}
+MODULE_NAMES = {
+    "default",
+    "py3-web",
+    "py3-api",
+    "py3-tasks-io",
+    "py3-tasks-cpu-enqueue",
+    "py3-tasks-cpu",
+}
 
 # Wait up to |TIME_LIMIT| for all modules to start and webpack to build
 start_time = time.time()

--- a/src/backend/tasks_cpu/handlers/insights.py
+++ b/src/backend/tasks_cpu/handlers/insights.py
@@ -27,9 +27,9 @@ from backend.common.models.keys import Year
 blueprint = Blueprint("insights", __name__)
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/insights/<kind>/<int:year>")
+@blueprint.route("/backend-tasks-b2/enqueue/math/insights/<kind>/<int:year>")
 @blueprint.route(
-    "/backend-tasks-b2/math/enqueue/insights/<kind>", defaults={"year": None}
+    "/backend-tasks-b2/enqueue/math/insights/<kind>", defaults={"year": None}
 )
 def enqueue_year_insights(kind: str, year: Optional[Year] = None) -> Response:
     if year is None:
@@ -60,7 +60,7 @@ def enqueue_year_insights(kind: str, year: Optional[Year] = None) -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks-b2/math/do/insights/<kind>/<int:year>")
+@blueprint.route("/backend-tasks-b2/do/math/insights/<kind>/<int:year>")
 def do_year_insights(kind: str, year: Year) -> Response:
     """
     Calculates insights of a given kind for a given year.
@@ -98,7 +98,7 @@ def do_year_insights(kind: str, year: Year) -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks-b2/math/do/insights/leaderboards/<kind>/<int:year>")
+@blueprint.route("/backend-tasks-b2/do/math/insights/leaderboards/<kind>/<int:year>")
 def do_leaderboard_year_insights(kind: LeaderboardKeyType, year: Year) -> Response:
     if kind not in Insight.TYPED_LEADERBOARD_KEY_TYPES.values():
         return make_response(f"Unknown leaderboard kind {escape(kind)}")
@@ -118,10 +118,10 @@ def do_leaderboard_year_insights(kind: LeaderboardKeyType, year: Year) -> Respon
 
 
 @blueprint.route(
-    "/backend-tasks-b2/math/enqueue/insights/leaderboards/<kind>/<int:year>"
+    "/backend-tasks-b2/enqueue/math/insights/leaderboards/<kind>/<int:year>"
 )
 @blueprint.route(
-    "/backend-tasks-b2/math/enqueue/insights/leaderboards/<kind>",
+    "/backend-tasks-b2/enqueue/math/insights/leaderboards/<kind>",
     defaults={"year": None},
 )
 def enqueue_leaderboard_year_insights(
@@ -142,7 +142,7 @@ def enqueue_leaderboard_year_insights(
     )
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/insights/leaderboards/<kind>/all")
+@blueprint.route("/backend-tasks-b2/enqueue/math/insights/leaderboards/<kind>/all")
 def enqueue_all_leaderboard_insights(kind: LeaderboardKeyType) -> Response:
     for year in SeasonHelper.get_valid_years():
         taskqueue.add(
@@ -162,8 +162,8 @@ def enqueue_all_leaderboard_insights(kind: LeaderboardKeyType) -> Response:
     return make_response(f"enqueued {escape(kind)} leaderboard insights for all years")
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/notables/<int:year>")
-@blueprint.route("/backend-tasks-b2/math/enqueue/notables", defaults={"year": None})
+@blueprint.route("/backend-tasks-b2/enqueue/math/notables/<int:year>")
+@blueprint.route("/backend-tasks-b2/enqueue/math/notables", defaults={"year": None})
 def enqueue_notables_year_insights(year: Optional[Year] = None) -> Response:
     if year is None:
         year = SeasonHelper.get_current_season()
@@ -178,7 +178,7 @@ def enqueue_notables_year_insights(year: Optional[Year] = None) -> Response:
     return make_response(f"enqueued notable insights for year {escape(str(year))}")
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/notables/all")
+@blueprint.route("/backend-tasks-b2/enqueue/math/notables/all")
 def enqueue_all_notables_insights() -> Response:
     for year in SeasonHelper.get_valid_years():
         taskqueue.add(
@@ -198,7 +198,7 @@ def enqueue_all_notables_insights() -> Response:
     return make_response("enqueued all notable insights")
 
 
-@blueprint.route("/backend-tasks-b2/math/do/notables/<int:year>")
+@blueprint.route("/backend-tasks-b2/do/math/notables/<int:year>")
 def do_notables_year_insights(year: Year) -> Response:
     insights = InsightsNotableHelper.make_insights(year)
 
@@ -208,7 +208,7 @@ def do_notables_year_insights(year: Year) -> Response:
     return make_response(repr(insights))
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/overallinsights/<kind>")
+@blueprint.route("/backend-tasks-b2/enqueue/math/overallinsights/<kind>")
 def enqueue_overall_insights(kind: str) -> Response:
     """
     Enqueues Overall Insights calculation for a given kind.
@@ -230,7 +230,7 @@ def enqueue_overall_insights(kind: str) -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks-b2/math/do/overallinsights/<kind>")
+@blueprint.route("/backend-tasks-b2/do/math/overallinsights/<kind>")
 def do_overall_insights(kind: str) -> Response:
     """
     Calculates overall insights of a given kind.
@@ -256,7 +256,7 @@ def do_overall_insights(kind: str) -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/insights/<kind>/all")
+@blueprint.route("/backend-tasks-b2/enqueue/math/insights/<kind>/all")
 def enqueue_all_insights_of_kind(kind: str) -> Response:
     """
     Enqueues all insights (all valid years) of a given kind.
@@ -286,7 +286,7 @@ def enqueue_all_insights_of_kind(kind: str) -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks-b2/math/do/insights/delete/<name>")
+@blueprint.route("/backend-tasks-b2/do/math/insights/delete/<name>")
 def do_insights_delete(name: str) -> Response:
     """
     Deletes an insight from the datastore.

--- a/src/backend/tasks_cpu/handlers/tests/insights_test.py
+++ b/src/backend/tasks_cpu/handlers/tests/insights_test.py
@@ -7,12 +7,12 @@ from backend.common.consts.insight_type import InsightType
 
 
 def test_enqueue_bad_kind(tasks_cpu_client: Client) -> None:
-    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/asdf/2023")
+    resp = tasks_cpu_client.get("/backend-tasks-b2/enqueue/math/insights/asdf/2023")
     assert resp.status_code == 404
 
 
 def test_enqueue_bad_year(tasks_cpu_client: Client) -> None:
-    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/matches/asdf")
+    resp = tasks_cpu_client.get("/backend-tasks-b2/enqueue/math/insights/matches/asdf")
     assert resp.status_code == 404
 
 
@@ -20,19 +20,19 @@ def test_enqueue(
     tasks_cpu_client: Client,
     taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
 ) -> None:
-    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/matches/2023")
+    resp = tasks_cpu_client.get("/backend-tasks-b2/enqueue/math/insights/matches/2023")
     assert resp.status_code == 200
 
     tasks = tasks_cpu_client = taskqueue_stub.get_filtered_tasks(
         queue_names="backend-tasks"
     )
     assert len(tasks) == 1
-    assert tasks[0].url == "/backend-tasks-b2/math/do/insights/matches/2023"
+    assert tasks[0].url == "/backend-tasks-b2/do/math/insights/matches/2023"
 
 
 def test_enqueue_no_output_in_taskqueue(tasks_cpu_client: Client) -> None:
     resp = tasks_cpu_client.get(
-        "/backend-tasks-b2/math/enqueue/insights/matches/2023",
+        "/backend-tasks-b2/enqueue/math/insights/matches/2023",
         headers={
             "X-Appengine-Taskname": "test",
         },
@@ -46,37 +46,37 @@ def test_enqueue_defaults_to_current_season(
     tasks_cpu_client: Client,
     taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
 ) -> None:
-    resp = tasks_cpu_client.get("/backend-tasks-b2/math/enqueue/insights/matches")
+    resp = tasks_cpu_client.get("/backend-tasks-b2/enqueue/math/insights/matches")
     assert resp.status_code == 200
 
     tasks = tasks_cpu_client = taskqueue_stub.get_filtered_tasks(
         queue_names="backend-tasks"
     )
     assert len(tasks) == 1
-    assert tasks[0].url == "/backend-tasks-b2/math/do/insights/matches/2020"
+    assert tasks[0].url == "/backend-tasks-b2/do/math/insights/matches/2020"
 
 
 def test_do_bad_kind(tasks_cpu_client: Client) -> None:
-    resp = tasks_cpu_client.get("/backend-tasks-b2/math/do/insights/asdf/2023")
+    resp = tasks_cpu_client.get("/backend-tasks-b2/do/math/insights/asdf/2023")
     assert resp.status_code == 404
 
 
 def test_do_bad_year(tasks_cpu_client: Client) -> None:
-    resp = tasks_cpu_client.get("/backend-tasks-b2/math/do/insights/matches/asdf")
+    resp = tasks_cpu_client.get("/backend-tasks-b2/do/math/insights/matches/asdf")
     assert resp.status_code == 404
 
 
 @pytest.mark.parametrize("insight_type", list(InsightType))  # pyre-ignore[6]
 def test_calc(tasks_cpu_client: Client, insight_type: InsightType) -> None:
     resp = tasks_cpu_client.get(
-        f"/backend-tasks-b2/math/do/insights/{insight_type}/2023"
+        f"/backend-tasks-b2/do/math/insights/{insight_type}/2023"
     )
     assert resp.status_code == 200
 
 
 def test_calc_no_output_in_taskqueue(tasks_cpu_client: Client) -> None:
     resp = tasks_cpu_client.get(
-        "/backend-tasks-b2/math/do/insights/matches/2023",
+        "/backend-tasks-b2/do/math/insights/matches/2023",
         headers={
             "X-Appengine-Taskname": "test",
         },

--- a/src/backend/tasks_cpu/handlers/typeahead.py
+++ b/src/backend/tasks_cpu/handlers/typeahead.py
@@ -14,7 +14,7 @@ from backend.common.models.typeahead_entry import TypeaheadEntry
 blueprint = Blueprint("typeahead", __name__)
 
 
-@blueprint.route("/backend-tasks-b2/math/enqueue/typeaheadcalc")
+@blueprint.route("/backend-tasks-b2/enqueue/math/typeaheadcalc")
 def enqueue_typeahead() -> Response:
     """
     Enqueues typeahead calculation
@@ -33,7 +33,7 @@ def enqueue_typeahead() -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks-b2/math/do/typeaheadcalc")
+@blueprint.route("/backend-tasks-b2/do/math/typeaheadcalc")
 def do_typeahead() -> Response:
     """
     Calculates typeahead entries

--- a/src/backend/web/templates/admin/tasks.html
+++ b/src/backend/web/templates/admin/tasks.html
@@ -235,7 +235,7 @@
         </form>
         <script>
         $("#enqueue_award_insights_year_submit").click(function() {
-            window.location = "/backend-tasks-b2/math/enqueue/insights/awards/" + $("#enqueue_award_insights_year").val();
+            window.location = "/backend-tasks-b2/enqueue/math/insights/awards/" + $("#enqueue_award_insights_year").val();
         });
         </script>
     </div>
@@ -251,7 +251,7 @@
         </form>
         <script>
         $("#enqueue_match_insights_year_submit").click(function() {
-            window.location = "/backend-tasks-b2/math/enqueue/insights/matches/" + $("#enqueue_match_insights_year").val();
+            window.location = "/backend-tasks-b2/enqueue/math/insights/matches/" + $("#enqueue_match_insights_year").val();
         });
         </script>
     </div>
@@ -259,10 +259,10 @@
 <h3>Calculate Overall Insights</h3>
 <div class="row">
     <div class="col-sm-6">
-        <a class="btn btn-warning" href="/backend-tasks-b2/math/enqueue/overallinsights/awards">Enqueue Overall Award Insights</a>
+        <a class="btn btn-warning" href="/backend-tasks-b2/enqueue/math/overallinsights/awards">Enqueue Overall Award Insights</a>
     </div>
     <div class="col-sm-6">
-        <a class="btn btn-warning" href="/backend-tasks-b2.yaml/math/enqueue/overallinsights/matches">Enqueue Overall Match Insights</a>
+        <a class="btn btn-warning" href="/backend-tasks-b2/enqueue/math/overallinsights/matches">Enqueue Overall Match Insights</a>
     </div>
 </div>
 

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -1,170 +1,170 @@
 cron:
-- description: FIRST event list scraping. Also includes event details/event teams/team details scraping.
-  url: /backend-tasks/enqueue/event_list/current
-  schedule: every day 01:00
-  timezone: America/Los_Angeles
+  - description: FIRST event list scraping. Also includes event details/event teams/team details scraping.
+    url: /backend-tasks/enqueue/event_list/current
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
 
-- description: FIRST team detail scraping
-  url: /tasks/enqueue/fmsapi_team_details_rolling
-  schedule: every day 03:30
-  timezone: America/Los_Angeles
+  - description: FIRST team detail scraping
+    url: /tasks/enqueue/fmsapi_team_details_rolling
+    schedule: every day 03:30
+    timezone: America/Los_Angeles
 
-- description: FIRST match scraping for current events
-  url: /tasks/enqueue/fmsapi_matches/now
-  schedule: every 1 minutes
+  - description: FIRST match scraping for current events
+    url: /tasks/enqueue/fmsapi_matches/now
+    schedule: every 1 minutes
 
-- description: FIRST event ranking scraping for current events
-  url: /tasks/enqueue/fmsapi_event_rankings/now
-  schedule: every 1 minutes
+  - description: FIRST event ranking scraping for current events
+    url: /tasks/enqueue/fmsapi_event_rankings/now
+    schedule: every 1 minutes
 
-- description: FIRST event alliance scraping for current events
-  url: /tasks/enqueue/fmsapi_event_alliances/now
-  schedule: every 30 minutes
+  - description: FIRST event alliance scraping for current events
+    url: /tasks/enqueue/fmsapi_event_alliances/now
+    schedule: every 30 minutes
 
-- description: FIRST event alliance scraping for current events on their last day
-  url: /tasks/enqueue/fmsapi_event_alliances/last_day_only
-  schedule: every 5 minutes
+  - description: FIRST event alliance scraping for current events on their last day
+    url: /tasks/enqueue/fmsapi_event_alliances/last_day_only
+    schedule: every 5 minutes
 
-- description: FIRST award scraping for current events
-  url: /tasks/enqueue/fmsapi_awards/now
-  schedule: every 1 hours
+  - description: FIRST award scraping for current events
+    url: /tasks/enqueue/fmsapi_awards/now
+    schedule: every 1 hours
 
-- description: FIRST award scraping for current events on their last day
-  url: /tasks/enqueue/fmsapi_awards/last_day_only
-  schedule: every 5 minutes
+  - description: FIRST award scraping for current events on their last day
+    url: /tasks/enqueue/fmsapi_awards/last_day_only
+    schedule: every 5 minutes
 
-- description: Regional Championship Advancement fetch for current season
-  url: /tasks/get/regional_advancement/
-  schedule: every day 03:00
+  - description: Regional Championship Advancement fetch for current season
+    url: /tasks/get/regional_advancement/
+    schedule: every day 03:00
 
-- description: Nexus pit locations for current events
-  url: /tasks/enqueue/nexus_pit_locations/now
-  schedule: every 1 hours
+  - description: Nexus pit locations for current events
+    url: /tasks/enqueue/nexus_pit_locations/now
+    schedule: every 1 hours
 
-- description: Nexus queue status current events
-  url: /tasks/enqueue/nexus_queue_status/now
-  schedule: every 1 minutes
+  - description: Nexus queue status current events
+    url: /tasks/enqueue/nexus_queue_status/now
+    schedule: every 1 minutes
 
-- description: Nexus pit locations for all season events
-  url: /tasks/enqueue/nexus_pit_locations/current_year
-  schedule: every day 02:00
-  timezone: America/Los_Angeles
+  - description: Nexus pit locations for all season events
+    url: /tasks/enqueue/nexus_pit_locations/current_year
+    schedule: every day 02:00
+    timezone: America/Los_Angeles
 
-- description: Hall of Fame team list scraping
-  url: /tasks/get/hof_teams
-  schedule: every thursday 01:00
-  timezone: America/Los_Angeles
+  - description: Hall of Fame team list scraping
+    url: /tasks/get/hof_teams
+    schedule: every thursday 01:00
+    timezone: America/Los_Angeles
 
-- description: Typeahead Calculation
-  url: /backend-tasks-b2/math/enqueue/typeaheadcalc
-  schedule: every day 01:00
-  timezone: America/Los_Angeles
+  - description: Typeahead Calculation
+    url: backend-tasks-b2/enqueue/math/typeaheadcalc
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
 
-- description: Match Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/matches
-  schedule: every day 01:02
-  timezone: America/Los_Angeles
+  - description: Match Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/matches
+    schedule: every day 01:02
+    timezone: America/Los_Angeles
 
-- description: Award Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/awards
-  schedule: every day 01:04
-  timezone: America/Los_Angeles
+  - description: Award Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/awards
+    schedule: every day 01:04
+    timezone: America/Los_Angeles
 
-- description: Prediction Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/predictions
-  schedule: every day 01:06
-  timezone: America/Los_Angeles
+  - description: Prediction Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/predictions
+    schedule: every day 01:06
+    timezone: America/Los_Angeles
 
-- description: Match Overall Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/overallinsights/matches
-  schedule: every day 01:08
-  timezone: America/Los_Angeles
+  - description: Match Overall Insights Calculation
+    url: backend-tasks-b2/enqueue/math/overallinsights/matches
+    schedule: every day 01:08
+    timezone: America/Los_Angeles
 
-- description: Team Leaderboard Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/leaderboards/team
-  schedule: every day 01:15
-  timezone: America/Los_Angeles
+  - description: Team Leaderboard Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/leaderboards/team
+    schedule: every day 01:15
+    timezone: America/Los_Angeles
 
-- description: Event Leaderboard Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/leaderboards/event
-  schedule: every day 01:17
-  timezone: America/Los_Angeles
+  - description: Event Leaderboard Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/leaderboards/event
+    schedule: every day 01:17
+    timezone: America/Los_Angeles
 
-- description: Match Leaderboard Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/leaderboards/match
-  schedule: every day 01:19
-  timezone: America/Los_Angeles
+  - description: Match Leaderboard Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/leaderboards/match
+    schedule: every day 01:19
+    timezone: America/Los_Angeles
 
-- description: Team Overall Leaderboard Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/leaderboards/team/0
-  schedule: every day 01:25
-  timezone: America/Los_Angeles
+  - description: Team Overall Leaderboard Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/leaderboards/team/0
+    schedule: every day 01:25
+    timezone: America/Los_Angeles
 
-- description: Event Overall Leaderboard Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/leaderboards/event/0
-  schedule: every day 01:30
-  timezone: America/Los_Angeles
+  - description: Event Overall Leaderboard Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/leaderboards/event/0
+    schedule: every day 01:30
+    timezone: America/Los_Angeles
 
-- description: Match Overall Leaderboard Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/leaderboards/match/0
-  schedule: every day 01:35
-  timezone: America/Los_Angeles
+  - description: Match Overall Leaderboard Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/leaderboards/match/0
+    schedule: every day 01:35
+    timezone: America/Los_Angeles
 
-- description: Notable Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/notables
-  schedule: every day 01:21
-  timezone: America/Los_Angeles
+  - description: Notable Insights Calculation
+    url: backend-tasks-b2/enqueue/math/notables
+    schedule: every day 01:21
+    timezone: America/Los_Angeles
 
-- description: Notable Overall Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/notables/0
-  schedule: every day 01:23
-  timezone: America/Los_Angeles
+  - description: Notable Overall Insights Calculation
+    url: backend-tasks-b2/enqueue/math/notables/0
+    schedule: every day 01:23
+    timezone: America/Los_Angeles
 
-- description: District Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/insights/districts/0
-  schedule: every day 01:40
-  timezone: America/Los_Angeles
+  - description: District Insights Calculation
+    url: backend-tasks-b2/enqueue/math/insights/districts/0
+    schedule: every day 01:40
+    timezone: America/Los_Angeles
 
-- description: Award Overall Insights Calculation
-  url: /backend-tasks-b2/math/enqueue/overallinsights/awards
-  schedule: every day 01:10
-  timezone: America/Los_Angeles
+  - description: Award Overall Insights Calculation
+    url: backend-tasks-b2/enqueue/math/overallinsights/awards
+    schedule: every day 01:10
+    timezone: America/Los_Angeles
 
-- description: District Rankings Calculation
-  url: /tasks/math/enqueue/district_rankings_calc
-  schedule: every day 1:05
-  timezone: America/Los_Angeles
+  - description: District Rankings Calculation
+    url: /tasks/math/enqueue/district_rankings_calc
+    schedule: every day 1:05
+    timezone: America/Los_Angeles
 
-#- description: Upcoming match notification sending
-#  url: /tasks/notifications/upcoming_match
-#  schedule: every 2 minutes
+  #- description: Upcoming match notification sending
+  #  url: /tasks/notifications/upcoming_match
+  #  schedule: every 2 minutes
 
-- description: Update live events (and bluezone)
-  url: /tasks/do/update_live_events
-  schedule: every 5 minutes
+  - description: Update live events (and bluezone)
+    url: /tasks/do/update_live_events
+    schedule: every 5 minutes
 
-- description: Predict Match Times
-  url: /tasks/math/enqueue/predict_match_times
-  schedule: every 1 minutes
+  - description: Predict Match Times
+    url: /tasks/math/enqueue/predict_match_times
+    schedule: every 1 minutes
 
-- description: Suggestion Queue Nag
-  url: /tasks/do/nag_suggestions
-  schedule: every day 08:00
-  timezone: America/Los_Angeles
+  - description: Suggestion Queue Nag
+    url: /tasks/do/nag_suggestions
+    schedule: every day 08:00
+    timezone: America/Los_Angeles
 
-- description: Backup Cron job
-  url: /backend-tasks/backup/enqueue
-  schedule: every monday 03:00
-  timezone: America/Los_Angeles
+  - description: Backup Cron job
+    url: /backend-tasks/backup/enqueue
+    schedule: every monday 03:00
+    timezone: America/Los_Angeles
 
-# - description: BlueZone Update
-#   url: /tasks/do/bluezone_update
-#   schedule: every 1 minutes
+  # - description: BlueZone Update
+  #   url: /tasks/do/bluezone_update
+  #   schedule: every 1 minutes
 
-- description: Update Team Search Indexes
-  url: /tasks/enqueue/update_all_team_search_index
-  schedule: every monday 04:00
+  - description: Update Team Search Indexes
+    url: /tasks/enqueue/update_all_team_search_index
+    schedule: every monday 04:00
 
-- description: Archive Old API Keys
-  url: /tasks/do/archive_api_keys
-  schedule: 1 of jan 1:00
+  - description: Archive Old API Keys
+    url: /tasks/do/archive_api_keys
+    schedule: 1 of jan 1:00

--- a/src/dispatch.yaml
+++ b/src/dispatch.yaml
@@ -18,7 +18,10 @@ dispatch:
   - url: "*/_ah/queue/deferred*"
     service: py3-tasks-io
 
-  - url: "*/backend-tasks-b2/*"
+  - url: "*/backend-tasks-b2/enqueue/*"
+    service: py3-tasks-cpu-enqueue
+
+  - url: "*/backend-tasks-b2/do/*"
     service: py3-tasks-cpu
 
   - url: "*/*"

--- a/src/tasks_cpu_enqueue.yaml
+++ b/src/tasks_cpu_enqueue.yaml
@@ -1,0 +1,13 @@
+service: py3-tasks-cpu-enqueue
+runtime: python312
+entrypoint: gunicorn -t 0 -b :$PORT backend.tasks_cpu.main:app
+app_engine_apis: true
+
+instance_class: F1
+automatic_scaling:
+  max_idle_instances: 1
+
+handlers:
+  - url: .*
+    script: auto
+    login: admin


### PR DESCRIPTION
Handle `/backend-tasks-b2/enqueue/*` and `/backend-tasks-b2/do/*` on separate instance types since `tasks-cpu` doesn't autoscale.

Replaces #7891