### PR TITLE
Support additional match timestamps in trusted API

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_matches_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_matches_parser.py
@@ -41,6 +41,8 @@ class ParsedMatch(TypedDict):
     score_breakdown_json: Optional[str]
     time_string: str
     time: datetime.datetime
+    actual_start_time: Optional[datetime.datetime]
+    post_results_time: Optional[datetime.datetime]
     team_key_names: Sequence[TeamKey]
     display_name: Optional[str]
 
@@ -79,6 +81,8 @@ class JSONMatchesParser:
             score_breakdown = match.get("score_breakdown", None)
             time_string = match.get("time_string", None)
             time_utc = match.get("time_utc", None)
+            actual_start_time_utc = match.get("actual_start_time_utc", None)
+            post_results_time_utc = match.get("post_results_time_utc", None)
             display_name = match.get("display_name", None)
 
             if comp_level is None:
@@ -173,6 +177,30 @@ class JSONMatchesParser:
                         "Could not parse 'time_utc'. Check that it is in ISO 8601 format."
                     )
 
+            if actual_start_time_utc is not None:
+                try:
+                    actual_start_time_utc = datetime.datetime.fromisoformat(
+                        actual_start_time_utc
+                    )
+                    # remove timezone info because DatetimeProperty can't handle timezones
+                    actual_start_time_utc = actual_start_time_utc.replace(tzinfo=None)
+                except ValueError:
+                    raise ParserInputException(
+                        "Could not parse 'actual_start_time_utc'. Check that it is in ISO 8601 format."
+                    )
+
+            if post_results_time_utc is not None:
+                try:
+                    post_results_time_utc = datetime.datetime.fromisoformat(
+                        post_results_time_utc
+                    )
+                    # remove timezone info because DatetimeProperty can't handle timezones
+                    post_results_time_utc = post_results_time_utc.replace(tzinfo=None)
+                except ValueError:
+                    raise ParserInputException(
+                        "Could not parse 'post_results_time_utc'. Check that it is in ISO 8601 format."
+                    )
+
             if display_name is not None and type(display_name) is not str:
                 raise ParserInputException("'display_name' must be a string")
 
@@ -201,6 +229,8 @@ class JSONMatchesParser:
                 ),
                 "time_string": time_string,
                 "time": datetime_utc,
+                "actual_start_time": actual_start_time_utc,
+                "post_results_time": post_results_time_utc,
                 "team_key_names": parsed_alliances[AllianceColor.RED]["teams"]
                 + parsed_alliances[AllianceColor.BLUE]["teams"],
                 "display_name": display_name,

--- a/src/backend/api/handlers/tests/update_event_matches_test.py
+++ b/src/backend/api/handlers/tests/update_event_matches_test.py
@@ -217,6 +217,24 @@ def test_no_auth(api_client: Client) -> None:
                 "time_utc": "foo",
             }
         ],
+        [
+            {
+                "comp_level": "qf",
+                "set_number": 1,
+                "match_number": 1,
+                "alliances": {},
+                "actual_start_time_utc": "foo",
+            }
+        ],
+        [
+            {
+                "comp_level": "qf",
+                "set_number": 1,
+                "match_number": 1,
+                "alliances": {},
+                "post_results_time_utc": "foo",
+            }
+        ],
     ],
 )
 def test_bad_json(api_client: Client, request_data: Any) -> None:
@@ -294,6 +312,8 @@ def test_matches_update(api_client: Client) -> None:
             },
             "time_string": "10:00 AM",
             "time_utc": "2014-08-31T17:00:00",
+            "actual_start_time_utc": "2014-08-31T17:01:00",
+            "post_results_time_utc": "2014-08-31T17:05:00",
         }
     ]
     request_body = json.dumps(matches)
@@ -314,6 +334,8 @@ def test_matches_update(api_client: Client) -> None:
     assert match is not None
     assert match.time == datetime.datetime(2014, 8, 31, 17, 0)
     assert match.time_string == "10:00 AM"
+    assert match.actual_time == datetime.datetime(2014, 8, 31, 17, 1)
+    assert match.post_result_time == datetime.datetime(2014, 8, 31, 17, 5)
     assert match.alliances[AllianceColor.RED]["teams"] == ["frc1", "frc2", "frc3"]
     assert match.alliances[AllianceColor.RED]["score"] == 250
     assert match.alliances[AllianceColor.RED]["surrogates"] == ["frc1"]

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -234,6 +234,8 @@ def update_event_matches(event_key: EventKey) -> Response:
             score_breakdown_json=match["score_breakdown_json"],
             time_string=match["time_string"],
             time=match["time"],
+            actual_time=match["actual_start_time"],
+            post_result_time=match["post_results_time"],
             display_name=match["display_name"],
         )
 

--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -665,7 +665,17 @@
           },
           "time_utc": {
             "type": "string",
-            "description": "UTC time of match in ISO 8601 format (YYYY-MM-DDTHH:MM:SS)",
+            "description": "UTC time of the match's scheduled time in ISO 8601 format (YYYY-MM-DDTHH:MM:SS)",
+            "example": "2008-01-02T10:30:00.000Z"
+          },
+          "actual_start_time_utc": {
+            "type": "string",
+            "description": "UTC time of when the match actually started in ISO 8601 format (YYYY-MM-DDTHH:MM:SS)",
+            "example": "2008-01-02T10:30:00.000Z"
+          },
+          "post_results_time_utc": {
+            "type": "string",
+            "description": "UTC time of when the match results were shown to the audience in ISO 8601 format (YYYY-MM-DDTHH:MM:SS)",
             "example": "2008-01-02T10:30:00.000Z"
           },
           "display_name": {


### PR DESCRIPTION
Supports `actual_start_time` and `post_result_time` being set