### PR TITLE
Fix Firebase RTDB emulator host in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - PUPPETEER_SKIP_DOWNLOAD=true
       - TBA_DOCKER_COMPOSE=true
       - FIREBASE_AUTH_EMULATOR_HOST=firebase:9099
+      - FIREBASE_DATABASE_EMULATOR_HOST=firebase:9000
 
   test:
     build:


### PR DESCRIPTION
## Summary
- Adds `FIREBASE_DATABASE_EMULATOR_HOST=firebase:9000` to `docker-compose.yml`
- The auth emulator host was already overridden (`firebase:9099`) but the RTDB emulator host was missing, falling back to `localhost:9000` from `tba_dev_config.json`
- In Docker Compose, `localhost` inside the `tba` container doesn't reach the `firebase` container, so all firebase deferred tasks failed with connection refused
- This clogged the task queues (~21K stuck tasks) and blocked cache clearing, causing stale API responses after data writes

## Test plan
- [x] Verified `FIREBASE_DATABASE_EMULATOR_HOST=firebase:9000` in dev_appserver process args after container recreate
- [x] Verified `firebase:9000` responds from inside `tba` container
- [x] Confirmed zero task failures in logs after fix
- [x] Confirmed API returns fresh data after manipulator writes (cache clearing works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)