### PR TITLE
Fix pre-2021 FIRST Inspires event links

### DIFF
--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -78,7 +78,7 @@
           </span>
         {% endif %}
         {% if event.website %}<br><span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank" rel="noopener noreferrer">{{ event.website }}</a>{% endif %}
-        {% if event.first_eid or event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="{% if event.first_eid %}https://www.firstinspires.org/team-event-search/event?id={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank" rel="noopener noreferrer">firstinspires.org</a>{% endif %}
+        {% if event.first_eid or event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="{% if event.first_eid %}https://www.firstinspires.org/event-detail?eventId={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank" rel="noopener noreferrer">firstinspires.org</a>{% endif %}
         {% if event.year == 2022 %}{% if event.official %}<br><span class="glyphicon glyphicon-plus"></span> <a href="https://www.firstinspires.org/sites/default/files/uploads/frc/{{event.year}}-events/{{event.year}}_{{event.first_api_code}}_SiteInfo.pdf" target="_blank" rel="noopener noreferrer">COVID-19 Site Information</a>{% endif %}{% endif %}
         {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank" rel="noopener noreferrer">RSVP on Facebook</a><br>{% endif %}
       </p>


### PR DESCRIPTION
## Summary
- Updates the URL format for events with `first_eid` from the deprecated `team-event-search/event?id=` format to the new `event-detail?eventId=` format
- Fixes broken "info on firstinspires.org" links for pre-2021 FRC events

Fixes #8752

## Test plan
- [ ] Visit an event page for a pre-2021 event (e.g., 2019 event)
- [ ] Click the "details on firstinspires.org" link
- [ ] Verify it navigates to the correct FIRST event page instead of a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)