### PR TITLE
Add Artifact Registry cleanup policy

### DIFF
--- a/ops/artifact-registry-cleanup-policy.json
+++ b/ops/artifact-registry-cleanup-policy.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "delete-old-images",
+    "action": {"type": "Delete"},
+    "condition": {
+      "olderThan": "2592000s"
+    }
+  },
+  {
+    "name": "keep-minimum-versions",
+    "action": {"type": "Keep"},
+    "mostRecentVersions": {
+      "keepCount": 10
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Adds a cleanup policy JSON file for the `gae-standard` Artifact Registry repository
- Policy deletes images older than 30 days while always keeping the 10 most recent versions per package
- Already applied to `tbatv-prod-hrd` via gcloud CLI

Closes #8905

## Test plan
- [x] Policy applied and confirmed active via `gcloud artifacts repositories describe`
- [ ] Check back in ~24h to confirm storage has decreased from ~203 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)