### PR TITLE
Fix clearing first_code via admin event edit

### DIFF
--- a/src/backend/common/manipulators/tests/event_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/event_manipulator_test.py
@@ -106,6 +106,35 @@ def test_updateWebcast_noUnion(old_event: Event, new_event: Event) -> None:
 
 
 @pytest.mark.usefixtures("ndb_context", "taskqueue_stub")
+def test_clear_first_code() -> None:
+    event_with_code = Event(
+        id="2011ct",
+        end_date=datetime.datetime(2011, 4, 2, 0, 0),
+        event_short="ct",
+        event_type_enum=EventType.REGIONAL,
+        first_code="my_code",
+        name="Test Event",
+        start_date=datetime.datetime(2011, 3, 31, 0, 0),
+        year=2011,
+    )
+    EventManipulator.createOrUpdate(event_with_code)
+    assert none_throws(Event.get_by_id("2011ct")).first_code == "my_code"
+
+    event_without_code = Event(
+        id="2011ct",
+        end_date=datetime.datetime(2011, 4, 2, 0, 0),
+        event_short="ct",
+        event_type_enum=EventType.REGIONAL,
+        first_code=None,
+        name="Test Event",
+        start_date=datetime.datetime(2011, 3, 31, 0, 0),
+        year=2011,
+    )
+    EventManipulator.createOrUpdate(event_without_code, auto_union=False)
+    assert none_throws(Event.get_by_id("2011ct")).first_code is None
+
+
+@pytest.mark.usefixtures("ndb_context", "taskqueue_stub")
 @pytest.mark.parametrize("official", [True, False])
 @patch.object(LocationHelper, "get_timezone_id")
 @patch.object(LocationHelper, "get_event_location")

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -170,6 +170,7 @@ class Event(CachedModel):
 
     _allow_none_attrs: Set[str] = {
         "district_key",
+        "first_code",
     }
 
     _list_attrs: Set[str] = {


### PR DESCRIPTION
## Summary
- Add `first_code` to `Event._allow_none_attrs` so the manipulator properly writes `None` values to Datastore
- Previously, blanking out the "FIRST API Code" field in the admin panel was silently ignored because `_update_attrs` skips `None` values for attributes not in `_allow_none_attrs`

Fixes #8907

## Test plan
- [x] Added `test_clear_first_code` to verify that setting `first_code` to `None` via `EventManipulator.createOrUpdate` actually clears the stored value

🤖 Generated with [Claude Code](https://claude.com/claude-code)