### PR TITLE
[pwa] rm stray deps, update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,16 +25,12 @@ updates:
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: "@sentry/*"
-  - dependency-name: "@types/node"
-    versions:
-    - ">=23.0.0"
   labels:
     - PWA
   groups:
-    react-router:
+    tanstack:
       patterns:
-        - "@react-router/*"
-        - "react-router"
+        - "@tanstack/*"
     embla-carousel:
       patterns:
         - "embla-carousel-autoplay"
@@ -49,6 +45,7 @@ updates:
         - "vitest"
         - "@vitest/coverage-v8"
         - "@julr/vite-plugin-validate-env"
+        - "@vitejs/plugin-react"
     linting:
       patterns:
         - "@eslint/*"
@@ -67,6 +64,7 @@ updates:
         - "prettier-plugin-classnames"
         - "prettier-plugin-merge"
         - "prettier-plugin-tailwindcss"
+        - "@trivago/prettier-plugin-sort-imports"
     sentry:
       patterns:
         - "@sentry/*"
@@ -87,15 +85,14 @@ updates:
         - "react-dom"
         - "@types/react"
         - "@types/react-dom"
-    forms-and-validation:
-      patterns:
-        - "react-hook-form"
-        - "@hookform/resolvers"
-        - "zod"
+        - "react-intersection-observer"
     firebase:
       patterns:
         - "firebase"
         - "firebase-admin"
+    testing:
+      patterns:
+        - "@playwright/test"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -18,7 +18,6 @@
     "openapi-ts": "openapi-ts"
   },
   "dependencies": {
-    "@hookform/resolvers": "5.2.2",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-avatar": "1.1.11",
     "@radix-ui/react-checkbox": "1.3.3",
@@ -63,7 +62,6 @@
     "morgan": "1.10.1",
     "react": "19.2.1",
     "react-dom": "19.2.1",
-    "react-hook-form": "7.68.0",
     "react-intersection-observer": "10.0.0",
     "recharts": "2.15.3",
     "srvx": "0.9.7",

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@hookform/resolvers':
-        specifier: 5.2.2
-        version: 5.2.2(react-hook-form@7.68.0(react@19.2.1))
       '@radix-ui/react-accordion':
         specifier: 1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -143,9 +140,6 @@ importers:
       react-dom:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
-      react-hook-form:
-        specifier: 7.68.0
-        version: 7.68.0(react@19.2.1)
       react-intersection-observer:
         specifier: 10.0.0
         version: 10.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -1117,11 +1111,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5.5.3'
-
-  '@hookform/resolvers@5.2.2':
-    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
-    peerDependencies:
-      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2219,9 +2208,6 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -5020,12 +5006,6 @@ packages:
     peerDependencies:
       react: ^19.2.1
 
-  react-hook-form@7.68.0:
-    resolution: {integrity: sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
-
   react-intersection-observer@10.0.0:
     resolution: {integrity: sha512-JJRgcnFQoVXmbE5+GXr1OS1NDD1gHk0HyfpLcRf0575IbJz+io8yzs4mWVlfaqOQq1FiVjLvuYAdEEcrrCfveg==}
     peerDependencies:
@@ -6771,11 +6751,6 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.68.0(react@19.2.1))':
-    dependencies:
-      '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.68.0(react@19.2.1)
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -7956,8 +7931,6 @@ snapshots:
       - supports-color
 
   '@standard-schema/spec@1.0.0': {}
-
-  '@standard-schema/utils@0.3.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
     dependencies:
@@ -11160,10 +11133,6 @@ snapshots:
     dependencies:
       react: 19.2.1
       scheduler: 0.27.0
-
-  react-hook-form@7.68.0(react@19.2.1):
-    dependencies:
-      react: 19.2.1
 
   react-intersection-observer@10.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:


### PR DESCRIPTION
updated some dependabot groups. dependabot now once again checks for @types/node at 24 or higher (we were on 22 before).

removed react-hook-form and associated package. those were going to be used with RR7 authentication which never fully happened. i may add them again for tanstack auth but that's a future endeavor. we can remove them for now.