### PR TITLE
[pwa] improve team searching

### DIFF
--- a/pwa/app/lib/search/fuzzysortFilterer.ts
+++ b/pwa/app/lib/search/fuzzysortFilterer.ts
@@ -10,11 +10,15 @@ function searchTeams(
   query: string,
   limit: number,
 ): SearchableTeam[] {
-  const results = fuzzysort.go(query, teams, {
-    limit,
-    keys: ['key', 'nickname'],
-    threshold: 0.5,
-  });
+  const results = fuzzysort.go(
+    query,
+    teams.map((t) => ({ ...t, team_number: Number(t.key.substring(3)) })),
+    {
+      limit,
+      keys: ['key', 'nickname', 'team_number'],
+      threshold: 0.5,
+    },
+  );
 
   return results.map((result) => result.obj);
 }


### PR DESCRIPTION
previously typing `27` would bring up multiple teams before team 27. now it's much better with shorter team numbers.