### PR TITLE
Remove old react router typegen from CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -218,8 +218,6 @@ jobs:
           TBA_API_READ_KEY: TEST_KEY
       - name: Install Dependencies
         run: pnpm --dir pwa install --frozen-lockfile
-      - name: Generate react-router types
-        run: pnpm --dir pwa run typecheck
       - name: Run Format
         run: pnpm --dir pwa run format
       - name: Run Lint
@@ -364,10 +362,6 @@ jobs:
       - name: Install Dependencies
         working-directory: pwa
         run: pnpm install --frozen-lockfile
-
-      - name: Generate react-router types
-        working-directory: pwa
-        run: pnpm run typecheck
 
       - name: Run generate-api.sh
         working-directory: ./pwa

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -161,9 +161,6 @@ jobs:
       - name: Install Dependencies
         if: contains(github.event.commits[0].message, '[clowntown]') == false
         run: pnpm --dir pwa install --frozen-lockfile
-      - name: Generate react-router types
-        if: contains(github.event.commits[0].message, '[clowntown]') == false
-        run: pnpm --dir pwa run typecheck
       - name: Run Format
         if: contains(github.event.commits[0].message, '[clowntown]') == false
         run: pnpm --dir pwa run format
@@ -324,10 +321,6 @@ jobs:
       - name: Install Dependencies
         working-directory: pwa
         run: pnpm install --frozen-lockfile
-
-      - name: Generate react-router types
-        working-directory: pwa
-        run: pnpm run typecheck
 
       - name: Run generate-api.sh
         working-directory: ./pwa


### PR DESCRIPTION
we have a separate ci check for typechecking; this used to be required to generate the react router types before running any other steps but react router is no longer