### PR TITLE
Fix docker build

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -23,12 +23,15 @@ ENV PYTHON_VERSION=python3.13
 RUN apt-get update && apt-get install -y \
     "$PYTHON_VERSION" \
     "$PYTHON_VERSION-venv" \
-    "$PYTHON_VERSION-dev" \
-    python3-pip
+    "$PYTHON_VERSION-dev"
 RUN update-alternatives --install /usr/bin/python python "/usr/bin/$PYTHON_VERSION" 1
 RUN update-alternatives --install /usr/bin/python3 python3 "/usr/bin/$PYTHON_VERSION" 1
 RUN echo 1 | update-alternatives --config python
 RUN echo 1 | update-alternatives --config python3
+
+# The ubuntu python3-pip package depends on distutils, which is not available in Python 3.13
+# So we install pip manually using get-pip.py
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 
 # Add gcloud repository and Cloud SDK dependencies
 RUN apt-get update && apt-get install -y apt-transport-https curl

--- a/ops/dev/firebase/Dockerfile.firebase
+++ b/ops/dev/firebase/Dockerfile.firebase
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-RUN apk --no-cache add default-jre && \
+RUN apk --no-cache add openjdk21-jre && \
     npm cache clean --force && \
     npm i -g firebase-tools
 


### PR DESCRIPTION
`docker compose up` was breaking for 2 reasons. default-jre is no longer available, and we upgraded to py3.13 which doesn't ship with distutils anymore, but the python3-pip apt pkg depends on it to install.