### PR TITLE
Fix [py3] Coverage CI failure with relative_files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True


### PR DESCRIPTION
## Summary

The **[py3] Coverage** CI job has been failing on every PR with:

```
No source for code: '/tba/src/backend/__init__.py'
```

### Why this happens

The CI pipeline splits tests into 5 parallel shards, each producing a `.coverage` data file. A separate **Coverage** job then downloads all 5 files and runs `coverage combine` + `coverage xml` to merge them and upload to Codecov.

The problem is a **path mismatch**. When pytest-cov records coverage data, it stores the **absolute file paths** from the environment where tests ran. When `coverage combine` runs in a different job (different filesystem), those absolute paths don't exist, so coverage.py fails with "No source for code."

This is a [documented issue](https://coverage.readthedocs.io/en/latest/config.html#run-relative-files) in coverage.py. From the docs:

> **relative_files** — Store relative file paths in the data file. This makes it easier to measure code in one (or multiple) environments, and then report in another.

### The fix

A one-line `.coveragerc` config:

```ini
[run]
relative_files = True
```

This tells coverage.py to store `src/backend/__init__.py` instead of `/home/runner/work/.../src/backend/__init__.py`. The relative paths resolve correctly in any environment, so `coverage combine` succeeds.

### References
- [coverage.py docs: `relative_files`](https://coverage.readthedocs.io/en/latest/config.html#run-relative-files)
- [coverage.py docs: "No source for code" error](https://coverage.readthedocs.io/en/latest/messages.html#error-no-source)

## Test plan
- [ ] CI `[py3] Coverage` job passes (this has been failing on all recent PRs)
- [x] All other CI checks unaffected (this only changes how paths are recorded in coverage data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)