### PR TITLE
[pwa] Add RP dots back

### DIFF
--- a/pwa/app/components/tba/match/matchRows.tsx
+++ b/pwa/app/components/tba/match/matchRows.tsx
@@ -44,6 +44,7 @@ export default function SimpleMatchRowsWithBreaks({
       <MatchRow
         match={match}
         playoffType={event.playoff_type ?? PlayoffType.CUSTOM}
+        year={event.year}
         key={match.key}
       />,
     );
@@ -70,9 +71,11 @@ export default function SimpleMatchRowsWithBreaks({
 export function MatchRow({
   match,
   playoffType,
+  year,
 }: {
   match: Match;
   playoffType: PlayoffType;
+  year: number;
 }) {
   const maybeVideoURL = maybeGetFirstMatchVideoURL(match);
   const isPlayed =
@@ -156,6 +159,8 @@ export function MatchRow({
             className="col-start-6 row-start-1 xl:col-span-1 xl:col-start-auto
               xl:row-start-auto"
             winner={match.winning_alliance === 'red'}
+            scoreBreakdown={match.score_breakdown?.red}
+            year={year}
           />
         )}
 
@@ -167,6 +172,8 @@ export function MatchRow({
             className="col-start-6 row-start-2 xl:col-span-1 xl:col-start-auto
               xl:row-start-auto"
             winner={match.winning_alliance === 'blue'}
+            scoreBreakdown={match.score_breakdown?.blue}
+            year={year}
           />
         )}
       </div>

--- a/pwa/app/components/tba/match/scoreCell.tsx
+++ b/pwa/app/components/tba/match/scoreCell.tsx
@@ -1,8 +1,10 @@
 import { VariantProps, cva } from 'class-variance-authority';
 
+import { Match } from '~/api/tba/read';
+import RpDots from '~/components/tba/rpDot';
 import { cn } from '~/lib/utils';
 
-const scoreCellVariants = cva('flex items-center justify-center', {
+const scoreCellVariants = cva('relative flex items-center justify-center', {
   variants: {
     winner: {
       true: 'font-semibold',
@@ -23,12 +25,16 @@ interface ScoreCellProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof scoreCellVariants> {
   score: number;
+  scoreBreakdown?: NonNullable<Match['score_breakdown']>['red'];
+  year?: number;
 }
 
 export default function ScoreCell({
   score,
   winner,
   allianceColor,
+  scoreBreakdown,
+  year,
   className,
   ...props
 }: ScoreCellProps) {
@@ -37,6 +43,9 @@ export default function ScoreCell({
       className={cn(scoreCellVariants({ winner, allianceColor }), className)}
       {...props}
     >
+      {scoreBreakdown && year && (
+        <RpDots score_breakdown={scoreBreakdown} year={year} />
+      )}
       {score}
     </div>
   );

--- a/pwa/app/components/tba/rpDot.tsx
+++ b/pwa/app/components/tba/rpDot.tsx
@@ -9,27 +9,27 @@ import {
   RANKING_POINT_LABELS,
   getBonusRankingPoints,
 } from '~/lib/rankingPoints';
-import { cn } from '~/lib/utils';
 
 function RpDot({
-  rpIndex,
   tooltipText,
+  achieved,
 }: {
-  rpIndex: number;
   tooltipText: string;
+  achieved: boolean;
 }) {
   return (
     <TooltipProvider delayDuration={100}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <svg
-            className={cn('absolute top-[2px] left-[3px] h-[4px] w-[4px]', {
-              'ml-0': rpIndex === 0,
-              'ml-[6px]': rpIndex === 1,
-              'ml-[12px]': rpIndex === 2,
-            })}
-          >
-            <circle cx={2} cy={2} r={2} />
+          <svg className="h-[5px] w-[5px]">
+            <circle
+              cx={2.5}
+              cy={2.5}
+              r={achieved ? 2.5 : 2}
+              fill={achieved ? 'currentColor' : 'none'}
+              stroke={achieved ? 'none' : '#9ca3af'}
+              strokeWidth={achieved ? 0 : 1}
+            />
           </svg>
         </TooltipTrigger>
         <TooltipContent>
@@ -51,16 +51,14 @@ export default function RpDots({
   const tooltipTexts = RANKING_POINT_LABELS[year];
 
   return (
-    <>
-      {rpsAchieved.map((rp, index) =>
-        rp ? (
-          <RpDot
-            key={index}
-            rpIndex={index}
-            tooltipText={tooltipTexts[index]}
-          />
-        ) : null,
-      )}
-    </>
+    <div className="absolute top-[2px] left-[3px] flex gap-[2px]">
+      {rpsAchieved.map((achieved, index) => (
+        <RpDot
+          key={index}
+          tooltipText={tooltipTexts[index]}
+          achieved={achieved}
+        />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
Also added a faint outline for unsuccessful RPs (idea from #8389)

<img width="605" height="287" alt="image" src="https://github.com/user-attachments/assets/673fc2a5-0115-4dd0-a6d2-5d446cd54273" />
