### PR TITLE
Added navigation select to team stats page, added blue banner count

### DIFF
--- a/pwa/app/routes/team.$teamNumber.history.tsx
+++ b/pwa/app/routes/team.$teamNumber.history.tsx
@@ -131,6 +131,7 @@ function TeamHistoryPage(): React.JSX.Element {
               params: { teamNumber: String(team.team_number), year: value },
             });
           }}
+          value='history'
         >
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder={'History'} />
@@ -220,8 +221,9 @@ function TeamHistoryPage(): React.JSX.Element {
               ))}
             </TableBody>
           </Table>
-          <div>
-            {bannerAwards.length > 0 && (
+          {bannerAwards.length > 0 && (
+            <div>
+              <h1 className="text-xl w-full text-center mb-3"><span className="font-bold">{bannerAwards.length}</span> Blue Banners</h1>
               <div className="flex w-96 flex-row flex-wrap justify-center gap-2">
                 {bannerAwards.map((a) => {
                   const event = history.events.find(
@@ -239,8 +241,8 @@ function TeamHistoryPage(): React.JSX.Element {
                   );
                 })}
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

Added select dropdown for navigating between team history, stats, and specific years on the stats pages. Added default selections of Stats and History on their respective pages. Added blue banner count to team history page.

## Motivation and Context
Navigating to the team stats page leads to a dead end, as the select disappeared. The Stats page select is defaulted to Stats and the History had no default value selected, now it is History. Oftentimes users navigate to history to see their blue banners, so a count was added above the banners for quick reference.

## How Has This Been Tested?
Only web page was tested, page was rendered on mobile and desktop

## Screenshots (if appropriate):

<img width="520" height="596" alt="image" src="https://github.com/user-attachments/assets/673972f3-a64e-4ad6-92ff-69781b7792ca" />

<img width="1243" height="557" alt="image" src="https://github.com/user-attachments/assets/660e92c4-e950-4952-a010-768d141ed791" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
