### PR TITLE
Update 4 team double elimination bracket placeholder text

### DIFF
--- a/src/backend/web/templates/bracket_partials/double_elim_4_bracket_table.html
+++ b/src/backend/web/templates/bracket_partials/double_elim_4_bracket_table.html
@@ -131,7 +131,7 @@
             <td colspan="10"></td>
             <td class="dash" colspan="1"></td>
             <td rowspan="2" class="match">
-                {{ bracket_match('Finals', bracket_table.get('f', {}).get('f1'), 'Winner of M4', 'Winner of M5') }}
+                {{ bracket_match('Finals', bracket_table.get('f', {}).get('f1'), 'Winner of M3', 'Winner of M5') }}
             </td>
         </tr>
 


### PR DESCRIPTION


## Description
The current version of the unfilled 4 team double elimination bracket shows the red alliance for finals coming from M4, but it should actually be the winner of M3.

## How Has This Been Tested?
It has not, but I can't imagine it causing issues

## Screenshots (if appropriate):

(Current behavior)
<img width="1249" height="870" alt="image" src="https://github.com/user-attachments/assets/10f250d0-11e0-4c57-9f1d-a45644ef6c1d" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)