### PR TITLE
[pwa] Link cleanup

### DIFF
--- a/pwa/app/components/tba/navigation/footer.tsx
+++ b/pwa/app/components/tba/navigation/footer.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { Link, LinkOptions } from '@tanstack/react-router';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { Fragment } from 'react/jsx-runtime';
 
@@ -13,13 +13,11 @@ import {
 } from '~/components/ui/dropdown-menu';
 import andymarkLogo from '~/images/images/andymark-logo.png';
 import { useTheme } from '~/lib/theme';
-import { FileRouteTypes } from '~/routeTree.gen';
 
-interface InternalLink {
+type InternalLink = {
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   label: string;
-  to: FileRouteTypes['to'];
-}
+} & Pick<LinkOptions, 'to' | 'params'>;
 
 interface ExternalLink {
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;

--- a/pwa/app/components/tba/navigation/navbar.tsx
+++ b/pwa/app/components/tba/navigation/navbar.tsx
@@ -61,7 +61,7 @@ export function Navbar() {
                   className="flex list-none flex-row items-center gap-1 px-6
                     max-sm:hidden"
                 >
-                  {NAV_ITEMS_LIST.map(({ title, to, icon: Icon }) => (
+                  {NAV_ITEMS_LIST.map(({ title, to, params, icon: Icon }) => (
                     <NavigationMenuItem key={title}>
                       <NavigationMenuLink
                         className={`flex cursor-pointer items-center
@@ -69,7 +69,11 @@ export function Navbar() {
                         text-white hover:bg-black/20 hover:text-white`}
                         asChild
                       >
-                        <Link to={to} className="hover:no-underline">
+                        <Link
+                          to={to}
+                          params={params}
+                          className="hover:no-underline"
+                        >
                           <Icon className="text-inherit" />
                           <span>{title}</span>
                         </Link>

--- a/pwa/app/components/tba/teamEventAppearance.tsx
+++ b/pwa/app/components/tba/teamEventAppearance.tsx
@@ -12,7 +12,7 @@ import {
 } from '~/api/tba/read';
 import { AwardBanner } from '~/components/tba/banner';
 import DetailEntity from '~/components/tba/detailEntity';
-import { EventLink, TeamLink } from '~/components/tba/links';
+import { EventLink, EventLocationLink, TeamLink } from '~/components/tba/links';
 import {
   CHANGE_IN_COMP_LEVEL_BREAKER,
   END_OF_DAY_BREAKER,
@@ -64,13 +64,7 @@ export default function TeamEventAppearance({
             )}
           </DetailEntity>
           <DetailEntity icon={<LocationIcon />}>
-            <a
-              href={`https://maps.google.com/maps?q=${encodeURIComponent(`${event.city}, ${event.state_prov}, ${event.country}`)}`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {event.city}, {event.state_prov}, {event.country}
-            </a>
+            <EventLocationLink event={event} />
           </DetailEntity>
         </div>
 

--- a/pwa/app/components/tba/teamPageTeamInfo.tsx
+++ b/pwa/app/components/tba/teamPageTeamInfo.tsx
@@ -1,3 +1,5 @@
+import { TeamLocationLink } from 'app/components/tba/links';
+
 import SponsorsIcon from '~icons/lucide/anchor';
 import SourceIcon from '~icons/lucide/badge-check';
 import StatbotIcon from '~icons/lucide/chart-spline';
@@ -44,11 +46,7 @@ export default function TeamPageTeamInfo({
 
         <div className="mb-2 space-y-1">
           <DetailEntity icon={<LocationIcon />}>
-            <a
-              href={`https://maps.google.com/maps?q=${team.city}, ${team.state_prov}, ${team.country}`}
-            >
-              {team.city}, {team.state_prov}, {team.country}
-            </a>
+            <TeamLocationLink team={team} />
           </DetailEntity>
 
           {sponsors.length > 0 ? (

--- a/pwa/app/lib/navigation/content.ts
+++ b/pwa/app/lib/navigation/content.ts
@@ -1,3 +1,4 @@
+import { LinkOptions } from '@tanstack/react-router';
 import { ElementType } from 'react';
 
 import EventsIcon from '~icons/lucide/calendar';
@@ -6,13 +7,10 @@ import myTBAIcon from '~icons/lucide/star';
 import TeamsIcon from '~icons/lucide/users-round';
 import WebcastIcon from '~icons/lucide/video';
 
-import { FileRouteTypes } from '~/routeTree.gen';
-
-export type NavItemChild = {
+type NavItemChild = {
   title: string;
-  to: FileRouteTypes['to'];
   icon: ElementType;
-};
+} & Pick<LinkOptions, 'to' | 'params'>;
 
 export const NAV_ITEMS_LIST: NavItemChild[] = [
   {
@@ -23,11 +21,13 @@ export const NAV_ITEMS_LIST: NavItemChild[] = [
   {
     title: 'Events',
     to: '/events/{-$year}',
+    params: { year: undefined },
     icon: EventsIcon,
   },
   {
     title: 'Teams',
     to: '/teams/{-$pgNum}',
+    params: { pgNum: undefined },
     icon: TeamsIcon,
   },
   {
@@ -38,6 +38,7 @@ export const NAV_ITEMS_LIST: NavItemChild[] = [
   {
     title: 'Insights',
     to: '/insights/{-$year}',
+    params: { year: undefined },
     icon: InsightsIcon,
   },
 ];

--- a/pwa/app/routes/district.$districtAbbreviation.{-$year}.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.{-$year}.tsx
@@ -14,7 +14,12 @@ import {
 } from '~/api/tba/read';
 import { TitledCard } from '~/components/tba/cards';
 import { DataTable } from '~/components/tba/dataTable';
-import { EventLink, LocationLink, TeamLink } from '~/components/tba/links';
+import {
+  EventLink,
+  EventLocationLink,
+  TeamLink,
+  TeamLocationLink,
+} from '~/components/tba/links';
 import { Badge } from '~/components/ui/badge';
 import { Divider } from '~/components/ui/divider';
 import {
@@ -405,12 +410,7 @@ function DistrictEventsTable({
               <EventLink eventOrKey={event.key}>{event.name}</EventLink>
             </TableCell>
             <TableCell>
-              <LocationLink
-                city={event.city ?? ''}
-                state_prov={event.state_prov ?? ''}
-                country={event.country ?? ''}
-                hideUSA
-              />
+              <EventLocationLink event={event} hideUSA hideVenue />
             </TableCell>
             <TableCell>
               {event.week !== null && (
@@ -490,12 +490,7 @@ function DistrictTeamsTable({ teams, year }: { teams: Team[]; year: number }) {
               </TeamLink>
             </TableCell>
             <TableCell>
-              <LocationLink
-                city={team.city ?? ''}
-                state_prov={team.state_prov ?? ''}
-                country={team.country ?? ''}
-                hideUSA
-              />
+              <TeamLocationLink team={team} hideUSA />
             </TableCell>
             <TableCell>{team.rookie_year}</TableCell>
           </TableRow>

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -36,7 +36,11 @@ import { DataTable } from '~/components/tba/dataTable';
 import DetailEntity from '~/components/tba/detailEntity';
 import EliminationBracket from '~/components/tba/eliminationBracket';
 import InlineIcon from '~/components/tba/inlineIcon';
-import { LocationLink, TeamLink } from '~/components/tba/links';
+import {
+  EventLocationLink,
+  TeamLink,
+  TeamLocationLink,
+} from '~/components/tba/links';
 import {
   CHANGE_IN_COMP_LEVEL_BREAKER,
   CHANGE_IN_DOUBLE_ELIM_ROUND_BREAKER,
@@ -102,7 +106,6 @@ import {
 } from '~/lib/rankingPoints';
 import { sortTeamKeysComparator, sortTeamsComparator } from '~/lib/teamUtils';
 import {
-  STATE_TO_ABBREVIATION,
   camelCaseToHumanReadable,
   cn,
   doThrowNotFound,
@@ -274,15 +277,7 @@ function EventPage() {
           )}
         </DetailEntity>
         <DetailEntity icon={<LocationIcon />}>
-          {event.gmaps_url ? (
-            <a href={event.gmaps_url}>
-              {event.city}, {event.state_prov}, {event.country}
-            </a>
-          ) : (
-            <>
-              {event.city}, {event.state_prov}, {event.country}
-            </>
-          )}
+          <EventLocationLink event={event} />
         </DetailEntity>
         {event.website && (
           <DetailEntity icon={<WebsiteIcon />}>
@@ -449,7 +444,11 @@ function EventPage() {
 
         <TabsContent value="teams">
           {teamsQuery.data && teamMediaQuery.data && (
-            <TeamsTab teams={teamsQuery.data} media={teamMediaQuery.data} />
+            <TeamsTab
+              teams={teamsQuery.data}
+              media={teamMediaQuery.data}
+              year={event.year}
+            />
           )}
         </TabsContent>
 
@@ -524,7 +523,15 @@ function AwardsTab({ awards }: { awards: Award[] }) {
   );
 }
 
-function TeamsTab({ teams, media }: { teams: Team[]; media: Media[] }) {
+function TeamsTab({
+  teams,
+  media,
+  year,
+}: {
+  teams: Team[];
+  media: Media[];
+  year: number;
+}) {
   teams.sort(sortTeamsComparator);
 
   const teamChunks = splitIntoNChunks(teams, 2);
@@ -550,11 +557,6 @@ function TeamsTab({ teams, media }: { teams: Team[]; media: Media[] }) {
               const maybeAvatar = teamMedia.find((m) => m.type === 'avatar');
               const maybeRobotPic = getTeamPreferredRobotPicMedium(teamMedia);
 
-              const abbreviatedStateProv =
-                STATE_TO_ABBREVIATION.get(t.state_prov ?? '') ?? t.state_prov;
-
-              const teamLocation = `${t.city}, ${abbreviatedStateProv}, ${t.country}`;
-
               return (
                 <TableRow key={t.key}>
                   <TableCell
@@ -572,17 +574,13 @@ function TeamsTab({ teams, media }: { teams: Team[]; media: Media[] }) {
                     )}
                   </TableCell>
                   <TableCell className="mt-1 flex flex-col">
-                    <TeamLink teamOrKey={t.key}>{t.team_number}</TeamLink>
+                    <TeamLink teamOrKey={t.key} year={year}>
+                      {t.team_number}
+                    </TeamLink>
                     <div>{t.nickname}</div>
                   </TableCell>
                   <TableCell className={'text-xs'}>
-                    <LocationLink
-                      city={t.city ?? ''}
-                      state_prov={t.state_prov ?? ''}
-                      country={t.country ?? ''}
-                    >
-                      {teamLocation}
-                    </LocationLink>
+                    <TeamLocationLink team={t} />
                   </TableCell>
                   {maybeRobotPic && (
                     <TableCell>

--- a/pwa/tests/team.spec.ts
+++ b/pwa/tests/team.spec.ts
@@ -123,7 +123,7 @@ test.describe('/team/604/2024', () => {
   test('Header', async ({ page }) => {
     await expect(page.locator('h1')).toHaveText('Team 604 - Quixilver');
     await expect(
-      page.getByRole('link', { name: 'San Jose, California, USA' }),
+      page.getByRole('link', { name: 'San Jose, CA, USA' }),
     ).toBeVisible();
 
     await expect(


### PR DESCRIPTION
Need to explicitly set params to undefined, or else it will [inherit](https://tanstack.com/router/latest/docs/framework/react/guide/navigation#parameter-inheritance-vs-removal) the existing one (e.g. navigating from `/team/254/2023` to `/events` ends up at `/events/2023`

Also cleaned up team & event links