### PR TITLE
Normalize event suggestion keys

### DIFF
--- a/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
@@ -38,11 +38,12 @@ class SuggestOffseasonEventReviewController(
     def create_target_model(
         self, suggestion: Suggestion
     ) -> Optional[SuggestOffseasonTargetModel]:
-        event_id = request.form.get("event_short", None)
-        event_key = str(request.form.get("year")) + str.lower(
-            str(request.form.get("event_short"))
-        )
-        if not event_id:
+        year = int(request.form.get("year", 0))
+        event_short = request.form.get("event_short", None)
+        if event_short:
+            event_short = event_short.lower()
+        event_key = f"{year}{event_short}"
+        if not event_short:
             # Need to supply a key :(
             return SuggestOffseasonTargetModel(status="missing_key", event_key=None)
         if not Event.validate_key_name(event_key):
@@ -62,10 +63,12 @@ class SuggestOffseasonEventReviewController(
             return SuggestOffseasonTargetModel(status="duplicate_key", event_key=None)
 
         first_code = request.form.get("first_code")
+        if first_code:
+            first_code = first_code.upper()
         event = Event(
             id=event_key,
             end_date=end_date,
-            event_short=request.form.get("event_short"),
+            event_short=event_short,
             event_type_enum=EventType.OFFSEASON,
             district_key=None,
             venue=request.form.get("venue"),
@@ -77,7 +80,7 @@ class SuggestOffseasonEventReviewController(
             short_name=request.form.get("short_name"),
             start_date=start_date,
             website=request.form.get("website"),
-            year=int(request.form.get("year", "")),
+            year=year,
             first_code=first_code,
             official=(first_code is not None and first_code != ""),
         )

--- a/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_review_controller_test.py
+++ b/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_review_controller_test.py
@@ -109,6 +109,40 @@ def test_accept_suggestion(
     assert event is not None
 
 
+def test_accept_suggestion_normalize_event_short_and_first_code(
+    login_user_with_permission,
+    web_client: Client,
+    ndb_stub,
+    taskqueue_stub,
+) -> None:
+    suggestion_id = createSuggestion(login_user_with_permission)
+    queue, form_fields = get_suggestion_queue_and_fields(
+        web_client, f"review_{suggestion_id}"
+    )
+    assert queue == [suggestion_id]
+    assert form_fields is not {}
+
+    form_fields["event_short"] = "TEST"
+    form_fields["first_code"] = "frctest"
+    form_fields["verdict"] = "accept"
+    response = web_client.post(
+        "/suggest/offseason/review",
+        data=form_fields,
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    suggestion = Suggestion.get_by_id(suggestion_id)
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_ACCEPTED
+
+    event = Event.get_by_id("2016test")
+    assert event is not None
+    assert event.event_short == "test"
+    assert event.official is True
+    assert event.first_code == "FRCTEST"
+
+
 def test_reject_suggestion(
     login_user_with_permission, web_client: Client, ndb_stub
 ) -> None:


### PR DESCRIPTION
having an offseason event key that's capitalized makes things not work so well. Clean up the key assignment logic to make sure we always normalize the key name and event short.