### PR TITLE
Allow node engines >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tba-react",
   "version": "0.0.0",
   "engines": {
-    "node": "^24"
+    "node": ">=22"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -114,7 +114,7 @@
     "vitest": "4.0.15"
   },
   "engines": {
-    "node": "24.11.1"
+    "node": ">=22"
   },
   "overrides": {
     "react-is": "19.1.0"


### PR DESCRIPTION
Dependabot needs to be on v22 for now.