### PR TITLE
Add schema.org CollectionPage structured data to event and team list pages

### DIFF
--- a/src/backend/web/templates/event_list.html
+++ b/src/backend/web/templates/event_list.html
@@ -12,6 +12,7 @@
 {% endblock %}
 
 {% block schema_org_markup %}
+{% include "event_partials/event_list_schema_org_markup.html" %}
 {% include "event_partials/event_list_breadcrumb_schema.html" %}
 {% endblock %}
 

--- a/src/backend/web/templates/event_partials/event_list_schema_org_markup.html
+++ b/src/backend/web/templates/event_partials/event_list_schema_org_markup.html
@@ -1,0 +1,27 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "{% if explicit_year %}{{ selected_year }} {% endif %}FIRST Robotics Competition Events{% if state_prov %} in {{ state_prov }}{% endif %}",
+  "description": "List of FIRST Robotics Competition events{% if state_prov %} in {{ state_prov }}{% endif %}{% if explicit_year %} for the {{ selected_year }} season{% endif %}",
+  "url": "https://www.thebluealliance.com/events{% if explicit_year %}/{{ selected_year }}{% endif %}",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": {{ events|length }},
+    "itemListElement": [
+      {% for event in events[:20] %}
+      {
+        "@type": "ListItem",
+        "position": {{ loop.index }},
+        "item": {
+          "@type": "SportsEvent",
+          "@id": "https://www.thebluealliance.com/event/{{ event.key_name }}",
+          "name": "{{ event.name }}"
+        }
+      }{% if not loop.last %},{% endif %}
+
+      {% endfor %}
+    ]
+  }
+}
+</script>

--- a/src/backend/web/templates/team_list.html
+++ b/src/backend/web/templates/team_list.html
@@ -11,6 +11,10 @@
   <meta property="og:site_name" content="The Blue Alliance" />
 {% endblock %}
 
+{% block schema_org_markup %}
+{% include "team_partials/team_list_schema_org_markup.html" %}
+{% endblock %}
+
 {% block teams_active %}active{% endblock %}
 {% block teams_active_collapsed %}active{% endblock %}
 

--- a/src/backend/web/templates/team_partials/team_list_schema_org_markup.html
+++ b/src/backend/web/templates/team_partials/team_list_schema_org_markup.html
@@ -1,0 +1,38 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "FIRST Robotics Competition Teams {{ cur_page_label }}",
+  "description": "List of FIRST Robotics Competition teams",
+  "url": "https://www.thebluealliance.com/teams{% if current_page > 1 %}/{{ current_page }}{% endif %}",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": {{ num_teams }},
+    "itemListElement": [
+      {% for team in teams_a %}
+      {
+        "@type": "ListItem",
+        "position": {{ loop.index }},
+        "item": {
+          "@type": "SportsTeam",
+          "@id": "https://www.thebluealliance.com/team/{{ team.team_number }}",
+          "name": "{% if team.nickname %}{{ team.nickname }}{% else %}Team {{ team.team_number }}{% endif %}"
+        }
+      },
+      {% endfor %}
+      {% for team in teams_b %}
+      {
+        "@type": "ListItem",
+        "position": {{ teams_a|length + loop.index }},
+        "item": {
+          "@type": "SportsTeam",
+          "@id": "https://www.thebluealliance.com/team/{{ team.team_number }}",
+          "name": "{% if team.nickname %}{{ team.nickname }}{% else %}Team {{ team.team_number }}{% endif %}"
+        }
+      }{% if not loop.last %},{% endif %}
+
+      {% endfor %}
+    ]
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- Adds schema.org `CollectionPage` with `ItemList` structured data to list pages
- Completes #8929

**Event list page (`/events`, `/events/{year}`):**
- CollectionPage with event count
- ItemList with first 20 events (SportsEvent references)

**Team list page (`/teams`):**
- CollectionPage with total team count
- ItemList with all teams on current page (SportsTeam references)

## Test plan
- [ ] View page source on `/events/2024` to verify JSON-LD output
- [ ] View page source on `/teams` to verify JSON-LD output
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Validate JSON syntax with [Schema.org Validator](https://validator.schema.org/)

🤖 Generated with [Claude Code](https://claude.ai/code)