### PR TITLE
[eventwizard] Move internal APIs to own blueprint

### DIFF
--- a/src/backend/api/eventwizard_api_main.py
+++ b/src/backend/api/eventwizard_api_main.py
@@ -1,0 +1,20 @@
+# Eventwizard Internal API
+from flask import Blueprint
+from flask_cors import CORS
+
+from backend.api.handlers.eventwizard_internal import add_fms_report_archive
+
+# Eventwizard Internal API
+eventwizard_api = Blueprint("eventwizard_api", __name__, url_prefix="/_eventwizard/")
+CORS(
+    eventwizard_api,
+    origins="*",
+    methods=["OPTIONS", "POST"],
+    allow_headers=["Content-Type", "X-TBA-Auth-Id", "X-TBA-Auth-Sig"],
+)
+
+eventwizard_api.add_url_rule(
+    "/event/<string:event_key>/fms_reports/<string:report_type>",
+    methods=["POST"],
+    view_func=add_fms_report_archive,
+)

--- a/src/backend/api/handlers/eventwizard_internal.py
+++ b/src/backend/api/handlers/eventwizard_internal.py
@@ -1,0 +1,65 @@
+import logging
+from io import BytesIO
+from pathlib import Path
+
+from flask import make_response, request, Response
+from openpyxl import load_workbook
+from pyre_extensions import none_throws
+
+from backend.api.handlers.decorators import require_write_auth, validate_keys
+from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.common.auth import current_user
+from backend.common.models.keys import EventKey
+from backend.common.storage import (
+    get_files as storage_get_files,
+    write as storage_write,
+)
+
+
+@require_write_auth(None, file_param="reportFile")
+@validate_keys
+def add_fms_report_archive(event_key: EventKey, report_type: str) -> Response:
+    form_data = request.files.get("reportFile")
+    if not form_data:
+        return make_response(profiled_jsonify({"Error": "Missing report file"}), 400)
+
+    file_contents: bytes = form_data.read()
+
+    try:
+        workbook = load_workbook(filename=BytesIO(file_contents))
+        mtime = workbook.properties.modified
+    except Exception:
+        logging.exception("Failed to parse uploaded Excel file")
+        return make_response(
+            profiled_jsonify({"Error": "Uploaded file is not a valid Excel file"}), 400
+        )
+
+    filename = Path(form_data.filename or "fms_report.xlsx")
+    file_name = filename.stem
+    extension = ".".join(filename.suffixes)
+
+    storage_dir = f"fms_reports/{event_key}/{report_type}"
+    storage_file = f"{file_name}.{mtime}{extension}"
+    storage_path = f"{storage_dir}/{storage_file}"
+
+    existing_reports = storage_get_files(
+        path=storage_dir,
+        bucket="eventwizard-fms-reports",
+    )
+    if not any(
+        existing.split("/")[-1] == storage_file for existing in existing_reports
+    ):
+        user = current_user()
+        storage_write(
+            storage_path,
+            file_contents,
+            bucket="eventwizard-fms-reports",
+            content_type=none_throws(form_data.content_type),
+            metadata={
+                "X-TBA-Auth-User": str(user.uid) if user else None,
+                "X-TBA-Auth-User-Email": user.email if user else None,
+                "X-TBA-Auth-Id": request.headers.get("X-TBA-Auth-Id"),
+            },
+        )
+
+    return profiled_jsonify({"Success": "FMS report successfully uploaded"})

--- a/src/backend/api/handlers/tests/add_fms_report_archive_test.py
+++ b/src/backend/api/handlers/tests/add_fms_report_archive_test.py
@@ -101,7 +101,7 @@ def test_upload_qual_rankings_success(
     file_content = create_excel_file()
     file_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),
@@ -109,8 +109,10 @@ def test_upload_qual_rankings_success(
         content_type="application/vnd.ms-excel",
     )
 
-    with patch("backend.api.handlers.trusted.storage_write") as mock_write:
-        with patch("backend.api.handlers.trusted.storage_get_files") as mock_get_files:
+    with patch("backend.api.handlers.eventwizard_internal.storage_write") as mock_write:
+        with patch(
+            "backend.api.handlers.eventwizard_internal.storage_get_files"
+        ) as mock_get_files:
             mock_get_files.return_value = []
 
             resp = api_client.post(
@@ -145,7 +147,7 @@ def test_upload_missing_file(
         expiration=None,
     )
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     resp = api_client.post(
         request_path,
@@ -178,7 +180,7 @@ def test_upload_invalid_excel_file(
     file_content = b"This is not an Excel file"
     file_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),
@@ -220,7 +222,7 @@ def test_upload_wrong_permission(
     file_content = create_excel_file()
     file_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),
@@ -263,7 +265,7 @@ def test_upload_mismatched_digest(
     wrong_digest = hashlib.sha256(b"wrong content").hexdigest()
     correct_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),
@@ -305,7 +307,7 @@ def test_upload_duplicate_file_not_written(
     file_content = create_excel_file()
     file_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),
@@ -319,8 +321,10 @@ def test_upload_duplicate_file_not_written(
         "fms_reports/2019nyny/qual_rankings/rankings.2019-06-01 00:00:00.xlsx"
     ]
 
-    with patch("backend.api.handlers.trusted.storage_write") as mock_write:
-        with patch("backend.api.handlers.trusted.storage_get_files") as mock_get_files:
+    with patch("backend.api.handlers.eventwizard_internal.storage_write") as mock_write:
+        with patch(
+            "backend.api.handlers.eventwizard_internal.storage_get_files"
+        ) as mock_get_files:
             mock_get_files.return_value = existing_files
 
             resp = api_client.post(
@@ -358,7 +362,7 @@ def test_upload_with_metadata(
     file_content = create_excel_file()
     file_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),
@@ -366,8 +370,10 @@ def test_upload_with_metadata(
         content_type="application/vnd.ms-excel",
     )
 
-    with patch("backend.api.handlers.trusted.storage_write") as mock_write:
-        with patch("backend.api.handlers.trusted.storage_get_files") as mock_get_files:
+    with patch("backend.api.handlers.eventwizard_internal.storage_write") as mock_write:
+        with patch(
+            "backend.api.handlers.eventwizard_internal.storage_get_files"
+        ) as mock_get_files:
             mock_get_files.return_value = []
 
             resp = api_client.post(
@@ -401,7 +407,7 @@ def test_upload_not_authenticated(ndb_stub, api_client: Client) -> None:
     file_content = create_excel_file()
     file_digest = hashlib.sha256(file_content).hexdigest()
 
-    request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+    request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
     file_storage = FileStorage(
         stream=io.BytesIO(file_content),

--- a/src/backend/api/handlers/tests/trustedapi_auth_test.py
+++ b/src/backend/api/handlers/tests/trustedapi_auth_test.py
@@ -808,7 +808,7 @@ def test_file_upload_no_file_param(
 
     with api_client.application.test_request_context():  # pyre-ignore[16]
         request_data = ""
-        request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+        request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
         resp = api_client.post(
             request_path,
             headers={
@@ -844,7 +844,7 @@ def test_file_upload_mismatched_digest(
         wrong_digest = hashlib.sha256(b"wrong content").hexdigest()
         correct_digest = hashlib.sha256(file_content).hexdigest()
 
-        request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+        request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
         # Create file storage object
         file_storage = FileStorage(
@@ -890,7 +890,7 @@ def test_file_upload_correct_digest(
         file_content = create_excel_file()
         file_digest = hashlib.sha256(file_content).hexdigest()
 
-        request_path = "/api/trusted/v1/event/2019nyny/fms_reports/qual_rankings"
+        request_path = "/_eventwizard/event/2019nyny/fms_reports/qual_rankings"
 
         # Create file storage object
         file_storage = FileStorage(
@@ -947,7 +947,7 @@ def test_file_upload_succeeds_with_correct_permission(
         file_content = create_excel_file()
         file_digest = hashlib.sha256(file_content).hexdigest()
 
-        request_path = f"/api/trusted/v1/event/2019nyny/fms_reports/{report_type}"
+        request_path = f"/_eventwizard/event/2019nyny/fms_reports/{report_type}"
 
         # Create file storage object
         file_storage = FileStorage(

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -1,12 +1,9 @@
 import json
 import logging
-from io import BytesIO
-from pathlib import Path
 from typing import List, Optional, Set
 
 from flask import make_response, request, Response
 from google.appengine.ext import ndb
-from openpyxl import load_workbook
 from pyre_extensions import none_throws, safe_json
 
 from backend.api.api_trusted_parsers.json_alliance_selections_parser import (
@@ -28,7 +25,6 @@ from backend.api.api_trusted_parsers.json_zebra_motionworks_parser import (
 )
 from backend.api.handlers.decorators import require_write_auth, validate_keys
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
-from backend.common.auth import current_user
 from backend.common.consts.alliance_color import ALLIANCE_COLORS, AllianceColor
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
@@ -55,10 +51,6 @@ from backend.common.models.match import Match
 from backend.common.models.media import Media
 from backend.common.models.team import Team
 from backend.common.models.zebra_motionworks import ZebraMotionWorks
-from backend.common.storage import (
-    get_files as storage_get_files,
-    write as storage_write,
-)
 
 
 @require_write_auth({AuthType.EVENT_TEAMS})
@@ -442,52 +434,3 @@ def add_match_zebra_motionworks_info(event_key: EventKey) -> Response:
 
     ndb.put_multi(to_put)
     return profiled_jsonify({"Success": "Media successfully added"})
-
-
-@require_write_auth(None, file_param="reportFile")
-@validate_keys
-def add_fms_report_archive(event_key: EventKey, report_type: str) -> Response:
-    form_data = request.files.get("reportFile")
-    if not form_data:
-        return make_response(profiled_jsonify({"Error": "Missing report file"}), 400)
-
-    file_contents: bytes = form_data.read()
-
-    try:
-        workbook = load_workbook(filename=BytesIO(file_contents))
-        mtime = workbook.properties.modified
-    except Exception:
-        logging.exception("Failed to parse uploaded Excel file")
-        return make_response(
-            profiled_jsonify({"Error": "Uploaded file is not a valid Excel file"}), 400
-        )
-
-    filename = Path(form_data.filename or "fms_report.xlsx")
-    file_name = filename.stem
-    extension = ".".join(filename.suffixes)
-
-    storage_dir = f"fms_reports/{event_key}/{report_type}"
-    storage_file = f"{file_name}.{mtime}{extension}"
-    storage_path = f"{storage_dir}/{storage_file}"
-
-    existing_reports = storage_get_files(
-        path=storage_dir,
-        bucket="eventwizard-fms-reports",
-    )
-    if not any(
-        existing.split("/")[-1] == storage_file for existing in existing_reports
-    ):
-        user = current_user()
-        storage_write(
-            storage_path,
-            file_contents,
-            bucket="eventwizard-fms-reports",
-            content_type=none_throws(form_data.content_type),
-            metadata={
-                "X-TBA-Auth-User": str(user.uid) if user else None,
-                "X-TBA-Auth-User-Email": user.email if user else None,
-                "X-TBA-Auth-Id": request.headers.get("X-TBA-Auth-Id"),
-            },
-        )
-
-    return profiled_jsonify({"Success": "FMS report successfully uploaded"})

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -4,6 +4,7 @@ from werkzeug.routing import BaseConverter
 
 from backend.api.apiv3_main import api_v3
 from backend.api.client_api_main import client_api
+from backend.api.eventwizard_api_main import eventwizard_api
 from backend.api.handlers.error import handle_404
 from backend.api.trusted_api_main import trusted_api
 from backend.common.flask_cache import configure_flask_cache
@@ -39,6 +40,7 @@ app.url_map.converters["event_detail_type"] = EventDetailTypeConverter
 
 
 app.register_blueprint(api_v3)
+app.register_blueprint(eventwizard_api)
 app.register_blueprint(trusted_api)
 app.register_blueprint(client_api)
 app.register_error_handler(404, handle_404)

--- a/src/backend/api/trusted_api_main.py
+++ b/src/backend/api/trusted_api_main.py
@@ -6,7 +6,6 @@ from flask_cors import CORS
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.trusted import (
     add_event_media,
-    add_fms_report_archive,
     add_match_video,
     add_match_zebra_motionworks_info,
     delete_all_event_matches,
@@ -89,11 +88,6 @@ trusted_api.add_url_rule(
     "/event/<string:event_key>/zebra_motionworks/add",
     methods=["POST"],
     view_func=add_match_zebra_motionworks_info,
-)
-trusted_api.add_url_rule(
-    "/event/<string:event_key>/fms_reports/<string:report_type>",
-    methods=["POST"],
-    view_func=add_fms_report_archive,
 )
 
 

--- a/src/frontend/eventwizard/utils/fmsReportUpload.ts
+++ b/src/frontend/eventwizard/utils/fmsReportUpload.ts
@@ -23,7 +23,7 @@ export async function uploadFmsReport(
   formData.append("fileDigest", fileDigest);
   
   await makeTrustedRequest(
-    `/api/trusted/v1/event/${eventKey}/fms_reports/${reportType}`,
+    `/_eventwizard/event/${eventKey}/fms_reports/${reportType}`,
     formData
   );
 }


### PR DESCRIPTION
There's going to be another couple endpoints needed, which will be a bit different from the core trusted API, so move all the code to its own handler file