### PR TITLE
Add Scouting tab to event pages

### DIFF
--- a/src/backend/web/handlers/admin/event.py
+++ b/src/backend/web/handlers/admin/event.py
@@ -282,7 +282,11 @@ def event_edit_post(event_key: Optional[EventKey] = None) -> Response:
         else []
     )
 
-    website = "None" if request.form.get("website") == "None" else WebsiteHelper.format_url(request.form.get("website"))
+    website = (
+        "None"
+        if request.form.get("website") == "None"
+        else WebsiteHelper.format_url(request.form.get("website"))
+    )
 
     key = str(request.form.get("year")) + str.lower(
         str(request.form.get("event_short"))

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -1,9 +1,13 @@
 import collections
+import csv
+import io
 import json
 import re
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
+import pytz
 from flask import abort, redirect, request
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
@@ -21,6 +25,9 @@ from backend.common.helpers.district_point_tiebreakers_sorting_helper import (
 )
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.match_helper import MatchHelper
+from backend.common.helpers.match_time_prediction_helper import (
+    MatchTimePredictionHelper,
+)
 from backend.common.helpers.media_helper import MediaHelper
 from backend.common.helpers.playlist_helper import PlaylistHelper
 from backend.common.helpers.playoff_advancement_helper import PlayoffAdvancementHelper
@@ -175,6 +182,123 @@ def event_detail(event_key: EventKey) -> Response:
         middle_value += 1
     teams_a, teams_b = team_and_medias[:middle_value], team_and_medias[middle_value:]
 
+    # Helper to convert OrderedDict list to CSV string
+    def dicts_to_csv(rows: List[OrderedDict]) -> str:
+        if not rows:
+            return ""
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+        return output.getvalue()
+
+    # Build Team List CSV
+    team_rows = []
+    for team, medias in team_and_medias:
+        preferred_media = next(
+            (m for m in medias if m.is_image and team.key in m.preferred_references),
+            None,
+        )
+        team_rows.append(
+            OrderedDict(
+                [
+                    ("team_number", team.team_number),
+                    ("team_name", (team.nickname or "").replace(",", ";")),
+                    ("city", (team.city or "").replace(",", ";")),
+                    ("state_prov", (team.state_prov or "").replace(",", ";")),
+                    ("country", (team.country or "").replace(",", ";")),
+                    (
+                        "robot_image_url",
+                        preferred_media.image_direct_url_med if preferred_media else "",
+                    ),
+                ]
+            )
+        )
+    team_list_csv = dicts_to_csv(team_rows)
+
+    # Build Schedule CSV
+    event_tz = pytz.timezone(event.timezone_id) if event.timezone_id else None
+    all_matches_list = [
+        match
+        for comp_level_enum in COMP_LEVELS
+        if matches.get(comp_level_enum)
+        for match in matches[comp_level_enum]
+    ]
+
+    # Determine max teams per alliance (usually 3, but can be 2 or 5)
+    max_teams = max(
+        (
+            len(match.alliances[color]["teams"])
+            for match in all_matches_list
+            for color in [AllianceColor.RED, AllianceColor.BLUE]
+        ),
+        default=3,
+    )
+
+    def format_match_time(match_time: Optional[datetime]) -> Tuple[str, str]:
+        if not match_time or not event_tz:
+            return "", ""
+        local_time = MatchTimePredictionHelper.as_local(match_time, event_tz)
+        return (
+            (local_time.strftime("%Y-%m-%d"), local_time.strftime("%I:%M %p"))
+            if local_time
+            else ("", "")
+        )
+
+    # Build Schedule CSV
+    schedule_rows = []
+    for match in all_matches_list:
+        date_str, time_str = format_match_time(match.time)
+        red_teams = [
+            t.replace("frc", "") for t in match.alliances[AllianceColor.RED]["teams"]
+        ]
+        blue_teams = [
+            t.replace("frc", "") for t in match.alliances[AllianceColor.BLUE]["teams"]
+        ]
+        red_teams.extend([""] * (max_teams - len(red_teams)))
+        blue_teams.extend([""] * (max_teams - len(blue_teams)))
+        red_score = match.alliances[AllianceColor.RED]["score"]
+        blue_score = match.alliances[AllianceColor.BLUE]["score"]
+        row = OrderedDict(
+            [
+                ("match_key", match.key_name),
+                ("scheduled_date", date_str),
+                ("scheduled_time", time_str),
+                ("comp_level", match.comp_level),
+                ("match_number", match.match_number),
+                ("set_number", match.set_number),
+            ]
+        )
+        for i in range(max_teams):
+            row[f"red{i + 1}"] = red_teams[i]
+            row[f"blue{i + 1}"] = blue_teams[i]
+        row["red_score"] = str(red_score) if red_score >= 0 else ""
+        row["blue_score"] = str(blue_score) if blue_score >= 0 else ""
+        schedule_rows.append(row)
+    schedule_csv = dicts_to_csv(schedule_rows)
+
+    # Build Flat Schedule CSV
+    flat_schedule_rows = []
+    for match in all_matches_list:
+        date_str, time_str = format_match_time(match.time)
+        for color in [AllianceColor.RED, AllianceColor.BLUE]:
+            for team in match.alliances[color]["teams"]:
+                flat_schedule_rows.append(
+                    OrderedDict(
+                        [
+                            ("match_key", match.key_name),
+                            ("scheduled_date", date_str),
+                            ("scheduled_time", time_str),
+                            ("comp_level", match.comp_level),
+                            ("match_number", match.match_number),
+                            ("set_number", match.set_number),
+                            ("color", color.value),
+                            ("team", team.replace("frc", "")),
+                        ]
+                    )
+                )
+    flat_schedule_csv = dicts_to_csv(flat_schedule_rows)
+
     oprs = []
     copr_leaders: Dict[Component, List[Tuple[TeamId, float]]] = {}
 
@@ -302,6 +426,9 @@ def event_detail(event_key: EventKey) -> Response:
         "coprs_json": json.dumps(copr_leaders),
         "copr_items": copr_items,
         "nexus_pit_locations": nexus_pit_locations,
+        "team_list_csv": team_list_csv,
+        "schedule_csv": schedule_csv,
+        "flat_schedule_csv": flat_schedule_csv,
     }
 
     return make_cached_response(

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -96,6 +96,7 @@
         <li class="{% if match_count == 0 %}active{% endif %}"><a href="#teams" data-toggle="tab">Teams <span class="badge">{{num_teams}}</span></a></li>
         {% if event_insights_qual or event_insights_playoff or oprs|length > 0 %}<li><a href="#event-insights" data-toggle="tab">Insights</a></li>{% endif %}
         <li><a href="#media" data-toggle="tab">Media <span class="badge">{{medias_by_slugname.youtube|length}}</span></a></li>
+        <li><a href="#scouting" data-toggle="tab">Scouting</a></li>
       </ul>
     </div>
   </div>
@@ -458,6 +459,27 @@
           </div>
         </div>
       </div>
+
+    <div class="tab-pane" id="scouting">
+      <div class="row">
+        <div class="col-sm-12">
+          <h2>Scouting</h2>
+          <p>Copy the CSV data below for scouting purposes:</p>
+          <div class="form-group">
+            <label>Team List</label>
+            <textarea class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ team_list_csv|safe }}</textarea>
+          </div>
+          <div class="form-group">
+            <label>Schedule</label>
+            <textarea class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ schedule_csv|safe }}</textarea>
+          </div>
+          <div class="form-group">
+            <label>Flat Schedule</label>
+            <textarea class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ flat_schedule_csv|safe }}</textarea>
+          </div>
+        </div>
+      </div>
+    </div>
 
       </div>
     </div>


### PR DESCRIPTION
(There was a brief formatting change in `src/backend/web/handlers/admin/event.py`. That is irrelevant to this pr, and I don't feel like splitting it out to another PR)

Adds a `Scouting` tab to event pages. This is intended to be copyable CSVs that teams can import into various scouting systems. This saves the hassle of having to figure out how to use the TBA API in gSheets.

<img width="1298" height="1911" alt="image" src="https://github.com/user-attachments/assets/ec376be4-6203-49bf-93e2-b984b14882bc" />

Tested manually on official, unofficial, past, and future events.