### PR TITLE
Fix Team api spec (add motto, fix requireds)

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -138,11 +138,15 @@ export type Team = {
   /**
    * Official website associated with the team.
    */
-  website?: string | null;
+  website: string | null;
   /**
    * First year the team officially competed.
    */
   rookie_year: number | null;
+  /**
+   * Team's motto or tagline.
+   */
+  motto: string | null;
 };
 
 export type TeamRobot = {

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -42,8 +42,9 @@ export const zTeam = z.object({
   lat: z.union([z.number(), z.null()]),
   lng: z.union([z.number(), z.null()]),
   location_name: z.union([z.string(), z.null()]),
-  website: z.optional(z.union([z.string(), z.null()])),
+  website: z.union([z.string(), z.null()]),
   rookie_year: z.union([z.int(), z.null()]),
+  motto: z.union([z.string(), z.null()]),
 });
 
 export const zTeamRobot = z.object({

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5125,7 +5125,9 @@
           "lat",
           "lng",
           "location_name",
-          "rookie_year"
+          "website",
+          "rookie_year",
+          "motto"
         ],
         "type": "object",
         "properties": {
@@ -5239,6 +5241,13 @@
               "null"
             ],
             "description": "First year the team officially competed."
+          },
+          "motto": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Team's motto or tagline."
           }
         }
       },


### PR DESCRIPTION
excessively inconsequential change but for the sake of correctness. `motto` was missing from the apispec even though it's being returned. also fixes a couple fields that were able to be undefined but actually are never undefined. tested on all teams