### PR TITLE
Update references to PlayoffType definition in docs

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -316,7 +316,7 @@ export type Event = {
    */
   parent_event_key: string | null;
   /**
-   * Playoff Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py#L4, or null.
+   * Playoff Type, as defined under `PlayoffType`: https://github.com/the-blue-alliance/the-blue-alliance/blob/py3/src/backend/common/consts/playoff_type.py#L37, or null.
    */
   playoff_type: number | null;
   /**

--- a/src/backend/web/static/swagger/api_trusted_v1.json
+++ b/src/backend/web/static/swagger/api_trusted_v1.json
@@ -529,7 +529,7 @@
           "playoff_type": {
             "type": "integer",
             "nullable": true,
-            "description": "Integer constant representing the playoff format. References constants here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py",
+            "description": "Integer constant representing the playoff format. References constants defined under `PlayoffType`: https://github.com/the-blue-alliance/the-blue-alliance/blob/py3/src/backend/common/consts/playoff_type.py#L37",
             "example": "0"
           },
           "webcasts": {

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5562,7 +5562,7 @@
               "integer",
               "null"
             ],
-            "description": "Playoff Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py#L4, or null."
+            "description": "Playoff Type, as defined under `PlayoffType`: https://github.com/the-blue-alliance/the-blue-alliance/blob/py3/src/backend/common/consts/playoff_type.py#L37, or null."
           },
           "playoff_type_string": {
             "type": [


### PR DESCRIPTION
These links point to the old `master` branch, which led to some confusion on Slack, particularly because `DOUBLE_ELIM_8_TEAM` on `master` corresponds to `LEGACY_DOUBLE_ELIM_8_TEAM` on `py3`.

Build not tested - relying on CI here. In particular, not sure if `types.gen.ts` or `api_v3.json` are generated from each other (I just copied the same text to both places)