### PR TITLE
Add /event/<key>/html/* routes

### DIFF
--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -31,6 +31,9 @@ from backend.web.handlers.event import (
     event_insights,
     event_list,
     event_rss,
+    simple_event_flat_schedule,
+    simple_event_schedule,
+    simple_event_teams,
 )
 from backend.web.handlers.eventwizard import eventwizard, eventwizard2
 from backend.web.handlers.gameday import gameday, gameday_redirect
@@ -98,6 +101,11 @@ app.add_url_rule("/gameday", view_func=gameday)
 app.add_url_rule("/event/<event_key>", view_func=event_detail)
 app.add_url_rule("/event/<event_key>/agenda", view_func=event_agenda)
 app.add_url_rule("/event/<event_key>/feed", view_func=event_rss)
+app.add_url_rule(
+    "/event/<event_key>/html/flat_schedule", view_func=simple_event_flat_schedule
+)
+app.add_url_rule("/event/<event_key>/html/schedule", view_func=simple_event_schedule)
+app.add_url_rule("/event/<event_key>/html/teams", view_func=simple_event_teams)
 app.add_url_rule("/event/<event_key>/insights", view_func=event_insights)
 app.add_url_rule("/events/<int:year>", view_func=event_list)
 app.add_url_rule(

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -464,7 +464,10 @@
       <div class="row">
         <div class="col-sm-12">
           <h2>Scouting</h2>
-          <p>Copy the CSV data below for scouting purposes:</p>
+          <p>Copy the CSV data below for scouting purposes, or use <code>IMPORTHTML()</code>:</p>
+          <pre>=IMPORTHTML("https://www.thebluealliance.com/event/{{ event.key_name }}/html/teams", "table")</pre>
+          <pre>=IMPORTHTML("https://www.thebluealliance.com/event/{{ event.key_name }}/html/schedule", "table")</pre>
+          <pre>=IMPORTHTML("https://www.thebluealliance.com/event/{{ event.key_name }}/html/flat_schedule", "table")</pre>
           <div class="form-group">
             <label>Team List</label>
             <textarea class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ team_list_csv|safe }}</textarea>

--- a/src/backend/web/templates/simple_event_flat_schedule.html
+++ b/src/backend/web/templates/simple_event_flat_schedule.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div style="text-align: center;">
+  <table style="margin: 0 auto;">
+    <thead>
+      <tr>
+        {% for header in headers %}
+        <th style="text-align: center;">{{header}}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        {% for cell in row %}
+        <td>{{cell}}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/src/backend/web/templates/simple_event_schedule.html
+++ b/src/backend/web/templates/simple_event_schedule.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div style="text-align: center;">
+  <table style="margin: 0 auto;">
+    <thead>
+      <tr>
+        {% for header in headers %}
+        <th style="text-align: center;">{{header}}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        {% for cell in row %}
+        <td>{{cell}}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/src/backend/web/templates/simple_event_teams.html
+++ b/src/backend/web/templates/simple_event_teams.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div style="text-align: center;">
+  <table style="margin: 0 auto;">
+    <thead>
+      <tr>
+        {% for header in headers %}
+        <th style="text-align: center;">{{header}}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        {% for cell in row %}
+        <td>{{cell}}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds 3 new routes:

- /event/<key>/html/teams
- /event/<key>/html/schedule
- /event/<key>/html/flat_schedule

These offer easier uses for `=IMPORTHTML()` in gSheets. I successfully tested importing them by using a local tunnel (since GSheets runs `IMPORTHTML` logic on the server and I needed to route it to a localhost).


<details><summary>Details</summary>
<img width="1918" height="1081" alt="image" src="https://github.com/user-attachments/assets/982231eb-40c6-4908-9939-569478de1a54" />

<img width="1918" height="1081" alt="image" src="https://github.com/user-attachments/assets/f51efe49-6b7d-42b7-ba30-f010065d5978" />

<img width="1918" height="1081" alt="image" src="https://github.com/user-attachments/assets/ecc8135f-99ab-41b2-8eed-0219ae987d6c" />

<img width="1918" height="1081" alt="image" src="https://github.com/user-attachments/assets/15b63843-913d-4f75-a0a3-e4187c62ec4b" />

</details> 