### PR TITLE
Fix admin homepage stats

### DIFF
--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -2,7 +2,6 @@ from flask import abort, Blueprint
 from google.appengine.api import users as gae_login
 
 from backend.common.consts.suggestion_state import SuggestionState
-from backend.common.environment import Environment
 from backend.common.memcache import MemcacheClient
 from backend.common.models.account import Account
 from backend.common.models.suggestion import Suggestion
@@ -143,15 +142,6 @@ def admin_home() -> str:
         "memcache_stats": memcache_stats,
         "users": users,
         "suggestions_count": suggestions_count,
-        "contbuild_enabled": False,
-        "git_branch_name": "",
-        "build_time": "",
-        "build_number": "",
-        "commit_hash": "",
-        "commit_author": "",
-        "commit_date": "",
-        "commit_msg": "",
-        "debug": Environment.is_dev(),
     }
     return render_template("admin/index.html", template_values)
 

--- a/src/backend/web/templates/admin/base.html
+++ b/src/backend/web/templates/admin/base.html
@@ -77,8 +77,6 @@
               <li>Events</li>
               <li><a href="/admin/events">View all</a></li>
               <li><a href="/admin/event/create">Create</a></li>
-              <li><a href="/admin/offseasons">Scrape USFIRST Offseasons</a></li>
-              <li><a href="/admin/offseasons/spreadsheet">Scrape Spreadsheet Offseasons</a></li>
 
               <li>Districts</li>
               <li><a href="/admin/districts">View all</a></li>
@@ -87,7 +85,6 @@
 
               <li>Matches</li>
               <li><a href="/admin/matches">Edit</a></li>
-              <li><a href="/admin/match/cleanup">Cleanup</a></li>
 
               <li>Awards</li>
               <li><a href="/admin/awards">Edit</a></li>
@@ -95,8 +92,6 @@
               <li>Media</li>
               <li><a href="/admin/gameday">GameDay</a></li>
               <li><a href="/admin/media">Dashboard</a></li>
-              <li><a href="/admin/media/import/instagram">Bulk Import from Instagram</a></li>
-              <li><a href="/admin/videos/add">Add YouTube Videos</a></li>
 
               <li>Teams</li>
               <li><a href="/admin/media/modcodes/list">View Mods</a></li>
@@ -111,21 +106,12 @@
               <li><a href="/admin/api_auth/add">Add Authentication</a></li>
               <li><a href="/admin/api_auth/manage">Manage Authentication</a></li>
 
-              <li>Migration</li>
-              <li><a href="/admin/migration">Migration Utils</a></li>
-
-              <li>Memcache</li>
-              <li><a href="/admin/memcache">Stats + Flushing</a></li>
-
               <li>Misc</li>
-              <li><a href="/admin/debug">Debug Panel</a></li>
               <li><a href="/admin/sitevars">Sitevars</a></li>
               <li><a href="/admin/main_landing">Landing Page Config</a></li>
               <li><a href="/admin/tasks">Task Launcher</a></li>
-              <li><a href="/admin/mobile">Mobile Clients</a></li>
               <li><a href="/admin/apistatus">API Status</a></li>
               <li><a href="/admin/authkeys">Third Party API Keys</a></li>
-              <li><a href="/admin/tbans">TBANS Debug</a></li>
               <li><a href="/admin/cache">CachedQueryResult Debug</a></li>
             </ul>
           </div>

--- a/src/backend/web/templates/admin/index.html
+++ b/src/backend/web/templates/admin/index.html
@@ -14,7 +14,7 @@ $(function () {
             plotShadow: false
         },
         title: {
-            text: '<a href="/admin/memcache">Memcache</a>',
+            text: '<a href="/admin/cache">Memcache</a>',
             useHTML: true
         },
         tooltip: {
@@ -59,57 +59,13 @@ $(function () {
 {% block content %}
 
 <div class="row">
-    <div class="col-xs-6">
-        <div class="panel {% if debug %}panel-default{% else %}panel-primary{% endif %}">
-            <div class="panel-heading">
-                <h3 class="panel-title">{% if debug %}Development{% else %}Production{% endif %} Server Version Info</h3>
-            </div>
-            <div class="panel-body">
-                <p>Build time: {{build_time}}</p>
-                <br>
-                <p>Branch: <strong>{{git_branch_name}}</strong></p>
-                <p class="text-warning">Commit: <a href="https://github.com/the-blue-alliance/the-blue-alliance/commit/{{commit_hash.1}}">{{commit_hash.1}}</a></p>
-                <p>{{commit_author}}</p>
-                <p>{{commit_date}}</p>
-                <p>{{commit_msg}}</p>
-            </div>
-        </div>
-    </div>
-    <div class="col-xs-6">
-       <div class="panel panel-info">
-          <div class="panel-heading">
-            <h3 class="panel-title">Continuous Deployment</h3>
-          </div>
-         <div class="panel-body">
-           <p>Continuous Deployment is <b>{% if contbuild_enabled %}ENABLED{% else %}DISABLED{% endif %}</b>!
-           </p>
-           <img src="https://travis-ci.org/the-blue-alliance/the-blue-alliance.svg?branch=master" />
-           <p>Travis build: {% if build_number %}<a href="https://travis-ci.org/the-blue-alliance/the-blue-alliance/builds/{{ build_number }}">{{ build_number }}</a>{% else %}unknown{% endif %}</p>
-           <a class="btn btn-danger" href="/admin/contbuild/{% if contbuild_enabled %}disable{% else %}enable{% endif %}">
-             <span class="glyphicon glyphicon-{% if contbuild_enabled %}pause{% else %}play{% endif %}"></span> {% if contbuild_enabled %}Disable{% else %}Enable{% endif %} Continuous Push
-           </a>
-         </div>
-       </div>
-       <div class="panel panel-default">
+    <div class="col-xs-12">
+        <div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title">Setup</h3>
             </div>
             <div class="panel-body">
-                <div class="alert alert-info">Run <code>paver setup</code> to set up a dev instance.</div>
-                <div class="btn-group">
-                    <a class="btn btn-default" href="/tasks/get/fms_team_list">Get FMS Teams</a>
-                </div>
-                <div class="btn-group">
-                    <a class="btn btn-default" href="/admin/team/create/test">Create Test Teams</a>
-                    <a class="btn btn-default" href="/admin/event/create/test">Create Test Events</a>
-                    <a class="btn btn-default" href="/admin/suggestions/create/test">Create Test Suggestions</a>
-                    <a class="btn btn-default" href="/admin/user/create/test">Give Current User All Permissions</a>
-                </div>
-                <br /><br />
-                <form class="form-inline" action="/admin/memcache" method="post">
-                    <input name="webcast_keys" value="webcast_keys" type="hidden" />
-                    <button class="btn btn-danger" type="submit"><span class="glyphicon glyphicon-trash"></span> Flush Webcast Memcache</button>
-                </form>
+                <p>See the <a href="https://github.com/the-blue-alliance/the-blue-alliance/blob/master/docs/Setup/Setup-Guide-Beta.md">Setup Guide</a> to set up a dev instance.</p>
             </div>
         </div>
     </div>
@@ -158,9 +114,6 @@ $(function () {
             </div>
         </div>
     </div>
-</div>
-<div class="row">
-
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Remove dead links from /admin

## Description
Removes links to deprecated tools from /admin to make the page easier to parse and use

## Motivation and Context
Makes it more obvious what works and doesn't

## How Has This Been Tested?
1. Load /admin locally, compare to prod
2. New tests

## Screenshots (if appropriate):
### Before
<img width="1183" height="728" alt="image" src="https://github.com/user-attachments/assets/b5a68b79-183a-4b03-bc47-f91919d880f0" />

### After
(green means 'local dev', not a style change)
<img width="1188" height="792" alt="image" src="https://github.com/user-attachments/assets/894f463f-4027-4b44-81af-39f1f51eae93" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
