### PR TITLE
Move district route

### DIFF
--- a/pwa/app/routes/district.$districtAbbreviation.($year).tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.($year).tsx
@@ -37,7 +37,7 @@ import {
   parseParamsForYearElseDefault,
 } from '~/lib/utils';
 
-import { Route } from '.react-router/types/app/routes/+types/events.$districtAbbreviation.($year)';
+import { Route } from '.react-router/types/app/routes/+types/district.$districtAbbreviation.($year)';
 
 async function loadData(params: Route.LoaderArgs['params']) {
   const year = await parseParamsForYearElseDefault(params);

--- a/pwa/app/routes/district.$districtAbbreviation.insights.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.insights.tsx
@@ -32,7 +32,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { confidence } from '~/lib/utils';
 
-import { Route } from '.react-router/types/app/routes/+types/events.$districtAbbreviation.insights';
+import { Route } from '.react-router/types/app/routes/+types/district.$districtAbbreviation.insights';
 
 async function loadData(params: Route.LoaderArgs['params']) {
   const [history, insights] = await Promise.all([


### PR DESCRIPTION
Fixes route collision between `/events/(year)` and `/events/<district_key>`. We can technically resolve it by switching what to render based on a regex match, but this organization makes more sense. This will break some links but it's probably ok.