### PR TITLE
Match meta description including results.

### DIFF
--- a/src/backend/web/handlers/match.py
+++ b/src/backend/web/handlers/match.py
@@ -1,10 +1,11 @@
 import json
 from datetime import timedelta
-from typing import Optional
+from typing import List, Optional
 
 from flask import abort
 from werkzeug.wrappers import Response
 
+from backend.common.consts.alliance_color import AllianceColor
 from backend.common.decorators import cached_public
 from backend.common.flask_cache import make_cached_response
 from backend.common.models.event import Event
@@ -12,6 +13,66 @@ from backend.common.models.keys import MatchKey
 from backend.common.models.match import Match
 from backend.common.models.zebra_motionworks import ZebraMotionWorks
 from backend.web.profiled_render import render_template
+
+
+def _format_team_list(team_keys: List[str]) -> str:
+    """Format team keys like ['frc254', 'frc971B'] into '254, 971B'."""
+    return ", ".join(key.replace("frc", "") for key in team_keys)
+
+
+def _build_match_meta_description(match: Match, event: Event) -> str:
+    """
+    Build a meta description for a match page based on match status.
+
+    Examples:
+    - Played: "Teams 254, 971 beat 433, 1114 with a score of 125 to 120 in Quals 1
+              at the 2024 Event Name in Location. Match results and videos."
+    - Scheduled: "Teams 254, 971 vs 433, 1114 in Quals 1
+                 at the 2024 Event Name in Location."
+    - Unscheduled: "Quals 1 at the 2024 Event Name FIRST Robotics Competition
+                   in Location."
+    """
+    red_teams = match.alliances.get(AllianceColor.RED, {}).get("teams", [])
+    blue_teams = match.alliances.get(AllianceColor.BLUE, {}).get("teams", [])
+    event_suffix = f"at the {event.year} {event.name} in {event.location}."
+
+    # No teams assigned yet
+    if not red_teams:
+        return (
+            f"{match.verbose_name} at the {event.year} {event.name} "
+            f"FIRST Robotics Competition in {event.location}."
+        )
+
+    red_str = _format_team_list(red_teams)
+    blue_str = _format_team_list(blue_teams)
+
+    if match.has_been_played:
+        red_score = match.alliances[AllianceColor.RED]["score"]
+        blue_score = match.alliances[AllianceColor.BLUE]["score"]
+        winner = match.winning_alliance
+
+        if winner == AllianceColor.RED:
+            result = (
+                f"Teams {red_str} beat {blue_str} "
+                f"with a score of {red_score} to {blue_score}"
+            )
+        elif winner == AllianceColor.BLUE:
+            result = (
+                f"Teams {blue_str} beat {red_str} "
+                f"with a score of {blue_score} to {red_score}"
+            )
+        else:
+            # Tie - put red first
+            result = (
+                f"Teams {red_str} tied {blue_str} "
+                f"with a score of {red_score} to {blue_score}"
+            )
+        return (
+            f"{result} in {match.verbose_name} {event_suffix} "
+            f"Match results and videos."
+        )
+    else:
+        return f"Teams {red_str} vs {blue_str} in {match.verbose_name} {event_suffix}"
 
 
 @cached_public
@@ -46,6 +107,7 @@ def match_detail(match_key: MatchKey) -> Response:
         "event": event,
         "match": match,
         "match_breakdown_template": match_breakdown_template,
+        "meta_description": _build_match_meta_description(match, event),
         "timeseries_data": None,  # timeseries_data,
         "zebra_data": json.dumps(zebra_data.data) if zebra_data else None,
     }

--- a/src/backend/web/handlers/tests/match_detail_test.py
+++ b/src/backend/web/handlers/tests/match_detail_test.py
@@ -2,6 +2,170 @@ from bs4 import BeautifulSoup
 from freezegun import freeze_time
 from werkzeug.test import Client
 
+from backend.common.models.event import Event
+from backend.common.models.match import Match
+from backend.web.handlers.match import (
+    _build_match_meta_description,
+    _format_team_list,
+)
+
+
+def test_format_team_list() -> None:
+    assert _format_team_list(["frc254", "frc971", "frc1678"]) == "254, 971, 1678"
+    assert _format_team_list(["frc254B", "frc971"]) == "254B, 971"
+    assert _format_team_list([]) == ""
+
+
+def test_build_meta_description_played_blue_wins(ndb_stub) -> None:
+    event = Event(
+        id="2024test",
+        year=2024,
+        name="Test Regional",
+        event_short="test",
+        event_type_enum=0,
+        city="Test City",
+        state_prov="CA",
+        country="USA",
+    )
+    event.put()
+
+    match = Match(
+        id="2024test_qm1",
+        event=event.key,
+        year=2024,
+        comp_level="qm",
+        set_number=1,
+        match_number=1,
+        alliances_json='{"red": {"teams": ["frc254", "frc971", "frc1678"], "score": 100}, "blue": {"teams": ["frc118", "frc148", "frc2056"], "score": 120}}',
+        team_key_names=["frc254", "frc971", "frc1678", "frc118", "frc148", "frc2056"],
+    )
+
+    description = _build_match_meta_description(match, event)
+    assert description.startswith("Teams 118, 148, 2056 beat 254, 971, 1678")
+    assert "with a score of 120 to 100" in description
+    assert "in Quals 1" in description
+    assert "at the 2024 Test Regional" in description
+    assert "in Test City" in description
+    assert description.endswith("Match results and videos.")
+
+
+def test_build_meta_description_played_red_wins(ndb_stub) -> None:
+    event = Event(
+        id="2024test",
+        year=2024,
+        name="Test Regional",
+        event_short="test",
+        event_type_enum=0,
+        city="Test City",
+        state_prov="CA",
+        country="USA",
+    )
+    event.put()
+
+    match = Match(
+        id="2024test_qm1",
+        event=event.key,
+        year=2024,
+        comp_level="qm",
+        set_number=1,
+        match_number=1,
+        alliances_json='{"red": {"teams": ["frc254", "frc971", "frc1678"], "score": 150}, "blue": {"teams": ["frc118", "frc148", "frc2056"], "score": 120}}',
+        team_key_names=["frc254", "frc971", "frc1678", "frc118", "frc148", "frc2056"],
+    )
+
+    description = _build_match_meta_description(match, event)
+    assert "Teams 254, 971, 1678 beat 118, 148, 2056" in description
+    assert "with a score of 150 to 120" in description
+
+
+def test_build_meta_description_played_tie(ndb_stub) -> None:
+    event = Event(
+        id="2024test",
+        year=2024,
+        name="Test Regional",
+        event_short="test",
+        event_type_enum=0,
+        city="Test City",
+        state_prov="CA",
+        country="USA",
+    )
+    event.put()
+
+    match = Match(
+        id="2024test_qm1",
+        event=event.key,
+        year=2024,
+        comp_level="qm",
+        set_number=1,
+        match_number=1,
+        alliances_json='{"red": {"teams": ["frc254", "frc971", "frc1678"], "score": 100}, "blue": {"teams": ["frc118", "frc148", "frc2056"], "score": 100}}',
+        team_key_names=["frc254", "frc971", "frc1678", "frc118", "frc148", "frc2056"],
+    )
+
+    description = _build_match_meta_description(match, event)
+    # Red listed first in tie
+    assert "Teams 254, 971, 1678 tied 118, 148, 2056" in description
+    assert "with a score of 100 to 100" in description
+
+
+def test_build_meta_description_scheduled(ndb_stub) -> None:
+    event = Event(
+        id="2024test",
+        year=2024,
+        name="Test Regional",
+        event_short="test",
+        event_type_enum=0,
+        city="Test City",
+        state_prov="CA",
+        country="USA",
+    )
+    event.put()
+
+    match = Match(
+        id="2024test_qm1",
+        event=event.key,
+        year=2024,
+        comp_level="qm",
+        set_number=1,
+        match_number=1,
+        alliances_json='{"red": {"teams": ["frc254", "frc971", "frc1678"], "score": -1}, "blue": {"teams": ["frc118", "frc148", "frc2056"], "score": -1}}',
+        team_key_names=["frc254", "frc971", "frc1678", "frc118", "frc148", "frc2056"],
+    )
+
+    description = _build_match_meta_description(match, event)
+    assert "Match results and video" not in description
+    assert "Teams 254, 971, 1678 vs 118, 148, 2056" in description
+    assert "in Quals 1" in description
+
+
+def test_build_meta_description_unscheduled(ndb_stub) -> None:
+    event = Event(
+        id="2024test",
+        year=2024,
+        name="Test Regional",
+        event_short="test",
+        event_type_enum=0,
+        city="Test City",
+        state_prov="CA",
+        country="USA",
+    )
+    event.put()
+
+    match = Match(
+        id="2024test_qm1",
+        event=event.key,
+        year=2024,
+        comp_level="qm",
+        set_number=1,
+        match_number=1,
+        alliances_json='{"red": {"teams": [], "score": -1}, "blue": {"teams": [], "score": -1}}',
+        team_key_names=[],
+    )
+
+    description = _build_match_meta_description(match, event)
+    assert "Quals 1 at the 2024 Test Regional" in description
+    assert "FIRST Robotics Competition" in description
+
 
 def test_get_bad_match_key(web_client: Client) -> None:
     resp = web_client.get("/match/asoudfhsakj")
@@ -37,3 +201,28 @@ def test_render_match_short_cache(web_client: Client, setup_full_match) -> None:
     resp = web_client.get("/match/2019nyny_qm1")
     assert resp.status_code == 200
     assert "max-age=61" in resp.headers["Cache-Control"]
+
+
+def test_render_match_meta_description(web_client: Client, setup_full_match) -> None:
+    setup_full_match("2019nyny_qm1")
+
+    resp = web_client.get("/match/2019nyny_qm1")
+    assert resp.status_code == 200
+
+    soup = BeautifulSoup(resp.data, "html.parser")
+
+    # Check meta description tag
+    meta_desc = soup.find("meta", {"name": "description"})
+    assert meta_desc is not None
+    content = meta_desc.get("content")
+    # Blue won 49-39, so blue teams should be listed first
+    assert content.startswith("Teams 1880, 743, 6590 beat 4640, 354, 5599")
+    assert "with a score of 49 to 39" in content
+    assert "in Quals 1" in content
+    assert "2019 New York City Regional" in content
+    assert content.endswith("Match results and videos.")
+
+    # Check og:description tag
+    og_desc = soup.find("meta", {"property": "og:description"})
+    assert og_desc is not None
+    assert og_desc.get("content") == content

--- a/src/backend/web/templates/match_details.html
+++ b/src/backend/web/templates/match_details.html
@@ -3,7 +3,7 @@
 
 {% block title %}{{match.verbose_name}} - {{event.name}} {{event.year}} - The Blue Alliance{% endblock %}
 
-{% block meta_description %}Match results and video for {{match.verbose_name}} at the {{event.year}} {{event.name}} FIRST Robotics Competition (FRC) in {{event.location}}.{% endblock %}
+{% block meta_description %}{{meta_description}}{% endblock %}
 
 {% block more_head_tags %}
   <meta property="og:title" content="{{match.verbose_name}} - {{event.year}} {{event.name}}" />
@@ -14,7 +14,7 @@
   {% else %}
     <meta property="og:image" content="https://www.thebluealliance.com/images/logo_square_512.png" />
   {% endif %}
-  <meta property="og:description" content="{{match.verbose_name}} at the {{event.year}} {{event.name}} FIRST Robotics Competition in {{event.location}}."/>
+  <meta property="og:description" content="{{meta_description}}"/>
   <meta property="og:site_name" content="The Blue Alliance" />
   {% if match.youtube_videos_formatted %}
     <meta property="og:video" content="https://www.youtube.com/v/{{match.youtube_videos_formatted.0}}" />


### PR DESCRIPTION
Include more information in meta descriptions to improve search engine and social media results.

Fixes #4292 

## Description
Include who beat who with what scores, or who is playing who if just scheduled.

## Motivation and Context
Better for search and social.

## How Has This Been Tested?
New tests.
Loaded view-source:http://localhost:8080/match/2010dc_qm1 and confirmed <meta> tag was as expected.

## Screenshots (if appropriate):
```
<meta property="og:description" content="Teams 48, 2377, 701 beat 2537, 3340, 3246 with a score of 4 to 0 in Quals 1 at the 2010 Washington DC  Regional in Washington, DC, USA. Match results and videos."/>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
