### PR TITLE
Add seed test team dev tool with media

### DIFF
--- a/src/backend/web/local/blueprint.py
+++ b/src/backend/web/local/blueprint.py
@@ -26,7 +26,7 @@ from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.event import Event
 from backend.common.sitevars.apiv3_key import Apiv3Key
 from backend.web.local.bootstrap import LocalDataBootstrap
-from backend.web.local.dev_tools import seed_test_event
+from backend.web.local.dev_tools import seed_test_event, seed_test_team
 from backend.web.profiled_render import render_template
 
 """
@@ -196,6 +196,12 @@ def create_test_event(event_key: str) -> Response:
 local_routes.add_url_rule(
     "/seed_test_event",
     view_func=seed_test_event,
+    methods=["POST"],
+)
+
+local_routes.add_url_rule(
+    "/seed_test_team",
+    view_func=seed_test_team,
     methods=["POST"],
 )
 

--- a/src/backend/web/local/dev_tools.py
+++ b/src/backend/web/local/dev_tools.py
@@ -9,13 +9,16 @@ from werkzeug import Response
 
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import MediaType
 from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.manipulators.event_team_manipulator import EventTeamManipulator
 from backend.common.manipulators.match_manipulator import MatchManipulator
+from backend.common.manipulators.media_manipulator import MediaManipulator
 from backend.common.manipulators.team_manipulator import TeamManipulator
 from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.models.match import Match
+from backend.common.models.media import Media
 from backend.common.models.team import Team
 
 NUM_COMPLETED = 15
@@ -198,6 +201,68 @@ def _get_or_create_teams() -> List[Team]:
         teams.append(team)
     TeamManipulator.createOrUpdate(teams)
     return teams
+
+
+def seed_test_team() -> Response:
+    now = datetime.datetime.now()
+    year = now.year
+
+    team = Team(
+        id="frc2",
+        team_number=2,
+        nickname="The Reindeer",
+        name="North Pole High School & The Reindeer",
+        city="North Pole",
+        state_prov="AK",
+        country="USA",
+        school_name="North Pole High School",
+        website="https://www.thebluealliance.com/team/2",
+        rookie_year=1997,
+        motto="Dasher, Dancer, Prancer, Vixen!",
+    )
+    TeamManipulator.createOrUpdate(team)
+
+    team_ref = Media.create_reference("team", "frc2")
+    media_list = [
+        Media(
+            id=Media.render_key_name(MediaType.YOUTUBE_VIDEO, "dQw4w9WgXcQ"),
+            media_type_enum=MediaType.YOUTUBE_VIDEO,
+            foreign_key="dQw4w9WgXcQ",
+            year=year,
+            references=[team_ref],
+        ),
+        Media(
+            id=Media.render_key_name(MediaType.IMGUR, "aF8T5ZE"),
+            media_type_enum=MediaType.IMGUR,
+            foreign_key="aF8T5ZE",
+            year=year,
+            references=[team_ref],
+        ),
+        Media(
+            id=Media.render_key_name(MediaType.INSTAGRAM_IMAGE, "B9ZUsERhIWi"),
+            media_type_enum=MediaType.INSTAGRAM_IMAGE,
+            foreign_key="B9ZUsERhIWi",
+            year=year,
+            references=[team_ref],
+        ),
+        Media(
+            id=Media.render_key_name(MediaType.YOUTUBE_CHANNEL, "bobcatrobotics"),
+            media_type_enum=MediaType.YOUTUBE_CHANNEL,
+            foreign_key="bobcatrobotics",
+            year=year,
+            references=[team_ref],
+        ),
+        Media(
+            id=Media.render_key_name(MediaType.INSTAGRAM_PROFILE, "bobcatrobotics"),
+            media_type_enum=MediaType.INSTAGRAM_PROFILE,
+            foreign_key="bobcatrobotics",
+            year=year,
+            references=[team_ref],
+        ),
+    ]
+    MediaManipulator.createOrUpdate(media_list)
+
+    return redirect("/team/2")
 
 
 def _teams_for_match(teams: List[Team], match_number: int) -> tuple:

--- a/src/backend/web/local/tests/test_seed_team.py
+++ b/src/backend/web/local/tests/test_seed_team.py
@@ -1,0 +1,82 @@
+from freezegun import freeze_time
+from werkzeug.test import Client
+
+from backend.common.consts.media_type import MediaType
+from backend.common.models.media import Media
+from backend.common.models.team import Team
+
+
+@freeze_time("2025-03-15")
+def test_seed_team_redirects(local_client: Client, taskqueue_stub) -> None:
+    resp = local_client.post("/local/seed_test_team")
+    assert resp.status_code == 302
+    assert "/team/2" in resp.headers["Location"]
+
+
+@freeze_time("2025-03-15")
+def test_seed_team_creates_team(local_client: Client, taskqueue_stub) -> None:
+    local_client.post("/local/seed_test_team")
+
+    team = Team.get_by_id("frc2")
+    assert team is not None
+    assert team.team_number == 2
+    assert team.nickname == "The Reindeer"
+    assert team.name == "North Pole High School & The Reindeer"
+    assert team.city == "North Pole"
+    assert team.state_prov == "AK"
+    assert team.country == "USA"
+    assert team.school_name == "North Pole High School"
+    assert team.website == "https://www.thebluealliance.com/team/2"
+    assert team.rookie_year == 1997
+    assert team.motto == "Dasher, Dancer, Prancer, Vixen!"
+
+
+@freeze_time("2025-03-15")
+def test_seed_team_creates_media(local_client: Client, taskqueue_stub) -> None:
+    local_client.post("/local/seed_test_team")
+
+    team_ref = Media.create_reference("team", "frc2")
+
+    # YouTube video
+    yt_video = Media.get_by_id(
+        Media.render_key_name(MediaType.YOUTUBE_VIDEO, "dQw4w9WgXcQ")
+    )
+    assert yt_video is not None
+    assert yt_video.media_type_enum == MediaType.YOUTUBE_VIDEO
+    assert yt_video.foreign_key == "dQw4w9WgXcQ"
+    assert yt_video.year == 2025
+    assert team_ref in yt_video.references
+
+    # Imgur image
+    imgur = Media.get_by_id(Media.render_key_name(MediaType.IMGUR, "aF8T5ZE"))
+    assert imgur is not None
+    assert imgur.media_type_enum == MediaType.IMGUR
+    assert imgur.foreign_key == "aF8T5ZE"
+    assert team_ref in imgur.references
+
+    # Instagram image
+    ig_image = Media.get_by_id(
+        Media.render_key_name(MediaType.INSTAGRAM_IMAGE, "B9ZUsERhIWi")
+    )
+    assert ig_image is not None
+    assert ig_image.media_type_enum == MediaType.INSTAGRAM_IMAGE
+    assert ig_image.foreign_key == "B9ZUsERhIWi"
+    assert team_ref in ig_image.references
+
+    # YouTube channel
+    yt_channel = Media.get_by_id(
+        Media.render_key_name(MediaType.YOUTUBE_CHANNEL, "bobcatrobotics")
+    )
+    assert yt_channel is not None
+    assert yt_channel.media_type_enum == MediaType.YOUTUBE_CHANNEL
+    assert yt_channel.foreign_key == "bobcatrobotics"
+    assert team_ref in yt_channel.references
+
+    # Instagram profile
+    ig_profile = Media.get_by_id(
+        Media.render_key_name(MediaType.INSTAGRAM_PROFILE, "bobcatrobotics")
+    )
+    assert ig_profile is not None
+    assert ig_profile.media_type_enum == MediaType.INSTAGRAM_PROFILE
+    assert ig_profile.foreign_key == "bobcatrobotics"
+    assert team_ref in ig_profile.references

--- a/src/backend/web/templates/local/bootstrap.html
+++ b/src/backend/web/templates/local/bootstrap.html
@@ -47,9 +47,13 @@
 
   <div class="row">
     <h2>Dev Tools</h2>
-    <form method="POST" action="/local/seed_test_event">
+    <form method="POST" action="/local/seed_test_event" style="display: inline-block; margin-right: 10px;">
         <button type="submit" class="btn btn-success">Seed Test Event</button>
         <p class="help-block">Creates "North Pole Regional" with completed, upcoming, and unscheduled matches.</p>
+    </form>
+    <form method="POST" action="/local/seed_test_team" style="display: inline-block;">
+        <button type="submit" class="btn btn-success">Seed Test Team</button>
+        <p class="help-block">Creates Team 2 "The Reindeer" with YouTube, Imgur, and Instagram media.</p>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- Adds `/local/seed_test_team` dev tool that creates Team 2 "The Reindeer" (North Pole, AK) with 5 media objects: YouTube video, Imgur image, Instagram image, YouTube channel, and Instagram profile
- Adds button on the bootstrap page alongside the existing "Seed Test Event" button
- Companion to the seed test event tool in #8987

## Test plan
- [x] Tests for redirect, team field verification, and all 5 media objects with correct types and references
- [x] Manually verified endpoint returns 302 and team page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)