### PR TITLE
Increase stale issues operations-per-run to 100

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -19,4 +19,5 @@ jobs:
           exempt-issue-labels: "data-issue"
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          operations-per-run: 100
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Increases `operations-per-run` from the default of 30 to 100 to process the backlog of stale issues more efficiently

## Test plan
- [ ] Verify the next scheduled run processes more issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)