### PR TITLE
[PWA] add blog route

### DIFF
--- a/pwa/app/components/tba/nav.tsx
+++ b/pwa/app/components/tba/nav.tsx
@@ -172,7 +172,11 @@ export const Nav = () => {
                 title="Insights"
                 route="/insights"
               />
-              <DropMenuItem icon={<BiPencilFill />} title="Blog" route="https://blog.thebluealliance.com" />
+              <DropMenuItem
+                icon={<BiPencilFill />}
+                title="Blog"
+                route="https://blog.thebluealliance.com"
+              />
               <DropMenuItem
                 icon={<BiGearFill />}
                 title="Account"


### PR DESCRIPTION
I added the blog route to the PWA.

## Description
PWA appbar was missing routing to the blog page.

## Motivation and Context
The PWA was missing functionality. I added routing to the blogpage using a route to `blog.thebluealliance.com` (`base.html` handles blog routing the same way).
Solves #8182 

## How Has This Been Tested?
I ran the code locally and the routing worked.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
