### PR TITLE
Fix OG meta tags to match page title and description

### DIFF
--- a/src/backend/web/templates/district_details.html
+++ b/src/backend/web/templates/district_details.html
@@ -4,6 +4,14 @@
 
 {% block meta_description %}{{district_name}} district details for the FIRST Robotics Competition (FRC){% if explicit_year %} from {{year}}{% endif %}.{% endblock %}
 
+{% block more_head_tags %}
+<meta property="og:title" content="{% if explicit_year %}{{year}} {% endif %}FIRST Robotics {{district_name}} District" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://www.thebluealliance.com/images/logo_square_512.png" />
+<meta property="og:description" content="{{district_name}} district details for the FIRST Robotics Competition (FRC){% if explicit_year %} from {{year}}{% endif %}." />
+<meta property="og:site_name" content="The Blue Alliance" />
+{% endblock %}
+
 {% block events_active %}active{% endblock %}
 
 {% block content %}

--- a/src/backend/web/templates/regional_details.html
+++ b/src/backend/web/templates/regional_details.html
@@ -4,6 +4,14 @@
 
 {% block meta_description %}Regional Events for the FIRST Robotics Competition (FRC){% if explicit_year %} from {{year}}{% endif %}.{% endblock %}
 
+{% block more_head_tags %}
+<meta property="og:title" content="{% if explicit_year %}{{year}} {% endif %}FIRST Robotics Regional Events" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://www.thebluealliance.com/images/logo_square_512.png" />
+<meta property="og:description" content="Regional Events for the FIRST Robotics Competition (FRC){% if explicit_year %} from {{year}}{% endif %}." />
+<meta property="og:site_name" content="The Blue Alliance" />
+{% endblock %}
+
 {% block events_active %}active{% endblock %}
 
 {% block inline_javascript %}


### PR DESCRIPTION
## Summary
Fix Open Graph meta tags on district and regional pages to match the page title and meta description, instead of falling back to generic defaults from base.html.

## Problem
Pages like `/events/ne` (New England District) had:
- **Title**: "2026 FIRST Robotics New England District - The Blue Alliance"  
- **og:title**: "The Blue Alliance" (generic default)

This caused poor social media sharing previews.

## Changes
- Add `more_head_tags` block to `district_details.html` with page-specific OG tags
- Add `more_head_tags` block to `regional_details.html` with page-specific OG tags

## Test plan
- [x] All district and regional detail tests pass
- [ ] Verify OG tags render correctly on deployed pages

🤖 Generated with [Claude Code](https://claude.ai/code)