### PR TITLE
Fix FCM error handling index bug that deleted wrong client tokens

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -747,13 +747,9 @@ class TBANSHelper:
                 UnregisteredError,
             )
 
-            for index, response in enumerate(
-                [
-                    response
-                    for response in batch_response.responses
-                    if not response.success
-                ]
-            ):
+            for index, response in enumerate(batch_response.responses):
+                if response.success:
+                    continue
                 client = subclients[index]
                 if isinstance(response.exception, UnregisteredError):
                     logging.info(


### PR DESCRIPTION
## Summary
- Fixed index mismatch in `_send_fcm` error handling where filtering to only failed responses before enumerating caused the wrong client to be looked up from the `subclients` list
- When early tokens succeeded and a later one failed, the successful client's token was deleted instead of the failing one
- Added a multi-client regression test that sends to two clients where the first succeeds and the second fails with `UnregisteredError`, verifying only the failing client's token is deleted

## Test plan
- [x] Existing single-client FCM error tests all pass (14/14)
- [x] New `test_send_fcm_unregister_error_multi_client` regression test passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)