### PR TITLE
Support YouTube Shorts URLs

### DIFF
--- a/src/backend/common/helpers/tests/youtube_video_helper_test.py
+++ b/src/backend/common/helpers/tests/youtube_video_helper_test.py
@@ -42,6 +42,19 @@ def test_parse_id_from_url() -> None:
         == "1v8_2dW7Kik"
     )
 
+    # YouTube Shorts
+    assert (
+        YouTubeVideoHelper.parse_id_from_url(
+            "https://www.youtube.com/shorts/S8m53ArvTRc"
+        )
+        == "S8m53ArvTRc"
+    )
+    # YouTube Shorts without www
+    assert (
+        YouTubeVideoHelper.parse_id_from_url("https://youtube.com/shorts/S8m53ArvTRc")
+        == "S8m53ArvTRc"
+    )
+
     # Standard with start time
     assert (
         YouTubeVideoHelper.parse_id_from_url(

--- a/src/backend/common/helpers/youtube_video_helper.py
+++ b/src/backend/common/helpers/youtube_video_helper.py
@@ -16,6 +16,14 @@ class YouTubePlaylistItem(TypedDict):
 
 
 class YouTubeVideoHelper(object):
+    # Patterns to extract YouTube video ID from various URL formats
+    VIDEO_ID_PATTERNS = [
+        r".*youtu\.be\/([a-zA-Z0-9_-]*)",  # Short links: youtu.be/ID
+        r".*v=([a-zA-Z0-9_-]*)",  # Standard: youtube.com/watch?v=ID
+        r".*/embed/([a-zA-Z0-9_-]*)",  # Embed: youtube.com/embed/ID
+        r".*/shorts/([a-zA-Z0-9_-]*)",  # Shorts: youtube.com/shorts/ID
+    ]
+
     @classmethod
     def parse_id_from_url(cls, youtube_url: str) -> Optional[str]:
         """
@@ -25,18 +33,12 @@ class YouTubeVideoHelper(object):
         """
         youtube_id = None
 
-        # Try to parse for ID
-        regex1 = re.match(r".*youtu\.be\/([a-zA-Z0-9_-]*)", youtube_url)
-        if regex1 is not None:
-            youtube_id = regex1.group(1)
-        else:
-            regex2 = re.match(r".*v=([a-zA-Z0-9_-]*)", youtube_url)
-            if regex2 is not None:
-                youtube_id = regex2.group(1)
-            else:
-                regex3 = re.match(r".*/embed/([a-zA-Z0-9_-]*)", youtube_url)
-                if regex3 is not None:
-                    youtube_id = regex3.group(1)
+        # Try to parse for ID using each pattern
+        for pattern in cls.VIDEO_ID_PATTERNS:
+            match = re.match(pattern, youtube_url)
+            if match is not None:
+                youtube_id = match.group(1)
+                break
 
         # Try to parse for time
         if youtube_id is not None:

--- a/src/backend/common/suggestions/media_parser.py
+++ b/src/backend/common/suggestions/media_parser.py
@@ -40,6 +40,7 @@ class MediaParser:
         MediaType.YOUTUBE_VIDEO: [
             (r".*youtu\.be\/(.*)", 1),
             (r".*v=([a-zA-Z0-9_-]*)", 1),
+            (r".*/shorts/([a-zA-Z0-9_-]*)", 1),
         ],
         MediaType.IMGUR: [
             (r".*imgur.com\/(\w+)\/?\Z", 1),
@@ -66,6 +67,7 @@ class MediaParser:
         ("chiefdelphi.com/media/photos/", MediaType.CD_PHOTO_THREAD),
         ("chiefdelphi.com/t/", MediaType.CD_THREAD),
         ("youtube.com/watch", MediaType.YOUTUBE_VIDEO),
+        ("youtube.com/shorts", MediaType.YOUTUBE_VIDEO),
         ("youtu.be", MediaType.YOUTUBE_VIDEO),
         ("imgur.com/", MediaType.IMGUR),
         ("grabcad.com/library/", MediaType.GRABCAD),

--- a/src/backend/common/suggestions/tests/media_url_parse_test.py
+++ b/src/backend/common/suggestions/tests/media_url_parse_test.py
@@ -39,6 +39,14 @@ class TestMediaUrlParser(unittest.TestCase):
         self.assertEqual(yt_from_playlist["media_type_enum"], MediaType.YOUTUBE_VIDEO)
         self.assertEqual(yt_from_playlist["foreign_key"], "VP992UKFbko")
 
+    def test_youtube_parse_shorts(self) -> None:
+        yt_shorts = MediaParser.partial_media_dict_from_url(
+            "https://www.youtube.com/shorts/S8m53ArvTRc"
+        )
+        self.assertIsNotNone(yt_shorts)
+        self.assertEqual(yt_shorts["media_type_enum"], MediaType.YOUTUBE_VIDEO)
+        self.assertEqual(yt_shorts["foreign_key"], "S8m53ArvTRc")
+
     @pytest.mark.skip(reason="CD media is dead")
     def test_cdphotothread_parsetest_cdphotothread_parse(self):
         cd = MediaParser.partial_media_dict_from_url(


### PR DESCRIPTION
## Summary
- Adds support for parsing YouTube Shorts URLs (`youtube.com/shorts/VIDEO_ID`)
- Refactored `YouTubeVideoHelper.parse_id_from_url` to iterate over a list of patterns instead of nested if-else blocks
- Added `/shorts/` pattern to both `YouTubeVideoHelper` and `MediaParser`

Fixes #8169

## Test plan
- [x] Added unit tests for Shorts URL parsing in `youtube_video_helper_test.py`
- [x] Added unit test for Shorts URL in `media_url_parse_test.py`
- [x] Try submitting a YouTube Shorts video as match media

Works locally:
<img width="772" height="725" alt="image" src="https://github.com/user-attachments/assets/da5bdbe1-195d-4397-8829-a2cf56c2fa9a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)