### PR TITLE
Move seed_test_event to local blueprint and improve event type

### DIFF
--- a/src/backend/web/local/dev_tools.py
+++ b/src/backend/web/local/dev_tools.py
@@ -38,7 +38,7 @@ def seed_test_event() -> Response:
         id=event_key,
         event_short="test",
         year=year,
-        name="North Pole Regional",
+        name="North Pole Showdown",
         event_type_enum=EventType.PRESEASON if now.month <= 2 else EventType.OFFSEASON,
         start_date=datetime.datetime(year, now.month, now.day)
         - datetime.timedelta(days=1),

--- a/src/backend/web/local/tests/test_seed_event.py
+++ b/src/backend/web/local/tests/test_seed_event.py
@@ -18,7 +18,7 @@ def test_seed_creates_event_and_matches(local_client: Client, taskqueue_stub) ->
     # Verify event
     event = Event.get_by_id("2025test")
     assert event is not None
-    assert event.name == "North Pole Regional"
+    assert event.name == "North Pole Showdown"
     assert event.year == 2025
     assert event.event_type_enum == EventType.OFFSEASON
 

--- a/src/backend/web/templates/local/bootstrap.html
+++ b/src/backend/web/templates/local/bootstrap.html
@@ -49,7 +49,7 @@
     <h2>Dev Tools</h2>
     <form method="POST" action="/local/seed_test_event">
         <button type="submit" class="btn btn-success">Seed Test Event</button>
-        <p class="help-block">Creates "North Pole Regional" with completed, upcoming, and unscheduled matches.</p>
+        <p class="help-block">Creates "North Pole Showdown" with completed, upcoming, and unscheduled matches.</p>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- Moves `seed_test_event` from the admin blueprint to the local-only blueprint, so it's only available in dev environments
- Sets event type based on current month: **Preseason** for January/February, **Offseason** otherwise (instead of hardcoded Regional)
- Renames the test event to "North Pole Showdown"

## Test plan
- [ ] Verify `seed_test_event` endpoint works at `/local/seed_test_event`
- [ ] Verify event type is Preseason when seeded in Jan/Feb
- [ ] Verify event type is Offseason when seeded in other months
- [ ] Run `test_seed_event.py` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)