### PR TITLE
[eventwizard] Quality of life fixes

### DIFF
--- a/src/frontend/eventwizard/components/AuthTools.js
+++ b/src/frontend/eventwizard/components/AuthTools.js
@@ -1,21 +1,37 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import Alert from "@mui/material/Alert";
 
 class AuthTools extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      alert: null,
+    };
     this.storeAuth = this.storeAuth.bind(this);
     this.loadAuth = this.loadAuth.bind(this);
+    this.clearAlert = this.clearAlert.bind(this);
+  }
+
+  clearAlert() {
+    this.setState({ alert: null });
   }
 
   storeAuth() {
     if (!this.props.selectedEvent) {
-      alert("You must enter an event key");
+      this.setState({
+        alert: { severity: "error", message: "You must enter an event key" },
+      });
       return;
     }
 
     if (!this.props.authId || !this.props.authSecret) {
-      alert("You must enter you auth ID and secret");
+      this.setState({
+        alert: {
+          severity: "error",
+          message: "You must enter you auth ID and secret",
+        },
+      });
       return;
     }
 
@@ -27,24 +43,31 @@ class AuthTools extends Component {
       `${this.props.selectedEvent}_auth`,
       JSON.stringify(auth)
     );
-    alert("Auth Stored");
+    this.setState({ alert: { severity: "success", message: "Auth Stored" } });
   }
 
   loadAuth() {
     if (!this.props.selectedEvent) {
-      alert("You must select an event");
+      this.setState({
+        alert: { severity: "error", message: "You must select an event" },
+      });
       return;
     }
 
     const auth = localStorage.getItem(`${this.props.selectedEvent}_auth`);
     if (!auth) {
-      alert(`No auth found for ${this.props.selectedEvent}`);
+      this.setState({
+        alert: {
+          severity: "error",
+          message: `No auth found for ${this.props.selectedEvent}`,
+        },
+      });
       return;
     }
 
     const authData = JSON.parse(auth);
     this.props.setAuth(authData.id, authData.secret);
-    alert("Auth Loaded");
+    this.setState({ alert: { severity: "success", message: "Auth Loaded" } });
   }
 
   render() {
@@ -58,6 +81,16 @@ class AuthTools extends Component {
           Auth Tools
         </label>
         <div className="col-sm-10">
+          {this.state.alert && (
+            <Alert
+              severity={this.state.alert.severity}
+              icon={false}
+              onClose={this.clearAlert}
+              sx={{ mb: 2, fontSize: 14 }}
+            >
+              {this.state.alert.message}
+            </Alert>
+          )}
           <button
             type="button"
             className="btn btn-default"

--- a/src/frontend/eventwizard/components/EventSelector.js
+++ b/src/frontend/eventwizard/components/EventSelector.js
@@ -33,8 +33,16 @@ class EventSelector extends Component {
     this.state = {
       eventSelectLabel: "",
     };
+    this.debounceTimer = null;
     this.onEventSelected = this.onEventSelected.bind(this);
     this.onManualEventChange = this.onManualEventChange.bind(this);
+  }
+
+  componentWillUnmount() {
+    // Clean up timer on unmount
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
   }
 
   onEventSelected(newEvent) {
@@ -51,7 +59,17 @@ class EventSelector extends Component {
   }
 
   onManualEventChange(event) {
-    this.props.setEvent(event.target.value);
+    const value = event.target.value;
+
+    // Clear existing timer
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+
+    // Set new timer to update after 500ms of no typing
+    this.debounceTimer = setTimeout(() => {
+      this.props.setEvent(value);
+    }, 500);
   }
 
   render() {

--- a/src/frontend/eventwizard/components/__tests__/EventSelector.test.js
+++ b/src/frontend/eventwizard/components/__tests__/EventSelector.test.js
@@ -125,7 +125,8 @@ describe("EventSelector", () => {
     expect(mockSetEvent).toHaveBeenCalledWith("");
   });
 
-  it("calls setEvent when manual event key changes", () => {
+  it("calls setEvent when manual event key changes after debounce", () => {
+    jest.useFakeTimers();
     const component = new EventSelector({
       manualEvent: true,
       setEvent: mockSetEvent,
@@ -133,6 +134,12 @@ describe("EventSelector", () => {
       clearAuth: mockClearAuth,
     });
     component.onManualEventChange({ target: { value: "2024test" } });
+    // Should not be called immediately
+    expect(mockSetEvent).not.toHaveBeenCalled();
+    // Fast-forward time by 500ms (the debounce delay)
+    jest.advanceTimersByTime(500);
+    // Now it should have been called
     expect(mockSetEvent).toHaveBeenCalledWith("2024test");
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
 - debounce the event selector box, so we don't trigger a bunch of API calls for every typed character
 - use a MUI alert for loading/storing auth instead of native `alert`