### PR TITLE
Added download CSV + Copy to Clipboard functions to Scouting page

### DIFF
--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -468,7 +468,7 @@
           <div class="form-group">
             <div class="clearfix">
               <label class="control-label" style="display:inline-block; margin:0; padding-top:6px;">Team List</label>
-              <button type="button" class="btn btn-default btn-xs pull-right" style="margin-left:4px;" onclick="downloadCSVFromTextarea('team-list-csv', 'team_list.csv')"><span class="glyphicon glyphicon-download"></span> Download CSV</button>
+              <button type="button" class="btn btn-default btn-xs pull-right" style="margin-left:4px;" onclick="downloadCSVFromTextarea('team-list-csv', '{{ event.key_name }}_team_list.csv')"><span class="glyphicon glyphicon-download"></span> Download CSV</button>
               <button type="button" class="btn btn-default btn-xs pull-right" onclick="copyCSVFromTextarea('team-list-csv')"><span class="glyphicon glyphicon-copy"></span> Copy to Clipboard</button>
             </div>
             <textarea id="team-list-csv" class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ team_list_csv|safe }}</textarea>
@@ -476,7 +476,7 @@
           <div class="form-group">
             <div class="clearfix">
               <label class="control-label" style="display:inline-block; margin:0; padding-top:6px;">Schedule</label>
-              <button type="button" class="btn btn-default btn-xs pull-right" style="margin-left:4px;" onclick="downloadCSVFromTextarea('schedule-csv', 'schedule.csv')"><span class="glyphicon glyphicon-download"></span> Download CSV</button>
+              <button type="button" class="btn btn-default btn-xs pull-right" style="margin-left:4px;" onclick="downloadCSVFromTextarea('schedule-csv', '{{ event.key_name }}_schedule.csv')"><span class="glyphicon glyphicon-download"></span> Download CSV</button>
               <button type="button" class="btn btn-default btn-xs pull-right" onclick="copyCSVFromTextarea('schedule-csv')"><span class="glyphicon glyphicon-copy"></span> Copy to Clipboard</button>
             </div>
             <textarea id="schedule-csv" class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ schedule_csv|safe }}</textarea>
@@ -484,7 +484,7 @@
           <div class="form-group">
             <div class="clearfix">
               <label class="control-label" style="display:inline-block; margin:0; padding-top:6px;">Flat Schedule</label>
-              <button type="button" class="btn btn-default btn-xs pull-right" style="margin-left:4px;" onclick="downloadCSVFromTextarea('flat-schedule-csv', 'flat_schedule.csv')"><span class="glyphicon glyphicon-download"></span> Download CSV</button>
+              <button type="button" class="btn btn-default btn-xs pull-right" style="margin-left:4px;" onclick="downloadCSVFromTextarea('flat-schedule-csv', '{{ event.key_name }}_flat_schedule.csv')"><span class="glyphicon glyphicon-download"></span> Download CSV</button>
               <button type="button" class="btn btn-default btn-xs pull-right" onclick="copyCSVFromTextarea('flat-schedule-csv')"><span class="glyphicon glyphicon-copy"></span> Copy to Clipboard</button>
             </div>
             <textarea id="flat-schedule-csv" class="form-control" rows="20" readonly style="font-family: monospace; resize: vertical;">{{ flat_schedule_csv|safe }}</textarea>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds two buttons:
A "Download CSV" button, that downloads an appropriately named CSV file from the associated textarea on the Scouting page.
A "Copy to Clipboard" button that copies the contents of the textarea to the user's clipboard. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes combined are a small UX experience improvement for users using this page for the intended purpose of copying into scouting google docs or excel sheets.

The js for this is entirely clientside. It is unclear to me if the approach I took of adding this to the template as an inline script is preferable compared to adding it to the TBA bundled javascript. Happy to revise that bit of the implementation if that is desired.

As implemented, this functionality should be functional on ~95% of browsers per MDN/caniuse. Browsers prior to 2020 may not support the clipboard functionality, browsers prior to 2017 might not support the download functionality. If we want those workarounds included, I can add those as well.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed all tests and lint locally, though I think since this is all in the templates it may not actually be being linted.
Tested on Firefox, Edge, and Chrome on Windows 11 with TBA running in Docker on WSL. 

## Screenshots (if appropriate):

<img width="1159" height="703" alt="image" src="https://github.com/user-attachments/assets/eadbb233-73cc-4728-9d09-4e47c52296ba" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)


Disclosure: I did use GH Copilot as part of this PR, but all code was reviewed by (and almost all significantly edited by) me.