### PR TITLE
Add workflow to close issues inactive for 2+ years

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 700
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had activity in over 2 years. It will be closed in 30 days if no further activity occurs."
+          close-issue-message: "This issue was closed because it has been inactive for over 2 years. If this is still relevant, please reopen it."
+          exempt-issue-labels: "data-issue"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow using `actions/stale@v10` that runs daily
- Marks issues as stale after 700 days of inactivity, then closes them 30 days later (~2 years total)
- Issues with the `data-issue` label are exempt, since they represent real data corrections that stay valid regardless of age
- Pull requests are not affected

## Test plan
- [x] Verify the workflow appears in the Actions tab after merge
- [ ] Confirm `data-issue` labeled issues are not marked stale
- [ ] Monitor first run to ensure stale labeling and closing works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)