### PR TITLE
Improve event list meta description for better SEO

### DIFF
--- a/src/backend/web/templates/event_list.html
+++ b/src/backend/web/templates/event_list.html
@@ -2,12 +2,12 @@
 
 {% block title %}{% if explicit_year %}{{selected_year}} {% endif %}FIRST Robotics Events{% if state_prov %} in {{state_prov}}{% endif %} - The Blue Alliance{% endblock %}
 
-{% block meta_description %}Information, match results, and videos for FIRST Robotics Competition (FRC) events{% if state_prov %} in {{state_prov}}{% endif %}{% if explicit_year %} from {{selected_year}}{% endif %}.{% endblock %}
+{% block meta_description %}{{selected_year}} FIRST Robotics Competition (FRC) season calendar{% if state_prov %} for {{state_prov}}{% endif %}: Regional, District, and Championship events with live scores, team rosters, and match replays.{% endblock %}
 
 {% block more_head_tags %}
   <meta property="og:title" content="{{selected_year}} FRC Event List{% if state_prov %} in {{state_prov}}{% endif %}" />
   <meta property="og:image" content="https://www.thebluealliance.com/images/logo_square_512.png" />
-  <meta property="og:description" content="Event list for the {{selected_year}} FIRST Robotics Competition{% if state_prov %} in {{state_prov}}{% endif %}."/>
+  <meta property="og:description" content="{{selected_year}} FIRST Robotics Competition (FRC) season calendar{% if state_prov %} for {{state_prov}}{% endif %}: Regional, District, and Championship events with live scores, team rosters, and match replays."/>
   <meta property="og:site_name" content="The Blue Alliance" />
 {% endblock %}
 


### PR DESCRIPTION
## Summary

- Updates the meta description and og:description for event list pages (`/events`, `/events/{year}`)
- Uses a "season calendar" framing to be more compelling in search results
- Highlights key features: event types, live scores, team rosters, match replays

**Before:**
> "Information, match results, and videos for FIRST Robotics Competition (FRC) events from 2026."

**After:**
> "2026 FIRST Robotics Competition (FRC) season calendar: Regional, District, and Championship events with live scores, team rosters, and match replays."

## Context

Per #8924, the `/events` page has 104k impressions but only 0.48% CTR. A more compelling meta description should help improve click-through rate from search results.

## Test plan

- [ ] View page source on `/events` and `/events/2026` to verify meta description
- [ ] Check og:description matches

🤖 Generated with [Claude Code](https://claude.ai/code)