### PR TITLE
Change firebase auth domain to thebluealliance.com

### DIFF
--- a/src/frontend/liveevent/firebaseapp.js
+++ b/src/frontend/liveevent/firebaseapp.js
@@ -4,7 +4,7 @@ import "firebase/compat/database";
 
 const FirebaseApp = firebase.initializeApp({
   apiKey: "AIzaSyDBlFwtAgb2i7hMCQ5vBv44UEKVsA543hs",
-  authDomain: "tbatv-prod-hrd.firebaseapp.com",
+  authDomain: "thebluealliance.com",
   databaseURL: "https://tbatv-prod-hrd.firebaseio.com",
 });
 


### PR DESCRIPTION
A little bit of a YOLO here (might have to revert this one) but - fixes the Firebase Auth domain to be `thebluealliance.com` so that our auth should prompt to login to `thebluealliance.com` and not our appspot domain