### PR TITLE
Fix black formatting violations in 4 files

### DIFF
--- a/ops/check_venv_deps.py
+++ b/ops/check_venv_deps.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from packaging.requirements import Requirement
 
-
 REQUIREMENTS_FILES = [
     Path(__file__).parent.parent / "requirements.txt",
     Path(__file__).parent.parent / "src/requirements.txt",

--- a/src/backend/common/helpers/tests/youtube_video_helper_test.py
+++ b/src/backend/common/helpers/tests/youtube_video_helper_test.py
@@ -233,9 +233,7 @@ def test_get_playlist_videos_no_secret(ndb_context) -> None:
         YouTubeVideoHelper.videos_in_playlist("playlist").get_result()
 
 
-def test_get_playlist_videos_unauthorized(
-    ndb_context, mock_google_api_secret
-) -> None:
+def test_get_playlist_videos_unauthorized(ndb_context, mock_google_api_secret) -> None:
     error_resp = {
         "error": {
             "code": 403,
@@ -251,7 +249,9 @@ def test_get_playlist_videos_unauthorized(
     }
 
     mock_urlfetch_result = URLFetchResult.mock_for_content(
-        "https://www.googleapis.com/youtube/v3/playlistItems", 403, json.dumps(error_resp)
+        "https://www.googleapis.com/youtube/v3/playlistItems",
+        403,
+        json.dumps(error_resp),
     )
     mock_future = InstantFuture(mock_urlfetch_result)
 
@@ -287,9 +287,7 @@ def test_get_playlist_videos(ndb_context, mock_google_api_secret) -> None:
     )
 
 
-def test_get_playlist_videos_paginate(
-    ndb_context, mock_google_api_secret
-) -> None:
+def test_get_playlist_videos_paginate(ndb_context, mock_google_api_secret) -> None:
     with open(
         os.path.join(os.path.dirname(__file__), "data/youtube_playlist_response.json"),
         "r",

--- a/src/backend/common/helpers/youtube_video_helper.py
+++ b/src/backend/common/helpers/youtube_video_helper.py
@@ -111,9 +111,7 @@ class YouTubeVideoHelper(object):
                     "pageToken": next_page_token,
                     "key": yt_secret,
                 }
-                query_string = "&".join(
-                    f"{k}={v}" for k, v in params.items() if v
-                )
+                query_string = "&".join(f"{k}={v}" for k, v in params.items() if v)
                 url = f"{base_url}?{query_string}"
 
                 ndb_context = ndb.get_context()

--- a/src/backend/web/local/blueprint.py
+++ b/src/backend/web/local/blueprint.py
@@ -126,9 +126,9 @@ def get_fms_companion_db(event_key: str) -> Response:
 
     response = make_response(file_contents)
     response.headers["Content-Type"] = "application/x-sqlite3"
-    response.headers[
-        "Content-Disposition"
-    ] = f"attachment; filename={f'{event_key}_companion.db'}"
+    response.headers["Content-Disposition"] = (
+        f"attachment; filename={f'{event_key}_companion.db'}"
+    )
     return response
 
 


### PR DESCRIPTION
## Summary
- Runs `black` on 4 files that had formatting violations undetected due to #9028
- Affected files:
  - `ops/check_venv_deps.py`
  - `src/backend/common/helpers/youtube_video_helper.py`
  - `src/backend/common/helpers/tests/youtube_video_helper_test.py`
  - `src/backend/web/local/blueprint.py`

## Test plan
- [ ] `make lint` passes (black + flake8)
- [ ] No functional changes — formatting only

Fixes #9029

🤖 Generated with [Claude Code](https://claude.com/claude-code)