### PR TITLE
Populate direct_url and view_url for social media profiles

### DIFF
--- a/src/backend/common/queries/dict_converters/media_converter.py
+++ b/src/backend/common/queries/dict_converters/media_converter.py
@@ -4,7 +4,7 @@ from typing import Dict, List, NewType, Optional
 from google.appengine.ext import ndb
 
 from backend.common.consts.api_version import ApiMajorVersion
-from backend.common.consts.media_type import SLUG_NAME_TO_TYPE
+from backend.common.consts.media_type import PROFILE_URLS, SLUG_NAME_TO_TYPE
 from backend.common.models.keys import TeamKey
 from backend.common.models.media import Media
 from backend.common.models.team import Team
@@ -15,7 +15,7 @@ MediaDict = NewType("MediaDict", Dict)
 
 class MediaConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        ApiMajorVersion.API_V3: 6,
+        ApiMajorVersion.API_V3: 7,
     }
 
     @classmethod
@@ -47,6 +47,12 @@ class MediaConverter(ConverterBase):
                 media.foreign_key
             )
             dict["view_url"] = media.youtube_url_link
+        elif media.media_type_enum in PROFILE_URLS:
+            profile_url = PROFILE_URLS[media.media_type_enum].format(
+                media.foreign_key
+            )
+            dict["direct_url"] = profile_url
+            dict["view_url"] = profile_url
         else:
             dict["direct_url"] = media.image_direct_url
             dict["view_url"] = media.view_image_url

--- a/src/backend/common/queries/dict_converters/tests/media_converter_test.py
+++ b/src/backend/common/queries/dict_converters/tests/media_converter_test.py
@@ -1,0 +1,77 @@
+from google.appengine.ext import ndb
+
+from backend.common.consts.media_type import MediaType
+from backend.common.models.media import Media
+from backend.common.queries.dict_converters.media_converter import MediaConverter
+
+
+def test_mediaConverter_v3_social_media_urls(ndb_context) -> None:
+    media = Media(
+        id="facebook-profile_team4element",
+        media_type_enum=MediaType.FACEBOOK_PROFILE,
+        foreign_key="team4element",
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["view_url"] == "https://www.facebook.com/team4element"
+    assert result["direct_url"] == "https://www.facebook.com/team4element"
+
+
+def test_mediaConverter_v3_github_profile_url(ndb_context) -> None:
+    media = Media(
+        id="github-profile_tba",
+        media_type_enum=MediaType.GITHUB_PROFILE,
+        foreign_key="the-blue-alliance",
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["view_url"] == "https://github.com/the-blue-alliance"
+    assert result["direct_url"] == "https://github.com/the-blue-alliance"
+
+
+def test_mediaConverter_v3_youtube_channel_url(ndb_context) -> None:
+    media = Media(
+        id="youtube-channel_frcteam4element",
+        media_type_enum=MediaType.YOUTUBE_CHANNEL,
+        foreign_key="@frcteam4element",
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["view_url"] == "https://www.youtube.com/@frcteam4element"
+    assert result["direct_url"] == "https://www.youtube.com/@frcteam4element"
+
+
+def test_mediaConverter_v3_youtube_video(ndb_context) -> None:
+    media = Media(
+        id="youtube_abc123",
+        media_type_enum=MediaType.YOUTUBE_VIDEO,
+        foreign_key="abc123",
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["view_url"] == "https://youtu.be/abc123"
+    assert result["direct_url"] == "https://img.youtube.com/vi/abc123/hqdefault.jpg"
+
+
+def test_mediaConverter_v3_instagram_profile_url(ndb_context) -> None:
+    media = Media(
+        id="instagram-profile_frc4",
+        media_type_enum=MediaType.INSTAGRAM_PROFILE,
+        foreign_key="frc4",
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["view_url"] == "https://www.instagram.com/frc4"
+    assert result["direct_url"] == "https://www.instagram.com/frc4"
+
+
+def test_mediaConverter_v3_twitter_profile_url(ndb_context) -> None:
+    media = Media(
+        id="twitter-profile_frc4",
+        media_type_enum=MediaType.TWITTER_PROFILE,
+        foreign_key="frc4",
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["view_url"] == "https://twitter.com/frc4"
+    assert result["direct_url"] == "https://twitter.com/frc4"


### PR DESCRIPTION
## Summary
- The `/team/{team_key}/social_media` API endpoint was returning empty strings for `direct_url` and `view_url` on all social media profile types (Facebook, Twitter, GitHub, Instagram, YouTube channels, etc.)
- The `MediaConverter` now uses the existing `PROFILE_URLS` mapping to generate proper URLs from the `foreign_key` for social profile types
- Bumps the APIv3 media converter subversion from 6 to 7

Fixes #7926

## Test plan
- [x] Added unit tests for Facebook, GitHub, YouTube channel, YouTube video, Instagram, and Twitter profile URL generation
- [ ] Verify on staging that `/team/frc4/social_media` returns populated URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)