### PR TITLE
Pin click==8.1.8 to resolve pyre-check/Flask dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ flake8-tidy-imports
 blinker==1.9.0
 freezegun==1.5.5
 packaging==26.0
+click==8.1.8
 pre-commit
 pyre-check==0.9.25
 pytest


### PR DESCRIPTION
## Summary
- Pins `click==8.1.8` in `requirements.txt` to resolve the dependency conflict between `pyre-check==0.9.25` (requires `click<8.2.0`) and `Flask==3.1.2` (requires `click>=8.1.3`)
- `click==8.1.8` is the latest 8.1.x release and satisfies both constraints
- Without this pin, pip defaults to `click==8.3.1` which violates pyre-check's constraint

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] `[py3] Type Check` CI passes (pyre still works)

Fixes #9030

🤖 Generated with [Claude Code](https://claude.com/claude-code)