### PR TITLE
Move offline warning to bottom of viewport

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_base.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_base.less
@@ -66,7 +66,7 @@ body {
 
 #fixed-alert-container {
   position: fixed;
-  top: 20px;
+  bottom: 20px;
   left: 0px;
   right: 0px;
   margin-right: auto;


### PR DESCRIPTION
## Summary
- Position the "Event is offline" alert at the bottom of the screen instead of the top
- Prevents the warning from covering the header and event name on mobile devices

Fixes #2746

## Test plan
- [ ] View an event page with the offline warning on mobile
- [ ] Verify the alert appears at the bottom of the viewport
- [ ] Verify the header and event name are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)