### PR TITLE
remove PWA E2E Test from PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -299,49 +299,6 @@ jobs:
       - name: Run Build
         run: pnpm --dir pwa run build
 
-  pwa-e2e:
-    name: "[pwa] E2E Tests"
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: "10.24.0"
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "pnpm"
-          cache-dependency-path: "pwa/pnpm-lock.yaml"
-
-      - name: Install Dependencies
-        working-directory: pwa
-        run: pnpm install --frozen-lockfile
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pwa/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install Playwright Browsers
-        working-directory: pwa
-        run: pnpm exec playwright install --with-deps chromium webkit
-
-      - name: Run Playwright tests
-        working-directory: pwa
-        run: pnpm exec playwright test
-        env:
-          VITE_TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
-          VITE_FIREBASE_API_KEY: "fake-api-key"
-          VITE_FIREBASE_AUTH_DOMAIN: "demo-test"
-          VITE_FIREBASE_PROJECT_ID: "demo-test"
-
   check-pwa-api:
     name: "[pwa] Check API regeneration"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This is the other way to fix https://github.com/the-blue-alliance/the-blue-alliance/issues/8811 :stuck_out_tongue: 

Since this is getting noisy, and we shouldn't be having "expected" failures on diffs.