### PR TITLE
Support disabling indivdual parts of sync

### DIFF
--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -150,6 +150,9 @@ def update_event_info(event_key: EventKey) -> Response:
     if "timezone" in parsed_info:
         event.timezone_id = parsed_info["timezone"]
 
+    if "sync_disabled_flags" in parsed_info:
+        event.disable_sync_flags = parsed_info["sync_disabled_flags"]
+
     EventManipulator.createOrUpdate(event, auto_union=False)
     return profiled_jsonify({"Success": f"Event {event_key} updated"})
 

--- a/src/backend/common/consts/event_sync_type.py
+++ b/src/backend/common/consts/event_sync_type.py
@@ -1,0 +1,9 @@
+from enum import IntFlag
+
+
+class EventSyncType(IntFlag):
+    EVENT_ALLIANCES = 1
+    EVENT_RANKINGS = 2
+    EVENT_QUAL_MATCHES = 4
+    EVENT_PLAYOFF_MATCHES = 8
+    EVENT_AWARDS = 16

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/test_fms_api_match_tiebreaker.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/test_fms_api_match_tiebreaker.py
@@ -48,6 +48,7 @@ def test_2017flwp_sequence(ndb_stub, taskqueue_stub) -> None:
         event_short="flwp",
         year=2017,
         event_type_enum=0,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()
@@ -134,6 +135,7 @@ def test_2017flwp(ndb_stub, taskqueue_stub) -> None:
         event_short="flwp",
         year=2017,
         event_type_enum=0,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()
@@ -202,6 +204,7 @@ def test_2017pahat(ndb_stub, taskqueue_stub) -> None:
         event_short="pahat",
         year=2017,
         event_type_enum=0,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()
@@ -270,6 +273,7 @@ def test_2017scmb_sequence(ndb_stub, taskqueue_stub) -> None:
         event_short="scmb",
         year=2017,
         event_type_enum=0,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()
@@ -356,6 +360,7 @@ def test_2017scmb(ndb_stub, taskqueue_stub) -> None:
         event_short="scmb",
         year=2017,
         event_type_enum=0,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()
@@ -533,6 +538,7 @@ def test_2017ncwin(ndb_stub, taskqueue_stub) -> None:
         event_short="ncwin",
         year=2017,
         event_type_enum=0,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()
@@ -711,6 +717,7 @@ def test_2023ncash_double_elim(ndb_stub, taskqueue_stub) -> None:
         year=2023,
         event_type_enum=EventType.DISTRICT,
         playoff_type=PlayoffType.DOUBLE_ELIM_8_TEAM,
+        official=True,
         timezone_id="America/New_York",
     )
     event.put()

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_fms_api_event_matches_test.py
@@ -1,10 +1,14 @@
+import datetime
 import json
 from unittest.mock import call, patch
 
 import pytest
 
+from backend.common.consts.event_sync_type import EventSyncType
+from backend.common.consts.event_type import EventType
 from backend.common.frc_api import FRCAPI
 from backend.common.futures import InstantFuture
+from backend.common.models.event import Event
 from backend.common.sitevars.fms_api_secrets import (
     ContentType as FMSApiSecretsContentType,
 )
@@ -79,6 +83,125 @@ def test_get_event_matches_cmp() -> None:
     mock_match_scores_api.assert_has_calls(
         [call(2014, "galileo", "qual"), call(2014, "galileo", "playoff")]
     )
+    mock_schedule_parse.assert_has_calls(
+        [call({"Schedule": []}), call({"Schedule": []})]
+    )
+
+
+def test_get_event_matches_qual_sync_disabled() -> None:
+    e = Event(
+        id="2025casj",
+        year=2025,
+        event_short="casj",
+        start_date=datetime.datetime(2025, 4, 1),
+        end_date=datetime.datetime(2025, 4, 3),
+        event_type_enum=EventType.OFFSEASON,
+        official=True,
+        disable_sync_flags=(0 | EventSyncType.EVENT_QUAL_MATCHES),
+    )
+    e.put()
+
+    schedule_response = URLFetchResult.mock_for_content(
+        "", 200, json.dumps({"Schedule": []})
+    )
+    score_response = URLFetchResult.mock_for_content("", 200, "")
+
+    df = DatafeedFMSAPI()
+    with patch.object(
+        FRCAPI, "hybrid_schedule", return_value=InstantFuture(schedule_response)
+    ) as mock_hybrid_schedule_api, patch.object(
+        FRCAPI, "match_scores", return_value=InstantFuture(score_response)
+    ) as mock_match_scores_api, patch.object(
+        FMSAPIHybridScheduleParser, "parse"
+    ) as mock_schedule_parse, patch.object(
+        FMSAPIMatchDetailsParser, "parse"
+    ) as mock_match_detail_parser:
+        mock_schedule_parse.side_effect = ([], [])
+        mock_match_detail_parser.return_value = {}
+        df.get_event_matches("2025casj").get_result()
+
+    mock_hybrid_schedule_api.assert_has_calls([call(2025, "casj", "playoff")])
+    mock_match_scores_api.assert_has_calls([call(2025, "casj", "playoff")])
+    mock_schedule_parse.assert_has_calls(
+        [call({"Schedule": []}), call({"Schedule": []})]
+    )
+
+
+def test_get_event_matches_playoff_sync_disabled() -> None:
+    e = Event(
+        id="2025casj",
+        year=2025,
+        event_short="casj",
+        start_date=datetime.datetime(2025, 4, 1),
+        end_date=datetime.datetime(2025, 4, 3),
+        event_type_enum=EventType.OFFSEASON,
+        official=True,
+        disable_sync_flags=(0 | EventSyncType.EVENT_PLAYOFF_MATCHES),
+    )
+    e.put()
+
+    schedule_response = URLFetchResult.mock_for_content(
+        "", 200, json.dumps({"Schedule": []})
+    )
+    score_response = URLFetchResult.mock_for_content("", 200, "")
+
+    df = DatafeedFMSAPI()
+    with patch.object(
+        FRCAPI, "hybrid_schedule", return_value=InstantFuture(schedule_response)
+    ) as mock_hybrid_schedule_api, patch.object(
+        FRCAPI, "match_scores", return_value=InstantFuture(score_response)
+    ) as mock_match_scores_api, patch.object(
+        FMSAPIHybridScheduleParser, "parse"
+    ) as mock_schedule_parse, patch.object(
+        FMSAPIMatchDetailsParser, "parse"
+    ) as mock_match_detail_parser:
+        mock_schedule_parse.side_effect = ([], [])
+        mock_match_detail_parser.return_value = {}
+        df.get_event_matches("2025casj").get_result()
+
+    mock_hybrid_schedule_api.assert_has_calls([call(2025, "casj", "qual")])
+    mock_match_scores_api.assert_has_calls([call(2025, "casj", "qual")])
+    mock_schedule_parse.assert_has_calls(
+        [call({"Schedule": []}), call({"Schedule": []})]
+    )
+
+
+def test_get_event_matches_both_sync_disabled() -> None:
+    e = Event(
+        id="2025casj",
+        year=2025,
+        event_short="casj",
+        start_date=datetime.datetime(2025, 4, 1),
+        end_date=datetime.datetime(2025, 4, 3),
+        event_type_enum=EventType.OFFSEASON,
+        official=True,
+        disable_sync_flags=(
+            0 | EventSyncType.EVENT_QUAL_MATCHES | EventSyncType.EVENT_PLAYOFF_MATCHES
+        ),
+    )
+    e.put()
+
+    schedule_response = URLFetchResult.mock_for_content(
+        "", 200, json.dumps({"Schedule": []})
+    )
+    score_response = URLFetchResult.mock_for_content("", 200, "")
+
+    df = DatafeedFMSAPI()
+    with patch.object(
+        FRCAPI, "hybrid_schedule", return_value=InstantFuture(schedule_response)
+    ) as mock_hybrid_schedule_api, patch.object(
+        FRCAPI, "match_scores", return_value=InstantFuture(score_response)
+    ) as mock_match_scores_api, patch.object(
+        FMSAPIHybridScheduleParser, "parse"
+    ) as mock_schedule_parse, patch.object(
+        FMSAPIMatchDetailsParser, "parse"
+    ) as mock_match_detail_parser:
+        mock_schedule_parse.side_effect = ([], [])
+        mock_match_detail_parser.return_value = {}
+        df.get_event_matches("2025casj").get_result()
+
+    mock_hybrid_schedule_api.assert_has_calls([])
+    mock_match_scores_api.assert_has_calls([])
     mock_schedule_parse.assert_has_calls(
         [call({"Schedule": []}), call({"Schedule": []})]
     )

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -9,6 +9,7 @@ from google.appengine.ext import ndb
 from markupsafe import Markup
 from pyre_extensions import none_throws
 
+from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType
 from backend.common.environment import Environment
 from backend.common.helpers.event_helper import EventHelper
@@ -556,6 +557,8 @@ def enqueue_event_alliances(
         events = ndb.get_multi(event_keys)
 
     for event in events:
+        if not event.is_sync_enabled(EventSyncType.EVENT_ALLIANCES):
+            continue
         taskqueue.add(
             queue_name="datafeed",
             target="py3-tasks-io",
@@ -626,6 +629,8 @@ def enqueue_event_rankings(year: Optional[Year]) -> Response:
         events = ndb.get_multi(event_keys)
 
     for event in events:
+        if not event.is_sync_enabled(EventSyncType.EVENT_RANKINGS):
+            continue
         taskqueue.add(
             queue_name="datafeed",
             target="py3-tasks-io",
@@ -694,6 +699,10 @@ def enqueue_event_matches(year: Optional[Year]) -> Response:
         events = ndb.get_multi(event_keys)
 
     for event in events:
+        if not event.is_sync_enabled(
+            EventSyncType.EVENT_QUAL_MATCHES
+        ) and not event.is_sync_enabled(EventSyncType.EVENT_PLAYOFF_MATCHES):
+            continue
         taskqueue.add(
             queue_name="datafeed",
             target="py3-tasks-io",
@@ -787,6 +796,8 @@ def awards_year(year: Optional[int], when: Optional[str] = None) -> Response:
         events = ndb.get_multi(event_keys)
 
     for event in events:
+        if not event.is_sync_enabled(EventSyncType.EVENT_AWARDS):
+            continue
         taskqueue.add(
             queue_name="datafeed",
             target="py3-tasks-io",

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_rankings_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_rankings_test.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from google.appengine.ext import testbed
 from werkzeug.test import Client
 
+from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType
 from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
@@ -14,7 +15,11 @@ from backend.common.models.event_ranking import EventRanking
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
 
-def create_event(official: bool, remap_teams: Optional[Dict[str, str]] = None) -> None:
+def create_event(
+    official: bool,
+    remap_teams: Optional[Dict[str, str]] = None,
+    disable_sync_flags: int = 0,
+) -> None:
     Event(
         id="2020nyny",
         year=2020,
@@ -23,6 +28,7 @@ def create_event(official: bool, remap_teams: Optional[Dict[str, str]] = None) -
         start_date=datetime.datetime(2020, 4, 1),
         end_date=datetime.datetime(2020, 4, 2),
         official=official,
+        disable_sync_flags=disable_sync_flags,
         remap_teams=remap_teams,
     ).put()
 
@@ -55,6 +61,19 @@ def test_enqueue_current_skips_unofficial(
     tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
 ) -> None:
     create_event(official=False)
+    resp = tasks_client.get("/tasks/enqueue/fmsapi_event_rankings/now")
+    assert resp.status_code == 200
+    assert len(resp.data) > 0
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
+    assert len(tasks) == 0
+
+
+@freeze_time("2020-4-1")
+def test_enqueue_current_skips_sync_disabled(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    create_event(official=True, disable_sync_flags=EventSyncType.EVENT_RANKINGS)
     resp = tasks_client.get("/tasks/enqueue/fmsapi_event_rankings/now")
     assert resp.status_code == 200
     assert len(resp.data) > 0

--- a/src/backend/web/handlers/admin/event.py
+++ b/src/backend/web/handlers/admin/event.py
@@ -9,6 +9,7 @@ from pyre_extensions import none_throws
 from werkzeug.wrappers import Response
 
 from backend.common.consts.comp_level import COMP_LEVELS, COMP_LEVELS_VERBOSE_FULL
+from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType, TYPE_NAMES as EVENT_TYPE_NAMES
 from backend.common.consts.playoff_type import (
     PlayoffType,
@@ -174,6 +175,7 @@ def event_detail(event_key: EventKey) -> str:
         "regional_champs_pool_points_sorted": regional_champs_pool_points_sorted,
         "webcast_online_status": webcast_online_status,
         "nexus_queue_status": nexus_queue_status,
+        "event_sync_types": dict(EventSyncType.__members__.items()),
     }
 
     return render_template("admin/event_details.html", template_values)
@@ -190,6 +192,7 @@ def event_edit(event_key: EventKey) -> Response:
         "rankings": json.dumps(event.rankings),
         "playoff_types": PLAYOFF_TYPE_NAMES,
         "event_types": EVENT_TYPE_NAMES,
+        "event_sync_types": dict(EventSyncType.__members__.items()),
     }
     return render_template("admin/event_edit.html", template_values)
 
@@ -287,6 +290,11 @@ def event_edit_post(event_key: Optional[EventKey] = None) -> Response:
     if event_key is not None and event_key != key:
         abort(400)
 
+    sync_disabled_flags = 0
+    for flag_name, flag_value in EventSyncType.__members__.items():
+        if request.form.get(f"sync_disabled::{flag_name}"):
+            sync_disabled_flags |= flag_value
+
     event = Event(
         id=key,
         end_date=end_date,
@@ -313,6 +321,7 @@ def event_edit_post(event_key: Optional[EventKey] = None) -> Response:
         official={"true": True, "false": False}.get(
             request.form.get("official", "false").lower()
         ),
+        disable_sync_flags=sync_disabled_flags,
         enable_predictions={"true": True, "false": False}.get(
             request.form.get("enable_predictions", "false").lower()
         ),

--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -560,6 +560,27 @@
             "type": "string",
             "description": "Timezone name for the event",
             "example": "America/New_York"
+          },
+          "disable_sync": {
+            "type": "object",
+            "description": "flags controlling disabling certain aspects of sync",
+            "properties": {
+              "event_alliances": {
+                "type": "boolean"
+              },
+              "event_rankings": {
+                "type": "boolean"
+              },
+              "event_qual_matches": {
+                "type": "boolean"
+              },
+              "event_playoff_matches": {
+                "type": "boolean"
+              },
+              "event_awards": {
+                "type": "boolean"
+              }
+            }
           }
         }
       },

--- a/src/backend/web/templates/admin/event_details.html
+++ b/src/backend/web/templates/admin/event_details.html
@@ -115,6 +115,18 @@
         <td>{{ event.official }}</td>
       </tr>
       <tr>
+        <td>
+          Sync Disabled Flags - {{event.sync_disabled_flags}}
+        </td>
+        <td>
+          <ul>
+            {% for name, val in event_sync_types.items() %}
+            <li><input type="checkbox" disabled {% if not event.is_sync_enabled(val) %}checked{%endif%}> {{name}}</li>
+            {% endfor %}
+          </ul>
+        </td>
+      </tr>
+      <tr>
         <td>FIRST Event ID</td>
         <td>{{ event.first_eid }}</td>
       </tr>

--- a/src/backend/web/templates/admin/event_edit.html
+++ b/src/backend/web/templates/admin/event_edit.html
@@ -95,6 +95,20 @@
             <td><input type="text" name="official" value="{{event.official}}" /></td>
         </tr>
         <tr>
+            <td>
+                Sync Disabled Flags
+            </td>
+            <td>
+                <ul>
+                    {% for name, val in event_sync_types.items() %}
+                        <li>
+                            <input type="checkbox" name="sync_disabled::{{name}}" value="on" {% if not event.is_sync_enabled(val) %}checked{%endif%}> {{name}}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </td>
+        </tr>
+        <tr>
             <td>FIRST Event ID</td>
             <td><input type="text" name="first_eid" value="{{event.first_eid}}" /></td>
         </tr>


### PR DESCRIPTION
This is a feature we'll want to be controlled by the TBA companion, so for example, if they run custom playoffs, they can turn off pulling from the API to avoid the test-match results getting clobbered.