### PR TITLE
PWA: Add 'Add Webcast' button when event has no webcasts

### DIFF
--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -67,6 +67,7 @@ import {
 import TeamAvatar from '~/components/tba/teamAvatar';
 import { Avatar, AvatarImage } from '~/components/ui/avatar';
 import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
 import {
   Card,
   CardContent,
@@ -408,7 +409,7 @@ function EventPage() {
         </TabsContent>
 
         <TabsContent value="media">
-          <MediaTab webcasts={event.webcasts} />
+          <MediaTab webcasts={event.webcasts} eventKey={event.key} />
         </TabsContent>
       </Tabs>
     </div>
@@ -805,13 +806,27 @@ function ComponentsTable({ coprs, year }: { coprs: EventCoprs; year: number }) {
   );
 }
 
-function MediaTab({ webcasts }: { webcasts: Webcast[] }) {
+function MediaTab({
+  webcasts,
+  eventKey,
+}: {
+  webcasts: Webcast[];
+  eventKey: string;
+}) {
   return (
     <div>
       <h1 className="text-2xl font-bold">Webcasts</h1>
-      {webcasts.map((w) => (
-        <WebcastIcon webcast={w} key={w.channel} />
-      ))}
+      {webcasts.length > 0 ? (
+        webcasts.map((w) => <WebcastIcon webcast={w} key={w.channel} />)
+      ) : (
+        <Button variant="secondary" asChild>
+          <a
+            href={`https://www.thebluealliance.com/suggest/event/webcast?event_key=${eventKey}`}
+          >
+            Add Webcast
+          </a>
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a secondary-style "Add Webcast" button to the event Media tab when no webcasts exist
- Button links to the webcast suggestion form on the main TBA site (`/suggest/event/webcast?event_key=...`)
- Encourages community contribution of webcast links for events

## Test plan
- [x] Navigate to an event without webcasts in the PWA
- [x] Verify the "Add Webcast" button appears in the Media tab
- [x] Verify the button links to the correct suggestion URL with the event key
- [x] Navigate to an event with webcasts and verify the button does not appear

### Before
<img width="1072" height="1162" alt="image" src="https://github.com/user-attachments/assets/e8bb866a-a23a-4b2f-8edf-2f252da80f38" />
### After
<img width="1072" height="1162" alt="image" src="https://github.com/user-attachments/assets/823fe1a4-fb24-4302-8ff8-c98c6ced4df9" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)