### PR TITLE
Updating typing in API helpers. Add missing API helper tests

### DIFF
--- a/src/backend/api/handlers/helpers/add_alliance_status.py
+++ b/src/backend/api/handlers/helpers/add_alliance_status.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from google.appengine.ext import ndb
 
 from backend.common.models.alliance import EventAlliance
@@ -8,8 +6,8 @@ from backend.common.models.event_team import EventTeam
 
 # Adds the alliance captain's EventTeamStatusPlayoff to the alliance status.
 def add_alliance_status(
-    event_key: str, alliances: List[EventAlliance]
-) -> List[EventAlliance]:
+    event_key: str, alliances: list[EventAlliance]
+) -> list[EventAlliance]:
     captain_team_keys = []
     for alliance in alliances:
         if alliance["picks"]:

--- a/src/backend/api/handlers/helpers/model_properties.py
+++ b/src/backend/api/handlers/helpers/model_properties.py
@@ -1,4 +1,4 @@
-from typing import List, NewType
+from typing import NewType
 
 from backend.common.queries.dict_converters.event_converter import EventDict
 from backend.common.queries.dict_converters.match_converter import MatchDict
@@ -55,7 +55,7 @@ search_event_properties = [
 ]
 
 
-def filter_event_properties(events: List[EventDict], model_type: ModelType) -> List:
+def filter_event_properties(events: list[EventDict], model_type: ModelType) -> list:
     if not events:
         return []
     if model_type == "simple":
@@ -72,7 +72,7 @@ def filter_event_properties(events: List[EventDict], model_type: ModelType) -> L
         raise Exception("Unknown model_type: {}".format(model_type))
 
 
-def filter_team_properties(teams: List[TeamDict], model_type: ModelType) -> List:
+def filter_team_properties(teams: list[TeamDict], model_type: ModelType) -> list:
     if not teams:
         return []
     if model_type == "simple":
@@ -85,7 +85,7 @@ def filter_team_properties(teams: List[TeamDict], model_type: ModelType) -> List
         raise Exception("Unknown model_type: {}".format(model_type))
 
 
-def filter_match_properties(matches: List[MatchDict], model_type: ModelType) -> List:
+def filter_match_properties(matches: list[MatchDict], model_type: ModelType) -> list:
     if not matches:
         return []
     if model_type == "simple":

--- a/src/backend/api/handlers/helpers/tests/make_error_response_test.py
+++ b/src/backend/api/handlers/helpers/tests/make_error_response_test.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+from flask import Flask
+
+from backend.api.handlers.helpers.make_error_response import make_error_response
+
+
+@pytest.fixture
+def app() -> Flask:
+    app = Flask(__name__)
+    return app
+
+
+def test_make_error_response(app: Flask) -> None:
+    with app.app_context():
+        error_dict = {"Error": "Not found"}
+        response = make_error_response(404, error_dict)
+
+        assert response.status_code == 404
+        assert response.content_type == "application/json"
+        assert json.loads(response.data) == error_dict
+
+
+def test_make_error_response_different_status_codes(app: Flask) -> None:
+    with app.app_context():
+        error_dict = {"Error": "Bad request"}
+        response = make_error_response(400, error_dict)
+        assert response.status_code == 400
+
+        error_dict = {"Error": "Unauthorized"}
+        response = make_error_response(401, error_dict)
+        assert response.status_code == 401
+
+        error_dict = {"Error": "Internal server error"}
+        response = make_error_response(500, error_dict)
+        assert response.status_code == 500
+
+
+def test_make_error_response_complex_error_dict(app: Flask) -> None:
+    with app.app_context():
+        error_dict = {
+            "Error": "Validation failed",
+            "details": ["field1 is required", "field2 must be a number"],
+            "code": 1001,
+        }
+        response = make_error_response(422, error_dict)
+
+        assert response.status_code == 422
+        assert json.loads(response.data) == error_dict

--- a/src/backend/api/handlers/helpers/tests/profiled_jsonify_test.py
+++ b/src/backend/api/handlers/helpers/tests/profiled_jsonify_test.py
@@ -1,0 +1,51 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+
+
+@pytest.fixture
+def app() -> Flask:
+    app = Flask(__name__)
+    return app
+
+
+def test_profiled_jsonify_dict(app: Flask) -> None:
+    with app.app_context():
+        data = {"key": "value", "number": 42}
+        response = profiled_jsonify(data)
+
+        assert response.content_type == "application/json"
+        assert json.loads(response.data) == data
+
+
+def test_profiled_jsonify_list(app: Flask) -> None:
+    with app.app_context():
+        data = [1, 2, 3, "test"]
+        response = profiled_jsonify(data)
+
+        assert response.content_type == "application/json"
+        assert json.loads(response.data) == data
+
+
+def test_profiled_jsonify_nested(app: Flask) -> None:
+    with app.app_context():
+        data = {
+            "teams": [{"name": "Team 1"}, {"name": "Team 2"}],
+            "count": 2,
+        }
+        response = profiled_jsonify(data)
+
+        assert response.content_type == "application/json"
+        assert json.loads(response.data) == data
+
+
+@patch("backend.api.handlers.helpers.profiled_jsonify.Span")
+def test_profiled_jsonify_uses_span(mock_span, app: Flask) -> None:
+    with app.app_context():
+        profiled_jsonify({"test": "data"})
+
+    mock_span.assert_called_once_with("profiled_jsonify")

--- a/src/backend/api/handlers/helpers/tests/track_call_test.py
+++ b/src/backend/api/handlers/helpers/tests/track_call_test.py
@@ -1,0 +1,128 @@
+from unittest.mock import patch
+
+import pytest
+from flask import Flask, g
+
+
+from backend.api.handlers.helpers.track_call import track_call_after_response
+
+
+@pytest.fixture
+def app() -> Flask:
+    app = Flask(__name__)
+    return app
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response(mock_track_event, app: Flask) -> None:
+    with app.app_context():
+        g.auth_owner_id = "owner123"
+        g.auth_description = "Test API Key"
+
+        track_call_after_response("teams/list", api_label="2020")
+
+        mock_track_event.assert_called_once_with(
+            "owner123",
+            "api_v03",
+            {
+                "client_id": "_owner123",
+                "owner_description": "owner123:Test API Key",
+                "action": "teams/list",
+                "label": "2020",
+            },
+            run_after=True,
+        )
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response_with_model_type(
+    mock_track_event, app: Flask
+) -> None:
+    with app.app_context():
+        g.auth_owner_id = "owner123"
+        g.auth_description = "Test API Key"
+
+        track_call_after_response("teams/list", api_label="2020", model_type="simple")
+
+        mock_track_event.assert_called_once_with(
+            "owner123",
+            "api_v03",
+            {
+                "client_id": "_owner123",
+                "owner_description": "owner123:Test API Key",
+                "action": "teams/list/simple",
+                "label": "2020",
+            },
+            run_after=True,
+        )
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response_no_label(mock_track_event, app: Flask) -> None:
+    with app.app_context():
+        g.auth_owner_id = "owner123"
+        g.auth_description = "Test API Key"
+
+        track_call_after_response("teams/list")
+
+        mock_track_event.assert_called_once_with(
+            "owner123",
+            "api_v03",
+            {
+                "client_id": "_owner123",
+                "owner_description": "owner123:Test API Key",
+                "action": "teams/list",
+                "label": None,
+            },
+            run_after=True,
+        )
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response_missing_auth_owner_id(
+    mock_track_event, app: Flask
+) -> None:
+    with app.app_context():
+        g.auth_description = "Test API Key"
+
+        track_call_after_response("teams/list")
+
+        mock_track_event.assert_not_called()
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response_missing_auth_description(
+    mock_track_event, app: Flask
+) -> None:
+    with app.app_context():
+        g.auth_owner_id = "owner123"
+
+        track_call_after_response("teams/list")
+
+        mock_track_event.assert_not_called()
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response_non_string_auth_owner_id(
+    mock_track_event, app: Flask
+) -> None:
+    with app.app_context():
+        g.auth_owner_id = 12345
+        g.auth_description = "Test API Key"
+
+        track_call_after_response("teams/list")
+
+        mock_track_event.assert_not_called()
+
+
+@patch("backend.api.handlers.helpers.track_call.GoogleAnalytics.track_event")
+def test_track_call_after_response_non_string_auth_description(
+    mock_track_event, app: Flask
+) -> None:
+    with app.app_context():
+        g.auth_owner_id = "owner123"
+        g.auth_description = 12345
+
+        track_call_after_response("teams/list")
+
+        mock_track_event.assert_not_called()

--- a/src/backend/api/handlers/helpers/track_call.py
+++ b/src/backend/api/handlers/helpers/track_call.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 from flask import g
 
 from backend.common.google_analytics import GoogleAnalytics
 
 
 def track_call_after_response(
-    api_action: str, api_label: Optional[str] = None, model_type: Optional[str] = None
+    api_action: str, api_label: str | None = None, model_type: str | None = None
 ) -> None:
     """
     Schedules a callback to Google Analytics to track an API call.
@@ -14,6 +12,10 @@ def track_call_after_response(
     # Save |auth_owner_id| and |auth_description| while we stil have access to the flask request context.
     auth_owner_id = g.auth_owner_id if hasattr(g, "auth_owner_id") else None
     auth_description = g.auth_description if hasattr(g, "auth_description") else None
+
+    # Make sure auth_owner_id + auth_description are 1) not None and 2) strings
+    if not isinstance(auth_owner_id, str) or not isinstance(auth_description, str):
+        return
 
     if model_type is not None:
         api_action += f"/{model_type}"


### PR DESCRIPTION
Splitting out https://github.com/the-blue-alliance/the-blue-alliance/pull/8516

Nothing crazy here. Mostly some AI written tests. The only thing that got updated was `track_call_after_response` needed some code to ensure our `auth_owner_id` and `auth_description` were strings/not-None for use later on. `GoogleAnalytics.track_event` expected `client_id` to be a `str` not a `str | None` which - seems right, from an API standpoint. So if we're missing either of those variables from the global context, we just bail on tracking the API call (as opposed to logging Nones)