### PR TITLE
Fix fullstack test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -445,6 +445,10 @@ jobs:
               - 'src/**'
               - 'package.json'
               - 'requirements.txt'
+      # See https://github.com/puppeteer/puppeteer/issues/12818
+      # Ubuntu 23+ doesn't like running puppeteer without disabling AppArmor.
+      - name: Disable AppArmor
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: Set up Python 3.13
         if: steps.changes.outputs.web == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -393,6 +393,10 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v6
+      # See https://github.com/puppeteer/puppeteer/issues/12818
+      # Ubuntu 23+ doesn't like running puppeteer without disabling AppArmor.
+      - name: Disable AppArmor
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
This is failing with 

```
[12707:12707:1202/030059.631143:FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc:128] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

See: https://github.com/puppeteer/puppeteer/issues/12818