### PR TITLE
[trusted-api] Prevent sync from clobbering playoff types

### DIFF
--- a/src/backend/api/api_trusted_parsers/json_event_info_parser.py
+++ b/src/backend/api/api_trusted_parsers/json_event_info_parser.py
@@ -33,7 +33,7 @@ class EventInfoInput(TypedDict, total=False):
 
 class EventInfoParsed(TypedDict, total=False):
     first_event_code: Optional[str]
-    playoff_type: PlayoffType
+    playoff_type: Optional[PlayoffType]
     webcasts: List[Webcast]
     remap_teams: Dict[TeamKey, TeamKey]
     timezone: str
@@ -97,11 +97,19 @@ class JSONEventInfoParser:
             parsed_info["remap_teams"] = info_dict["remap_teams"]
 
         if "playoff_type" in info_dict:
-            if info_dict["playoff_type"] not in PlayoffType._value2member_map_:
+            playoff_type = info_dict.get("playoff_type")
+            if (
+                playoff_type is not None
+                and playoff_type not in PlayoffType._value2member_map_
+            ):
                 raise ParserInputException(
                     f"Bad playoff type: {info_dict['playoff_type']}"
                 )
-            parsed_info["playoff_type"] = PlayoffType(info_dict["playoff_type"])
+            parsed_info["playoff_type"] = (
+                PlayoffType(info_dict["playoff_type"])
+                if playoff_type is not None
+                else None
+            )
 
         if "first_event_code" in info_dict:
             parsed_info["first_event_code"] = info_dict["first_event_code"]

--- a/src/backend/api/handlers/tests/update_event_info_test.py
+++ b/src/backend/api/handlers/tests/update_event_info_test.py
@@ -18,12 +18,19 @@ AUTH_SECRET = "321tEsTsEcReT"
 REQUEST_PATH = "/api/trusted/v1/event/2014casj/info/update"
 
 
-def setup_event() -> None:
+def setup_event(
+    official: bool | None = None,
+    playoff_type: PlayoffType | None = None,
+    manual_attrs: list[str] | None = None,
+) -> None:
     Event(
         id="2014casj",
         year=2014,
         event_short="casj",
         event_type_enum=EventType.OFFSEASON,
+        official=official,
+        playoff_type=playoff_type,
+        manual_attrs=manual_attrs if manual_attrs is not None else [],
     ).put()
 
 
@@ -333,6 +340,106 @@ def test_invalid_remap_teams_mapping_bad_end_format(
     event: Optional[Event] = Event.get_by_id("2014casj")
     assert event is not None
     assert event.remap_teams is None
+    assert len(taskqueue_stub.get_filtered_tasks(queue_names="admin")) == 0
+
+
+def test_bad_playoff_type(
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub, api_client: Client
+) -> None:
+    setup_event()
+    setup_auth(access_types=[AuthType.EVENT_INFO])
+
+    request = {"playoff_type": "DoubleElim"}
+    request_body = json.dumps(request)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+
+    assert response.status_code == 400
+    event: Optional[Event] = Event.get_by_id("2014casj")
+    assert event is not None
+    assert event.timezone_id is None
+    assert len(taskqueue_stub.get_filtered_tasks(queue_names="admin")) == 0
+
+
+def test_playoff_type_sets_manual_attr(
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub, api_client: Client
+) -> None:
+    setup_event()
+    setup_auth(access_types=[AuthType.EVENT_INFO])
+
+    request = {
+        "first_event_code": "TEST",
+        "playoff_type": int(PlayoffType.ROUND_ROBIN_6_TEAM),
+    }
+    request_body = json.dumps(request)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+
+    assert response.status_code == 200
+    event: Optional[Event] = Event.get_by_id("2014casj")
+    assert event is not None
+    assert event.playoff_type == PlayoffType.ROUND_ROBIN_6_TEAM
+    assert event.official is True
+    assert event.manual_attrs == ["playoff_type"]
+    assert len(taskqueue_stub.get_filtered_tasks(queue_names="admin")) == 0
+
+
+def test_playoff_type_sets_manual_attr_dedup(
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub, api_client: Client
+) -> None:
+    setup_event(manual_attrs=["playoff_type"])
+    setup_auth(access_types=[AuthType.EVENT_INFO])
+
+    request = {
+        "first_event_code": "TEST",
+        "playoff_type": int(PlayoffType.ROUND_ROBIN_6_TEAM),
+    }
+    request_body = json.dumps(request)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+
+    assert response.status_code == 200
+    event: Optional[Event] = Event.get_by_id("2014casj")
+    assert event is not None
+    assert event.playoff_type == PlayoffType.ROUND_ROBIN_6_TEAM
+    assert event.official is True
+    assert event.manual_attrs == ["playoff_type"]
+    assert len(taskqueue_stub.get_filtered_tasks(queue_names="admin")) == 0
+
+
+def test_playoff_type_None_clears_manual_attr(
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub, api_client: Client
+) -> None:
+    setup_event(
+        official=True,
+        playoff_type=PlayoffType.ROUND_ROBIN_6_TEAM,
+        manual_attrs=["playoff_type"],
+    )
+    setup_auth(access_types=[AuthType.EVENT_INFO])
+
+    request = {"playoff_type": None}
+    request_body = json.dumps(request)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+
+    assert response.status_code == 200
+    event: Optional[Event] = Event.get_by_id("2014casj")
+    assert event is not None
+    assert event.playoff_type == PlayoffType.ROUND_ROBIN_6_TEAM
+    assert event.official is True
+    assert event.manual_attrs == []
     assert len(taskqueue_stub.get_filtered_tasks(queue_names="admin")) == 0
 
 

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -145,7 +145,17 @@ def update_event_info(event_key: EventKey) -> Response:
         event.first_code = parsed_info["first_event_code"]
 
     if "playoff_type" in parsed_info:
-        event.playoff_type = parsed_info["playoff_type"]
+        playoff_type = parsed_info["playoff_type"]
+        if playoff_type is not None:
+            event.playoff_type = playoff_type
+            if event.official:
+                # If this event is pulling info from the FRC API, we want to prevent it from being clobbered
+                event.manual_attrs = list(set(event.manual_attrs) | {"playoff_type"})
+        else:
+            # We can clear the "manual attr" (and allow the API to re-clobber) by setting
+            # a None value in the API
+            if event.official:
+                event.manual_attrs = list(set(event.manual_attrs) - {"playoff_type"})
 
     if "timezone" in parsed_info:
         event.timezone_id = parsed_info["timezone"]

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
@@ -9,6 +9,7 @@ from google.appengine.ext import ndb, testbed
 from werkzeug.test import Client
 
 from backend.common.consts.comp_level import CompLevel
+from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType
 from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
@@ -16,7 +17,11 @@ from backend.common.models.match import Match
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
 
-def create_event(official: bool, remap_teams: Optional[Dict[str, str]] = None) -> None:
+def create_event(
+    official: bool,
+    remap_teams: Optional[Dict[str, str]] = None,
+    disable_sync_flags: int = 0,
+) -> None:
     Event(
         id="2020nyny",
         year=2020,
@@ -26,6 +31,7 @@ def create_event(official: bool, remap_teams: Optional[Dict[str, str]] = None) -
         end_date=datetime.datetime(2020, 4, 2),
         official=official,
         remap_teams=remap_teams,
+        disable_sync_flags=disable_sync_flags,
     ).put()
 
 
@@ -57,6 +63,24 @@ def test_enqueue_current_skips_unofficial(
     tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
 ) -> None:
     create_event(official=False)
+    resp = tasks_client.get("/tasks/enqueue/fmsapi_matches/now")
+    assert resp.status_code == 200
+    assert len(resp.data) > 0
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
+    assert len(tasks) == 0
+
+
+@freeze_time("2020-4-1")
+def test_enqueue_current_skips_sync_disabled(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    create_event(
+        official=True,
+        disable_sync_flags=(
+            EventSyncType.EVENT_QUAL_MATCHES | EventSyncType.EVENT_PLAYOFF_MATCHES
+        ),
+    )
     resp = tasks_client.get("/tasks/enqueue/fmsapi_matches/now")
     assert resp.status_code == 200
     assert len(resp.data) > 0

--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -528,6 +528,7 @@
           },
           "playoff_type": {
             "type": "integer",
+            "nullable": true,
             "description": "Integer constant representing the playoff format. References constants here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py",
             "example": "0"
           },


### PR DESCRIPTION
If an event sets their own custom playoff type, but is using API sync, we want the value they set to take precedence