### PR TITLE
Don't fail on 3rd party deprecations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ filterwarnings =
     ignore::DeprecationWarning:dateutil
     ignore::DeprecationWarning:flask*
     ignore::DeprecationWarning:google*
+    ignore::DeprecationWarning:httplib2*
     ignore::DeprecationWarning:urllib3
     ignore:Deprecated call to `pkg_resources.declare_namespace\('google'\)
     ignore:'cgi' is deprecated


### PR DESCRIPTION
```
_________________________ ERROR collecting src/backend _________________________
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
src/backend/conftest.py:12: in <module>
    from backend.tests.json_data_importer import JsonDataImporter
src/backend/tests/json_data_importer.py:17: in <module>
    from backend.common.queries.dict_converters.award_converter import AwardConverter
src/backend/common/queries/dict_converters/award_converter.py:10: in <module>
    from backend.common.queries.dict_converters.converter_base import ConverterBase
src/backend/common/queries/dict_converters/converter_base.py:6: in <module>
    from backend.common.profiler import Span
src/backend/common/profiler.py:7: in <module>
    from googleapiclient import discovery
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/googleapiclient/discovery.py:48: in <module>
    import httplib2
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/httplib2/__init__.py:51: in <module>
    from . import auth
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/httplib2/auth.py:19: in <module>
    token = pp.Word(tchar).setName("token")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/pyparsing/util.py:434: in _inner
    warnings.warn(
E   DeprecationWarning: 'setName' deprecated - use 'set_name'
=========================== short test summary info ============================
ERROR src/backend - DeprecationWarning: 'setName' deprecated - use 'set_name'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 1.65s ===============================
```