### PR TITLE
Always include name field in Schema.org location markup

### DIFF
--- a/src/backend/web/templates/event_partials/event_schema_org_markup.html
+++ b/src/backend/web/templates/event_partials/event_schema_org_markup.html
@@ -12,7 +12,7 @@
   {% if event.venue_or_venue_from_address or event.city or event.state_prov or event.country %}
   "location": {
     "@type": "Place",
-    {% if event.venue_or_venue_from_address %}"name": "{{ event.venue_or_venue_from_address }}",{% endif %}
+    "name": "{{ event.venue_or_venue_from_address or [event.city, event.state_prov, event.country]|select|join(', ') }}",
     "address": {
       "@type": "PostalAddress"
       {% if event.city %}, "addressLocality": "{{ event.city }}"{% endif %}

--- a/src/backend/web/templates/match_partials/match_schema_org_markup.html
+++ b/src/backend/web/templates/match_partials/match_schema_org_markup.html
@@ -8,8 +8,8 @@
   {% if match.time %}"startDate": "{{ match.time.strftime('%Y-%m-%dT%H:%M:%SZ') }}",{% elif event.start_date %}"startDate": "{{ event.start_date.strftime('%Y-%m-%d') }}",{% endif %}
   {% if event.venue_or_venue_from_address or event.city or event.state_prov or event.country %}
   "location": {
-    "@type": "Place"
-    {% if event.venue_or_venue_from_address %},"name": "{{ event.venue_or_venue_from_address }}"{% endif %}
+    "@type": "Place",
+    "name": "{{ event.venue_or_venue_from_address or [event.city, event.state_prov, event.country]|select|join(', ') }}"
     {% if event.city or event.state_prov or event.country %}
     ,"address": {
       "@type": "PostalAddress"
@@ -34,8 +34,8 @@
     {% if event.end_date %}"endDate": "{{ event.end_date.strftime('%Y-%m-%d') }}",{% endif %}
     {% if event.venue_or_venue_from_address or event.city or event.state_prov or event.country %}
     "location": {
-      "@type": "Place"
-      {% if event.venue_or_venue_from_address %},"name": "{{ event.venue_or_venue_from_address }}"{% endif %}
+      "@type": "Place",
+      "name": "{{ event.venue_or_venue_from_address or [event.city, event.state_prov, event.country]|select|join(', ') }}"
       {% if event.city or event.state_prov or event.country %}
       ,"address": {
         "@type": "PostalAddress"


### PR DESCRIPTION
## Summary
- Google Search Console reported "Missing field `name` (in `location`)" for match and event pages where the venue was not set
- The `location.name` was previously conditional on `venue_or_venue_from_address`, so events with only city/state/country data emitted a `Place` with no `name`
- Now always includes `name`, falling back to a comma-separated city/state/country string (e.g. "Worcester, MA, USA") when venue is unavailable
- Fixed in both match and event Schema.org templates (3 locations total)

## Test plan
- [ ] Verify structured data on a match page with full venue info (e.g. `/match/2024arc_qm1`) still shows venue name
- [ ] Verify structured data on a match page for an older event without venue (e.g. `/match/2006arc_qm89`) now shows city/state/country as location name
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results) that no warnings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)