### PR TITLE
Auto-create stable dev read API key on bootstrap

### DIFF
--- a/pwa/default.env
+++ b/pwa/default.env
@@ -3,7 +3,7 @@
 # NAME IT ".env" BEFORE FILLING IN YOUR CREDENTIALS
 
 # Find your Read API Keys at https://www.thebluealliance.com/account
-VITE_TBA_API_READ_KEY="myKey"
+VITE_TBA_API_READ_KEY="tba-dev-key"
 
 VITE_FIREBASE_API_KEY="fake-api-key"
 VITE_FIREBASE_AUTH_DOMAIN="demo-test"

--- a/src/backend/web/local/tests/test_dev_api_key.py
+++ b/src/backend/web/local/tests/test_dev_api_key.py
@@ -1,0 +1,45 @@
+import pytest
+from werkzeug.test import Client
+
+from backend.common.consts.auth_type import AuthType
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.web.local.blueprint import DEV_AUTH_KEY, ensure_dev_api_key
+
+
+def test_ensure_dev_api_key_creates_key(mock_dev_env) -> None:
+    key = ensure_dev_api_key()
+    assert key == DEV_AUTH_KEY
+
+    auth = ApiAuthAccess.get_by_id(DEV_AUTH_KEY)
+    assert auth is not None
+    assert auth.auth_types_enum == [AuthType.READ_API]
+    assert auth.is_read_key
+
+
+def test_ensure_dev_api_key_idempotent(mock_dev_env) -> None:
+    key1 = ensure_dev_api_key()
+    key2 = ensure_dev_api_key()
+    assert key1 == key2 == DEV_AUTH_KEY
+
+    # Should still be exactly one entity
+    auth = ApiAuthAccess.get_by_id(DEV_AUTH_KEY)
+    assert auth is not None
+
+
+def test_ensure_dev_api_key_raises_outside_dev() -> None:
+    with pytest.raises(RuntimeError, match="must only be called in dev mode"):
+        ensure_dev_api_key()
+
+
+def test_bootstrap_shows_dev_key(local_client: Client) -> None:
+    resp = local_client.get("/local/bootstrap")
+    assert resp.status_code == 200
+    assert DEV_AUTH_KEY.encode() in resp.data
+
+
+def test_bootstrap_creates_key_in_datastore(local_client: Client) -> None:
+    local_client.get("/local/bootstrap")
+
+    auth = ApiAuthAccess.get_by_id(DEV_AUTH_KEY)
+    assert auth is not None
+    assert auth.is_read_key

--- a/src/backend/web/templates/local/bootstrap.html
+++ b/src/backend/web/templates/local/bootstrap.html
@@ -47,6 +47,12 @@
 
   <div class="row">
     <h2>Dev Tools</h2>
+    <div class="well">
+        <h4>Dev Read API Key</h4>
+        <p>A stable read API key is auto-created for local development:</p>
+        <pre id="dev-auth-key">{{ dev_auth_key }}</pre>
+        <small class="text-muted">Use this key with <code>X-TBA-Auth-Key</code> header or the PWA's <code>.env</code> file.</small>
+    </div>
     <form method="POST" action="/local/seed_test_event" style="display: inline-block; margin-right: 10px;">
         <button type="submit" class="btn btn-success">Seed Test Event</button>
         <p class="help-block">Creates "North Pole Showdown" with completed, upcoming, and unscheduled matches.</p>


### PR DESCRIPTION
## Summary
- Auto-creates a well-known read API key (`tba-dev-key`) when visiting `/local/bootstrap`, so developers don't need to manually create one after every Docker rebuild
- Displays the key on the bootstrap page for easy copying
- Updates `pwa/default.env` to use `tba-dev-key` so the PWA works out of the box in dev

## Test plan
- [x] `ensure_dev_api_key()` creates key in dev mode
- [x] Idempotent — second call doesn't duplicate the key
- [x] Raises `RuntimeError` when called outside dev mode
- [x] Bootstrap page renders the key
- [x] Key is persisted to Datastore as READ_API type
- [x] All 35 existing local tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)