### PR TITLE
Style API docs for PWA to mirror py3 look

### DIFF
--- a/pwa/app/routes/apidocs.tsx
+++ b/pwa/app/routes/apidocs.tsx
@@ -1,99 +1,151 @@
 import { Link } from 'react-router';
 
-export default function ApiDocs(): React.JSX.Element {
-  return (
-    <>
-      <div className="flex flex-col divide-y **:mt-4">
-        <div>
-          <h1 className="text-3xl font-medium">
-            The Blue Alliance Developer APIs
-          </h1>
-          <p>
-            The Blue Alliance cares about making our data publicly accessible
-            via our various APIs. We want to help inspire people to build their
-            own projects and get started with data analysis and software
-            development. This page explains the APIs we provide and how to get
-            started using them.
-          </p>
-        </div>
+import IconMenu2 from '~icons/tabler/menu-2';
 
+import {
+  Credenza,
+  CredenzaBody,
+  CredenzaContent,
+  CredenzaHeader,
+  CredenzaTitle,
+  CredenzaTrigger,
+} from '~/components/ui/credenza';
+import {
+  TableOfContentsItem,
+  TableOfContentsLink,
+  TableOfContentsList,
+} from '~/components/ui/toc';
+
+export default function ApiDocs(): React.JSX.Element {
+  const tocItems = [
+    { slug: 'getting-started', label: 'Getting Started' },
+    { slug: 'apiv3', label: 'Read API (v3)' },
+    { slug: 'webhooks', label: 'Webhooks' },
+    { slug: 'trusted', label: 'Write API' },
+    { slug: 'guidelines', label: 'Developer Guidelines' },
+  ];
+
+  const tocContent = (
+    <TableOfContentsList className="mt-2">
+      {tocItems.map((item) => (
+        <TableOfContentsItem key={item.slug}>
+          <TableOfContentsLink to={`#${item.slug}`} replace={true}>
+            {item.label}
+          </TableOfContentsLink>
+        </TableOfContentsItem>
+      ))}
+    </TableOfContentsList>
+  );
+
+  return (
+    <div className="flex flex-wrap gap-8 lg:flex-nowrap">
+      <Credenza>
+        <CredenzaTrigger asChild>
+          <button
+            className="fixed right-4 bottom-4 z-40 flex size-14 items-center
+              justify-center rounded-full bg-primary text-primary-foreground
+              shadow-lg md:hidden"
+            aria-label="Table of Contents"
+          >
+            <IconMenu2 className="size-6" />
+          </button>
+        </CredenzaTrigger>
+        <CredenzaContent>
+          <CredenzaHeader>
+            <CredenzaTitle>Table of Contents</CredenzaTitle>
+          </CredenzaHeader>
+          <CredenzaBody className="overflow-y-auto">{tocContent}</CredenzaBody>
+        </CredenzaContent>
+      </Credenza>
+
+      <div className="hidden basis-full md:block md:basis-1/6">
+        <div className="sticky top-14 pt-8">{tocContent}</div>
+      </div>
+      <div className="basis-full py-8 md:basis-5/6">
         <div>
-          <h3 className="text-2xl">Need Help?</h3>
-          <p>
-            Here are some areas where you can ask the TBA developer community
-            for assistance if you run into trouble. for guidance.
-          </p>
-          <ul>
-            <li className="list-disc">
-              <p>
-                Have questions? Reach out using resources on our{' '}
-                <Link to="/contact">contact</Link> page.
-              </p>
-            </li>
-            <li className="list-disc">
-              <p>
-                Found a bug or have a feature request? File an{' '}
+          <section className="py-4">
+            <h1 className="mb-2 text-3xl font-medium">
+              The Blue Alliance Developer APIs
+            </h1>
+            <p>
+              The Blue Alliance cares about making our data publicly accessible
+              via our various APIs. We want to help inspire people to build
+              their own projects and get started with data analysis and software
+              development. This page explains the APIs we provide and how to get
+              started using them.
+            </p>
+          </section>
+
+          <section className="py-4">
+            <h2 className="mb-2 text-2xl font-medium">Need Help?</h2>
+            <p>
+              Here are some areas where you can ask the TBA developer community
+              for assistance if you run into trouble.
+            </p>
+            <ul className="mt-2 ml-8 list-disc">
+              <li>
+                <strong>Have questions?</strong> Reach out using resources on
+                our <Link to="/contact">contact</Link> page.
+              </li>
+              <li>
+                <strong>Found a bug or have a feature request?</strong> File an{' '}
                 <a href="https://github.com/the-blue-alliance/the-blue-alliance/issues/new">
                   issue on GitHub.
-                </a>{' '}
-              </p>
-            </li>
-            <li className="list-disc">
-              <p>
-                Want to contribute?{' '}
+                </a>
+              </li>
+              <li>
+                <strong>Want to contribute?</strong>{' '}
                 <a href="https://github.com/the-blue-alliance/the-blue-alliance">
                   Check out our code and send us a pull request!
-                </a>{' '}
-              </p>
-            </li>
-          </ul>
-        </div>
+                </a>
+              </li>
+            </ul>
+          </section>
 
-        <div>
-          <h3 className="text-2xl">Getting Started</h3>
-          <p>
-            Before you get started using The Blue Alliance APIs, you need to be
-            familiar with a few elements of web technology. The Blue Alliance
-            APIs work by having your computer send a web request to our servers
-            asking for some piece of data, and our servers send the data back to
-            your computer. You can ask for information about teams or matches,
-            or even send us information, like letting us know there&apos;s a
-            robot photo we should add to our data set.
-          </p>
-          <p>
-            First, you need some way of sending HTTPS Requests to The Blue
-            Alliance&apos;s servers. This will be your primary means of
-            communication with TBA. For testing purposes, your web browser may
-            suffice. For more advanced applications, you may want to use an
-            external library, such as{' '}
-            <a href="https://www.w3schools.com/jquery/jquery_ajax_intro.asp">
-              jQuery
-            </a>{' '}
-            (Javascript),{' '}
-            <a href="http://docs.python-requests.org/en/master/">Requests</a>{' '}
-            (Python), or <a href="https://square.github.io/okhttp/">OkHttp</a>{' '}
-            (Java), or others.
-          </p>
-          <p>
-            You will also need to be familiar with{' '}
-            <a href="https://en.wikipedia.org/wiki/Json">JSON</a>, a
-            machine-readable format for sending and receiving data. Most of the
-            TBA APIs use JSON-formatted data, so you should find out how to
-            parse JSON text in the language of your choice.
-          </p>
-          <p>
-            Once you&apos;ve figured out how to make HTTPS requests, you will
-            need to figure out how to manipulate request and response headers.
-            These will be used to pass authentication keys to TBA and understand
-            the cache life of returned data.
-          </p>
-        </div>
+          <section id="getting-started" className="py-4">
+            <h2 className="mb-2 text-2xl font-medium">Getting Started</h2>
+            <p>
+              Before you get started using The Blue Alliance APIs, you need to
+              be familiar with a few elements of web technology. The Blue
+              Alliance APIs work by having your computer send a web request to
+              our servers asking for some piece of data, and our servers send
+              the data back to your computer. You can ask for information about
+              teams or matches, or even send us information, like letting us
+              know there&apos;s a robot photo we should add to our data set.
+            </p>
+            <p>
+              First, you need some way of sending HTTPS Requests to The Blue
+              Alliance&apos;s servers. This will be your primary means of
+              communication with TBA. For testing purposes, your web browser may
+              suffice. For more advanced applications, you may want to use an
+              external library, such as{' '}
+              <a href="https://www.w3schools.com/jquery/jquery_ajax_intro.asp">
+                jQuery
+              </a>{' '}
+              (Javascript),{' '}
+              <a href="http://docs.python-requests.org/en/master/">Requests</a>{' '}
+              (Python), or <a href="https://square.github.io/okhttp/">OkHttp</a>{' '}
+              (Java), or others.
+            </p>
+            <p>
+              You will also need to be familiar with{' '}
+              <a href="https://en.wikipedia.org/wiki/Json">JSON</a>, a
+              machine-readable format for sending and receiving data. Most of
+              the TBA APIs use JSON-formatted data, so you should find out how
+              to parse JSON text in the language of your choice.
+            </p>
+            <p>
+              Once you&apos;ve figured out how to make HTTPS requests, you will
+              need to figure out how to manipulate request and response headers.
+              These will be used to pass authentication keys to TBA and
+              understand the cache life of returned data.
+            </p>
+          </section>
 
-        <div>
-          <div>
-            <h3 className="text-2xl">
+          <section id="apiv3" className="py-4">
+            <h2 className="mb-2 text-2xl font-medium">
               <Link to="/apidocs/v3">Read API (v3)</Link>
-            </h3>
+            </h2>
             <p>
               Most people want to pull event listings, team information, match
               results, or statistics from The Blue Alliance to use in their own
@@ -101,21 +153,15 @@ export default function ApiDocs(): React.JSX.Element {
               almost all of the data you see on TBA to your application in a
               machine-readable format called JSON.
             </p>
-          </div>
-
-          <div>
-            <h4 className="text-xl">API Endpoint</h4>
+            <h3 className="mt-4 mb-2 text-xl">API Endpoint</h3>
             <p>
               All requests should be made to the base URL:{' '}
               <code>https://www.thebluealliance.com/api/v3</code>.
             </p>
-          </div>
-
-          <div>
-            <h4 className="text-xl">Authentication</h4>
-            <h5 className="text-l">
+            <h3 className="mt-4 mb-2 text-xl">Authentication</h3>
+            <h4 className="text-l mb-2">
               <code>X-TBA-Auth-Key</code> Header
-            </h5>
+            </h4>
             <p>
               Generate an access token on your{' '}
               <Link to="/account">Account Dashboard</Link> in the Read API Keys
@@ -125,15 +171,12 @@ export default function ApiDocs(): React.JSX.Element {
             <p>
               If you are logged in to your TBA account, you can access the API
               without a key by simply navigating to an API URL in your web
-              browser
+              browser.
             </p>
-          </div>
-
-          <div>
-            <h4 className="text-xl">Caching</h4>
-            <h5 className="text-l">
+            <h3 className="mt-4 mb-2 text-xl">Caching</h3>
+            <h4 className="text-l mb-2">
               <code>ETag</code> and <code>If-None-Match</code> Headers
-            </h5>
+            </h4>
             <p>
               All API responses have an <code>Etag</code> header which specifies
               the version of the most recent response. When making repeated
@@ -157,9 +200,9 @@ export default function ApiDocs(): React.JSX.Element {
               </a>
               .
             </p>
-            <h5 className="text-l">
+            <h4 className="text-l mt-4 mb-2">
               <code>Cache-Control</code> Header
-            </h5>
+            </h4>
             <p>
               If your application makes many queries to the TBA API and you are
               capable of caching the results locally, the{' '}
@@ -173,10 +216,7 @@ export default function ApiDocs(): React.JSX.Element {
               </a>
               .
             </p>
-          </div>
-
-          <div>
-            <h4 className="text-xl">Client Libraries</h4>
+            <h3 className="mt-4 mb-2 text-xl">Client Libraries</h3>
             <p>
               The Blue Alliance automatically builds and publishes client
               libraries to make it easier for you to get started using APIv3.
@@ -188,130 +228,99 @@ export default function ApiDocs(): React.JSX.Element {
               looking to get started and can be found{' '}
               <a href="https://github.com/TBA-API">on the TBA-API GitHub</a>.
             </p>
-          </div>
-        </div>
+          </section>
 
-        <div>
-          <h3 className="text-2xl">
-            <Link to="/apidocs/webhooks">Webhooks</Link>
-          </h3>
-          <p>
-            The TBA API also includes support for{' '}
-            <a href="https://en.wikipedia.org/wiki/Webhook">webhooks</a>, or
-            HTTP callbacks. When an item of interest changes, TBA can send a
-            HTTP request to your server, allowing your application to react
-            instantly to the change. This can save both your client and our
-            server time and processing power, as it can reduce the need to poll
-            the API. See{' '}
-            <Link to="/apidocs/webhooks">our webhook documentation page</Link>{' '}
-            for more information.
-          </p>
-        </div>
+          <section id="webhooks" className="py-4">
+            <h2 className="mb-2 text-2xl font-medium">
+              <Link to="/apidocs/webhooks">Webhooks</Link>
+            </h2>
+            <p>
+              The TBA API also includes support for{' '}
+              <a href="https://en.wikipedia.org/wiki/Webhook">webhooks</a>, or
+              HTTP callbacks. When an item of interest changes, TBA can send a
+              HTTP request to your server, allowing your application to react
+              instantly to the change. This can save both your client and our
+              server time and processing power, as it can reduce the need to
+              poll the API. See{' '}
+              <Link to="/apidocs/webhooks">our webhook documentation page</Link>{' '}
+              for more information.
+            </p>
+          </section>
 
-        <div>
-          <h3 className="text-2xl">
-            <Link to="/apidocs/trusted/v1">Write API (v1)</Link>
-          </h3>
-          <p>
-            The Blue Alliance provides a Write API, called the Trusted API,
-            which allows users to import data to The Blue Alliance for archival.
-            For example, many offseason events use the Trusted API to provide
-            real-time match results to their audience. To get started, you need
-            to <Link to="/request/apiwrite">request access tokens</Link> for
-            your desired event. These need to be used when constructing each
-            request.
-          </p>
-          <p>
-            To see the complete specification of the trusted API, refer to the{' '}
-            <Link to="/apidocs/trusted/v1">full documentation</Link>.
-          </p>
-        </div>
+          <section id="trusted" className="py-4">
+            <h2 className="mb-2 text-2xl font-medium">
+              <Link to="/apidocs/trusted/v1">Write API (v1)</Link>
+            </h2>
+            <p>
+              The Blue Alliance provides a Write API, called the Trusted API,
+              which allows users to import data to The Blue Alliance for
+              archival. For example, many offseason events use the Trusted API
+              to provide real-time match results to their audience. To get
+              started, you need to{' '}
+              <Link to="/request/apiwrite">request access tokens</Link> for your
+              desired event. These need to be used when constructing each
+              request.
+            </p>
+            <p>
+              To see the complete specification of the trusted API, refer to the{' '}
+              <Link to="/apidocs/trusted/v1">full documentation</Link>.
+            </p>
+          </section>
 
-        <div>
-          <h3 className="text-2xl">
-            <a href="https://github.com/the-blue-alliance/the-blue-alliance-data">
-              Data Archives
-            </a>
-          </h3>
-          <p>
-            If you&apos;re looking to run SQL queries over the TBA database, you
-            can use this{' '}
-            <a href="https://www.thebluealliance.com/bigquery">BigQuery</a>{' '}
-            dataset. This contains a full replica of the TBA database, so the
-            possibilities are endless!
-          </p>
-          <p>
-            If these APIs are too complex for your application, The Blue
-            Alliance also provides periodic data archives in comma separated
-            value (CSV) format. The data provided here is less detailed, but is
-            simpler to use in someething like a spreadsheet.
-          </p>
-          <p>
-            You can find these data archives on
-            <a href="https://github.com/the-blue-alliance/the-blue-alliance-data">
-              {' '}
-              The Blue Alliance&apos;s TBA Data Repository
-            </a>
-          </p>
-        </div>
-
-        <div>
-          <h3 className="text-2xl">Developer Guidlines</h3>
-          <p>
-            We&apos;re excited to see you building things on top of The Blue
-            Alliance&apos;s APIs! We love seeing the creativity and utility in
-            these projects. We have a few developer guidelines to help guide
-            your work.
-          </p>
-
-          <div>
-            <h4 className="text-xl">1. Branding</h4>
-            <ul>
-              <li className="list-disc">
-                <p>
-                  We want people to know which apps are official The Blue
-                  Alliance apps, and which apps are powered by our API, but not
-                  supported by us.
-                </p>
+          <section id="guidelines" className="py-4">
+            <h2 className="mb-2 text-2xl font-medium">
+              TBA Developer Guidelines
+            </h2>
+            <p>
+              We&apos;re excited to see you building things on top of The Blue
+              Alliance&apos;s APIs! We love seeing the creativity and utility in
+              these projects. We have a few developer guidelines to help guide
+              your work.
+            </p>
+            <ol className="mt-4 ml-8 list-decimal space-y-4">
+              <li>
+                <strong>Branding</strong>
+                <ul className="ml-6 list-disc">
+                  <li>
+                    We want people to know which apps are official The Blue
+                    Alliance apps, and which apps are powered by our API, but
+                    not supported by us.
+                  </li>
+                  <li>
+                    Please do not use &quot;The Blue Alliance&quot;,
+                    &quot;TBA&quot;, or The Blue Alliance lamp logo in the name
+                    or brand identity of your app.
+                  </li>
+                  <li>
+                    If you&apos;d like your project to become an official part
+                    of The Blue Alliance, please{' '}
+                    <Link to="/contact">reach out to us</Link>. We&apos;d love
+                    to talk more!
+                  </li>
+                </ul>
               </li>
-              <li className="list-disc">
-                <p>
-                  Please do not use “The Blue Alliance”, “TBA”, or The Blue
-                  Alliance lamp logo in the name or brand identity of your app.
-                </p>
+              <li>
+                <strong>Attribution</strong>
+                <ul className="ml-6 list-disc">
+                  <li>
+                    Please note that your project is &quot;Powered by The Blue
+                    Alliance&quot; with a link back to{' '}
+                    <Link to="/">thebluealliance.com</Link>. This helps people
+                    discover our site, lets your users know where to report data
+                    issues, and helps more people get inspired to build on top
+                    of our APIs.
+                  </li>
+                  <li>
+                    If you offer links out of your app for more details about
+                    teams, events, or other data, we ask that you consider
+                    linking back to corresponding pages on The Blue Alliance.
+                  </li>
+                </ul>
               </li>
-              <li className="list-disc">
-                <p>
-                  If you&apos;d like your project to become an official part of
-                  The Blue Alliance, please{' '}
-                  <Link to="/contact">reach out to us</Link>. We&apos;d love to
-                  talk more!
-                </p>
-              </li>
-            </ul>
-            <h4 className="text-xl">2. Attribution</h4>
-            <ul>
-              <li className="list-disc">
-                <p>
-                  Please note that your project is “Powered by The Blue
-                  Alliance” with a link back to{' '}
-                  <Link to="/">thebluealliance.com</Link>. This helps people
-                  discover our site, lets your users know where to report data
-                  issues, and helps more people get inspired to build on top of
-                  our APIs.
-                </p>
-              </li>
-              <li className="list-disc">
-                <p>
-                  If you offer links out of your app for more details about
-                  teams, events, or other data, we ask that you consider linking
-                  back to corresponding pages on The Blue Alliance.
-                </p>
-              </li>
-            </ul>
-          </div>
+            </ol>
+          </section>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/pwa/app/tailwind.css
+++ b/pwa/app/tailwind.css
@@ -8,6 +8,9 @@
   --font-sans:
     Roboto, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
@@ -191,5 +194,15 @@
   /* Apply blue text and a hover underline to every link */
   a {
     @apply text-blue-800 hover:underline;
+  }
+
+  /* Bootstrap-style code styling */
+  code {
+    background-color: #f9f2f4;
+    border-radius: 4px;
+    color: #c7254e;
+    padding: 2px 4px;
+    font-size: 90%;
+    font-family: var(--font-mono);
   }
 }


### PR DESCRIPTION
These were ROUGH. I decided not to do the `InView` for the table of contents, because you can kind of see multiple sections at the same time, and writing that logic was wonky.

## Before

<img width="1289" height="998" alt="Screenshot 2025-12-02 at 12 07 12 PM" src="https://github.com/user-attachments/assets/1478d62d-ac04-4d56-904b-cbecb888bb14" />

## After

<img width="1301" height="999" alt="Screenshot 2025-12-02 at 12 00 54 PM" src="https://github.com/user-attachments/assets/4a5b2550-ec39-4654-abe8-0a34ee28c2af" />

<img width="812" height="845" alt="Screenshot 2025-12-02 at 12 01 01 PM" src="https://github.com/user-attachments/assets/89bac9ae-141c-4be3-b9b4-28893b218bb7" />

<img width="654" height="994" alt="Screenshot 2025-12-02 at 12 01 09 PM" src="https://github.com/user-attachments/assets/534c3433-82c0-43e8-872e-6be5ec43d121" />

<img width="653" height="994" alt="Screenshot 2025-12-02 at 12 01 15 PM" src="https://github.com/user-attachments/assets/daf640db-5618-4935-ad2c-989d50d07ab3" />
