### PR TITLE
[pwa] refactor social badges; add event livestreams to event page

### DIFF
--- a/pwa/app/components/tba/socialBadges.tsx
+++ b/pwa/app/components/tba/socialBadges.tsx
@@ -1,0 +1,138 @@
+import LogosFacebook from '~icons/logos/facebook';
+import LogosGithubIcon from '~icons/logos/github-icon';
+import LogosGitlab from '~icons/logos/gitlab';
+import LogosInstagramIcon from '~icons/logos/instagram-icon';
+import LogosTwitch from '~icons/logos/twitch';
+import LogosYoutubeIcon from '~icons/logos/youtube-icon';
+import MdiVideoOutline from '~icons/mdi/video-outline';
+import SimpleIconsX from '~icons/simple-icons/x';
+
+import { Media, Webcast } from '~/api/tba/read';
+import InlineIcon from '~/components/tba/inlineIcon';
+import { Badge } from '~/components/ui/badge';
+
+interface MediaBadgeProps {
+  className?: string;
+  icon: React.ReactNode;
+  href: string;
+  label: string;
+}
+
+function MediaBadge({ className, icon, href, label }: MediaBadgeProps) {
+  return (
+    <Badge className={className} variant="secondary">
+      <a href={href} className="text-secondary-foreground">
+        <InlineIcon>
+          {icon}
+          {label}
+        </InlineIcon>
+      </a>
+    </Badge>
+  );
+}
+
+export function MediaIcon({
+  media,
+  className,
+}: {
+  media: Media;
+  className?: string;
+}) {
+  switch (media.type) {
+    case 'youtube':
+    case 'youtube-channel':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosYoutubeIcon />}
+          href={`https://www.youtube.com/${media.foreign_key}`}
+          label={media.foreign_key}
+        />
+      );
+    case 'facebook-profile':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosFacebook />}
+          href={`https://www.facebook.com/${media.foreign_key}`}
+          label={media.foreign_key}
+        />
+      );
+    case 'github-profile':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosGithubIcon />}
+          href={`https://github.com/${media.foreign_key}`}
+          label={media.foreign_key}
+        />
+      );
+    case 'instagram-profile':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosInstagramIcon />}
+          href={`https://www.instagram.com/${media.foreign_key}`}
+          label={media.foreign_key}
+        />
+      );
+    case 'twitter-profile':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<SimpleIconsX />}
+          href={`https://x.com/${media.foreign_key}`}
+          label={media.foreign_key}
+        />
+      );
+    case 'gitlab-profile':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosGitlab />}
+          href={`https://gitlab.com/${media.foreign_key}`}
+          label={media.foreign_key}
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+export function WebcastIcon({
+  webcast,
+  className,
+}: {
+  webcast: Webcast;
+  className?: string;
+}) {
+  switch (webcast.type) {
+    case 'youtube':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosYoutubeIcon />}
+          href={`https://www.youtube.com/watch?v=${webcast.channel}`}
+          label={webcast.channel}
+        />
+      );
+    case 'twitch':
+      return (
+        <MediaBadge
+          className={className}
+          icon={<LogosTwitch />}
+          href={`https://www.twitch.tv/${webcast.channel}`}
+          label={webcast.channel}
+        />
+      );
+    default:
+      return (
+        <MediaBadge
+          className={className}
+          icon={<MdiVideoOutline />}
+          href={'#'}
+          label={webcast.type}
+        />
+      );
+  }
+}

--- a/pwa/app/components/tba/teamSocialMediaList.tsx
+++ b/pwa/app/components/tba/teamSocialMediaList.tsx
@@ -1,110 +1,17 @@
-import LogosFacebook from '~icons/logos/facebook';
-import LogosGithubIcon from '~icons/logos/github-icon';
-import LogosGitlab from '~icons/logos/gitlab';
-import LogosInstagramIcon from '~icons/logos/instagram-icon';
-import LogosYoutubeIcon from '~icons/logos/youtube-icon';
-import SimpleIconsX from '~icons/simple-icons/x';
-
 import { Media } from '~/api/tba/read';
-import InlineIcon from '~/components/tba/inlineIcon';
-import { badgeVariants } from '~/components/ui/badge';
-import { cn } from '~/lib/utils';
-
-function SingleSocialIcon({
-  media,
-  className,
-}: {
-  media: Media;
-  className: string;
-}) {
-  switch (media.type) {
-    case 'youtube':
-    case 'youtube-channel':
-      return (
-        <a
-          href={`https://www.youtube.com/${media.foreign_key}`}
-          className={className}
-        >
-          <InlineIcon>
-            <LogosYoutubeIcon />
-            {media.foreign_key}
-          </InlineIcon>
-        </a>
-      );
-    case 'facebook-profile':
-      return (
-        <a
-          href={`https://www.facebook.com/${media.foreign_key}`}
-          className={className}
-        >
-          <InlineIcon>
-            <LogosFacebook />
-            {media.foreign_key}
-          </InlineIcon>
-        </a>
-      );
-    case 'github-profile':
-      return (
-        <a
-          href={`https://github.com/${media.foreign_key}`}
-          className={className}
-        >
-          <InlineIcon>
-            <LogosGithubIcon />
-            {media.foreign_key}
-          </InlineIcon>
-        </a>
-      );
-    case 'instagram-profile':
-      return (
-        <a
-          href={`https://www.instagram.com/${media.foreign_key}`}
-          className={className}
-        >
-          <InlineIcon>
-            <LogosInstagramIcon />
-            {media.foreign_key}
-          </InlineIcon>
-        </a>
-      );
-    case 'twitter-profile':
-      return (
-        <a href={`https://x.com/${media.foreign_key}`} className={className}>
-          <InlineIcon>
-            <SimpleIconsX />
-            {media.foreign_key}
-          </InlineIcon>
-        </a>
-      );
-    case 'gitlab-profile':
-      return (
-        <a
-          href={`https://gitlab.com/${media.foreign_key}`}
-          className={className}
-        >
-          <InlineIcon>
-            <LogosGitlab />
-            {media.foreign_key}
-          </InlineIcon>
-        </a>
-      );
-    default:
-      return null;
-  }
-}
+import { MediaIcon } from '~/components/tba/socialBadges';
 
 export default function TeamSocialMediaList({ socials }: { socials: Media[] }) {
   socials.sort((a, b) => a.type.localeCompare(b.type));
 
   return (
-    <>
+    <div
+      className="my-2 flex flex-wrap justify-center gap-1 md:my-0
+        md:justify-start"
+    >
       {socials.map((m) => (
-        <SingleSocialIcon
-          media={m}
-          key={`${m.type}-${m.foreign_key}`}
-          className={cn(badgeVariants({ variant: 'secondary' }), 'm-0.5')}
-        />
+        <MediaIcon media={m} key={`${m.type}-${m.foreign_key}`} />
       ))}
-    </>
+    </div>
   );
 }

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -24,6 +24,7 @@ import {
   Match,
   Media,
   Team,
+  Webcast,
   getEvent,
   getEventAlliances,
   getEventMatches,
@@ -51,6 +52,7 @@ import {
 } from '~/components/tba/match/breakers';
 import SimpleMatchRowsWithBreaks from '~/components/tba/match/matchRows';
 import RankingsTable from '~/components/tba/rankingsTable';
+import { WebcastIcon } from '~/components/tba/socialBadges';
 import TeamAvatar from '~/components/tba/teamAvatar';
 import { Avatar, AvatarImage } from '~/components/ui/avatar';
 import { Badge } from '~/components/ui/badge';
@@ -469,7 +471,9 @@ function EventPage() {
           )}
         </TabsContent>
 
-        <TabsContent value="media">media</TabsContent>
+        <TabsContent value="media">
+          <MediaTab webcasts={event.webcasts} />
+        </TabsContent>
       </Tabs>
     </div>
   );
@@ -765,6 +769,17 @@ function ComponentsTable({ coprs, year }: { coprs: EventCoprs; year: number }) {
           />
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+function MediaTab({ webcasts }: { webcasts: Webcast[] }) {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Webcasts</h1>
+      {webcasts.map((w) => (
+        <WebcastIcon webcast={w} key={w.channel} />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Refactored the social media badges to be a little more composable

Team pages look the exact same

event pages just had this little badge added for webcasts. can be refactored to be more organized later once we add event media endpoint. but this helps me figure out which channel to grab vods from to upload matches

<img width="1347" height="370" alt="image" src="https://github.com/user-attachments/assets/67b91d81-c2e2-4eae-a683-bda7fc107440" />
