### PR TITLE
Add OS_ANDROID_FCM client type for push notifications

### DIFF
--- a/src/backend/api/handlers/tests/client_api_registration_test.py
+++ b/src/backend/api/handlers/tests/client_api_registration_test.py
@@ -46,6 +46,31 @@ def test_register_new_client(api_client: Client, mock_clientapi_auth: User) -> N
     assert client.display_name == "Test Device"
 
 
+def test_register_android_fcm_client(
+    api_client: Client, mock_clientapi_auth: User
+) -> None:
+    req = RegistrationRequest(
+        operating_system="android-fcm",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/register", req)
+    assert resp["code"] == 200
+
+    user_clients = MobileClient.query(
+        MobileClient.user_id == str(none_throws(mock_clientapi_auth.account_key).id())
+    ).fetch()
+    assert len(user_clients) == 1
+
+    client = user_clients[0]
+    assert client.user_id == "1"
+    assert client.messaging_id == "abc123"
+    assert client.client_type == ClientType.OS_ANDROID_FCM
+    assert client.device_uuid == "asdf"
+    assert client.display_name == "Test Device"
+
+
 def test_register_existing_client(
     api_client: Client, mock_clientapi_auth: User
 ) -> None:

--- a/src/backend/common/consts/client_type.py
+++ b/src/backend/common/consts/client_type.py
@@ -12,9 +12,11 @@ class ClientType(enum.IntEnum):
     WEBHOOK = 2
     WEB = 3
     TEST = 4
+    OS_ANDROID_FCM = 5
 
 
 FCM_CLIENTS: Set[ClientType] = {
+    ClientType.OS_ANDROID_FCM,
     ClientType.OS_IOS,
     ClientType.WEB,
 }
@@ -26,6 +28,7 @@ NAMES: Dict[ClientType, str] = {
     ClientType.WEBHOOK: "Webhook",
     ClientType.WEB: "Web",
     ClientType.TEST: "Test",
+    ClientType.OS_ANDROID_FCM: "Android-FCM",
 }
 
 ENUMS: Dict[str, ClientType] = {
@@ -34,4 +37,5 @@ ENUMS: Dict[str, ClientType] = {
     "webhook": ClientType.WEBHOOK,
     "web": ClientType.WEB,
     "test": ClientType.TEST,
+    "android-fcm": ClientType.OS_ANDROID_FCM,
 }


### PR DESCRIPTION
## Summary
- Adds `OS_ANDROID_FCM = 5` to the `ClientType` enum for new Compose-based Android clients
- Adds it to `FCM_CLIENTS` so the server sends push notifications to these clients
- Old Android clients (type 0 / `OS_ANDROID`) are unaffected — they won't receive FCM payloads they can't handle

## Why a new type?
The new Android app supports FCM push notifications, but the old Android app would crash on the new notification payloads. We can't just add `OS_ANDROID` to `FCM_CLIENTS`. Instead, the new app registers as `"android-fcm"` → server maps to `OS_ANDROID_FCM` → included in `FCM_CLIENTS`.

## Test plan
- [x] Added `test_register_android_fcm_client` — registers with `operating_system="android-fcm"`, asserts `client_type == ClientType.OS_ANDROID_FCM`
- [x] All existing registration tests still pass (9/9)
- [x] All tbans_helper tests still pass (73/73)

Fixes #8974
Companion Android PR: the-blue-alliance/the-blue-alliance-android#1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)