### PR TITLE
Handle missing fields in Onshape API response

### DIFF
--- a/src/backend/common/suggestions/media_parser.py
+++ b/src/backend/common/suggestions/media_parser.py
@@ -245,17 +245,21 @@ class MediaParser:
 
         if urlfetch_result.status_code != 200:
             logging.warning("Unable to retreive url: {}".format(url))
+            return None
 
         onshape_data = json.loads(urlfetch_result.content)
+        if not onshape_data:
+            return None
+
         image_url_base = "https://cad.onshape.com/api/thumbnails/d/{}/s/{}"
         image_url = image_url_base.format(media_dict["foreign_key"], "300x300")
 
         media_dict["details_json"] = json.dumps(
             {
-                "model_name": onshape_data["name"],
-                "model_description": onshape_data["description"],
+                "model_name": onshape_data.get("name", ""),
+                "model_description": onshape_data.get("description", ""),
                 "model_image": image_url,
-                "model_created": onshape_data["createdAt"],
+                "model_created": onshape_data.get("createdAt", ""),
             }
         )
         return media_dict


### PR DESCRIPTION
## Summary
- Return `None` early when the Onshape API returns a non-200 status (previously logged a warning but continued to parse)
- Return `None` when the response body is empty
- Use `.get()` with defaults for `name`, `description`, and `createdAt` fields that may be absent
- Add tests for all Onshape parsing paths (non-200, empty, missing fields, success)

Fixes #8893

## Test plan
- [ ] New tests cover non-200 response, empty response, missing fields, and success case
- [ ] Existing media parser tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)