### PR TITLE
Fix table layout issues on admin authkeys page

### DIFF
--- a/src/backend/web/templates/admin/authkeys.html
+++ b/src/backend/web/templates/admin/authkeys.html
@@ -9,40 +9,40 @@
 
 <form method="post">
 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-<table class="table table-striped">
-  <tr><th>TBA API</th></tr>
+<table class="table">
+  <tr class="active"><th colspan="2">TBA API</th></tr>
   <tr><td>API v3 Key</td><td><input name="apiv3_key" value="{{apiv3_key}}" class="form-control"/></td></tr>
 
-  <tr><th>Google</th></tr>
+  <tr class="active"><th colspan="2">Google</th></tr>
   <tr><td>API Key</td><td><input name="google_secret" value="{{google_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>Firebase</th></tr>
+  <tr class="active"><th colspan="2">Firebase</th></tr>
   <tr><td>API Key</td><td><input name="firebase_secret" value="{{firebase_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>FMS API</th></tr>
+  <tr class="active"><th colspan="2">FMS API</th></tr>
   <tr><td>Username</td><td><input name="fmsapi_user" value="{{fmsapi_user}}" class="form-control"/></td></tr>
   <tr><td>Auth Key</td><td><input name="fmsapi_secret" value="{{fmsapi_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>Mobile Apps</th></tr>
+  <tr class="active"><th colspan="2">Mobile Apps</th></tr>
   <tr><td>FCM Key</td><td><input name="gcm_key" value="{{gcm_key}}" class="form-control"/></td></tr>
   <tr><td>Web Client ID</td><td><input name="web_client_id" value="{{web_client_id}}" class="form-control"/></td></tr>
   <tr><td>Android Client ID</td><td><input name="android_client_id" value="{{android_client_id}}" class="form-control"/></td></tr>
   <tr><td>iOS Client ID</td><td><input name="ios_client_id" value="{{ios_client_id}}" class="form-control"/></td></tr>
 
-  <tr><th>Twitch</th></tr>
+  <tr class="active"><th colspan="2">Twitch</th></tr>
   <tr><td>Client ID</td><td><input name="twitch_client_id" value="{{twitch_client_id}}" class="form-control"/></td></tr>
   <tr><td>Secret</td><td><input name="twitch_secret" value="{{twitch_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>Livestream</th></tr>
+  <tr class="active"><th colspan="2">Livestream</th></tr>
   <tr><td>API Key</td><td><input name="livestream_secret" value="{{livestream_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>Instagram</th></tr>
+  <tr class="active"><th colspan="2">Instagram</th></tr>
   <tr><td>API Key</td><td><input name="instagram_secret" value="{{instagram_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>Nexus</th></tr>
+  <tr class="active"><th colspan="2">Nexus</th></tr>
   <tr><td>API Key</td><td><input name="nexus_secret" value="{{nexus_secret}}" class="form-control"/></td></tr>
 
-  <tr><th>Chief Delphi</th></tr>
+  <tr class="active"><th colspan="2">Chief Delphi</th></tr>
   <tr><td>User-Agent</td><td><input name="cd_request_user_agent" value="{{cd_request_user_agent}}" class="form-control"/></td></tr>
 </table>
 


### PR DESCRIPTION
## Summary
- Fixed column mismatch causing weird text wrapping (section headers had 1 cell, data rows had 2)
- Added `colspan="2"` to section header `<th>` elements
- Replaced zebra striping with grey backgrounds on section headers for cleaner visual hierarchy

<img width="1167" height="581" alt="image" src="https://github.com/user-attachments/assets/1ed50960-b2a3-4587-8d65-af6de87bca0a" />


## Test plan
- [ ] Visit `/admin/authkeys` and verify table displays correctly
- [ ] Section headers should have grey backgrounds and span full width
- [ ] Data rows should have white backgrounds
- [ ] No weird text wrapping or column width issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)