### PR TITLE
fix /team-threads 500

### DIFF
--- a/src/backend/web/handlers/team_threads.py
+++ b/src/backend/web/handlers/team_threads.py
@@ -21,6 +21,9 @@ def team_threads(year: Year) -> str:
 
     rows = []
     for thread in all_cd_threads:
+        if len(thread.references) == 0:
+            continue
+
         rows.append(
             {
                 "year": thread.year,


### PR DESCRIPTION
happens when a media is 'deleted' (unlinked from a team)