### PR TITLE
[PWA] Add in-memory KV cache

### DIFF
--- a/pwa/app/lib/middleware/network-cache.test.ts
+++ b/pwa/app/lib/middleware/network-cache.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearCache,
+  createCachedFetch,
+  getCacheStats,
+} from '~/lib/middleware/network-cache';
+
+describe('Network Cache Middleware', () => {
+  beforeEach(() => {
+    clearCache();
+    vi.clearAllMocks();
+  });
+
+  it('should create a cached fetch function', () => {
+    const cachedFetch = createCachedFetch();
+    expect(cachedFetch).toBeInstanceOf(Function);
+  });
+
+  it('should cache GET requests on server side', async () => {
+    // Mock fetch - return fresh Response on each call
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ data: 'test' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const cachedFetch = createCachedFetch({
+      maxEntries: 10,
+      ttl: 60000,
+      debug: false,
+    });
+
+    const url = 'https://api.example.com/data';
+
+    // First request - should hit network
+    const response1 = await cachedFetch(url);
+    const data1 = await response1.text();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(data1).toBe('{"data":"test"}');
+
+    // Second request - should use cache
+    const response2 = await cachedFetch(url);
+    const data2 = await response2.text();
+    expect(mockFetch).toHaveBeenCalledTimes(1); // Still 1, not 2
+    expect(data2).toBe('{"data":"test"}');
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should not cache non-GET requests', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const cachedFetch = createCachedFetch();
+
+    const url = 'https://api.example.com/data';
+
+    // POST request - should not cache
+    await cachedFetch(url, { method: 'POST' });
+    await cachedFetch(url, { method: 'POST' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should skip cache on client side', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('test', { status: 200 })),
+      );
+    global.fetch = mockFetch;
+
+    // Ensure window is defined (client side)
+    const originalWindow = global.window;
+    if (!global.window) {
+      // @ts-expect-error - mocking window
+      global.window = {};
+    }
+
+    const cachedFetch = createCachedFetch();
+
+    const url = 'https://api.example.com/data';
+
+    await cachedFetch(url);
+    await cachedFetch(url);
+
+    // Should call fetch both times (no caching on client)
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should respect TTL and expire old entries', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('test', { status: 200 })),
+      );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const cachedFetch = createCachedFetch({
+      ttl: 100, // 100ms TTL
+    });
+
+    const url = 'https://api.example.com/data';
+
+    // First request
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second request immediately - should use cache
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // Third request after TTL - should hit network again
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should respect maxEntries limit', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(new Response(url, { status: 200 })),
+      );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const maxEntries = 3;
+    const cachedFetch = createCachedFetch({ maxEntries });
+
+    // Make requests to different URLs
+    for (let i = 0; i < 5; i++) {
+      await cachedFetch(`https://api.example.com/data/${i}`);
+    }
+
+    const stats = getCacheStats();
+    expect(stats.size).toBeLessThanOrEqual(maxEntries);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should clear cache correctly', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('test', { status: 200 })),
+      );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const cachedFetch = createCachedFetch();
+    const url = 'https://api.example.com/data';
+
+    // Add to cache
+    await cachedFetch(url);
+    expect(getCacheStats().size).toBe(1);
+
+    // Clear cache
+    clearCache();
+    expect(getCacheStats().size).toBe(0);
+
+    // Next request should hit network
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should only cache successful responses (2xx)', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('error', { status: 404 })),
+      );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const cachedFetch = createCachedFetch();
+    const url = 'https://api.example.com/not-found';
+
+    // First 404 request
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second request - should not use cache (404 not cached)
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+
+  it('should generate different cache keys for different headers', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('test', { status: 200 })),
+      );
+    global.fetch = mockFetch;
+
+    // Mock server environment
+    const originalWindow = global.window;
+    // @ts-expect-error - mocking window
+    delete global.window;
+
+    const cachedFetch = createCachedFetch();
+    const url = 'https://api.example.com/data';
+
+    // Request with header 1
+    await cachedFetch(url, {
+      headers: { 'Accept-Language': 'en' },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Request with different header - should not use cache
+    await cachedFetch(url, {
+      headers: { 'Accept-Language': 'es' },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Request with same header - should use cache
+    await cachedFetch(url, {
+      headers: { 'Accept-Language': 'es' },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore window
+    global.window = originalWindow;
+  });
+});

--- a/pwa/app/lib/middleware/network-cache.ts
+++ b/pwa/app/lib/middleware/network-cache.ts
@@ -1,0 +1,283 @@
+/**
+ * Network cache middleware for API requests
+ *
+ * Implements an in-memory KV store to cache API responses across sessions.
+ * Includes logging to track cache hits and outbound requests.
+ */
+
+interface CacheEntry {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  timestamp: number;
+}
+
+interface NetworkCacheConfig {
+  /**
+   * Maximum number of entries to store in cache
+   * @default 500
+   */
+  maxEntries?: number;
+
+  /**
+   * Time-to-live for cache entries in milliseconds
+   * @default 300000 (5 minutes)
+   */
+  ttl?: number;
+
+  /**
+   * Enable debug logging
+   * @default false
+   */
+  debug?: boolean;
+
+  /**
+   * Methods to cache (only these HTTP methods will be cached)
+   * @default ['GET']
+   */
+  cacheableMethods?: string[];
+}
+
+/**
+ * In-memory cache store shared across all sessions
+ * Using a Map instead of LRUCache to avoid clone() issues
+ */
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * LRU tracking - keeps order of access
+ */
+const accessOrder: string[] = [];
+
+/**
+ * Default configuration
+ */
+const defaultConfig: Required<NetworkCacheConfig> = {
+  maxEntries: 500,
+  ttl: 10800000, // 3 hours
+  debug: false,
+  cacheableMethods: ['GET'],
+};
+
+/**
+ * Generate cache key from request
+ */
+function generateCacheKey(url: string, options: RequestInit = {}): string {
+  const method = options.method?.toUpperCase() || 'GET';
+  const headers = options.headers;
+  let headersStr = '';
+
+  if (headers) {
+    const headerEntries: string[] = [];
+
+    if (headers instanceof Headers) {
+      headers.forEach((value, key) => {
+        // Exclude auth and cache-control headers from cache key
+        if (
+          !key.toLowerCase().startsWith('x-tba-auth') &&
+          key.toLowerCase() !== 'cache-control'
+        ) {
+          headerEntries.push(`${key}:${value}`);
+        }
+      });
+    } else if (typeof headers === 'object') {
+      // Handle plain object or array of tuples
+      const headerObj: Record<string, string> = Array.isArray(headers)
+        ? Object.fromEntries(headers)
+        : headers;
+
+      Object.entries(headerObj).forEach(([key, value]) => {
+        if (
+          !key.toLowerCase().startsWith('x-tba-auth') &&
+          key.toLowerCase() !== 'cache-control'
+        ) {
+          headerEntries.push(`${key}:${value}`);
+        }
+      });
+    }
+
+    headersStr = headerEntries.sort().join('|');
+  }
+
+  return `${method}:${url}${headersStr ? ':' + headersStr : ''}`;
+}
+
+/**
+ * Update LRU tracking
+ */
+function updateAccessOrder(key: string, maxEntries: number): void {
+  // Remove existing entry if present
+  const existingIndex = accessOrder.indexOf(key);
+  if (existingIndex > -1) {
+    accessOrder.splice(existingIndex, 1);
+  }
+
+  // Add to end (most recently used)
+  accessOrder.push(key);
+
+  // Evict oldest entries if we exceed max
+  while (accessOrder.length > maxEntries) {
+    const oldestKey = accessOrder.shift();
+    if (oldestKey) {
+      cache.delete(oldestKey);
+    }
+  }
+}
+
+/**
+ * Check if entry is expired
+ */
+function isExpired(entry: CacheEntry, ttl: number): boolean {
+  return Date.now() - entry.timestamp > ttl;
+}
+
+/**
+ * Log cache activity
+ */
+function log(message: string, debug: boolean = false): void {
+  const timestamp = new Date().toISOString();
+  if (debug) {
+    // eslint-disable-next-line no-console
+    console.log(`[NetworkCache ${timestamp}] ${message}`);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`[NetworkCache] ${message}`);
+  }
+}
+
+/**
+ * Convert Response to CacheEntry
+ */
+async function responseToCacheEntry(response: Response): Promise<CacheEntry> {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  // Read body as text to avoid clone() issues
+  const body = await response.text();
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body,
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Convert CacheEntry to Response
+ */
+function cacheEntryToResponse(entry: CacheEntry): Response {
+  const headers = new Headers(entry.headers);
+
+  return new Response(entry.body, {
+    status: entry.status,
+    statusText: entry.statusText,
+    headers,
+  });
+}
+
+/**
+ * Create a caching fetch function
+ */
+export function createCachedFetch(
+  config: NetworkCacheConfig = {},
+): typeof fetch {
+  const finalConfig = { ...defaultConfig, ...config };
+
+  return async function cachedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const method = init?.method?.toUpperCase() || 'GET';
+
+    // Only cache specified methods (default: GET)
+    if (!finalConfig.cacheableMethods.includes(method)) {
+      if (finalConfig.debug) {
+        log(`Skipping cache for ${method} ${url}`, finalConfig.debug);
+      }
+      return fetch(input, init);
+    }
+
+    // Check if running on server
+    const isServer = typeof window === 'undefined';
+    if (!isServer) {
+      // Don't cache on client - only server-side
+      if (finalConfig.debug) {
+        log(`Client-side request, skipping cache: ${url}`, finalConfig.debug);
+      }
+      return fetch(input, init);
+    }
+
+    const cacheKey = generateCacheKey(url, init);
+
+    // Check cache
+    const cachedEntry = cache.get(cacheKey);
+    if (cachedEntry && !isExpired(cachedEntry, finalConfig.ttl)) {
+      updateAccessOrder(cacheKey, finalConfig.maxEntries);
+      log(`✓ Cache HIT: ${method} ${url}`);
+      return cacheEntryToResponse(cachedEntry);
+    }
+
+    // Cache miss or expired - fetch from network
+    log(`→ Outbound request: ${method} ${url}`);
+
+    try {
+      const response = await fetch(input, init);
+
+      // Only cache successful responses
+      if (response.ok && response.status >= 200 && response.status < 300) {
+        // Read response body immediately to avoid clone() issues
+        const entry = await responseToCacheEntry(response);
+
+        cache.set(cacheKey, entry);
+        updateAccessOrder(cacheKey, finalConfig.maxEntries);
+
+        if (finalConfig.debug) {
+          log(`Cached response for: ${method} ${url}`, finalConfig.debug);
+        }
+
+        // Return a new Response with the cached body
+        return cacheEntryToResponse(entry);
+      }
+
+      return response;
+    } catch (error) {
+      log(`✗ Request failed: ${method} ${url} - ${error}`);
+      throw error;
+    }
+  };
+}
+
+/**
+ * Clear the cache
+ */
+export function clearCache(): void {
+  cache.clear();
+  accessOrder.length = 0;
+  log('Cache cleared');
+}
+
+/**
+ * Get cache statistics
+ */
+export function getCacheStats(): {
+  size: number;
+  maxEntries: number;
+  keys: string[];
+} {
+  return {
+    size: cache.size,
+    maxEntries: defaultConfig.maxEntries,
+    keys: Array.from(cache.keys()),
+  };
+}


### PR DESCRIPTION
This was largely AI generated but spot checked and tested by hand.

Adds an in-memory KV store to network requests to cache API requests:

```
[NetworkCache] ✓ Cache HIT: GET https://www.thebluealliance.com/api/v3/event/2024mil
[NetworkCache] ✓ Cache HIT: GET https://www.thebluealliance.com/api/v3/event/2024mil/matches
[NetworkCache] ✓ Cache HIT: GET https://www.thebluealliance.com/api/v3/event/2024mil/alliances
GET /event/2024mil 200 - - 434.305 ms
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/media/2024
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/social_media
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/years_participated
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/events/2024
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/matches/2024
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/events/2024/statuses
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/team/frc2713/awards/2024
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024mabos/district_points
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024mabri/district_points
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024necmp2/district_points
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024bc/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024mabos/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024mabri/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024matb/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024mesh/alliances
[NetworkCache] ✓ Cache HIT: GET https://www.thebluealliance.com/api/v3/event/2024mil/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024necmp2/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024nhalt/alliances
[NetworkCache] → Outbound request: GET https://www.thebluealliance.com/api/v3/event/2024week0/alliances
GET /team/2713/2024 200 - - 1880.440 ms
```