### PR TITLE
Fix /avatars memcache overflow with 10k+ teams

### DIFF
--- a/src/backend/web/handlers/index.py
+++ b/src/backend/web/handlers/index.py
@@ -208,11 +208,12 @@ def avatar_list(year: Optional[Year] = None) -> Response:
 
     memcache = MemcacheClient.get()
 
+    NUM_SHARDS = 20
     avatars = []
     shards = memcache.get_multi(
-        [f"{year}avatars_{i}".encode("utf-8") for i in range(10)]
+        [f"{year}avatars_{i}".encode("utf-8") for i in range(NUM_SHARDS)]
     )
-    if len(shards) == 10:  # If missing a shard, must refetch all
+    if len(shards) == NUM_SHARDS:  # If missing a shard, must refetch all
         for _, shard in sorted(shards.items(), key=lambda kv: kv[0]):
             avatars += shard
 
@@ -225,8 +226,8 @@ def avatar_list(year: Optional[Year] = None) -> Response:
         avatars = sorted(avatars, key=lambda a: int(a.references[0].id()[3:]))
 
         shards = {}
-        size = len(avatars) / 10 + 1
-        for i in range(10):
+        size = len(avatars) / NUM_SHARDS + 1
+        for i in range(NUM_SHARDS):
             start = i * size
             end = start + size
             shards[f"{year}avatars_{i}"] = avatars[int(start) : int(end)]


### PR DESCRIPTION
## Summary
- Increase avatar cache shards from 10 to 20 to fix `ValueError` when caching avatar data
- With 10,000+ teams now having avatars, individual shards were exceeding memcache's 1MB value limit

## Error
```
ValueError: Values may not be more than 1000000 bytes in length; received 1065653 bytes
```

```
Exception on /avatars [GET]
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/workspace/backend/common/decorators.py", line 31, in decorated_function
    resp = make_response(cached(func)(*args, **kwargs))
                         ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/flask_caching/__init__.py", line 426, in decorated_function
    rv = self._call_fn(f, *args, **kwargs)
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/flask_caching/__init__.py", line 185, in _call_fn
    return ensure_sync(fn)(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/workspace/backend/web/handlers/index.py", line 233, in avatar_list
    memcache.set_multi(shards, 60 * 60 * 24)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/backend/common/cache/gae_builtin_cache.py", line 41, in set_multi
    self.memcache_client.set_multi(mapping, time=(time or 0), namespace=namespace)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/api/memcache/__init__.py", line 1207, in set_multi
    return self._set_multi_with_policy(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        MemcacheSetRequest.SET,
        ^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        key_prefix=key_prefix,
        ^^^^^^^^^^^^^^^^^^^^^^
        namespace=namespace)
        ^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/api/memcache/__init__.py", line 1089, in _set_multi_with_policy
    rpc = self._set_multi_async_with_policy(policy, mapping, time, key_prefix,
                                            namespace)
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/api/memcache/__init__.py", line 1136, in _set_multi_async_with_policy
    stored_value, flags = _validate_encode_value(value, self._do_pickle)
                          ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/api/memcache/__init__.py", line 302, in _validate_encode_value
    raise ValueError('Values may not be more than %d bytes in length; '
                     'received %d bytes' % (MAX_VALUE_SIZE, len(stored_value)))
ValueError: Values may not be more than 1000000 bytes in length; received 1065653 bytes
```

## Test plan
- [ ] Deploy and verify `/avatars` page loads without error
- [ ] Verify avatars are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)