### PR TITLE
[pwa] Add teams and times to match page

### DIFF
--- a/pwa/app/components/tba/match/matchDetails.tsx
+++ b/pwa/app/components/tba/match/matchDetails.tsx
@@ -1,8 +1,69 @@
 import ScoreBreakdown2025 from 'app/components/tba/match/scoreBreakdown2025';
 import { YoutubeEmbed } from 'app/components/tba/videoEmbeds';
+import { Checkbox } from 'app/components/ui/checkbox';
+import { useState } from 'react';
 
 import { Event, Match } from '~/api/tba/read';
+import { SimpleMatchRow } from '~/components/tba/match/matchRows';
 import { isScoreBreakdown2025 } from '~/lib/rankingPoints';
+
+function formatMatchDate(timestamp: number, timezone: string): string {
+  const date = new Date(timestamp * 1000);
+
+  return date.toLocaleString('en-US', {
+    timeZone: timezone,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatMatchTime(
+  timestamp: number,
+  timezone: string,
+): React.JSX.Element {
+  const date = new Date(timestamp * 1000);
+
+  const time = date.toLocaleString('en-US', {
+    timeZone: timezone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  return <span className="font-bold">{time}</span>;
+}
+
+function formatTimeDifference(
+  actualTime: number,
+  scheduledTime: number,
+): string {
+  const diffSeconds = actualTime - scheduledTime;
+  const diffMinutes = Math.round(diffSeconds / 60);
+
+  if (Math.abs(diffMinutes) < 1) {
+    return 'on time';
+  }
+
+  if (diffMinutes > 0) {
+    const hours = Math.floor(diffMinutes / 60);
+    const minutes = diffMinutes % 60;
+
+    if (hours > 0) {
+      return minutes > 0 ? `${hours}h ${minutes}m late` : `${hours}h late`;
+    }
+    return `${diffMinutes}m late`;
+  }
+
+  const absMinutes = Math.abs(diffMinutes);
+  const hours = Math.floor(absMinutes / 60);
+  const minutes = absMinutes % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m early` : `${hours}h early`;
+  }
+  return `${absMinutes}m early`;
+}
 
 export default function MatchDetails({
   match,
@@ -11,6 +72,16 @@ export default function MatchDetails({
   match: Match;
   event: Event;
 }) {
+  const [showUserTimezone, setShowUserTimezone] = useState(false);
+
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const eventTimezone = event.timezone ?? 'UTC';
+  const timezonesMatch = userTimezone === eventTimezone;
+  const displayTimezone = showUserTimezone ? userTimezone : eventTimezone;
+
+  const matchTimestamp =
+    match.actual_time ?? match.time ?? match.predicted_time;
+
   let sbDiv = null;
 
   if (isScoreBreakdown2025(match.score_breakdown)) {
@@ -24,7 +95,66 @@ export default function MatchDetails({
 
   return (
     <div className="flex flex-col gap-4 md:flex-row">
-      <div className="order-2 w-full md:order-1 md:w-lg">{sbDiv}</div>
+      <div className="order-2 w-full md:order-1 md:w-lg">
+        <div className="flex flex-col gap-2">
+          <SimpleMatchRow match={match} year={event.year} />
+          {sbDiv}
+          <div className="flex flex-col gap-2 rounded-lg border bg-muted/50 p-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">Match Times</h3>
+              {!timezonesMatch && (
+                <label
+                  htmlFor="timezone-toggle"
+                  className="flex cursor-pointer items-center gap-1.5 text-xs"
+                >
+                  <Checkbox
+                    id="timezone-toggle"
+                    checked={showUserTimezone}
+                    onCheckedChange={(checked) =>
+                      setShowUserTimezone(checked === true)
+                    }
+                  />
+                  <span>Show in my timezone</span>
+                </label>
+              )}
+            </div>
+            <div className="flex flex-col gap-1 text-xs">
+              {matchTimestamp && (
+                <div className="flex gap-1">
+                  <span className="w-20 font-medium">Date:</span>
+                  {formatMatchDate(matchTimestamp, displayTimezone)}
+                </div>
+              )}
+              {match.actual_time && (
+                <div className="flex gap-1">
+                  <span className="w-20 font-medium">Actual:</span>
+                  <span>
+                    {formatMatchTime(match.actual_time, displayTimezone)}
+                    {match.time && (
+                      <span className="text-muted-foreground">
+                        {' '}
+                        ({formatTimeDifference(match.actual_time, match.time)})
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+              {match.time && (
+                <div className="flex gap-1">
+                  <span className="w-20 font-medium">Scheduled:</span>
+                  {formatMatchTime(match.time, displayTimezone)}
+                </div>
+              )}
+              {match.predicted_time && (
+                <div className="flex gap-1">
+                  <span className="w-20 font-medium">Predicted:</span>
+                  {formatMatchTime(match.predicted_time, displayTimezone)}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
       <div className="order-1 flex w-full flex-col gap-2 md:order-2 md:w-xl">
         {match.videos
           .filter((v) => v.type === 'youtube')

--- a/pwa/app/components/tba/match/matchRows.tsx
+++ b/pwa/app/components/tba/match/matchRows.tsx
@@ -202,6 +202,116 @@ export function MatchRow({
   );
 }
 
+// Used on match pages, omits the play button and match title
+export function SimpleMatchRow({
+  match,
+  year,
+}: {
+  match: Match;
+  year: number;
+}) {
+  const isPlayed =
+    match.alliances.red.score !== -1 && match.alliances.blue.score !== -1;
+
+  return (
+    <div>
+      {/* 3x4 grid with header row */}
+      <div
+        className="mx-auto grid w-full max-w-6xl grid-cols-[repeat(4,1fr)]
+          grid-rows-[auto_repeat(2,2.5em)] gap-x-1 text-sm"
+      >
+        {/* Header: Teams */}
+        <div
+          className="col-span-3 col-start-1 row-start-1 flex items-center
+            justify-center text-sm font-semibold"
+        >
+          Teams
+        </div>
+
+        {/* Header: Score */}
+        <div
+          className="col-start-4 row-start-1 flex items-center justify-center
+            text-sm font-semibold"
+        >
+          Score
+        </div>
+
+        {/* Red Team Players - Subgrid Component */}
+        <TeamListSubgrid
+          teamKeys={match.alliances.red.team_keys}
+          allianceColor="red"
+          className="col-span-3 col-start-1 row-start-2"
+          winner={match.winning_alliance === 'red'}
+          dq={match.alliances.red.dq_team_keys}
+          surrogate={match.alliances.red.surrogate_team_keys}
+          year={year}
+          teamCellClassName="xl:first:rounded-bl-none xl:last:rounded-br-none"
+        />
+
+        {/* Blue Team Players - Subgrid Component */}
+        <TeamListSubgrid
+          teamKeys={match.alliances.blue.team_keys}
+          allianceColor="blue"
+          className="col-span-3 col-start-1 row-start-3"
+          winner={match.winning_alliance === 'blue'}
+          dq={match.alliances.blue.dq_team_keys}
+          surrogate={match.alliances.blue.surrogate_team_keys}
+          year={year}
+          teamCellClassName="xl:first:rounded-tl-none xl:last:rounded-tr-none"
+        />
+
+        {!isPlayed && (
+          <div
+            className="col-start-4 row-span-2 row-start-2 flex items-center
+              justify-center"
+          >
+            <span>
+              {match.predicted_time &&
+                new Date(match.predicted_time * 1000).toLocaleTimeString(
+                  'en-US',
+                  {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    weekday: 'short',
+                    hour12: true,
+                  },
+                )}
+            </span>
+          </div>
+        )}
+
+        {/* Red Score */}
+        {isPlayed && (
+          <ScoreCell
+            score={match.alliances.red.score}
+            allianceColor="red"
+            className="col-start-4 row-start-2 xl:rounded-br-none
+              xl:rounded-bl-none"
+            winner={match.winning_alliance === 'red'}
+            scoreBreakdown={match.score_breakdown?.red}
+            year={year}
+            compLevel={match.comp_level}
+          />
+        )}
+
+        {/* Blue Score */}
+        {isPlayed && (
+          <ScoreCell
+            score={match.alliances.blue.score}
+            allianceColor="blue"
+            className="col-start-4 row-start-3 xl:rounded-tl-none
+              xl:rounded-tr-none"
+            winner={match.winning_alliance === 'blue'}
+            scoreBreakdown={match.score_breakdown?.blue}
+            year={year}
+            compLevel={match.comp_level}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
 function maybeGetFirstMatchVideoURL(match: Match): string | undefined {
   if (match.videos.length === 0) {
     return undefined;

--- a/pwa/app/components/tba/match/teamListSubgrid.tsx
+++ b/pwa/app/components/tba/match/teamListSubgrid.tsx
@@ -37,6 +37,7 @@ interface TeamListSubgridProps
   surrogate: string[];
   year: number;
   focusTeamKey?: string;
+  teamCellClassName?: string;
 }
 
 export default function TeamListSubgrid({
@@ -48,6 +49,7 @@ export default function TeamListSubgrid({
   surrogate,
   year,
   focusTeamKey,
+  teamCellClassName,
   ...props
 }: TeamListSubgridProps) {
   return (
@@ -65,6 +67,7 @@ export default function TeamListSubgrid({
               allianceColor,
               winner,
             }),
+            teamCellClassName,
           )}
         />
       ))}

--- a/pwa/app/routes/match.$matchKey.tsx
+++ b/pwa/app/routes/match.$matchKey.tsx
@@ -61,7 +61,7 @@ function MatchPage() {
 
   return (
     <div>
-      <h1 className="mt-5 text-4xl">
+      <h1 className="mt-8 mb-4 text-4xl">
         {matchTitleShort(match, event.playoff_type ?? PlayoffType.CUSTOM)}{' '}
         <small className="text-xl">
           <EventLink eventOrKey={event}>


### PR DESCRIPTION
Adds the teams/score simple match row to the match page, which omits the play button and the match title. Also adds a match time box which shows some info about match times. If the event was in a different timezone than the user is, it will show a checkbox to allow the user to show the match times in their local tz. Otherwise the checkbox is hidden since it doesn't do anything.

<img width="1351" height="1495" alt="image" src="https://github.com/user-attachments/assets/243765a0-d32b-4bfc-9f3b-64656c7c91b8" />

<img width="1353" height="615" alt="image" src="https://github.com/user-attachments/assets/4a95d328-5ff7-4b2b-892c-db8a62abcc54" />

<img width="1375" height="615" alt="image" src="https://github.com/user-attachments/assets/859b426f-9266-42ad-a79d-d4b37e81663e" />
