### PR TITLE
Condense cron start times

### DIFF
--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -60,79 +60,85 @@ cron:
     schedule: every day 01:00
     timezone: America/Los_Angeles
 
+  # Legacy Insights
   - description: Match Insights Calculation
     url: /backend-tasks-b2/enqueue/math/insights/matches
-    schedule: every day 01:02
+    schedule: every day 01:00
     timezone: America/Los_Angeles
 
   - description: Award Insights Calculation
     url: /backend-tasks-b2/enqueue/math/insights/awards
-    schedule: every day 01:04
+    schedule: every day 01:00
     timezone: America/Los_Angeles
 
   - description: Prediction Insights Calculation
     url: /backend-tasks-b2/enqueue/math/insights/predictions
-    schedule: every day 01:06
+    schedule: every day 01:00
     timezone: America/Los_Angeles
 
+  # Legacy Overall Insights
+  # These depend on the yearly insights and should be scheduled after
   - description: Match Overall Insights Calculation
     url: /backend-tasks-b2/enqueue/math/overallinsights/matches
-    schedule: every day 01:08
-    timezone: America/Los_Angeles
-
-  - description: Team Leaderboard Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/team
-    schedule: every day 01:15
-    timezone: America/Los_Angeles
-
-  - description: Event Leaderboard Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/event
-    schedule: every day 01:17
-    timezone: America/Los_Angeles
-
-  - description: Match Leaderboard Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/match
-    schedule: every day 01:19
-    timezone: America/Los_Angeles
-
-  - description: Team Overall Leaderboard Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/team/0
-    schedule: every day 01:25
-    timezone: America/Los_Angeles
-
-  - description: Event Overall Leaderboard Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/event/0
-    schedule: every day 01:30
-    timezone: America/Los_Angeles
-
-  - description: Match Overall Leaderboard Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/match/0
-    schedule: every day 01:35
-    timezone: America/Los_Angeles
-
-  - description: Notable Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/notables
-    schedule: every day 01:21
-    timezone: America/Los_Angeles
-
-  - description: Notable Overall Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/notables/0
-    schedule: every day 01:23
-    timezone: America/Los_Angeles
-
-  - description: District Insights Calculation
-    url: /backend-tasks-b2/enqueue/math/insights/districts/0
-    schedule: every day 01:40
+    schedule: every day 01:05
     timezone: America/Los_Angeles
 
   - description: Award Overall Insights Calculation
     url: /backend-tasks-b2/enqueue/math/overallinsights/awards
-    schedule: every day 01:10
+    schedule: every day 01:05
     timezone: America/Los_Angeles
 
   - description: District Rankings Calculation
     url: /tasks/math/enqueue/district_rankings_calc
-    schedule: every day 1:05
+    schedule: every day 01:05
+    timezone: America/Los_Angeles
+
+  # Leaderboard Insights
+  - description: Team Leaderboard Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/team
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  - description: Event Leaderboard Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/event
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  - description: Match Leaderboard Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/match
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  - description: Team Overall Leaderboard Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/team/0
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  - description: Event Overall Leaderboard Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/event/0
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  - description: Match Overall Leaderboard Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/leaderboards/match/0
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  # Notable Insights
+  - description: Notable Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/notables
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  - description: Notable Overall Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/notables/0
+    schedule: every day 01:00
+    timezone: America/Los_Angeles
+
+  # District Insights
+  - description: District Insights Calculation
+    url: /backend-tasks-b2/enqueue/math/insights/districts/0
+    schedule: every day 01:00
     timezone: America/Los_Angeles
 
   #- description: Upcoming match notification sending


### PR DESCRIPTION
New enqueue logic & backend task queue makes spreading out start times unnecessary.