### PR TITLE
[py3] Configure api service with more workers and threads

### DIFF
--- a/src/api.yaml
+++ b/src/api.yaml
@@ -1,6 +1,6 @@
 service: py3-api
 runtime: python313
-entrypoint: gunicorn -t 0 -b :$PORT backend.api.main:app
+entrypoint: gunicorn -t 0 -b :$PORT --workers 2 --threads 4 backend.api.main:app
 app_engine_apis: true
 
 instance_class: F1
@@ -8,7 +8,7 @@ automatic_scaling:
   max_idle_instances: 1
   target_cpu_utilization: 0.9
   target_throughput_utilization: 0.9
-  max_concurrent_requests: 80
+  max_concurrent_requests: 10
 
 handlers:
   - url: .*


### PR DESCRIPTION
Seems like we weren't actually enabling concurrency properly...

https://docs.cloud.google.com/appengine/docs/standard/python3/runtime#entrypoint_best_practices