### PR TITLE
[PWA] Visual fixes for tool tips

### DIFF
--- a/pwa/app/components/ui/tooltip.tsx
+++ b/pwa/app/components/ui/tooltip.tsx
@@ -61,8 +61,8 @@ function TooltipContent({
         {...props}
       >
         <div
-          className="max-h-60 overflow-x-hidden overflow-y-auto px-3 py-1.5
-            text-center text-balance [&::-webkit-scrollbar]:w-2
+          className="relative z-10 max-h-60 overflow-x-hidden overflow-y-auto
+            px-3 py-1.5 text-center text-balance [&::-webkit-scrollbar]:w-2
             [&::-webkit-scrollbar-thumb]:rounded-full
             [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30
             [&::-webkit-scrollbar-track]:bg-transparent"
@@ -70,8 +70,8 @@ function TooltipContent({
           {children}
         </div>
         <TooltipPrimitive.Arrow
-          className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45
-            rounded-[2px] bg-popover fill-popover"
+          className="relative -z-10 size-3 translate-y-[calc(-50%_-_2px)]
+            rotate-45 rounded-[2px] bg-popover fill-popover"
         />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>

--- a/pwa/app/components/ui/tooltip.tsx
+++ b/pwa/app/components/ui/tooltip.tsx
@@ -45,8 +45,8 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           `z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)
-          animate-in rounded-md border border-gray-200 bg-white text-xs
-          text-gray-900 shadow-lg fade-in-0 zoom-in-95
+          animate-in rounded-md border bg-popover text-xs
+          text-popover-foreground fade-in-0 zoom-in-95
           data-[side=bottom]:slide-in-from-top-2
           data-[side=left]:slide-in-from-right-2
           data-[side=right]:slide-in-from-left-2
@@ -54,20 +54,24 @@ function TooltipContent({
           data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95`,
           className,
         )}
+        style={{
+          filter:
+            'drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1))',
+        }}
         {...props}
       >
         <div
           className="max-h-60 overflow-x-hidden overflow-y-auto px-3 py-1.5
-            text-balance [&::-webkit-scrollbar]:w-2
+            text-center text-balance [&::-webkit-scrollbar]:w-2
             [&::-webkit-scrollbar-thumb]:rounded-full
-            [&::-webkit-scrollbar-thumb]:bg-gray-300
+            [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30
             [&::-webkit-scrollbar-track]:bg-transparent"
         >
           {children}
         </div>
         <TooltipPrimitive.Arrow
           className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45
-            rounded-[2px] border-gray-200 bg-white fill-white"
+            rounded-[2px] bg-popover fill-popover"
         />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>

--- a/pwa/app/components/ui/tooltip.tsx
+++ b/pwa/app/components/ui/tooltip.tsx
@@ -44,9 +44,9 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          `z-50 w-fit origin-(--radix-tooltip-content-transform-origin)
-          animate-in rounded-md bg-primary px-3 py-1.5 text-xs text-balance
-          text-primary-foreground fade-in-0 zoom-in-95
+          `z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)
+          animate-in rounded-md border border-gray-200 bg-white text-xs
+          text-gray-900 shadow-lg fade-in-0 zoom-in-95
           data-[side=bottom]:slide-in-from-top-2
           data-[side=left]:slide-in-from-right-2
           data-[side=right]:slide-in-from-left-2
@@ -56,10 +56,18 @@ function TooltipContent({
         )}
         {...props}
       >
-        {children}
+        <div
+          className="max-h-60 overflow-x-hidden overflow-y-auto px-3 py-1.5
+            text-balance [&::-webkit-scrollbar]:w-2
+            [&::-webkit-scrollbar-thumb]:rounded-full
+            [&::-webkit-scrollbar-thumb]:bg-gray-300
+            [&::-webkit-scrollbar-track]:bg-transparent"
+        >
+          {children}
+        </div>
         <TooltipPrimitive.Arrow
           className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45
-            rounded-[2px] bg-primary fill-primary"
+            rounded-[2px] border-gray-200 bg-white fill-white"
         />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
Tailwind primary color changed to blue which made tool tips pretty unreadable.

## Description
- Updated colors for component
- Added a scroll bar for tool tips that are above a certain size for massive lists of teams for insights page that made things unreadable
- Fixed some weird text centering + better dropshadow

## Motivation and Context
Reading tool tips is good

## How Has This Been Tested?
Looks actually readable on insights page, checked a bunch of different usages and seems to work fine.

## Screenshots (if appropriate):

### Current Site
<img width="616" height="524" alt="image" src="https://github.com/user-attachments/assets/bbb82312-ce5f-4952-8908-8ff669b7b256" />
<img width="578" height="724" alt="image" src="https://github.com/user-attachments/assets/b41d3a2d-04e8-45aa-ab0e-ac67c1a1b56c" />


### Changed Component

<img width="683" height="376" alt="image" src="https://github.com/user-attachments/assets/b4420a8e-7550-474d-975b-478edb59aa0b" />



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
