### PR TITLE
Use `firebase emulators:exec` for importing Firebase Auth users

### DIFF
--- a/ops/dev/vagrant/run_firebase_emulator.sh
+++ b/ops/dev/vagrant/run_firebase_emulator.sh
@@ -5,11 +5,6 @@ source ops/dev/vagrant/config.sh
 
 project=$(project)
 
-firebase emulators:start --project="$project" &
+firebase emulators:exec --project="$project" --import=.firebase-data --export-on-exit=.firebase-data "python ops/dev/vagrant/create_auth_emulator_accounts.py --project='$project'"
 
-# Give the emualtor a second to boot before inserting users
-sleep 500
-
-python ops/dev/vagrant/create_auth_emulator_accounts.py --project="$project"
-
-fg
+firebase emulators:start --project="$project" --import=.firebase-data --export-on-exit=.firebase-data


### PR DESCRIPTION
This is certainly the right way to do this, which makes it where we don't have to do any sort of sleeps and whatnot.