### PR TITLE
Add set -e to lint_py3.sh to catch black failures

### DIFF
--- a/ops/lint_py3.sh
+++ b/ops/lint_py3.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ -n "$CI" ]; then
     echo "::add-matcher::./ops/problem_matchers/flake8_error.json"


### PR DESCRIPTION
## Summary
- Adds `set -e` to `ops/lint_py3.sh` so the script exits immediately if `black --check` finds formatting violations
- Without this, the script continues to `flake8` and the overall exit code is flake8's, silently masking black failures

## Test plan
- [ ] Run `make lint` with a file that has black formatting issues — verify it now exits non-zero
- [ ] Run `make lint` with all files properly formatted — verify it still passes

Fixes #9028

🤖 Generated with [Claude Code](https://claude.com/claude-code)