### PR TITLE
Add tba-cli reference to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,4 +110,5 @@ docker-compose exec tba bash
 - The PWA (Progressive Web App) is a separate project in `pwa/` with its own AGENTS.md
 - GAE deployment via `ops/deploy/` scripts (maintainers only)
 - Production data can be seeded locally (see docs/Developing/Development-Runbook.md)
+- [tba-cli](https://github.com/the-blue-alliance/tba-cli) is a CLI tool for accessing TBA data via the API, useful when agents need to look at data from TBA
 


### PR DESCRIPTION
## Summary
- Adds a note about [tba-cli](https://github.com/the-blue-alliance/tba-cli) to the Notes section of AGENTS.md so agents are aware they can use it to access TBA data via the API.

## Test plan
- [ ] Verify AGENTS.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)