### PR TITLE
Note that tests must run inside dev container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ docker-compose exec tba bash
 ```
 
 ## Testing & Linting
+**Note**: Tests must be run inside the dev container (docker-compose or devcontainer). They will not work on the host due to missing `google.appengine` dependencies.
+
 ```bash
 # Run tests
 ./ops/test_py3.sh


### PR DESCRIPTION
## Summary
- Add a note to AGENTS.md that tests must be run inside the dev container (docker-compose or devcontainer) since `google.appengine` dependencies aren't available on the host

## Test plan
- [ ] Documentation-only change, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)