### PR TITLE
Fix homepage countdown pluralization for '1 Days'

### DIFF
--- a/src/backend/web/static/javascript/tba_js/tba_countdown.js
+++ b/src/backend/web/static/javascript/tba_js/tba_countdown.js
@@ -26,6 +26,7 @@ function update_countdown() {
   }
 
   $('.countdown-days').text(days);
+  $('.day-label').text(days === 1 ? ' Day ' : ' Days ');
   $('.countdown-hours').text(hours);
   $('.countdown-minutes').text(minutes);
   $('.countdown-seconds').text(seconds);


### PR DESCRIPTION
## Summary
- Fixes the homepage countdown to display "1 Day" instead of "1 Days" when exactly one day remains until Week 1
- The `.day-label` span was hardcoded to "Days" in the template; the JS now dynamically updates it based on the count

Fixes #5754

## Test plan
- [ ] Verify by temporarily setting countdown target to ~1 day from now and confirming "1 Day" is displayed
- [ ] Verify plural "Days" still displays for counts other than 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)