### PR TITLE
Fix typos in FCM notification error logging

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -757,16 +757,16 @@ class TBANSHelper:
                 client = subclients[index]
                 if isinstance(response.exception, UnregisteredError):
                     logging.info(
-                        f"Deleting mobile client with ID: f{client.messaging_id}"
+                        f"Deleting mobile client with ID: {client.messaging_id}"
                     )
                     MobileClientQuery.delete_for_messaging_id(client.messaging_id)
                 elif isinstance(response.exception, SenderIdMismatchError):
                     logging.info(
-                        f"Deleting mobile client with ID: f{client.messaging_id}"
+                        f"Deleting mobile client with ID: {client.messaging_id}"
                     )
                     MobileClientQuery.delete_for_messaging_id(client.messaging_id)
                 elif isinstance(response.exception, QuotaExceededError):
-                    logging.error("Qutoa exceeded - retrying client...")
+                    logging.error("Quota exceeded - retrying client...")
                     retry_clients.append(client)
                 elif isinstance(response.exception, ThirdPartyAuthError):
                     logging.critical(
@@ -781,7 +781,7 @@ class TBANSHelper:
                         )
                     )
                 elif isinstance(response.exception, InternalError):
-                    logging.error("Interal FCM error - retrying client...")
+                    logging.error("Internal FCM error - retrying client...")
                     retry_clients.append(client)
                 elif isinstance(response.exception, UnavailableError):
                     logging.error("FCM unavailable - retrying client...")

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -1227,7 +1227,7 @@ class TestTBANSHelper(unittest.TestCase):
             "logging.error"
         ) as mock_error:
             TBANSHelper._send_fcm([client], MockNotification())
-            mock_error.assert_called_once_with("Qutoa exceeded - retrying client...")
+            mock_error.assert_called_once_with("Quota exceeded - retrying client...")
 
         # Sanity check
         assert fcm_messaging_ids("user_id") == ["messaging_id"]
@@ -1321,7 +1321,7 @@ class TestTBANSHelper(unittest.TestCase):
             "logging.error"
         ) as mock_error:
             TBANSHelper._send_fcm([client], MockNotification())
-            mock_error.assert_called_once_with("Interal FCM error - retrying client...")
+            mock_error.assert_called_once_with("Internal FCM error - retrying client...")
 
         # Sanity check
         assert fcm_messaging_ids("user_id") == ["messaging_id"]


### PR DESCRIPTION
## Summary
- Fix broken f-string that logged literal `f` prefix before `messaging_id` (e.g. `ftoken123` instead of `token123`)
- Fix "Qutoa" → "Quota" and "Interal" → "Internal" typos in error log messages
- Update corresponding test assertions

Fixes #8969

## Test plan
- [ ] Existing tests pass with updated string assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)