### PR TITLE
[pwa] fix eventlist coloring missing on last event of the table

### DIFF
--- a/pwa/app/components/ui/table.tsx
+++ b/pwa/app/components/ui/table.tsx
@@ -30,7 +30,7 @@ const TableBody = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tbody
     ref={ref}
-    className={cn('[&_tr:last-child]:border-0', className)}
+    className={cn('[&_tr:last-child]:border-b-0', className)}
     {...props}
   />
 ));


### PR DESCRIPTION
<img width="543" height="283" alt="image" src="https://github.com/user-attachments/assets/8055b527-c221-4c0a-8f36-8dc773126985" />


the last event of a table (in this case, ISR #3) wasn't being colored because the table component was overriding the left border