### PR TITLE
Support Event Timezone in trusted API

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_event_info_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_event_info_parser.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from typing import AnyStr, Dict, List, Optional, TypedDict
 
+import pytz
 from pyre_extensions import safe_json
 
 from backend.common.consts.playoff_type import PlayoffType
@@ -33,6 +34,7 @@ class EventInfoParsed(TypedDict, total=False):
     playoff_type: PlayoffType
     webcasts: List[Webcast]
     remap_teams: Dict[TeamKey, TeamKey]
+    timezone: str
 
 
 class JSONEventInfoParser:
@@ -100,5 +102,10 @@ class JSONEventInfoParser:
 
         if "first_event_code" in info_dict:
             parsed_info["first_event_code"] = info_dict["first_event_code"]
+
+        if timezone := info_dict.get("timezone"):
+            if timezone not in pytz.all_timezones_set:
+                raise ParserInputException(f"Unknown timezone {timezone}")
+            parsed_info["timezone"] = timezone
 
         return parsed_info

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -147,6 +147,9 @@ def update_event_info(event_key: EventKey) -> Response:
     if "playoff_type" in parsed_info:
         event.playoff_type = parsed_info["playoff_type"]
 
+    if "timezone" in parsed_info:
+        event.timezone_id = parsed_info["timezone"]
+
     EventManipulator.createOrUpdate(event, auto_union=False)
     return profiled_jsonify({"Success": f"Event {event_key} updated"})
 

--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -555,6 +555,11 @@
             "example": {
               "frc1337": "frc337B"
             }
+          },
+          "timezone": {
+            "type": "string",
+            "description": "Timezone name for the event",
+            "example": "America/New_York"
           }
         }
       },


### PR DESCRIPTION
Two things:
 - Support setting the event timezone via the trusted API
 - add test coverage specifically for posting rankings with `sortN` key names (which is how FMS stores them)