### PR TITLE
Fix kickoff datettimes using tzinfo=EST, instead use timezone itself to localize

### DIFF
--- a/src/backend/common/helpers/season_helper.py
+++ b/src/backend/common/helpers/season_helper.py
@@ -87,8 +87,8 @@ class SeasonHelper(object):
         Kickoff is always the first Saturday in January after Jan 2nd.
         2026 and later, it is the second Saturday in January after Jan 2nd.
         """
-        jan_2nd = datetime(
-            year=year, month=1, day=2, hour=10, minute=30, second=0, tzinfo=EST
+        jan_2nd = EST.localize(
+            datetime(year=year, month=1, day=2, hour=10, minute=30, second=0)
         )
         # Since 2021, Kickoff starts at 12:00am EST
         if year >= 2021:

--- a/src/backend/common/helpers/tests/season_helper_test.py
+++ b/src/backend/common/helpers/tests/season_helper_test.py
@@ -40,31 +40,31 @@ def test_kickoff_datetime() -> None:
     # ~zach
 
     # 2026 - Saturday the 10th, 12:00pm (noon) EST
-    kickoff_2026 = datetime(2026, 1, 10, 12, 00, 00, tzinfo=EST)
+    kickoff_2026 = EST.localize(datetime(2026, 1, 10, 12, 00, 00))
     kickoff_2026_utc = kickoff_2026.astimezone(UTC)
     assert SeasonHelper.kickoff_datetime_est(year=2026) == kickoff_2026
     assert SeasonHelper.kickoff_datetime_utc(year=2026) == kickoff_2026_utc
 
     # 2021 - Saturday the 9th, 12:00pm (noon) EST (https://www.firstinspires.org/robotics/frc/blog/2021-kickoff)
-    kickoff_2021 = datetime(2021, 1, 9, 12, 00, 00, tzinfo=EST)
+    kickoff_2021 = EST.localize(datetime(2021, 1, 9, 12, 00, 00))
     kickoff_2021_utc = kickoff_2021.astimezone(UTC)
     assert SeasonHelper.kickoff_datetime_est(year=2021) == kickoff_2021
     assert SeasonHelper.kickoff_datetime_utc(year=2021) == kickoff_2021_utc
 
     # 2020 - Saturday the 4th, 10:30am EST (https://www.firstinspires.org/robotics/frc/blog/2020-kickoff-downloads)
-    kickoff_2020 = datetime(2020, 1, 4, 10, 30, 00, tzinfo=EST)
+    kickoff_2020 = EST.localize(datetime(2020, 1, 4, 10, 30, 00))
     kickoff_2020_utc = kickoff_2020.astimezone(UTC)
     assert SeasonHelper.kickoff_datetime_est(year=2020) == kickoff_2020
     assert SeasonHelper.kickoff_datetime_utc(year=2020) == kickoff_2020_utc
 
     # 2019 - Saturday the 5th, 10:30am EST (https://en.wikipedia.org/wiki/Logo_Motion)
-    kickoff_2019 = datetime(2019, 1, 5, 10, 30, 00, tzinfo=EST)
+    kickoff_2019 = EST.localize(datetime(2019, 1, 5, 10, 30, 00))
     kickoff_2019_utc = kickoff_2019.astimezone(UTC)
     assert SeasonHelper.kickoff_datetime_est(year=2019) == kickoff_2019
     assert SeasonHelper.kickoff_datetime_utc(year=2019) == kickoff_2019_utc
 
     # 2010 - Saturday the 9th, 10:30am EST (https://en.wikipedia.org/wiki/Breakaway_(FIRST))
-    kickoff_2010 = datetime(2010, 1, 9, 10, 30, 00, tzinfo=EST)
+    kickoff_2010 = EST.localize(datetime(2010, 1, 9, 10, 30, 00))
     kickoff_2010_utc = kickoff_2010.astimezone(UTC)
     assert SeasonHelper.kickoff_datetime_est(year=2010) == kickoff_2010
     assert SeasonHelper.kickoff_datetime_utc(year=2010) == kickoff_2010_utc


### PR DESCRIPTION
I have no idea how I didn't notice this 🤷 