### PR TITLE
move away from legacy pkg_resources

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -21,10 +21,10 @@
     {"site-package": "markupsafe"},
     {"site-package": "numpy"},
     {"site-package": "openpyxl"},
+    {"site-package": "packaging"},
     {"site-package": "pytest"},
     {"site-package": "_pytest"},
     {"site-package": "pyre_extensions"},
-    {"site-package": "pkg_resources"},
     {"site-package": "six", "is_toplevel_module": true},
     {"site-package": "requests_mock"},
     {"site-package": "werkzeug"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ flake8-import-order
 flake8-tidy-imports
 blinker==1.9.0
 freezegun==1.5.5
+packaging==26.0
 pre-commit
 pyre-check==0.9.25
 pytest


### PR DESCRIPTION
pkg_resources / setuptools is deprecated in newer python versions and has been removed, so update it to use newer thins