### PR TITLE
Add missing Webcast fields to API spec

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -2525,6 +2525,18 @@ export type Webcast = {
    * File identification as may be required for some types. May be null.
    */
   file?: string | null;
+  /**
+   * The online status of the webcast, fetched from the streaming provider's API. May be null if not available.
+   */
+  status?: 'unknown' | 'online' | 'offline';
+  /**
+   * The title of the stream from the streaming provider. May be null.
+   */
+  stream_title?: string | null;
+  /**
+   * The current viewer count from the streaming provider. May be null.
+   */
+  viewer_count?: number | null;
 };
 
 export type Zebra = {

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -1552,6 +1552,9 @@ export const zWebcast = z.object({
   channel: z.string(),
   date: z.optional(z.union([z.string(), z.null()])),
   file: z.optional(z.union([z.string(), z.null()])),
+  status: z.optional(z.enum(['unknown', 'online', 'offline'])),
+  stream_title: z.optional(z.union([z.string(), z.null()])),
+  viewer_count: z.optional(z.union([z.int(), z.null()])),
 });
 
 export const zEvent = z.object({

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -10418,6 +10418,32 @@
               "null"
             ],
             "description": "File identification as may be required for some types. May be null."
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The online status of the webcast, fetched from the streaming provider's API. May be null if not available.",
+            "enum": [
+              "unknown",
+              "online",
+              "offline"
+            ]
+          },
+          "stream_title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The title of the stream from the streaming provider. May be null."
+          },
+          "viewer_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The current viewer count from the streaming provider. May be null."
           }
         }
       },


### PR DESCRIPTION
## Summary
- Adds `status`, `stream_title`, and `viewer_count` fields to the Webcast schema in the API spec
- These fields are already returned by the API (e.g., in `upcoming_match` notifications) but were missing from the spec
- All fields are nullable since they come from streaming provider APIs and may not always be available

Fixes #7240

## Test plan
- [ ] Verify the spec matches the `Webcast` TypedDict in `src/backend/common/models/webcast.py`
- [ ] Verify actual API responses include these fields when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)