### PR TITLE
Fix event schema to include venue name from venue_address fallback

### DIFF
--- a/src/backend/web/templates/event_partials/event_schema_org_markup.html
+++ b/src/backend/web/templates/event_partials/event_schema_org_markup.html
@@ -9,10 +9,10 @@
   {% if event.end_date %}"endDate": "{{ event.end_date.strftime('%Y-%m-%d') }}",{% endif %}
   "eventStatus": "https://schema.org/EventScheduled",
   "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-  {% if event.venue or event.city or event.state_prov or event.country %}
+  {% if event.venue_or_venue_from_address or event.city or event.state_prov or event.country %}
   "location": {
     "@type": "Place",
-    {% if event.venue %}"name": "{{ event.venue }}",{% endif %}
+    {% if event.venue_or_venue_from_address %}"name": "{{ event.venue_or_venue_from_address }}",{% endif %}
     "address": {
       "@type": "PostalAddress"
       {% if event.city %}, "addressLocality": "{{ event.city }}"{% endif %}


### PR DESCRIPTION
## Summary
Uses `venue_or_venue_from_address` instead of `venue` for the Place name in event schema.org markup.

The `venue_or_venue_from_address` property falls back to extracting the venue name from `venue_address` when `venue` is empty. This ensures older events (like 2006pa - Drexel University) that have venue info only in `venue_address` still get the Place name in structured data.

## Test plan
- [ ] Check `/event/2006pa` source - should now include `"name": "Drexel University"` in location
- [ ] Validate with [Schema.org Validator](https://validator.schema.org/)

🤖 Generated with [Claude Code](https://claude.ai/code)