### PR TITLE
[pwa] Tweak team status award bullets

### DIFF
--- a/pwa/app/components/tba/teamEventAppearance.tsx
+++ b/pwa/app/components/tba/teamEventAppearance.tsx
@@ -164,7 +164,7 @@ function TeamStatus({
               <ul
                 className={cn({
                   'list-none': awards.length == 1,
-                  'list-disc': awards.length > 1,
+                  'list-inside list-disc': awards.length > 1,
                 })}
               >
                 {awards.map((award) => {


### PR DESCRIPTION
Before:
<img width="381" height="846" alt="image" src="https://github.com/user-attachments/assets/3aa92268-29b1-4cc2-ab99-e71aa19e62c3" />

After:
<img width="384" height="799" alt="image" src="https://github.com/user-attachments/assets/b682ff75-7dfb-4efc-b962-3e5c8982ac35" />
