### PR TITLE
Revert "Re-enable Android push notifications via FCM (#8971)"

### DIFF
--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -15,7 +15,6 @@ class ClientType(enum.IntEnum):
 
 
 FCM_CLIENTS: Set[ClientType] = {
-    ClientType.OS_ANDROID,
     ClientType.OS_IOS,
     ClientType.WEB,
 }


### PR DESCRIPTION
## Summary
- Reverts #8971 — removes `ClientType.OS_ANDROID` from `FCM_CLIENTS`
- Android FCM messages are crashing legacy clients, so disabling until the client-side issue is resolved

## Test plan
- [x] Clean `git revert` of merge commit
- [ ] Verify Android clients no longer receive FCM push notifications
- [ ] Verify iOS and Web push notifications are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)