### PR TITLE
[eventwizard] Back up FMS Reports used

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -19,6 +19,7 @@
     {"site-package": "jinja2"},
     {"site-package": "markupsafe"},
     {"site-package": "numpy"},
+    {"site-package": "openpyxl"},
     {"site-package": "pytest"},
     {"site-package": "_pytest"},
     {"site-package": "pyre_extensions"},

--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -1,6 +1,6 @@
 import json
 from functools import wraps
-from typing import Callable, Set, Type, TypeVar
+from typing import Callable, Type, TypeVar
 
 from flask import g, jsonify, request, Response
 
@@ -9,6 +9,7 @@ from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
 from backend.common.auth import current_user
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
+from backend.common.consts.fms_report_type import FMSReportType
 from backend.common.consts.renamed_districts import RenamedDistricts
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.district import District
@@ -61,15 +62,24 @@ def api_authenticated(func):
     return decorated_function
 
 
-def require_write_auth(auth_types: Set[AuthType]):
+def require_write_auth(auth_types: set[AuthType] | None, file_param: str | None = None):
     def decorator(func):
         @wraps(func)
         def decorated_function(*args, **kwargs):
             with Span("require_write_auth"):
                 event_key = kwargs["event_key"]
+                fms_report_type = kwargs.get("report_type")
+                # Check if report_type is a valid FMS report type
+                if fms_report_type:
+                    try:
+                        FMSReportType(fms_report_type)
+                    except ValueError:
+                        fms_report_type = None
 
                 # This will abort the request on failure
-                TrustedApiAuthHelper.do_trusted_api_auth(event_key, auth_types)
+                TrustedApiAuthHelper.do_trusted_api_auth(
+                    event_key, fms_report_type, auth_types, file_param
+                )
             return func(*args, **kwargs)
 
         return decorated_function

--- a/src/backend/api/handlers/tests/add_fms_report_archive_test.py
+++ b/src/backend/api/handlers/tests/add_fms_report_archive_test.py
@@ -1,0 +1,421 @@
+"""
+Tests for the add_fms_report_archive handler
+"""
+
+import datetime
+import hashlib
+import io
+import random
+import string
+from typing import List, Optional, Tuple
+from unittest.mock import Mock, patch
+
+from freezegun import freeze_time
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+from pytest import MonkeyPatch
+from werkzeug.datastructures import FileStorage
+from werkzeug.test import Client
+
+from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
+from backend.common import auth
+from backend.common.consts.auth_type import AuthType
+from backend.common.consts.event_type import EventType
+from backend.common.models.account import Account
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.event import Event
+from backend.common.models.keys import EventKey
+
+
+def setup_event(event_type: EventType = EventType.OFFSEASON) -> None:
+    Event(
+        id="2019nyny",
+        year=2019,
+        event_short="nyny",
+        event_type_enum=event_type,
+    ).put()
+
+
+def setup_user(
+    monkeypatch: MonkeyPatch,
+    permissions: List = [],
+    is_admin: bool = False,
+) -> ndb.Key:
+    email = "zach@thebluealliance.com"
+    account = Account(
+        email=email,
+        permissions=permissions,
+    )
+    account.put()
+
+    monkeypatch.setattr(
+        auth, "_decoded_claims", Mock(return_value={"email": email, "admin": is_admin})
+    )
+    return account.key
+
+
+def setup_api_auth(
+    event_key: Optional[EventKey],
+    auth_types: List[AuthType] = [],
+    expiration: Optional[datetime.datetime] = None,
+) -> Tuple[str, str]:
+    auth = ApiAuthAccess(
+        id="".join(random.choices(string.ascii_letters + string.digits, k=10)),
+        secret="".join(random.choices(string.ascii_letters + string.digits, k=10)),
+        event_list=[ndb.Key(Event, event_key)] if event_key else [],
+        auth_types_enum=auth_types,
+        expiration=expiration,
+    )
+    auth.put()
+
+    return none_throws(auth.key.string_id()), none_throws(auth.secret)
+
+
+def create_excel_file() -> bytes:
+    """Create a minimal valid Excel file for testing"""
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws["A1"] = "Test Data"
+
+    output = io.BytesIO()
+    wb.save(output)
+    output.seek(0)
+    return output.read()
+
+
+@freeze_time("2019-06-01")
+def test_upload_qual_rankings_success(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test successfully uploading a qual_rankings FMS report"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_RANKINGS],
+        expiration=None,
+    )
+
+    file_content = create_excel_file()
+    file_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="rankings.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    with patch("backend.api.handlers.trusted.storage_write") as mock_write:
+        with patch("backend.api.handlers.trusted.storage_get_files") as mock_get_files:
+            mock_get_files.return_value = []
+
+            resp = api_client.post(
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, file_digest
+                    ),
+                },
+                data={
+                    "reportFile": file_storage,
+                    "fileDigest": file_digest,
+                },
+            )
+
+    assert resp.status_code == 200
+    assert "Success" in resp.json
+    mock_write.assert_called_once()
+
+
+@freeze_time("2019-06-01")
+def test_upload_missing_file(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test uploading with missing file"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_RANKINGS],
+        expiration=None,
+    )
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    resp = api_client.post(
+        request_path,
+        headers={
+            "X-TBA-Auth-Id": auth_id,
+            "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                auth_secret, request_path, ""
+            ),
+        },
+        data={},
+    )
+
+    assert resp.status_code == 401
+    assert "Expected file upload not found" in resp.json["Error"]
+
+
+@freeze_time("2019-06-01")
+def test_upload_invalid_excel_file(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test uploading with invalid Excel file"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_RANKINGS],
+        expiration=None,
+    )
+
+    file_content = b"This is not an Excel file"
+    file_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="notexcel.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    resp = api_client.post(
+        request_path,
+        headers={
+            "X-TBA-Auth-Id": auth_id,
+            "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                auth_secret, request_path, file_digest
+            ),
+        },
+        data={
+            "reportFile": file_storage,
+            "fileDigest": file_digest,
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "not a valid Excel file" in resp.json["Error"]
+
+
+@freeze_time("2019-06-01")
+def test_upload_wrong_permission(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test uploading with wrong permission type"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_TEAMS],  # Wrong permission for qual_rankings
+        expiration=None,
+    )
+
+    file_content = create_excel_file()
+    file_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="rankings.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    resp = api_client.post(
+        request_path,
+        headers={
+            "X-TBA-Auth-Id": auth_id,
+            "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                auth_secret, request_path, file_digest
+            ),
+        },
+        data={
+            "reportFile": file_storage,
+            "fileDigest": file_digest,
+        },
+    )
+
+    assert resp.status_code == 401
+    assert "Error" in resp.json
+
+
+@freeze_time("2019-06-01")
+def test_upload_mismatched_digest(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test uploading with mismatched file digest"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_RANKINGS],
+        expiration=None,
+    )
+
+    file_content = create_excel_file()
+    wrong_digest = hashlib.sha256(b"wrong content").hexdigest()
+    correct_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="rankings.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    resp = api_client.post(
+        request_path,
+        headers={
+            "X-TBA-Auth-Id": auth_id,
+            "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                auth_secret, request_path, correct_digest
+            ),
+        },
+        data={
+            "reportFile": file_storage,
+            "fileDigest": wrong_digest,
+        },
+    )
+
+    assert resp.status_code == 401
+    assert "File digest does not match" in resp.json["Error"]
+
+
+@freeze_time("2019-06-01")
+def test_upload_duplicate_file_not_written(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test that duplicate files are not written again"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_RANKINGS],
+        expiration=None,
+    )
+
+    file_content = create_excel_file()
+    file_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="rankings.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    # Simulate that the file already exists with the exact filename format
+    # mtime format is 2019-06-01 00:00:00
+    existing_files = [
+        "fms_reports/2019nyny/qual_rankings/rankings.2019-06-01 00:00:00.xlsx"
+    ]
+
+    with patch("backend.api.handlers.trusted.storage_write") as mock_write:
+        with patch("backend.api.handlers.trusted.storage_get_files") as mock_get_files:
+            mock_get_files.return_value = existing_files
+
+            resp = api_client.post(
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, file_digest
+                    ),
+                },
+                data={
+                    "reportFile": file_storage,
+                    "fileDigest": file_digest,
+                },
+            )
+
+    assert resp.status_code == 200
+    # storage_write should not be called since the file already exists
+    mock_write.assert_not_called()
+
+
+@freeze_time("2019-06-01")
+def test_upload_with_metadata(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test that upload includes proper metadata"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_RANKINGS],
+        expiration=None,
+    )
+
+    file_content = create_excel_file()
+    file_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="rankings.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    with patch("backend.api.handlers.trusted.storage_write") as mock_write:
+        with patch("backend.api.handlers.trusted.storage_get_files") as mock_get_files:
+            mock_get_files.return_value = []
+
+            resp = api_client.post(
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, file_digest
+                    ),
+                },
+                data={
+                    "reportFile": file_storage,
+                    "fileDigest": file_digest,
+                },
+            )
+
+    assert resp.status_code == 200
+    # Verify storage_write was called with metadata
+    mock_write.assert_called_once()
+    call_args = mock_write.call_args
+    assert "metadata" in call_args[1]
+    assert "X-TBA-Auth-Id" in call_args[1]["metadata"]
+    assert call_args[1]["metadata"]["X-TBA-Auth-Id"] == auth_id
+
+
+@freeze_time("2019-06-01")
+def test_upload_not_authenticated(ndb_stub, api_client: Client) -> None:
+    """Test uploading without authentication"""
+    setup_event(event_type=EventType.OFFSEASON)
+
+    file_content = create_excel_file()
+    file_digest = hashlib.sha256(file_content).hexdigest()
+
+    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+
+    file_storage = FileStorage(
+        stream=io.BytesIO(file_content),
+        filename="rankings.xlsx",
+        content_type="application/vnd.ms-excel",
+    )
+
+    resp = api_client.post(
+        request_path,
+        data={
+            "reportFile": file_storage,
+            "fileDigest": file_digest,
+        },
+    )
+
+    assert resp.status_code == 401
+    assert "Error" in resp.json

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -1,9 +1,12 @@
 import json
 import logging
+from io import BytesIO
+from pathlib import Path
 from typing import List, Optional, Set
 
 from flask import make_response, request, Response
 from google.appengine.ext import ndb
+from openpyxl import load_workbook
 from pyre_extensions import none_throws, safe_json
 
 from backend.api.api_trusted_parsers.json_alliance_selections_parser import (
@@ -25,6 +28,7 @@ from backend.api.api_trusted_parsers.json_zebra_motionworks_parser import (
 )
 from backend.api.handlers.decorators import require_write_auth, validate_keys
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.common.auth import current_user
 from backend.common.consts.alliance_color import ALLIANCE_COLORS, AllianceColor
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
@@ -51,6 +55,10 @@ from backend.common.models.match import Match
 from backend.common.models.media import Media
 from backend.common.models.team import Team
 from backend.common.models.zebra_motionworks import ZebraMotionWorks
+from backend.common.storage import (
+    get_files as storage_get_files,
+    write as storage_write,
+)
 
 
 @require_write_auth({AuthType.EVENT_TEAMS})
@@ -434,3 +442,52 @@ def add_match_zebra_motionworks_info(event_key: EventKey) -> Response:
 
     ndb.put_multi(to_put)
     return profiled_jsonify({"Success": "Media successfully added"})
+
+
+@require_write_auth(None, file_param="reportFile")
+@validate_keys
+def add_fms_report_archive(event_key: EventKey, report_type: str) -> Response:
+    form_data = request.files.get("reportFile")
+    if not form_data:
+        return make_response(profiled_jsonify({"Error": "Missing report file"}), 400)
+
+    file_contents: bytes = form_data.read()
+
+    try:
+        workbook = load_workbook(filename=BytesIO(file_contents))
+        mtime = workbook.properties.modified
+    except Exception:
+        logging.exception("Failed to parse uploaded Excel file")
+        return make_response(
+            profiled_jsonify({"Error": "Uploaded file is not a valid Excel file"}), 400
+        )
+
+    filename = Path(form_data.filename or "fms_report.xlsx")
+    file_name = filename.stem
+    extension = ".".join(filename.suffixes)
+
+    storage_dir = f"fms_reports/{event_key}/{report_type}"
+    storage_file = f"{file_name}.{mtime}{extension}"
+    storage_path = f"{storage_dir}/{storage_file}"
+
+    existing_reports = storage_get_files(
+        path=storage_dir,
+        bucket="eventwizard-fms-reports",
+    )
+    if not any(
+        existing.split("/")[-1] == storage_file for existing in existing_reports
+    ):
+        user = current_user()
+        storage_write(
+            storage_path,
+            file_contents,
+            bucket="eventwizard-fms-reports",
+            content_type=none_throws(form_data.content_type),
+            metadata={
+                "X-TBA-Auth-User": str(user.uid) if user else None,
+                "X-TBA-Auth-User-Email": user.email if user else None,
+                "X-TBA-Auth-Id": request.headers.get("X-TBA-Auth-Id"),
+            },
+        )
+
+    return profiled_jsonify({"Success": "FMS report successfully uploaded"})

--- a/src/backend/api/trusted_api_auth_helper.py
+++ b/src/backend/api/trusted_api_auth_helper.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
-from typing import Optional, Set
+import logging
+from typing import Optional
 
 from flask import abort, make_response, request
 from pyre_extensions import none_throws
@@ -11,6 +12,10 @@ from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.auth_type import AuthType, WRITE_TYPE_NAMES
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
 from backend.common.consts.event_type import EventType
+from backend.common.consts.fms_report_type import (
+    FMSReportType,
+    REQUIRED_REPORT_PERMISSOINS,
+)
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey
@@ -27,7 +32,11 @@ class TrustedApiAuthHelper:
 
     @classmethod
     def do_trusted_api_auth(
-        cls, event_key: EventKey, required_auth_types: Set[AuthType]
+        cls,
+        event_key: EventKey,
+        fms_report_type: FMSReportType | None,
+        required_auth_types: set[AuthType] | None,
+        file_param: str | None = None,
     ) -> None:
         event_key = EventCodeExceptions.resolve(event_key)
         event = Event.get_by_id(event_key)
@@ -58,6 +67,8 @@ class TrustedApiAuthHelper:
 
         # Next, check if the logged in user has any write API keys linked to their account
         # that are valid for this event
+        if required_auth_types is None:
+            required_auth_types = set()
         if user:
             user_has_auth = any(
                 cls._validate_auth(auth, event, required_auth_types) is None
@@ -93,9 +104,52 @@ class TrustedApiAuthHelper:
                 )
             )
 
+        if file_param:
+            file = request.files.get(file_param)
+            if not file:
+                abort(
+                    make_response(
+                        profiled_jsonify({"Error": "Expected file upload not found"}),
+                        401,
+                    )
+                )
+            file_contents = file.read()
+            file.seek(0)
+            request_data = hashlib.sha256(file_contents).hexdigest()
+            logging.info(f"Computed file digest: {request_data}")
+            file_digest = request.form.get("fileDigest")
+            if request_data != file_digest:
+                abort(
+                    make_response(
+                        profiled_jsonify(
+                            {"Error": "File digest does not match uploaded file"}
+                        ),
+                        401,
+                    )
+                )
+
+            # Create a new set for file upload auth types to avoid mutating the passed-in set
+            required_auth_types = set(required_auth_types)
+            if fms_report_type in REQUIRED_REPORT_PERMISSOINS:
+                required_auth_types.add(REQUIRED_REPORT_PERMISSOINS[fms_report_type])
+
+            if len(required_auth_types) == 0:
+                abort(
+                    make_response(
+                        profiled_jsonify(
+                            {
+                                "Error": "Unable to authorize request: no required auth types could be determined."
+                            }
+                        ),
+                        401,
+                    )
+                )
+        else:
+            request_data = request.get_data(as_text=True)
+
         auth = ApiAuthAccess.get_by_id(auth_id)
         expected_sig = cls.compute_auth_signature(
-            auth.secret if auth else None, request.path, request.get_data(as_text=True)
+            auth.secret if auth else None, request.path, request_data
         )
         if not auth or expected_sig != auth_sig:
             abort(
@@ -117,7 +171,7 @@ class TrustedApiAuthHelper:
         cls,
         auth: ApiAuthAccess,
         event: Event,
-        required_auth_types: Set[AuthType],
+        required_auth_types: set[AuthType],
     ) -> Optional[str]:
         allowed_event_keys = [none_throws(ekey.string_id()) for ekey in auth.event_list]
         if (

--- a/src/backend/api/trusted_api_main.py
+++ b/src/backend/api/trusted_api_main.py
@@ -6,6 +6,7 @@ from flask_cors import CORS
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.trusted import (
     add_event_media,
+    add_fms_report_archive,
     add_match_video,
     add_match_zebra_motionworks_info,
     delete_all_event_matches,
@@ -88,6 +89,11 @@ trusted_api.add_url_rule(
     "/event/<string:event_key>/zebra_motionworks/add",
     methods=["POST"],
     view_func=add_match_zebra_motionworks_info,
+)
+trusted_api.add_url_rule(
+    "/event/<string:event_key>/fms_reports/<string:report_type>",
+    methods=["POST"],
+    view_func=add_fms_report_archive,
 )
 
 

--- a/src/backend/common/consts/fms_report_type.py
+++ b/src/backend/common/consts/fms_report_type.py
@@ -1,0 +1,26 @@
+import enum
+
+from backend.common.consts.auth_type import AuthType
+from backend.common.consts.string_enum import StrEnum
+
+
+@enum.unique
+class FMSReportType(StrEnum):
+    QUAL_RANKINGS = "qual_rankings"
+    QUAL_SCHEDULE = "qual_schedule"
+    QUAL_RESULTS = "qual_results"
+    PLAYOFF_ALLIANCES = "playoff_alliances"
+    PLAYOFF_SCHEDULE = "playoff_schedule"
+    PLAYOFF_RESULTS = "playoff_results"
+    TEAM_LIST = "team_list"
+
+
+REQUIRED_REPORT_PERMISSOINS = {
+    FMSReportType.QUAL_RANKINGS: AuthType.EVENT_RANKINGS,
+    FMSReportType.QUAL_SCHEDULE: AuthType.EVENT_MATCHES,
+    FMSReportType.QUAL_RESULTS: AuthType.EVENT_MATCHES,
+    FMSReportType.PLAYOFF_ALLIANCES: AuthType.EVENT_ALLIANCES,
+    FMSReportType.PLAYOFF_SCHEDULE: AuthType.EVENT_MATCHES,
+    FMSReportType.PLAYOFF_RESULTS: AuthType.EVENT_MATCHES,
+    FMSReportType.TEAM_LIST: AuthType.EVENT_TEAMS,
+}

--- a/src/backend/common/frc_api/frc_api.py
+++ b/src/backend/common/frc_api/frc_api.py
@@ -244,8 +244,12 @@ class FRCAPI:
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
                 content = read(gcs_file)
                 if content is not None:
-                    with open(filename, "w") as f:
-                        f.write(content)
+                    if isinstance(content, str):
+                        with open(filename, "w") as f:
+                            f.write(content)
+                    else:
+                        with open(filename, "wb") as f:
+                            f.write(content)
                     files.append(f"{safe_dir_name}/{safe_file_name}")
         return sorted(files)
 

--- a/src/backend/common/storage/__init__.py
+++ b/src/backend/common/storage/__init__.py
@@ -7,38 +7,45 @@ from backend.common.storage.clients.local_client import LocalStorageClient
 from backend.common.storage.clients.storage_client import StorageClient
 
 
-def _client_for_env() -> StorageClient:
-    storage_path = Environment.storage_path()
+def _client_for_env(bucket: str | None = None) -> StorageClient:
+    storage_mode = Environment.storage_mode()
 
     if Environment.is_unit_test():
         return InMemoryClient.get()
-
-    storage_mode = Environment.storage_mode()
-    if Environment.is_dev() and storage_mode == EnvironmentMode.LOCAL:
-        return LocalStorageClient(storage_path)
 
     project = Environment.project()
     if not project:
         detail_string = "should be set in production"
         if storage_mode == EnvironmentMode.REMOTE:
             detail_string = "should be set when using remote storage mode"
-        raise Exception(
+        raise ValueError(
             f"Environment.project (GOOGLE_CLOUD_PROJECT) unset - {detail_string}."
         )
+    bucket = bucket or f"{project}.appspot.com"
 
-    return GCloudStorageClient(project)
+    if Environment.is_dev() and storage_mode == EnvironmentMode.LOCAL:
+        storage_path = Environment.storage_path() / project / bucket
+        return LocalStorageClient(storage_path)
+
+    return GCloudStorageClient(project, bucket)
 
 
-def write(file_name: str, content: str) -> None:
-    client = _client_for_env()
-    client.write(file_name, content)
+def write(
+    file_name: str,
+    content: str | bytes,
+    content_type: str = "text/plain",
+    bucket: str | None = None,
+    metadata: dict[str, str | None] | None = None,
+) -> None:
+    client = _client_for_env(bucket)
+    client.write(file_name, content, content_type, metadata)
 
 
-def read(file_name: str) -> Optional[str]:
-    client = _client_for_env()
+def read(file_name: str, bucket: str | None = None) -> Optional[str | bytes]:
+    client = _client_for_env(bucket)
     return client.read(file_name)
 
 
-def get_files(path: Optional[str] = None) -> List[str]:
-    client = _client_for_env()
+def get_files(path: Optional[str] = None, bucket: str | None = None) -> List[str]:
+    client = _client_for_env(bucket)
     return client.get_files(path)

--- a/src/backend/common/storage/clients/gcloud_client.py
+++ b/src/backend/common/storage/clients/gcloud_client.py
@@ -7,15 +7,29 @@ from backend.common.storage.clients.storage_client import StorageClient
 
 
 class GCloudStorageClient(StorageClient):
-    def __init__(self, project: str, credentials: Optional[Credentials] = None) -> None:
+
+    def __init__(
+        self,
+        project: str,
+        bucket: str | None = None,
+        credentials: Optional[Credentials] = None,
+    ) -> None:
         self.client = storage.Client(project=project, credentials=credentials)
-        self.bucket = self.client.get_bucket(f"{project}.appspot.com")
+        self.bucket = self.client.get_bucket(bucket or f"{project}.appspot.com")
 
-    def write(self, file_name: str, content: str) -> None:
+    def write(
+        self,
+        file_name: str,
+        content: str | bytes,
+        content_type: str = "text/plain",
+        metadata: dict[str, str | None] | None = None,
+    ) -> None:
         blob = self.bucket.blob(file_name)
-        blob.upload_from_string(content)
+        if metadata:
+            blob.metadata = metadata
+        blob.upload_from_string(content, content_type=content_type)
 
-    def read(self, file_name: str) -> Optional[str]:
+    def read(self, file_name: str) -> Optional[str | bytes]:
         blob = self.bucket.get_blob(file_name)
         if blob:
             with blob.open("r") as f:

--- a/src/backend/common/storage/clients/in_memory_client.py
+++ b/src/backend/common/storage/clients/in_memory_client.py
@@ -8,7 +8,7 @@ from backend.common.storage.clients.storage_client import StorageClient
 class InMemoryClient(StorageClient):
     CLIENT: Optional["InMemoryClient"] = None
 
-    data: Dict[str, str]
+    data: Dict[str, str | bytes]
 
     @classmethod
     def get(cls) -> "InMemoryClient":
@@ -19,10 +19,16 @@ class InMemoryClient(StorageClient):
     def __init__(self) -> None:
         self.data = {}
 
-    def write(self, file_name: str, content: str) -> None:
+    def write(
+        self,
+        file_name: str,
+        content: str | bytes,
+        content_type: str = "text/plain",
+        metadata: dict[str, str | None] | None = None,
+    ) -> None:
         self.data[file_name] = content
 
-    def read(self, file_name: str) -> Optional[str]:
+    def read(self, file_name: str) -> Optional[str | bytes]:
         return self.data.get(file_name)
 
     def get_files(self, path: Optional[str] = None) -> List[str]:

--- a/src/backend/common/storage/clients/local_client.py
+++ b/src/backend/common/storage/clients/local_client.py
@@ -8,14 +8,23 @@ class LocalStorageClient(StorageClient):
     def __init__(self, base_path: Path) -> None:
         self.base_path = base_path
 
-    def write(self, file_name: str, content: str) -> None:
+    def write(
+        self,
+        file_name: str,
+        content: str | bytes,
+        content_type: str = "text/plain",
+        metadata: dict[str, str | None] | None = None,
+    ) -> None:
         path = self.base_path / file_name
         if not path.parent.exists():
             Path.mkdir(path.parent, parents=True)
 
-        path.write_text(content)
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content)
 
-    def read(self, file_name: str) -> Optional[str]:
+    def read(self, file_name: str) -> Optional[str | bytes]:
         path = self.base_path / file_name
         if path.exists():
             with path.open() as f:
@@ -24,6 +33,8 @@ class LocalStorageClient(StorageClient):
         return None
 
     def get_files(self, path: Optional[str] = None) -> List[str]:
+        if not self.base_path.exists():
+            return []
         return [
             p.name
             for p in self.base_path.iterdir()

--- a/src/backend/common/storage/clients/storage_client.py
+++ b/src/backend/common/storage/clients/storage_client.py
@@ -4,10 +4,16 @@ from typing import List, Optional
 
 class StorageClient(abc.ABC):
     @abc.abstractmethod
-    def write(self, file_name: str, content: str) -> None: ...
+    def write(
+        self,
+        file_name: str,
+        content: str | bytes,
+        content_type: str,
+        metadata: dict[str, str | None] | None = None,
+    ) -> None: ...
 
     @abc.abstractmethod
-    def read(self, file_name: str) -> Optional[str]: ...
+    def read(self, file_name: str) -> Optional[str | bytes]: ...
 
     @abc.abstractmethod
     def get_files(self, path: Optional[str]) -> List[str]: ...

--- a/src/backend/common/storage/clients/tests/gcloud_client_test.py
+++ b/src/backend/common/storage/clients/tests/gcloud_client_test.py
@@ -39,7 +39,9 @@ def test_write():
 
     client.write(file_name, file_content)
     mock_bucket.blob.assert_called_with(file_name)
-    mock_blob.upload_from_string.assert_called_with(file_content)
+    mock_blob.upload_from_string.assert_called_with(
+        file_content, content_type="text/plain"
+    )
 
 
 def test_read_none():

--- a/src/backend/common/storage/tests/storage_test.py
+++ b/src/backend/common/storage/tests/storage_test.py
@@ -52,16 +52,24 @@ def test_client_for_env_unit_test_remote(set_storage_mode_remote):
     assert isinstance(client, InMemoryClient)
 
 
-def test_client_for_env_dev(set_override_tba_test, set_dev):
+def test_client_for_env_dev(set_override_tba_test, set_dev, set_project):
     client = storage._client_for_env()
     assert isinstance(client, LocalStorageClient)
-    assert client.base_path == Path(tempfile.gettempdir())
+    assert (
+        client.base_path
+        == Path(tempfile.gettempdir()) / "tbatv-prod-hrd" / "tbatv-prod-hrd.appspot.com"
+    )
 
 
-def test_client_for_env_dev_path(set_override_tba_test, set_dev, set_storage_path):
+def test_client_for_env_dev_path(
+    set_override_tba_test, set_dev, set_storage_path, set_project
+):
     client = storage._client_for_env()
     assert isinstance(client, LocalStorageClient)
-    assert client.base_path == Path("some/fake/path")
+    assert (
+        client.base_path
+        == Path("some/fake/path") / "tbatv-prod-hrd" / "tbatv-prod-hrd.appspot.com"
+    )
 
 
 def test_client_for_env_dev_remote_no_project(
@@ -84,7 +92,9 @@ def test_client_for_env_dev_remote(
     ) as gcloud_storage_client_init:
         client = storage._client_for_env()
 
-    gcloud_storage_client_init.assert_called_with("tbatv-prod-hrd")
+    gcloud_storage_client_init.assert_called_with(
+        "tbatv-prod-hrd", "tbatv-prod-hrd.appspot.com"
+    )
     assert isinstance(client, GCloudStorageClient)
 
 
@@ -104,7 +114,9 @@ def test_client_for_env_production(set_override_tba_test, set_prod, set_project)
     ) as gcloud_storage_client_init:
         client = storage._client_for_env()
 
-    gcloud_storage_client_init.assert_called_with("tbatv-prod-hrd")
+    gcloud_storage_client_init.assert_called_with(
+        "tbatv-prod-hrd", "tbatv-prod-hrd.appspot.com"
+    )
     assert isinstance(client, GCloudStorageClient)
 
 
@@ -116,7 +128,7 @@ def test_write():
     with patch.object(storage, "_client_for_env", return_value=client):
         storage.write(file_name, content)
 
-    client.write.assert_called_with(file_name, content)
+    client.write.assert_called_with(file_name, content, "text/plain", None)
 
 
 def test_read():

--- a/src/frontend/eventwizard/components/eventAlliances/EventAlliancesTab.tsx
+++ b/src/frontend/eventwizard/components/eventAlliances/EventAlliancesTab.tsx
@@ -15,7 +15,7 @@ export interface EventAlliancesTabProps {
   selectedEvent: string;
   makeTrustedRequest: (
     path: string,
-    body: string
+    body: string | FormData
   ) => Promise<Response>;
 }
 
@@ -144,6 +144,7 @@ const EventAlliancesTab: React.FC<EventAlliancesTabProps> = ({
               <FMSAllianceImport
                 selectedEvent={selectedEvent}
                 updateAlliances={handleFMSImport}
+                makeTrustedRequest={makeTrustedRequest}
               />
             </div>
           </div>

--- a/src/frontend/eventwizard/components/eventMatchResultsTab/EventMatchResultsTab.tsx
+++ b/src/frontend/eventwizard/components/eventMatchResultsTab/EventMatchResultsTab.tsx
@@ -6,7 +6,7 @@ export interface EventMatchResultsTabProps {
   selectedEvent: string;
   makeTrustedRequest: (
     path: string,
-    body: string
+    body: string | FormData
   ) => Promise<Response>;
   makeApiV3Request: <T = unknown>(
     path: string

--- a/src/frontend/eventwizard/components/eventMatchResultsTab/__tests__/FMSMatchResults.test.tsx
+++ b/src/frontend/eventwizard/components/eventMatchResultsTab/__tests__/FMSMatchResults.test.tsx
@@ -17,6 +17,18 @@ jest.mock("../../../utils/resultsParser");
 
 installMockFileReader();
 
+// Mock crypto.subtle.digest for SHA-256 hashing
+global.crypto.subtle = {
+  digest: jest.fn(async (algorithm: string, data: ArrayBuffer) => {
+    // Return a mock digest (in real tests, this would compute the actual SHA-256)
+    // We'll just return a consistent buffer for testing
+    const mockDigest = new ArrayBuffer(32);
+    const view = new Uint8Array(mockDigest);
+    view.fill(0xAB); // Fill with a constant value for predictable tests
+    return mockDigest;
+  }),
+} as any;
+
 describe("FMSMatchResults", () => {
   const mockMakeTrustedRequest = jest.fn();
   const selectedEvent = "2024nytr";
@@ -201,6 +213,14 @@ describe("FMSMatchResults", () => {
         type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       });
 
+      // Mock the arrayBuffer method on the file
+      const arrayBuffer = new ArrayBuffer(12);
+      const view = new Uint8Array(arrayBuffer);
+      view.set([100, 117, 109, 109, 121, 32, 99, 111, 110, 116, 101, 110]);
+      Object.defineProperty(file, "arrayBuffer", {
+        value: jest.fn().mockResolvedValue(arrayBuffer),
+      });
+
       fireEvent.change(fileInput, { target: { files: [file] } });
 
       await waitFor(() => {
@@ -237,6 +257,14 @@ describe("FMSMatchResults", () => {
       const fileInput = screen.getByLabelText("FMS Results Excel File");
       const file = new File(["dummy content"], "test.xlsx", {
         type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+
+      // Mock the arrayBuffer method on the file
+      const arrayBuffer = new ArrayBuffer(12);
+      const view = new Uint8Array(arrayBuffer);
+      view.set([100, 117, 109, 109, 121, 32, 99, 111, 110, 116, 101, 110]);
+      Object.defineProperty(file, "arrayBuffer", {
+        value: jest.fn().mockResolvedValue(arrayBuffer),
       });
 
       fireEvent.change(fileInput, { target: { files: [file] } });

--- a/src/frontend/eventwizard/components/eventRankingsTab/EventRankingsTab.tsx
+++ b/src/frontend/eventwizard/components/eventRankingsTab/EventRankingsTab.tsx
@@ -1,15 +1,17 @@
 import React, { useState, ChangeEvent } from "react";
 import { parseRankingsFile, Ranking } from "../../utils/rankingsParser";
+import { uploadFmsReport } from "../../utils/fmsReportUpload";
 
 interface EventRankingsTabProps {
   selectedEvent: string;
   makeTrustedRequest: (
     requestPath: string,
-    requestBody: string
+    requestBody: string | FormData
   ) => Promise<Response>;
 }
 
 function EventRankingsTab({ selectedEvent, makeTrustedRequest }: EventRankingsTabProps): React.ReactElement {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [rankings, setRankings] = useState<Ranking[]>([]);
   const [breakdowns, setBreakdowns] = useState<string[]>([]);
   const [headers, setHeaders] = useState<string[]>([]);
@@ -25,6 +27,7 @@ function EventRankingsTab({ selectedEvent, makeTrustedRequest }: EventRankingsTa
 
     setLoading(true);
     setStatusMessage("Loading rankings...");
+    setSelectedFile(selectedFile);
 
     try {
       const result = await parseRankingsFile(selectedFile);
@@ -69,6 +72,11 @@ function EventRankingsTab({ selectedEvent, makeTrustedRequest }: EventRankingsTa
         JSON.stringify(requestBody)
       );
       setStatusMessage("Rankings uploaded successfully!");
+      
+      if (selectedFile) {
+        await uploadFmsReport(selectedFile, selectedEvent, "qual_rankings", makeTrustedRequest);
+      }
+      
       setUploading(false);
     } catch (error) {
       setStatusMessage(`Error uploading rankings: ${error}`);

--- a/src/frontend/eventwizard/components/eventScheduleTab/EventScheduleTab.tsx
+++ b/src/frontend/eventwizard/components/eventScheduleTab/EventScheduleTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ChangeEvent } from "react";
 import { parseScheduleFile } from "../../utils/scheduleParser";
 import { ScheduleMatch } from "../../utils/scheduleParser";
+import { uploadFmsReport } from "../../utils/fmsReportUpload";
 
 export interface EventScheduleTabProps {
   selectedEvent: string;
@@ -145,6 +146,18 @@ const EventScheduleTab: React.FC<EventScheduleTabProps> = ({
         `event/${selectedEvent}/matches/update`,
         JSON.stringify(matchData)
       );
+      
+      // Upload the FMS report file to the backend for archival
+      // Determine report type based on competition level filter
+      let reportType = "qual_schedule";
+      if (compLevelFilter !== "qm" && compLevelFilter !== "all") {
+        reportType = "playoff_schedule";
+      }
+      
+      if (file) {
+        await uploadFmsReport(file, selectedEvent, reportType, makeTrustedRequest);
+      }
+      
       setUploading(false);
       setStatusMessage(
         `Successfully uploaded ${matches.length} matches to TBA!`

--- a/src/frontend/eventwizard/components/teamsTab/TeamListTab.tsx
+++ b/src/frontend/eventwizard/components/teamsTab/TeamListTab.tsx
@@ -12,7 +12,7 @@ interface TeamListTabProps {
   selectedEvent: string | null;
   makeTrustedRequest: (
     path: string,
-    body: string
+    body: string | FormData
   ) => Promise<Response>;
 }
 
@@ -109,6 +109,7 @@ class TeamListTab extends Component<TeamListTabProps, TeamListTabState> {
               updateTeamList={this.updateTeamList}
               showErrorMessage={this.showError}
               clearTeams={this.clearTeams}
+              makeTrustedRequest={this.props.makeTrustedRequest}
             />
             <hr />
 

--- a/src/frontend/eventwizard/containers/EventRankingsTabContainer.tsx
+++ b/src/frontend/eventwizard/containers/EventRankingsTabContainer.tsx
@@ -7,7 +7,7 @@ const mapStateToProps = (state: RootState) => ({
   selectedEvent: state.auth.selectedEvent,
   makeTrustedRequest: (
     requestPath: string,
-    requestBody: string
+    requestBody: string | FormData
   ) => {
     return makeTrustedApiRequest(
       state.auth.authId || "",

--- a/src/frontend/eventwizard/net/TrustedApiRequest.ts
+++ b/src/frontend/eventwizard/net/TrustedApiRequest.ts
@@ -6,12 +6,19 @@ async function makeTrustedApiRequest(
   authId: string,
   authSecret: string,
   requestPath: string,
-  requestBody: string
+  requestBody: string | FormData
 ): Promise<Response> {
-  const authSig = md5(authSecret + requestPath + requestBody);
   const headers = new Headers();
   headers.append("X-TBA-Auth-Id", authId);
-  headers.append("X-TBA-Auth-Sig", authSig);
+
+  if (!(requestBody instanceof FormData)) {
+    const authSig = md5(authSecret + requestPath + requestBody);
+    headers.append("X-TBA-Auth-Sig", authSig);
+  } else if ((requestBody as FormData).has("fileDigest")) {
+    const fileDigest = (requestBody as FormData).get("fileDigest") as string;
+    const authSig = md5(authSecret + requestPath + fileDigest);
+    headers.append("X-TBA-Auth-Sig", authSig);
+  }
   
   const response = await fetch(requestPath, {
     method: "POST",

--- a/src/frontend/eventwizard/net/__tests__/TrustedApiRequest.test.ts
+++ b/src/frontend/eventwizard/net/__tests__/TrustedApiRequest.test.ts
@@ -1,0 +1,193 @@
+import makeTrustedApiRequest from "../TrustedApiRequest";
+import md5 from "md5";
+
+describe("makeTrustedApiRequest", () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    global.fetch = mockFetch as any;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("makes a POST request with X-TBA-Auth-Id and X-TBA-Auth-Sig headers for string body", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/rankings/update";
+    const requestBody = '{"rankings": []}';
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, requestBody);
+
+    expect(mockFetch).toHaveBeenCalledWith(requestPath, {
+      method: "POST",
+      headers: expect.any(Headers),
+      credentials: "same-origin",
+      body: requestBody,
+    });
+  });
+
+  it("includes X-TBA-Auth-Id in headers for string body", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id-123";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/rankings/update";
+    const requestBody = '{"rankings": []}';
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, requestBody);
+
+    const callArgs = mockFetch.mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers.get("X-TBA-Auth-Id")).toBe(authId);
+  });
+
+  it("computes correct MD5 signature for string body", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/rankings/update";
+    const requestBody = '{"rankings": []}';
+    const expectedSig = md5(authSecret + requestPath + requestBody);
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, requestBody);
+
+    const callArgs = mockFetch.mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers.get("X-TBA-Auth-Sig")).toBe(expectedSig);
+  });
+
+  it("makes a POST request with FormData for file upload", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/fms_reports/qual_rankings";
+    
+    const formData = new FormData();
+    const mockFile = new File(["test file content"], "rankings.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+    formData.append("reportFile", mockFile);
+    formData.append("fileDigest", "abcd1234");
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, formData);
+
+    expect(mockFetch).toHaveBeenCalledWith(requestPath, {
+      method: "POST",
+      headers: expect.any(Headers),
+      credentials: "same-origin",
+      body: formData,
+    });
+  });
+
+  it("includes X-TBA-Auth-Id in headers for FormData with fileDigest", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/fms_reports/qual_rankings";
+    
+    const formData = new FormData();
+    const mockFile = new File(["test file content"], "rankings.xlsx");
+    formData.append("reportFile", mockFile);
+    formData.append("fileDigest", "abcd1234");
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, formData);
+
+    const callArgs = mockFetch.mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers.get("X-TBA-Auth-Id")).toBe(authId);
+  });
+
+  it("computes correct MD5 signature using fileDigest for FormData", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/fms_reports/qual_rankings";
+    const fileDigest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; // SHA-256 of empty string
+
+    const formData = new FormData();
+    const mockFile = new File([""], "test.xlsx");
+    formData.append("reportFile", mockFile);
+    formData.append("fileDigest", fileDigest);
+
+    const expectedSig = md5(authSecret + requestPath + fileDigest);
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, formData);
+
+    const callArgs = mockFetch.mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers.get("X-TBA-Auth-Sig")).toBe(expectedSig);
+  });
+
+  it("does not include X-TBA-Auth-Sig for FormData without fileDigest", async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/fms_reports/qual_rankings";
+    
+    const formData = new FormData();
+    const mockFile = new File(["test content"], "test.xlsx");
+    formData.append("reportFile", mockFile);
+
+    await makeTrustedApiRequest(authId, authSecret, requestPath, formData);
+
+    const callArgs = mockFetch.mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers.get("X-TBA-Auth-Sig")).toBeNull();
+  });
+
+  it("throws error on failed response", async () => {
+    const mockResponse = {
+      ok: false,
+      status: 401,
+      text: jest.fn().mockResolvedValue("Unauthorized"),
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const authId = "test-auth-id";
+    const authSecret = "test-secret";
+    const requestPath = "/api/trusted/v1/event/2024cmp/rankings/update";
+    const requestBody = '{"rankings": []}';
+
+    await expect(
+      makeTrustedApiRequest(authId, authSecret, requestPath, requestBody)
+    ).rejects.toThrow();
+  });
+});

--- a/src/frontend/eventwizard/utils/fmsReportUpload.ts
+++ b/src/frontend/eventwizard/utils/fmsReportUpload.ts
@@ -1,0 +1,29 @@
+/**
+ * Uploads an FMS report file to the backend for archival
+ * 
+ * @param file - The FMS report file to upload
+ * @param eventKey - The event key (e.g., "2024cmp")
+ * @param reportType - The type of report (e.g., "qual_rankings", "qual_schedule", "qual_results", "playoff_alliances", "team_list")
+ * @returns Promise that resolves when the upload is complete
+ */
+export async function uploadFmsReport(
+  file: File,
+  eventKey: string,
+  reportType: string,
+  makeTrustedRequest: (requestPath: string, requestBody: string | FormData) => Promise<Response>
+): Promise<void> {
+  // Calculate SHA-256 digest of the file
+  const fileBuffer = await file.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", fileBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const fileDigest = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+
+  const formData = new FormData();
+  formData.append("reportFile", file);
+  formData.append("fileDigest", fileDigest);
+  
+  await makeTrustedRequest(
+    `/api/trusted/v1/event/${eventKey}/fms_reports/${reportType}`,
+    formData
+  );
+}

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,3 +20,4 @@ requests==2.32.5
 typing-extensions==4.15.0
 Werkzeug==3.1.4
 appengine-python-standard==1.1.10
+openpyxl==3.1.5


### PR DESCRIPTION
This will allow us to archive the FMS Reports used in eventwizard, so we can keep an archive of what we were sent, like we do with the FRC API responses.

The auth setup is a bit weird here; we use a digest of the file contents as the "body" (and ensure it matches), which is preferable to actually figuring out the raw multi-part form upload format to hash client-side.