### PR TITLE
Add logging to try and event events with missing year

### DIFF
--- a/src/backend/common/helpers/offseason_event_helper.py
+++ b/src/backend/common/helpers/offseason_event_helper.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Tuple
 
 from backend.common.futures import TypedFuture
@@ -8,11 +9,17 @@ from backend.common.queries.event_query import EventListQuery
 
 class OffseasonEventHelper:
     @classmethod
-    def is_direct_match(cls, tba_event: Event, first_event: Event) -> None:
-        return tba_event.key_name == first_event.key_name or (
-            tba_event.first_code
-            and tba_event.first_code.lower() == first_event.event_short
-        )
+    def is_direct_match(cls, tba_event: Event, first_event: Event) -> bool:
+        try:
+            return tba_event.key_name == first_event.key_name or (
+                tba_event.first_code
+                and tba_event.first_code.lower() == first_event.event_short
+            )
+        except Exception as e:
+            logging.exception(
+                f"Error checking direct match between TBA event {tba_event.key_name} and FIRST event {first_event.key_name}: {e}\n{tba_event}"
+            )
+            return False
 
     @classmethod
     def is_maybe_match(cls, tba_event: Event, first_event: Event) -> bool:

--- a/src/backend/web/handlers/admin/tests/admin_blueprint_test.py
+++ b/src/backend/web/handlers/admin/tests/admin_blueprint_test.py
@@ -69,7 +69,9 @@ def test_admin_home_shows_pending_suggestions_count(
         resp.data,
     )
     assert match is not None, "Could not find pending suggestions badge"
-    assert match.group(1) == b"2", f"Expected 2 pending suggestions, got {match.group(1)}"
+    assert (
+        match.group(1) == b"2"
+    ), f"Expected 2 pending suggestions, got {match.group(1)}"
 
 
 def test_admin_home_shows_recent_users(


### PR DESCRIPTION
Towards https://github.com/the-blue-alliance/the-blue-alliance/issues/8862

So we can at least try to find which events are messed up