### PR TITLE
Show unfilled RP circles, hide playoff RP dots

### DIFF
--- a/src/backend/web/templates/match_partials/match_table_cell_macros.html
+++ b/src/backend/web/templates/match_partials/match_table_cell_macros.html
@@ -71,37 +71,47 @@
 {% macro match_score_td(match, alliance_color, cur_team_key, compact=False, force_played=False, predictions=None) %}
 <td{% if compact %} colspan="2"{% endif %} class="{{alliance_color}}Score{% if cur_team_key and cur_team_key in match.alliances.get(alliance_color).teams %} current-team{% endif %}">
   {% if match.score_breakdown and not predictions %}
-    {% if match.score_breakdown.get(alliance_color).teleopDefensesBreached
-      or match.score_breakdown.get(alliance_color).kPaRankingPointAchieved
-      or match.score_breakdown.get(alliance_color).kPaBonusPoints
-      or match.score_breakdown.get(alliance_color).autoQuestRankingPoint
-      or match.score_breakdown.get(alliance_color).completeRocketRankingPoint
-      or match.score_breakdown.get(alliance_color).shieldEnergizedRankingPoint
-      or match.score_breakdown.get(alliance_color).cargoBonusRankingPoint
-      or match.score_breakdown.get(alliance_color).sustainabilityBonusAchieved
-      or match.score_breakdown.get(alliance_color).melodyBonusAchieved
-      or match.score_breakdown.get(alliance_color).autoBonusAchieved %}
+    {% if match.year in [2016, 2017, 2018, 2019, 2020, 2022, 2023, 2024, 2025] %}
     <svg class="top-left-dot" rel="tooltip" title="{% if match.year == 2016 %}Defenses Breached{% elif match.year == 2017 %}Pressure Reached{% elif match.year == 2018 %}Auto Quest{% elif match.year == 2019 %}Complete Rocket{% elif match.year == 2020 %}Shield Energized{% elif match.year == 2022 %}Cargo Bonus{% elif match.year == 2023 %}Sustainability Bonus{% elif match.year == 2024 %}Melody Bonus{% elif match.year == 2025 %}Auto Bonus{% endif %}">
+      {% if match.score_breakdown.get(alliance_color).teleopDefensesBreached
+        or match.score_breakdown.get(alliance_color).kPaRankingPointAchieved
+        or match.score_breakdown.get(alliance_color).kPaBonusPoints
+        or match.score_breakdown.get(alliance_color).autoQuestRankingPoint
+        or match.score_breakdown.get(alliance_color).completeRocketRankingPoint
+        or match.score_breakdown.get(alliance_color).shieldEnergizedRankingPoint
+        or match.score_breakdown.get(alliance_color).cargoBonusRankingPoint
+        or match.score_breakdown.get(alliance_color).sustainabilityBonusAchieved
+        or match.score_breakdown.get(alliance_color).melodyBonusAchieved
+        or match.score_breakdown.get(alliance_color).autoBonusAchieved %}
       <circle cx="2" cy="2" r="2"/>
+      {% else %}
+      <circle cx="2" cy="2" r="1.5" fill="none" stroke="#9ca3af" stroke-width="1"/>
+      {% endif %}
     </svg>
-    {% endif %}
-    {% if match.score_breakdown.get(alliance_color).teleopTowerCaptured
-      or match.score_breakdown.get(alliance_color).rotorRankingPointAchieved
-      or match.score_breakdown.get(alliance_color).rotorBonusPoints
-      or match.score_breakdown.get(alliance_color).faceTheBossRankingPoint
-      or match.score_breakdown.get(alliance_color).habDockingRankingPoint
-      or match.score_breakdown.get(alliance_color).shieldOperationalRankingPoint
-      or match.score_breakdown.get(alliance_color).hangarBonusRankingPoint
-      or match.score_breakdown.get(alliance_color).activationBonusAchieved
-      or match.score_breakdown.get(alliance_color).ensembleBonusAchieved
-      or match.score_breakdown.get(alliance_color).coralBonusAchieved %}
     <svg class="top-left-dot-2" rel="tooltip" title="{% if match.year == 2016 %}Tower Captured{% elif match.year == 2017 %}All Rotors Engaged{% elif match.year == 2018 %}Face The Boss{% elif match.year == 2019 %}HAB Docking{% elif match.year == 2020 %}Shield Operational{% elif match.year == 2022 %}Hangar Bonus{% elif match.year == 2023 %}Activation Bonus{% elif match.year == 2024 %}Ensemble Bonus{% elif match.year == 2025 %}Coral Bonus{% endif %}">
+      {% if match.score_breakdown.get(alliance_color).teleopTowerCaptured
+        or match.score_breakdown.get(alliance_color).rotorRankingPointAchieved
+        or match.score_breakdown.get(alliance_color).rotorBonusPoints
+        or match.score_breakdown.get(alliance_color).faceTheBossRankingPoint
+        or match.score_breakdown.get(alliance_color).habDockingRankingPoint
+        or match.score_breakdown.get(alliance_color).shieldOperationalRankingPoint
+        or match.score_breakdown.get(alliance_color).hangarBonusRankingPoint
+        or match.score_breakdown.get(alliance_color).activationBonusAchieved
+        or match.score_breakdown.get(alliance_color).ensembleBonusAchieved
+        or match.score_breakdown.get(alliance_color).coralBonusAchieved %}
       <circle cx="2" cy="2" r="2"/>
+      {% else %}
+      <circle cx="2" cy="2" r="1.5" fill="none" stroke="#9ca3af" stroke-width="1"/>
+      {% endif %}
     </svg>
     {% endif %}
-    {% if match.score_breakdown.get(alliance_color).bargeBonusAchieved %}
-    <svg class="top-left-dot-3" rel="tooltip" title="{% if match.year == 2025 %}Barge Bonus{% endif %}">
+    {% if match.year == 2025 %}
+    <svg class="top-left-dot-3" rel="tooltip" title="Barge Bonus">
+      {% if match.score_breakdown.get(alliance_color).bargeBonusAchieved %}
       <circle cx="2" cy="2" r="2"/>
+      {% else %}
+      <circle cx="2" cy="2" r="1.5" fill="none" stroke="#9ca3af" stroke-width="1"/>
+      {% endif %}
     </svg>
     {% endif %}
   {% endif %}


### PR DESCRIPTION
Add a faint outline for unsuccessful RPs (idea from https://github.com/the-blue-alliance/the-blue-alliance/issues/8389), hide RP dots on playoffs (can happen for offseasons)

<img width="594" height="133" alt="image" src="https://github.com/user-attachments/assets/2badf8c6-2f67-4bb1-9282-f33fe91e5131" />
