### PR TITLE
Auto-populate event type for offseason event suggestions

### DIFF
--- a/src/backend/common/models/suggestion_dict.py
+++ b/src/backend/common/models/suggestion_dict.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, TypedDict
 
 from backend.common.consts.auth_type import AuthType
+from backend.common.consts.event_type import EventType
 from backend.common.consts.media_type import MediaType
 from backend.common.models.keys import Year
 from backend.common.models.webcast import Webcast
@@ -30,6 +31,7 @@ class SuggestionDict(TypedDict, total=False):
     state: str
     country: str
     venue_name: str
+    event_type: Optional[EventType]
 
     # For apiwrite suggestions
     event_key: str

--- a/src/backend/common/suggestions/tests/suggestion_creator_test.py
+++ b/src/backend/common/suggestions/tests/suggestion_creator_test.py
@@ -484,6 +484,50 @@ class TestOffseasonEventSuggestionCreator(SuggestionCreatorTest):
         self.assertEqual(status, "validation_failure")
         self.assertTrue("end_date" in none_throws(failures))
 
+    def test_event_type_preseason(self) -> None:
+        """Events in January or February should be classified as PRESEASON"""
+        status, _ = SuggestionCreator.createOffseasonEventSuggestion(
+            self.account.key,
+            "Preseason Event",
+            "2016-02-15",
+            "2016-02-16",
+            "http://foo.bar.com",
+            "The Venue",
+            "123 Fake Street",
+            "New York",
+            "NY",
+            "USA",
+        )
+        self.assertEqual(status, "success")
+
+        suggestions = Suggestion.query().fetch()
+        self.assertEqual(len(suggestions), 1)
+
+        suggestion = cast(Suggestion, suggestions[0])
+        self.assertEqual(suggestion.contents["event_type"], EventType.PRESEASON)
+
+    def test_event_type_offseason(self) -> None:
+        """Events in March or later should be classified as OFFSEASON"""
+        status, _ = SuggestionCreator.createOffseasonEventSuggestion(
+            self.account.key,
+            "Offseason Event",
+            "2016-05-15",
+            "2016-05-16",
+            "http://foo.bar.com",
+            "The Venue",
+            "123 Fake Street",
+            "New York",
+            "NY",
+            "USA",
+        )
+        self.assertEqual(status, "success")
+
+        suggestions = Suggestion.query().fetch()
+        self.assertEqual(len(suggestions), 1)
+
+        suggestion = cast(Suggestion, suggestions[0])
+        self.assertEqual(suggestion.contents["event_type"], EventType.OFFSEASON)
+
 
 class TestApiWriteSuggestionCreator(SuggestionCreatorTest):
     def test_create_suggestion(self) -> None:

--- a/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
@@ -65,11 +65,12 @@ class SuggestOffseasonEventReviewController(
         first_code = request.form.get("first_code")
         if first_code:
             first_code = first_code.upper()
+        event_type_enum = int(request.form.get("event_type_enum", EventType.OFFSEASON))
         event = Event(
             id=event_key,
             end_date=end_date,
             event_short=event_short,
-            event_type_enum=EventType.OFFSEASON,
+            event_type_enum=EventType(event_type_enum),
             district_key=None,
             venue=request.form.get("venue"),
             venue_address=request.form.get("venue_address"),
@@ -196,9 +197,10 @@ The Blue Alliance Admins\
         state = suggestion.contents["state"]
         country = suggestion.contents["country"]
         address = "{}\n{}\n{}, {}, {}".format(venue, address, city, state, country)
+        event_type = suggestion.contents.get("event_type", EventType.OFFSEASON)
         return none_throws(suggestion.key.id()), Event(
             end_date=end_date,
-            event_type_enum=EventType.OFFSEASON,
+            event_type_enum=event_type or EventType.OFFSEASON,
             district_key=None,
             venue=venue,
             city=city,

--- a/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_controller_test.py
+++ b/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_controller_test.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 from werkzeug.test import Client
 
+from backend.common.consts.event_type import EventType
 from backend.common.consts.suggestion_state import SuggestionState
 from backend.common.models.suggestion import Suggestion
 from backend.common.models.suggestion_dict import SuggestionDict
@@ -125,4 +126,5 @@ def test_suggest_event(
         country="USA",
         venue_name="This is a Venue",
         first_code=None,
+        event_type=EventType.OFFSEASON,
     )

--- a/src/backend/web/templates/event_partials/suggest_event_info.html
+++ b/src/backend/web/templates/event_partials/suggest_event_info.html
@@ -13,7 +13,16 @@
             <td><input type="text" name="first_code" {% if event.first_code%}value="{{ event.first_code }}{% endif %}"/></td>
             <td><p><strong>Example:</strong><br>IRI</p></td>
         </tr>
-        <tr><td>&nbsp;</td></tr>
+        <tr>
+            <td>Event Type</td>
+            <td>
+                <select name="event_type_enum">
+                    <option value="100" {% if event.event_type_enum == 100 %}selected{% endif %}>Preseason</option>
+                    <option value="99" {% if event.event_type_enum == 99 or event.event_type_enum != 100 %}selected{% endif %}>Offseason</option>
+                </select>
+            </td>
+            <td><p><strong>Preseason:</strong> Jan-Feb<br><strong>Offseason:</strong> Mar+</p></td>
+        </tr>
         <tr>
             <td>Name</td>
             <td><input type="text" name="name" {% if event.name %}value="{{ event.name }}"{% endif %}/></td>
@@ -26,17 +35,17 @@
         </tr>
         <tr>
             <td>Dates</td>
-            <td>
+            <td colspan="2">
                 <input type="text" name="start_date" {% if event.start_date %}value="{{ event.start_date.strftime("%Y-%m-%d")}}"{% endif %} placeholder="2012-04-04"/> to <input type="text" name="end_date" {% if event.end_date %}value="{{ event.end_date.strftime("%Y-%m-%d")}}" {% endif %}placeholder="2012-04-06"/>
             </td>
         </tr>
         <tr>
             <td>Website</td>
-            <td><input type="text" name="website" {% if event.website %}value="{{ event.website }}"{% endif %}/></td>
+            <td colspan="2"><input type="text" name="website" {% if event.website %}value="{{ event.website }}"{% endif %}/></td>
         </tr>
         <tr>
             <td>Year</td>
-            <td><input type="text" name="year" {% if event.year %}value="{{ event.year }}"{% endif %}/></td>
+            <td colspan="2"><input type="text" name="year" {% if event.year %}value="{{ event.year }}"{% endif %}/></td>
         </tr>
         <tr>
             <td>Event Venue</td>


### PR DESCRIPTION
## Summary

- Automatically determines Preseason vs Offseason event type when users suggest events
- Adds admin dropdown to override the auto-detected type during review

### Image
After Submit
<img width="1161" height="1323" alt="image" src="https://github.com/user-attachments/assets/1f8bc3af-a257-4440-ba20-c2e78901d54b" />

After Accept
<img width="1023" height="315" alt="image" src="https://github.com/user-attachments/assets/8d2ba526-2584-4473-bd4d-560140bcbf02" />


## Motivation

Previously, all suggested offseason events were hardcoded as `EventType.OFFSEASON`. This meant preseason events (January/February) were incorrectly categorized, requiring manual database fixes.

## Architecture

### Event Type Detection Logic
- **Preseason (EventType=100)**: Events with start date in January or February
- **Offseason (EventType=99)**: Events with start date in March or later (default)

### Data Flow

```
User submits suggestion → SuggestionCreator parses date → Determines event_type → Stores in suggestion.contents
                                                                                          ↓
Admin reviews suggestion ← _create_candidate_event reads event_type ← Shows in review form with dropdown
                                                                                          ↓
Admin accepts → create_target_model reads event_type_enum from form → Creates Event with correct type
```

### Files Modified

| File | Change |
|------|--------|
| `suggestion_dict.py` | Added `event_type: Optional[int]` field |
| `suggestion_creator.py` | Auto-detect event type from start date |
| `suggest_event_info.html` | Added Event Type dropdown for admins |
| `suggest_offseason_event_review_controller.py` | Read event_type from suggestion and form |

## Test plan

- [x] `test_event_type_preseason` - February date → PRESEASON type stored
- [x] `test_event_type_offseason` - May date → OFFSEASON type stored  
- [x] `test_accept_suggestion_preseason` - Accepting preseason creates PRESEASON event
- [x] `test_accept_suggestion_default_offseason` - Default behavior is OFFSEASON
- [x] `test_accept_suggestion_override_to_offseason` - Admin can override preseason to offseason

All 16 tests pass.

🤖 Generated with [Claude Code](https://claude.ai/code)