### PR TITLE
Re-enable Android push notifications via FCM

### DIFF
--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -15,6 +15,7 @@ class ClientType(enum.IntEnum):
 
 
 FCM_CLIENTS: Set[ClientType] = {
+    ClientType.OS_ANDROID,
     ClientType.OS_IOS,
     ClientType.WEB,
 }


### PR DESCRIPTION
## Summary
- Re-adds `ClientType.OS_ANDROID` to `FCM_CLIENTS` so Android devices receive push notifications using the modern FCM format (same as iOS and Web)
- Fixes `/account/ping` returning 500 for Android clients, since `_ping_client()` raises for any client type not in `FCM_CLIENTS`
- Android was removed from `FCM_CLIENTS` in commit 47c0c031a (Feb 2025) when the legacy webhook-like data format was cleaned up, but the modern FCM `MulticastMessage` with `android_config` natively supports Android without any special handling

## Test plan
- [ ] Existing tests parameterized over `FCM_CLIENTS` automatically pick up Android — all should pass without modification
- [ ] Verify `/account/ping` no longer 500s for Android clients
- [ ] Verify Android devices receive push notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)