### PR TITLE
Add CD Info Thread media type

### DIFF
--- a/src/backend/common/consts/account_permission.py
+++ b/src/backend/common/consts/account_permission.py
@@ -36,7 +36,7 @@ PERMISSIONS: Dict[AccountPermission, PermissionDescription] = {
     ),
     AccountPermission.REVIEW_DESIGNS: PermissionDescription(
         "REVIEW_DESIGNS",
-        "Can link CAD models and Behind the Design blog posts to team robot profiles",
+        "Can link CAD models, discussion threads, and Behind the Design blog posts to team robot profiles",
     ),
     AccountPermission.REVIEW_EVENT_MEDIA: PermissionDescription(
         "REVIEW_EVENT_MEDIA", "Can approve media (non-match video) linked to events"

--- a/src/backend/common/consts/media_type.py
+++ b/src/backend/common/consts/media_type.py
@@ -28,6 +28,7 @@ class MediaType(enum.IntEnum):
     AVATAR = 12
     ONSHAPE = 13
     GITLAB_PROFILE = 14
+    CD_THREAD = 15
 
 
 MEDIA_TYPES: Set[MediaType] = {t for t in MediaType}
@@ -49,6 +50,7 @@ SLUG_NAMES: Dict[MediaType, str] = {
     MediaType.EXTERNAL_LINK: "external-link",
     MediaType.AVATAR: "avatar",
     MediaType.GITLAB_PROFILE: "gitlab-profile",
+    MediaType.CD_THREAD: "cd-thread",
 }
 
 SLUG_NAME_TO_TYPE: Dict[str, MediaType] = {
@@ -71,6 +73,7 @@ TYPE_NAMES: Dict[MediaType, str] = {
     MediaType.AVATAR: "Avatar",
     MediaType.ONSHAPE: "Onshape",
     MediaType.GITLAB_PROFILE: "GitLab Profile",
+    MediaType.CD_THREAD: "Chief Delphi Thread",
 }
 
 IMAGE_TYPES: Set[MediaType] = {
@@ -93,6 +96,7 @@ SOCIAL_TYPES: Set[MediaType] = {
 ROBOT_TYPES: Set[MediaType] = {
     MediaType.GRABCAD,
     MediaType.ONSHAPE,
+    MediaType.CD_THREAD,
 }
 
 # Format with foreign_key
@@ -104,6 +108,7 @@ PROFILE_URLS: Dict[MediaType, str] = {
     MediaType.INSTAGRAM_PROFILE: "https://www.instagram.com/{}",
     MediaType.PERISCOPE_PROFILE: "https://www.periscope.tv/{}",
     MediaType.GITLAB_PROFILE: "https://www.gitlab.com/{}",
+    MediaType.CD_THREAD: "https://www.chiefdelphi.com/t/{}",
 }
 
 SOCIAL_SORT_ORDER: Dict[MediaType, int] = {

--- a/src/backend/common/models/media.py
+++ b/src/backend/common/models/media.py
@@ -198,6 +198,8 @@ class Media(CachedModel):
             return "https://cad.onshape.com/documents/{}".format(self.foreign_key)
         elif self.media_type_enum == MediaType.INSTAGRAM_IMAGE:
             return self.instagram_url
+        elif self.media_type_enum == MediaType.CD_THREAD:
+            return "https://www.chiefdelphi.com/t/{}".format(self.foreign_key)
         else:
             return ""
 

--- a/src/backend/web/templates/media_partials/cd_thread_partial.html
+++ b/src/backend/web/templates/media_partials/cd_thread_partial.html
@@ -1,0 +1,24 @@
+<div class="thumbnail cdphotothread-thumbnail">
+  <a
+    href="{{media.view_image_url}}"
+    target="_blank"
+    rel="noopener noreferrer"
+    style="
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 150px;
+      background-image: url(&quot;{{media.details.image_url}}&quot;);
+      background-size: cover;
+      background-position: center;
+      position: relative;
+    "
+  >
+  </a>
+  <div class="caption">
+    <a href="{{media.view_image_url}}" target="_blank" rel="noopener noreferrer"
+      >{{media.details.thread_title}}</a
+    >
+  </div>
+</div>
+

--- a/src/backend/web/templates/media_partials/media_display_partial.html
+++ b/src/backend/web/templates/media_partials/media_display_partial.html
@@ -13,4 +13,6 @@
     {% include "media_partials/instagram_partial.html" %}
 {% elif media.media_type_enum == 13 %}
     {% include "media_partials/onshape_partial.html" %}
+{% elif media.media_type_enum == 15 %}
+    {% include "media_partials/cd_thread_partial.html" %}
 {% endif %}

--- a/src/backend/web/templates/suggestions/suggest_designs_review.html
+++ b/src/backend/web/templates/suggestions/suggest_designs_review.html
@@ -7,9 +7,9 @@
 
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
-    <li class="active">Team CAD Models</li>
+    <li class="active">Team CAD Models & Discussion Threads</li>
   </ol>
-  <h1>{{ suggestions_and_references|length }} Pending CAD Suggestions</h1>
+  <h1>{{ suggestions_and_references|length }} Pending CAD Models & Discussion Thread Suggestions</h1>
 
   <form action="/suggest/cad/review" method="post" id='review_designs'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/src/backend/web/templates/suggestions/suggest_team_media.html
+++ b/src/backend/web/templates/suggestions/suggest_team_media.html
@@ -65,6 +65,7 @@
             <br>
             Onshape documents that are public but require an Onshape account are not yet supported. To make them accessible, select <code>Share</code>, <code>Link Sharing</code>, then <code>Turn on link sharing</code>.
             </li>
+            <li><strong>Chief Delphi build/technical threads</strong>, like <code>https://www.chiefdelphi.com/t/team-254-presents-2025-undertow-technical-binder-code-q-a/506115</code></li>
           </ul>
 
           <p><strong>Please do not submit:</strong></p>
@@ -134,10 +135,10 @@
           </div>
           {% endif %}
 
-          {% if medias_by_slugname.grabcad or medias_by_slugname.onshape %}
+          {% if medias_by_slugname.grabcad or medias_by_slugname.onshape or medias_by_slugname['cd-thread'] %}
           <div class="row">
             <div class="col-xs-12">
-              <h4>Existing CAD Models</h4>
+              <h4>Existing CAD Models & Discussion Threads</h4>
               {% for media in medias_by_slugname.grabcad %}
                 <div class="col-xs-12 col-md-6">
                 {% include "media_partials/grabcad_partial.html" %}
@@ -148,6 +149,11 @@
                 {% include "media_partials/onshape_partial.html" %}
                 </div>
                 {% endfor %}
+              {% for media in medias_by_slugname['cd-thread'] %}
+                <div class="col-xs-12 col-md-6">
+                {% include "media_partials/cd_thread_partial.html" %}
+                </div>
+              {% endfor %}
             </div>
           </div>
           {% endif %}

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -326,14 +326,14 @@
     <div class="row">
         <div class="col-xs-12">
           <hr>
-          <a class="btn btn-success pull-right" href="/suggest/team/media?team_key={{team.key_name}}&year={{year}}" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-plus"></span> Add CAD Model!</a>
+          <a class="btn btn-success pull-right" href="/suggest/team/media?team_key={{team.key_name}}&year={{year}}" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-plus"></span> Add CAD Model or Discussion Thread</a>
           <h2 id="robot-profile">Robot Profile</h2>
           {% if robot %}Robot Name: <strong>{{robot.robot_name}}</strong><br>{% endif %}
 
           <div class="row">
             <div class="col-xs-12">
-              <h3 id="photos">CAD Models</h3>
-              {% if medias_by_slugname.grabcad or medias_by_slugname.onshape %}
+              <h3 id="photos">CAD Models & Discussion Threads</h3>
+              {% if medias_by_slugname.grabcad or medias_by_slugname.onshape or medias_by_slugname['cd-thread'] %}
                 {% if medias_by_slugname.grabcad %}
                   {% for media in medias_by_slugname.grabcad %}
                     <div class="col-xs-6 col-sm-3">
@@ -343,6 +343,13 @@
                 {% endif %}
                 {% if medias_by_slugname.onshape %}
                   {% for media in medias_by_slugname.onshape %}
+                    <div class="col-xs-6 col-sm-3">
+                      {% include "media_partials/media_display_partial.html" %}
+                    </div>
+                  {% endfor %}
+                {% endif %}
+                {% if medias_by_slugname['cd-thread'] %}
+                  {% for media in medias_by_slugname['cd-thread'] %}
                     <div class="col-xs-6 col-sm-3">
                       {% include "media_partials/media_display_partial.html" %}
                     </div>

--- a/src/env_variables.yaml
+++ b/src/env_variables.yaml
@@ -1,3 +1,4 @@
 # This is for dev, and will get overwritten when deploying to prod
 env_variables:
   FLASK_SECRET_KEY: "thebluealliance"
+  CD_REQUEST_USER_AGENT: "default"


### PR DESCRIPTION
Adds media type for CD build/technical threads, like 254s technical binder & Q&A thread (https://www.chiefdelphi.com/t/team-254-presents-2025-undertow-technical-binder-code-q-a/506115).

Tested end to end, approvals and all work

<img width="1163" height="932" alt="image" src="https://github.com/user-attachments/assets/00114901-9eec-487e-87e6-41c61a153f2a" />

<img width="1249" height="1776" alt="image" src="https://github.com/user-attachments/assets/8d25a47f-4ead-4dfd-9404-e994e9600fd0" />
