### PR TITLE
Show user email for mod codes instead of user account. Link mod code emails to user inspect

### DIFF
--- a/src/backend/common/models/team_admin_access.py
+++ b/src/backend/common/models/team_admin_access.py
@@ -33,3 +33,12 @@ class TeamAdminAccess(ndb.Model):
     @classmethod
     def render_key_name(cls, team_number, year):
         return "frc{}_{}".format(team_number, year)
+
+    @property
+    def account_email(self) -> str | None:
+        if not self.account:
+            return None
+        account = self.account.get()
+        if not account:
+            return None
+        return account.email

--- a/src/backend/common/models/tests/team_admin_access_test.py
+++ b/src/backend/common/models/tests/team_admin_access_test.py
@@ -1,0 +1,12 @@
+from backend.common.models.account import Account
+from backend.common.models.team_admin_access import TeamAdminAccess
+
+
+def test_account_email() -> None:
+    mod_code = TeamAdminAccess()
+    assert mod_code.account is None
+    assert mod_code.account_email is None
+    account = Account(email="zach@thebluealliance.com").put()
+    mod_code = TeamAdminAccess(account=account)
+    assert mod_code.account is not None
+    assert mod_code.account_email == "zach@thebluealliance.com"

--- a/src/backend/web/templates/admin/team_media_mod_list.html
+++ b/src/backend/web/templates/admin/team_media_mod_list.html
@@ -45,7 +45,7 @@ $("#go_button").click(function() {
     <tr>
         <td><a href="/admin/team/{{auth_code.team_number}}">{{ auth_code.team_number }}</a></td>
         <td><a href="/admin/media/modcodes/edit/{{auth_code.team_number}}/{{auth_code.year}}">{{ auth_code.access_code }}</a></td>
-        <td>{{ auth_code.account }}</td>
+        <td>{% if auth_code.account %}<a href="/admin/user/{{ auth_code.account.id() }}">{{ auth_code.account_email }}</a>{% else %}{{ auth_code.account }}{% endif %}</td>
         <td>{{ auth_code.expiration|strftime("%Y-%m-%d")}}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Fixing one of the million papercuts I have in the admin console. The mod codes list will now show the email address associated with the mod code instead of the Account Key. The email address is now a link that will link out to the Account inspect page.

Before: 
<img width="901" height="395" alt="Screenshot 2025-11-24 at 12 36 40 AM" src="https://github.com/user-attachments/assets/ae255446-a6f0-46f4-a81d-2a0295a55de2" />

After:
<img width="1159" height="531" alt="Screenshot 2025-11-24 at 12 26 00 AM" src="https://github.com/user-attachments/assets/8f483479-471d-4504-b912-f8d66fafc47f" />
