### PR TITLE
Add coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+relative_files = True
+
+[report]
+ignore_errors = True


### PR DESCRIPTION
I think https://github.com/the-blue-alliance/the-blue-alliance/commit/636c0b8682d642f2c1093b2ed35cb01a24649455 broke combining coverage artifacts, since the tests run in-container, which means they end up prefixed with something different.

This commit should enable `relative_paths` as to avoid that, see https://coverage.readthedocs.io/en/7.13.3/config.html#config-paths
