### PR TITLE
Convenience link when bootstrapping to get APIv3 key

### DIFF
--- a/src/backend/web/templates/local/bootstrap.html
+++ b/src/backend/web/templates/local/bootstrap.html
@@ -51,7 +51,7 @@
         <div class="form-group">
             <label for="apiv3_key">APIv3 Key</label>
             <input type="text" id="apiv3_key" name="apiv3_key" class="form-control" placeholder="APIv3 Key" value="{{apiv3_key}}"/>
-            <small class="form-text text-muted">To save your API key for future use, set it in the <a href="/admin/authkeys">Admin Panel</a></small>
+            <small class="form-text text-muted">Get a Read API key from <a href="https://www.thebluealliance.com/account" target="_blank" rel="noopener noreferrer">thebluealliance.com/account</a>. To save it for future use, set it in the <a href="/admin/authkeys">Admin Panel</a>.</small>
         </div>
         <div class="form-group">
             <label for="bootstrap-key">Data Key</label>


### PR DESCRIPTION
## Description
Adds link to thebluealliance.com/account on /local/bootstrap to make bootstrapping setup easier.

## Motivation and Context
Saves a little bit of effort.

## How Has This Been Tested?
Tested locally.

## Screenshots (if appropriate):
<img width="604" height="280" alt="image" src="https://github.com/user-attachments/assets/9023a859-cef1-4606-ae8f-e157286c74c4" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
