### PR TITLE
[py3] Zod allow timezone offsets

### DIFF
--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -1015,7 +1015,7 @@ export const zMedia = z.object({
         width: z.int(),
       }),
       z.object({
-        model_created: z.iso.datetime(),
+        model_created: z.iso.datetime({ offset: true }),
         model_description: z.union([z.string(), z.null()]),
         model_image: z.url(),
         model_name: z.string(),

--- a/pwa/openapi-ts/read.config.ts
+++ b/pwa/openapi-ts/read.config.ts
@@ -13,5 +13,11 @@ export default defineConfig({
       name: '@hey-api/sdk',
       validator: true,
     },
+    {
+      name: 'zod',
+      dates: {
+        offset: true,
+      },
+    },
   ],
 });


### PR DESCRIPTION
Zod erroring because OnShape's `"model_created": "2025-05-21T22:15:39.771+00:00"` has a timezone offset, which isn't allowed [by default](https://zod.dev/api#iso-datetimes).