### PR TITLE
Add schema.org SportsEvent and VideoObject structured data to match pages

### DIFF
--- a/src/backend/web/templates/match_details.html
+++ b/src/backend/web/templates/match_details.html
@@ -24,6 +24,7 @@
 {% endblock %}
 
 {% block schema_org_markup %}
+{% include "match_partials/match_schema_org_markup.html" %}
 {% include "match_partials/match_breadcrumb_schema.html" %}
 {% endblock %}
 

--- a/src/backend/web/templates/match_partials/match_schema_org_markup.html
+++ b/src/backend/web/templates/match_partials/match_schema_org_markup.html
@@ -1,0 +1,50 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SportsEvent",
+  "name": "{{ event.year }} {{ event.name }} - {{ match.verbose_name }}",
+  "description": "{{ match.verbose_name }} at the {{ event.year }} {{ event.name }} FIRST Robotics Competition",
+  "sport": "Robotics",
+  {% if match.time %}"startDate": "{{ match.time.strftime('%Y-%m-%dT%H:%M:%SZ') }}",{% endif %}
+  {% if event.venue or event.city or event.state_prov or event.country %}
+  "location": {
+    "@type": "Place"
+    {% if event.venue %},"name": "{{ event.venue }}"{% endif %}
+    {% if event.city or event.state_prov or event.country %}
+    ,"address": {
+      "@type": "PostalAddress"
+      {% if event.city %},"addressLocality": "{{ event.city }}"{% endif %}
+      {% if event.state_prov %},"addressRegion": "{{ event.state_prov }}"{% endif %}
+      {% if event.country %},"addressCountry": "{{ event.country }}"{% endif %}
+    }
+    {% endif %}
+  },
+  {% endif %}
+  "competitor": [
+    {% for team_key in match.team_key_names %}
+    {"@type": "SportsTeam", "@id": "https://www.thebluealliance.com/team/{{ team_key|strip_frc }}"}{% if not loop.last %},{% endif %}
+
+    {% endfor %}
+  ],
+  "superEvent": {
+    "@type": "SportsEvent",
+    "@id": "https://www.thebluealliance.com/event/{{ event.key_name }}"
+  },
+  "url": "https://www.thebluealliance.com/match/{{ match.key_name }}"
+}
+</script>
+{% if match.youtube_videos_formatted %}
+{% for video_id in match.youtube_videos_formatted %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "{{ event.year }} {{ event.name }} - {{ match.verbose_name }}",
+  "description": "{{ match.verbose_name }} video from the {{ event.year }} {{ event.name }} FIRST Robotics Competition",
+  "thumbnailUrl": "https://img.youtube.com/vi/{{ video_id.split('?')[0] }}/hqdefault.jpg",
+  "contentUrl": "https://www.youtube.com/watch?v={{ video_id.split('?')[0] }}",
+  "embedUrl": "https://www.youtube.com/embed/{{ video_id }}"
+}
+</script>
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## Summary
- Adds schema.org `SportsEvent` structured data to match pages
- Adds `VideoObject` structured data for YouTube match videos
- Links matches to parent events via `superEvent`
- Part of #8929

**Match schema includes:**
- Match name and description
- Start date
- Location (from event)
- Competitors (all teams in the match)
- Parent event reference (`superEvent`)

**Video schema includes:**
- Video title and description
- YouTube thumbnail URL
- Content and embed URLs

## Test plan
- [ ] View page source on a match page to verify JSON-LD output
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Test match with videos and match without videos

🤖 Generated with [Claude Code](https://claude.ai/code)