### PR TITLE
Fix various small api schema mistakes

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -443,10 +443,7 @@ export type TeamEventStatusAllianceBackup = null | {
  * Playoff status for this team, may be null if the team did not make playoffs, or playoffs have not begun.
  */
 export type TeamEventStatusPlayoff = null | {
-  /**
-   * The highest playoff level the team reached.
-   */
-  level?: 'qm' | 'ef' | 'qf' | 'sf' | 'f';
+  level?: CompLevel;
   current_level_record?: WltRecord | null;
   record?: WltRecord | null;
   /**
@@ -477,9 +474,9 @@ export type EventRanking = {
      */
     extra_stats: Array<number>;
     /**
-     * Additional year-specific information, may be null. See parent `sort_order_info` for details.
+     * Additional year-specific information. See parent `sort_order_info` for details.
      */
-    sort_orders: Array<number> | null;
+    sort_orders: Array<number>;
     record: WltRecord | null;
     /**
      * The team's rank at the event as provided by FIRST.
@@ -519,7 +516,7 @@ export type EventRanking = {
      * Name of the field used in the `sort_order` array.
      */
     name: string;
-  }>;
+  }> | null;
 };
 
 export type EventDistrictPoints = {
@@ -1009,15 +1006,28 @@ export type EventPredictions = {
   [key: string]: unknown;
 };
 
+/**
+ * The competition level the match was played at.
+ */
+export type CompLevel = 'qm' | 'ef' | 'qf' | 'sf' | 'f';
+
+/**
+ * Double elimination round, if applicable.
+ */
+export type DoubleElimRound =
+  | 'Finals'
+  | 'Round 1'
+  | 'Round 2'
+  | 'Round 3'
+  | 'Round 4'
+  | 'Round 5';
+
 export type MatchSimple = {
   /**
    * TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may append the competition level if more than one match in required per set.
    */
   key: string;
-  /**
-   * The competition level the match was played at.
-   */
-  comp_level: 'qm' | 'ef' | 'qf' | 'sf' | 'f';
+  comp_level: CompLevel;
   /**
    * The set number in a series of matches where more than one match is required in the match series.
    */
@@ -1060,10 +1070,7 @@ export type Match = {
    * TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may be appended to the competition level if more than one match in required per set.
    */
   key: string;
-  /**
-   * The competition level the match was played at.
-   */
-  comp_level: 'qm' | 'ef' | 'qf' | 'sf' | 'f';
+  comp_level: CompLevel;
   /**
    * The set number in a series of matches where more than one match is required in the match series.
    */
@@ -2064,9 +2071,9 @@ export type Media = {
 
 export type EliminationAlliance = {
   /**
-   * Alliance name, may be null.
+   * Alliance name.
    */
-  name?: string | null;
+  name?: string;
   /**
    * Backup team called in, may be null.
    */
@@ -2089,12 +2096,39 @@ export type EliminationAlliance = {
    */
   picks: Array<string>;
   status?: {
+    /**
+     * Average match score during playoffs. Year specific. May be null.
+     */
     playoff_average?: number | null;
-    playoff_type?: number | null;
-    level?: string;
-    record?: WltRecord | null;
-    current_level_record?: WltRecord | null;
-    status?: string;
+    /**
+     * Playoff type, may be null.
+     */
+    playoff_type: number | null;
+    /**
+     * Match level, qm/ef/qf/sf/f.
+     */
+    level: CompLevel;
+    /**
+     * W-L-T record for the alliance, may be null.
+     */
+    record: WltRecord | null;
+    /**
+     * W-L-T record for the alliance at the current level, may be null.
+     */
+    current_level_record: WltRecord | null;
+    /**
+     * Status of the alliance.
+     */
+    status: 'eliminated' | 'playing' | 'won';
+    /**
+     * Whether the alliance advanced to round robin finals.
+     */
+    advanced_to_round_robin_finals?: boolean;
+    double_elim_round?: DoubleElimRound;
+    /**
+     * Rank in round robin play.
+     */
+    round_robin_rank?: number;
   };
 };
 
@@ -2222,7 +2256,7 @@ export type DistrictRanking = {
   /**
    * Any points added to a team as a result of the rookie bonus.
    */
-  rookie_bonus?: number;
+  rookie_bonus: number;
   /**
    * Total district points for the team.
    */
@@ -2230,7 +2264,7 @@ export type DistrictRanking = {
   /**
    * List of events that contributed to the point total for the team.
    */
-  event_points?: Array<{
+  event_points: Array<{
     /**
      * `true` if this event is a District Championship event.
      */
@@ -2260,6 +2294,14 @@ export type DistrictRanking = {
      */
     qual_points: number;
   }>;
+  /**
+   * Any points adjustments applied to the team.
+   */
+  adjustments?: number;
+  /**
+   * Any other bonus points awarded to the team.
+   */
+  other_bonus?: number;
 };
 
 /**

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -235,6 +235,23 @@ export const zEventCoprs = z.record(
  */
 export const zEventPredictions = z.record(z.string(), z.unknown());
 
+/**
+ * The competition level the match was played at.
+ */
+export const zCompLevel = z.enum(['qm', 'ef', 'qf', 'sf', 'f']);
+
+/**
+ * Double elimination round, if applicable.
+ */
+export const zDoubleElimRound = z.enum([
+  'Finals',
+  'Round 1',
+  'Round 2',
+  'Round 3',
+  'Round 4',
+  'Round 5',
+]);
+
 export const zMatchAlliance = z.object({
   score: z.int(),
   team_keys: z.array(z.string()),
@@ -244,7 +261,7 @@ export const zMatchAlliance = z.object({
 
 export const zMatchSimple = z.object({
   key: z.string(),
-  comp_level: z.enum(['qm', 'ef', 'qf', 'sf', 'f']),
+  comp_level: zCompLevel,
   set_number: z.int(),
   match_number: z.int(),
   alliances: z.object({
@@ -984,7 +1001,7 @@ export const zMatchScoreBreakdown2025 = z.object({
 
 export const zMatch = z.object({
   key: z.string(),
-  comp_level: z.enum(['qm', 'ef', 'qf', 'sf', 'f']),
+  comp_level: zCompLevel,
   set_number: z.int(),
   match_number: z.int(),
   alliances: z.object({
@@ -1135,21 +1152,21 @@ export const zDistrictInsightRegionData = z.object({
 export const zDistrictRanking = z.object({
   team_key: z.string(),
   rank: z.int(),
-  rookie_bonus: z.optional(z.int()),
+  rookie_bonus: z.int(),
   point_total: z.int(),
-  event_points: z.optional(
-    z.array(
-      z.object({
-        district_cmp: z.boolean(),
-        total: z.int(),
-        alliance_points: z.int(),
-        elim_points: z.int(),
-        award_points: z.int(),
-        event_key: z.string(),
-        qual_points: z.int(),
-      }),
-    ),
+  event_points: z.array(
+    z.object({
+      district_cmp: z.boolean(),
+      total: z.int(),
+      alliance_points: z.int(),
+      elim_points: z.int(),
+      award_points: z.int(),
+      event_key: z.string(),
+      qual_points: z.int(),
+    }),
   ),
+  adjustments: z.optional(z.int()),
+  other_bonus: z.optional(z.int()),
 });
 
 /**
@@ -1245,7 +1262,7 @@ export const zTeamEventStatusRank = z.object({
 export const zTeamEventStatusPlayoff = z.union([
   z.null(),
   z.object({
-    level: z.optional(z.enum(['qm', 'ef', 'qf', 'sf', 'f'])),
+    level: z.optional(zCompLevel),
     current_level_record: z.optional(z.union([zWltRecord, z.null()])),
     record: z.optional(z.union([zWltRecord, z.null()])),
     status: z.optional(z.enum(['won', 'eliminated', 'playing'])),
@@ -1270,7 +1287,7 @@ export const zEventRanking = z.object({
       matches_played: z.int(),
       qual_average: z.union([z.int(), z.null()]),
       extra_stats: z.array(z.number()),
-      sort_orders: z.union([z.array(z.number()), z.null()]),
+      sort_orders: z.array(z.number()),
       record: z.union([zWltRecord, z.null()]),
       rank: z.int(),
       dq: z.int(),
@@ -1283,16 +1300,19 @@ export const zEventRanking = z.object({
       name: z.string(),
     }),
   ),
-  sort_order_info: z.array(
-    z.object({
-      precision: z.int(),
-      name: z.string(),
-    }),
-  ),
+  sort_order_info: z.union([
+    z.array(
+      z.object({
+        precision: z.int(),
+        name: z.string(),
+      }),
+    ),
+    z.null(),
+  ]),
 });
 
 export const zEliminationAlliance = z.object({
-  name: z.optional(z.union([z.string(), z.null()])),
+  name: z.optional(z.string()),
   backup: z.optional(
     z.union([
       z.object({
@@ -1307,11 +1327,14 @@ export const zEliminationAlliance = z.object({
   status: z.optional(
     z.object({
       playoff_average: z.optional(z.union([z.number(), z.null()])),
-      playoff_type: z.optional(z.union([z.number(), z.null()])),
-      level: z.optional(z.string()),
-      record: z.optional(z.union([zWltRecord, z.null()])),
-      current_level_record: z.optional(z.union([zWltRecord, z.null()])),
-      status: z.optional(z.string()),
+      playoff_type: z.union([z.number(), z.null()]),
+      level: zCompLevel,
+      record: z.union([zWltRecord, z.null()]),
+      current_level_record: z.union([zWltRecord, z.null()]),
+      status: z.enum(['eliminated', 'playing', 'won']),
+      advanced_to_round_robin_finals: z.optional(z.boolean()),
+      double_elim_round: z.optional(zDoubleElimRound),
+      round_robin_rank: z.optional(z.int()),
     }),
   ),
 });

--- a/pwa/app/components/tba/rankingsTable.tsx
+++ b/pwa/app/components/tba/rankingsTable.tsx
@@ -42,7 +42,7 @@ export default function RankingsTable({
     },
   ];
 
-  const sortOrderCols: RankingColumnType = rankings.sort_order_info.map(
+  const sortOrderCols: RankingColumnType = (rankings.sort_order_info ?? []).map(
     (sortOrder, idx) => ({
       header: sortOrder.name,
       accessorFn: (row) => row.sort_orders?.[idx].toFixed(sortOrder.precision),

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5784,15 +5784,7 @@
         ],
         "properties": {
           "level": {
-            "type": "string",
-            "description": "The highest playoff level the team reached.",
-            "enum": [
-              "qm",
-              "ef",
-              "qf",
-              "sf",
-              "f"
-            ]
+            "$ref": "#/components/schemas/Comp_Level"
           },
           "current_level_record": {
             "type": [
@@ -5871,15 +5863,12 @@
                   }
                 },
                 "sort_orders": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
+                  "type": "array",
                   "items": {
                     "type": "number",
                     "format": "double"
                   },
-                  "description": "Additional year-specific information, may be null. See parent `sort_order_info` for details."
+                  "description": "Additional year-specific information. See parent `sort_order_info` for details."
                 },
                 "record": {
                   "type": [
@@ -5925,7 +5914,10 @@
             }
           },
           "sort_order_info": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "List of year-specific values provided in the `sort_orders` array for each team.",
             "items": {
               "required": [
@@ -6759,6 +6751,29 @@
         "type": "object",
         "description": "JSON Object containing prediction information for the event. Contains year-specific information and is subject to change."
       },
+      "Comp_Level": {
+        "type": "string",
+        "enum": [
+          "qm",
+          "ef",
+          "qf",
+          "sf",
+          "f"
+        ],
+        "description": "The competition level the match was played at."
+      },
+      "Double_Elim_Round": {
+        "type": "string",
+        "enum": [
+          "Finals",
+          "Round 1",
+          "Round 2",
+          "Round 3",
+          "Round 4",
+          "Round 5"
+        ],
+        "description": "Double elimination round, if applicable."
+      },
       "Match_Simple": {
         "required": [
           "key",
@@ -6779,15 +6794,7 @@
             "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may append the competition level if more than one match in required per set."
           },
           "comp_level": {
-            "type": "string",
-            "description": "The competition level the match was played at.",
-            "enum": [
-              "qm",
-              "ef",
-              "qf",
-              "sf",
-              "f"
-            ]
+            "$ref": "#/components/schemas/Comp_Level"
           },
           "set_number": {
             "type": "integer",
@@ -6875,15 +6882,7 @@
             "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may be appended to the competition level if more than one match in required per set."
           },
           "comp_level": {
-            "type": "string",
-            "description": "The competition level the match was played at.",
-            "enum": [
-              "qm",
-              "ef",
-              "qf",
-              "sf",
-              "f"
-            ]
+            "$ref": "#/components/schemas/Comp_Level"
           },
           "set_number": {
             "type": "integer",
@@ -9544,11 +9543,8 @@
         ],
         "properties": {
           "name": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Alliance name, may be null."
+            "type": "string",
+            "description": "Alliance name."
           },
           "backup": {
             "type": [
@@ -9589,40 +9585,69 @@
           },
           "status": {
             "type": "object",
+            "required": [
+              "current_level_record",
+              "level",
+              "playoff_type",
+              "record",
+              "status"
+            ],
             "properties": {
               "playoff_average": {
                 "type": [
                   "number",
                   "null"
                 ],
-                "format": "double"
+                "format": "double",
+                "description": "Average match score during playoffs. Year specific. May be null."
               },
               "playoff_type": {
                 "type": [
                   "number",
                   "null"
                 ],
-                "format": "int64"
+                "format": "int64",
+                "description": "Playoff type, may be null."
               },
               "level": {
-                "type": "string"
+                "$ref": "#/components/schemas/Comp_Level",
+                "description": "Match level, qm/ef/qf/sf/f."
               },
               "record": {
                 "type": [
                   "object",
                   "null"
                 ],
-                "$ref": "#/components/schemas/WLT_Record"
+                "$ref": "#/components/schemas/WLT_Record",
+                "description": "W-L-T record for the alliance, may be null."
               },
               "current_level_record": {
                 "type": [
                   "object",
                   "null"
                 ],
-                "$ref": "#/components/schemas/WLT_Record"
+                "$ref": "#/components/schemas/WLT_Record",
+                "description": "W-L-T record for the alliance at the current level, may be null."
               },
               "status": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "eliminated",
+                  "playing",
+                  "won"
+                ],
+                "description": "Status of the alliance."
+              },
+              "advanced_to_round_robin_finals": {
+                "type": "boolean",
+                "description": "Whether the alliance advanced to round robin finals."
+              },
+              "double_elim_round": {
+                "$ref": "#/components/schemas/Double_Elim_Round"
+              },
+              "round_robin_rank": {
+                "type": "integer",
+                "description": "Rank in round robin play."
               }
             }
           }
@@ -9871,8 +9896,10 @@
       },
       "District_Ranking": {
         "required": [
+          "event_points",
           "point_total",
           "rank",
+          "rookie_bonus",
           "team_key"
         ],
         "type": "object",
@@ -9938,6 +9965,14 @@
                 }
               }
             }
+          },
+          "adjustments": {
+            "type": "integer",
+            "description": "Any points adjustments applied to the team."
+          },
+          "other_bonus": {
+            "type": "integer",
+            "description": "Any other bonus points awarded to the team."
           }
         },
         "description": "Rank of a team in a district."


### PR DESCRIPTION
- Removes nullable from sort_orders (checked on all instances 1992-2025)
- Adds nullable to `sort_order_info`
- Refactors comp level to its own enum that we can use in pwa
- Refactors Double Elim round to its own enum that we can use in pwa
- Adds some comments (LLM)
- Add adjustments/other_bonus to district rankings (sometimes present)
- Marks event_points / rookie_bonus as required