### PR TITLE
Add GitHub sponsor button for PayPal donations

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://www.paypal.com/donate/?hosted_button_id=RNFK8Y7FU9VX8"]


### PR DESCRIPTION
## Summary
- Adds a `.github/FUNDING.yml` file that displays a "Sponsor" button on the GitHub repository
- Links to our existing PayPal donation page (`https://www.paypal.com/donate/?hosted_button_id=RNFK8Y7FU9VX8`) — the same link used on the website's `/donate` and `/about` pages

## Context
GitHub supports a [FUNDING.yml](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository) file that adds a "Sponsor" button to the repo header. This makes it easy for contributors and visitors to find the donation link.

## Test plan
- [ ] Verify the Sponsor button appears on the repo page after merge
- [ ] Verify clicking it links to the correct PayPal donation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)