### PR TITLE
Convert `Team.validate_key_name` from being a `classmethod` to `staticmethod`

### DIFF
--- a/src/backend/common/models/team.py
+++ b/src/backend/common/models/team.py
@@ -128,8 +128,8 @@ class Team(CachedModel):
     def key_name(self) -> TeamKey:
         return "frc%s" % self.team_number
 
-    @classmethod
-    def validate_key_name(self, team_key: str) -> bool:
+    @staticmethod
+    def validate_key_name(team_key: str) -> bool:
         key_name_regex = re.compile(r"^frc[1-9]\d*$")
         match = re.match(key_name_regex, team_key)
         return True if match else False


### PR DESCRIPTION
There's a handful of places in the codebase where we have these `@classmethods` that have `self` as a first argument. I'm gonna work on cleaning those up. This one in particular wasn't using the class anyways, so I converted it to a static method.