### PR TITLE
Add schema.org BreadcrumbList structured data to pages

### DIFF
--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -22,6 +22,7 @@
 
 {% block schema_org_markup %}
 {% include "event_partials/event_schema_org_markup.html" %}
+{% include "event_partials/event_breadcrumb_schema.html" %}
 {% endblock %}
 
 {% block content %}

--- a/src/backend/web/templates/event_list.html
+++ b/src/backend/web/templates/event_list.html
@@ -11,6 +11,10 @@
   <meta property="og:site_name" content="The Blue Alliance" />
 {% endblock %}
 
+{% block schema_org_markup %}
+{% include "event_partials/event_list_breadcrumb_schema.html" %}
+{% endblock %}
+
 {% block events_active %}active{% endblock %}
 
 {% block content %}

--- a/src/backend/web/templates/event_partials/event_breadcrumb_schema.html
+++ b/src/backend/web/templates/event_partials/event_breadcrumb_schema.html
@@ -1,0 +1,11 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Events", "item": "https://www.thebluealliance.com/events"},
+    {"@type": "ListItem", "position": 2, "name": "{{ event.year }} Events", "item": "https://www.thebluealliance.com/events/{{ event.year }}"},
+    {"@type": "ListItem", "position": 3, "name": "{{ event.name }}", "item": "https://www.thebluealliance.com/event/{{ event.key_name }}"}
+  ]
+}
+</script>

--- a/src/backend/web/templates/event_partials/event_list_breadcrumb_schema.html
+++ b/src/backend/web/templates/event_partials/event_list_breadcrumb_schema.html
@@ -1,0 +1,12 @@
+{% if explicit_year %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Events", "item": "https://www.thebluealliance.com/events"},
+    {"@type": "ListItem", "position": 2, "name": "{{ selected_year }} Events", "item": "https://www.thebluealliance.com/events/{{ selected_year }}"}
+  ]
+}
+</script>
+{% endif %}

--- a/src/backend/web/templates/match_details.html
+++ b/src/backend/web/templates/match_details.html
@@ -23,6 +23,10 @@
   {% endif %}
 {% endblock %}
 
+{% block schema_org_markup %}
+{% include "match_partials/match_breadcrumb_schema.html" %}
+{% endblock %}
+
 {% block content %}
 <div class="container">
   <div class="row">

--- a/src/backend/web/templates/match_partials/match_breadcrumb_schema.html
+++ b/src/backend/web/templates/match_partials/match_breadcrumb_schema.html
@@ -1,0 +1,12 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Events", "item": "https://www.thebluealliance.com/events"},
+    {"@type": "ListItem", "position": 2, "name": "{{ event.year }} Events", "item": "https://www.thebluealliance.com/events/{{ event.year }}"},
+    {"@type": "ListItem", "position": 3, "name": "{{ event.name }}", "item": "https://www.thebluealliance.com/event/{{ event.key_name }}"},
+    {"@type": "ListItem", "position": 4, "name": "{{ match.verbose_name }}", "item": "https://www.thebluealliance.com/match/{{ match.key_name }}"}
+  ]
+}
+</script>

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -13,6 +13,7 @@
 
 {% block schema_org_markup %}
 {% include "team_partials/team_schema_org_markup.html" %}
+{% include "team_partials/team_breadcrumb_schema.html" %}
 {% endblock %}
 
 {% block content %}

--- a/src/backend/web/templates/team_history.html
+++ b/src/backend/web/templates/team_history.html
@@ -11,6 +11,7 @@
 
 {% block schema_org_markup %}
 {% include "team_partials/team_schema_org_markup.html" %}
+{% include "team_partials/team_history_breadcrumb_schema.html" %}
 {% endblock %}
 
 {% block content %}

--- a/src/backend/web/templates/team_partials/team_breadcrumb_schema.html
+++ b/src/backend/web/templates/team_partials/team_breadcrumb_schema.html
@@ -1,0 +1,13 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Teams", "item": "https://www.thebluealliance.com/teams"},
+    {"@type": "ListItem", "position": 2, "name": "Team {{ team.team_number }}", "item": "https://www.thebluealliance.com/team/{{ team.team_number }}"}
+    {% if not is_canonical %}
+    ,{"@type": "ListItem", "position": 3, "name": "{{ year }} Season", "item": "https://www.thebluealliance.com/team/{{ team.team_number }}/{{ year }}"}
+    {% endif %}
+  ]
+}
+</script>

--- a/src/backend/web/templates/team_partials/team_history_breadcrumb_schema.html
+++ b/src/backend/web/templates/team_partials/team_history_breadcrumb_schema.html
@@ -1,0 +1,11 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Teams", "item": "https://www.thebluealliance.com/teams"},
+    {"@type": "ListItem", "position": 2, "name": "Team {{ team.team_number }}", "item": "https://www.thebluealliance.com/team/{{ team.team_number }}"},
+    {"@type": "ListItem", "position": 3, "name": "History", "item": "https://www.thebluealliance.com/team/{{ team.team_number }}/history"}
+  ]
+}
+</script>


### PR DESCRIPTION
## Summary
- Adds schema.org BreadcrumbList structured data to event, team, match, and list pages
- Improves SEO by enabling breadcrumb display in search results
- Part of #8929

**Breadcrumb paths:**
- Event pages: Events > {Year} Events > {Event Name}
- Team pages: Teams > Team {number} [> {Year} Season]
- Team history: Teams > Team {number} > History
- Match pages: Events > {Year} Events > {Event Name} > {Match}
- Event list (with year): Events > {Year} Events

## Test plan
- [ ] View page source on event, team, match pages to verify JSON-LD output
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Validate JSON syntax with [Schema.org Validator](https://validator.schema.org/)

🤖 Generated with [Claude Code](https://claude.ai/code)