### PR TITLE
Fix Dockerfile apt cache staleness for JDK install

### DIFF
--- a/ops/dev/docker/Dockerfile
+++ b/ops/dev/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y \
 ENV HTTPLIB2_CA_CERTS="/usr/lib/google-cloud-sdk/platform/google_appengine/lib/httplib2/httplib2/cacerts.txt"
 
 # Install JDK for firebase-tools
-RUN apt-get install default-jre -y
+RUN apt-get update && apt-get install default-jre -y
 
 # Set up nvm and nodejs
 ENV NVM_DIR=/nvm


### PR DESCRIPTION
## Summary
- Adds `apt-get update` before `apt-get install default-jre` in the dev Dockerfile
- Fixes 404 errors when the cached package index references removed openjdk versions

## Test plan
- [ ] `docker-compose build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)