### PR TITLE
Fix Match_alliance score description in API spec

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -1965,7 +1965,7 @@ export type MatchTimeseries2018 = {
 
 export type MatchAlliance = {
   /**
-   * Score for this alliance. Will be null or -1 for an unplayed match.
+   * Score for this alliance. Will be -1 for an unplayed match.
    */
   score: number;
   team_keys: Array<string>;

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -9326,7 +9326,7 @@
         "properties": {
           "score": {
             "type": "integer",
-            "description": "Score for this alliance. Will be null or -1 for an unplayed match."
+            "description": "Score for this alliance. Will be -1 for an unplayed match."
           },
           "team_keys": {
             "type": "array",


### PR DESCRIPTION
## Summary
- Fixes the `Match_alliance.score` description in the API spec to accurately state that the score will be `-1` for unplayed matches
- The previous description incorrectly said "null or -1" but the code always converts null to -1 before returning

Fixes #7395

## Test plan
- [ ] Verify the API spec description is accurate by checking `src/backend/common/models/match.py` lines 174-179 where null scores are converted to -1

🤖 Generated with [Claude Code](https://claude.com/claude-code)