### PR TITLE
Fix media details in api spec (again)

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -1966,7 +1966,7 @@ export type Media = {
    */
   details?:
     | {
-        [key: string]: unknown;
+        [key: string]: never;
       }
     | {
         base64Image: string;

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -992,7 +992,7 @@ export const zMedia = z.object({
   foreign_key: z.string(),
   details: z.optional(
     z.union([
-      z.record(z.string(), z.unknown()),
+      z.record(z.string(), z.never()),
       z.object({
         base64Image: z.string(),
       }),

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -9292,7 +9292,8 @@
             "oneOf": [
               {
                 "type": "object",
-                "properties": {}
+                "properties": {},
+                "additionalProperties": false
               },
               {
                 "properties": {


### PR DESCRIPTION
The change in #7892 specifies that `details` can be any arbitrary object, but the intention is that it can be an empty object. This change makes it explicit.