### PR TITLE
Fix GSC errors for missing startDate, location, name on match pages

### DIFF
--- a/src/backend/web/templates/match_partials/match_schema_org_markup.html
+++ b/src/backend/web/templates/match_partials/match_schema_org_markup.html
@@ -5,11 +5,11 @@
   "name": "{{ event.year }} {{ event.name }} - {{ match.verbose_name }}",
   "description": "{{ match.verbose_name }} at the {{ event.year }} {{ event.name }} FIRST Robotics Competition",
   "sport": "Robotics",
-  {% if match.time %}"startDate": "{{ match.time.strftime('%Y-%m-%dT%H:%M:%SZ') }}",{% endif %}
-  {% if event.venue or event.city or event.state_prov or event.country %}
+  {% if match.time %}"startDate": "{{ match.time.strftime('%Y-%m-%dT%H:%M:%SZ') }}",{% elif event.start_date %}"startDate": "{{ event.start_date.strftime('%Y-%m-%d') }}",{% endif %}
+  {% if event.venue_or_venue_from_address or event.city or event.state_prov or event.country %}
   "location": {
     "@type": "Place"
-    {% if event.venue %},"name": "{{ event.venue }}"{% endif %}
+    {% if event.venue_or_venue_from_address %},"name": "{{ event.venue_or_venue_from_address }}"{% endif %}
     {% if event.city or event.state_prov or event.country %}
     ,"address": {
       "@type": "PostalAddress"
@@ -28,7 +28,25 @@
   ],
   "superEvent": {
     "@type": "SportsEvent",
-    "@id": "https://www.thebluealliance.com/event/{{ event.key_name }}"
+    "@id": "https://www.thebluealliance.com/event/{{ event.key_name }}",
+    "name": "{{ event.name }} {{ event.year }}",
+    {% if event.start_date %}"startDate": "{{ event.start_date.strftime('%Y-%m-%d') }}",{% endif %}
+    {% if event.end_date %}"endDate": "{{ event.end_date.strftime('%Y-%m-%d') }}",{% endif %}
+    {% if event.venue_or_venue_from_address or event.city or event.state_prov or event.country %}
+    "location": {
+      "@type": "Place"
+      {% if event.venue_or_venue_from_address %},"name": "{{ event.venue_or_venue_from_address }}"{% endif %}
+      {% if event.city or event.state_prov or event.country %}
+      ,"address": {
+        "@type": "PostalAddress"
+        {% if event.city %},"addressLocality": "{{ event.city }}"{% endif %}
+        {% if event.state_prov %},"addressRegion": "{{ event.state_prov }}"{% endif %}
+        {% if event.country %},"addressCountry": "{{ event.country }}"{% endif %}
+      }
+      {% endif %}
+    },
+    {% endif %}
+    "url": "https://www.thebluealliance.com/event/{{ event.key_name }}"
   },
   "url": "https://www.thebluealliance.com/match/{{ match.key_name }}"
 }


### PR DESCRIPTION
## Summary
- Google Search Console flagged 14 match pages with invalid Event structured data: missing `startDate`, `name`, and `location`
- Root cause: the `superEvent` reference in match JSON-LD only had `@type` and `@id`, so Google treated it as a separate incomplete SportsEvent entity
- Populated `superEvent` with the event's actual data (`name`, `startDate`, `endDate`, `location`, `url`)
- Added `startDate` fallback to `event.start_date` when `match.time` is missing
- Changed match location to use `event.venue_or_venue_from_address` (matching the event page template) to cover older events with only `venue_address`

Verified fix locally using `gsm-gsc inspect` against the GSC API — the "Unnamed item" SportsEvent errors are resolved.

## Test plan
- [x] New `test_schema_org_match_sports_event` test validates both the main match SportsEvent and superEvent have all required fields
- [x] All existing match detail tests pass (12/12)
- [x] All existing event schema tests pass
- [x] Local dev server renders valid JSON-LD on match pages
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)