### PR TITLE
[pwa] Add search route

### DIFF
--- a/pwa/app/lib/search/searchRedirect.test.ts
+++ b/pwa/app/lib/search/searchRedirect.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { SearchIndex } from '~/api/tba/read';
+import { getSearchRedirect } from '~/lib/search/searchRedirect';
+
+// Mock search index data for testing
+const mockSearchIndex: SearchIndex = {
+  teams: [
+    { key: 'frc254', nickname: 'The Cheesy Poofs' },
+    { key: 'frc604', nickname: 'Quixilver' },
+    { key: 'frc1678', nickname: 'Citrus Circuits' },
+  ],
+  events: [
+    { key: '2024casj', name: 'Silicon Valley Regional' },
+    { key: '2024mil', name: 'Milstein' },
+    { key: '2024cmptx', name: 'Einstein Field' },
+  ],
+};
+
+describe('getSearchRedirect', () => {
+  describe('team searches', () => {
+    it('should redirect to team by number', () => {
+      const result = getSearchRedirect(mockSearchIndex, '254');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/254');
+    });
+
+    it('should redirect to team by key with frc prefix', () => {
+      const result = getSearchRedirect(mockSearchIndex, 'frc254');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/254');
+    });
+
+    it('should redirect to team by full nickname', () => {
+      const result = getSearchRedirect(mockSearchIndex, 'Cheesy Poofs');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/254');
+    });
+
+    it('should redirect to team by partial nickname', () => {
+      const result = getSearchRedirect(mockSearchIndex, 'Cheesy');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/254');
+    });
+
+    it('should redirect to team 604 by nickname', () => {
+      const result = getSearchRedirect(mockSearchIndex, 'Quixilver');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/604');
+    });
+  });
+
+  describe('event searches', () => {
+    it('should redirect to event by key', () => {
+      const result = getSearchRedirect(mockSearchIndex, '2024casj');
+      expect(result.type).toBe('event');
+      expect(result.path).toBe('/event/2024casj');
+    });
+
+    it('should redirect to event by full name', () => {
+      const result = getSearchRedirect(
+        mockSearchIndex,
+        'Silicon Valley Regional',
+      );
+      expect(result.type).toBe('event');
+      expect(result.path).toBe('/event/2024casj');
+    });
+
+    it('should redirect to event by partial name', () => {
+      const result = getSearchRedirect(mockSearchIndex, 'Silicon Valley');
+      expect(result.type).toBe('event');
+      // Should match either 2024casj or 2024casjcmp, both are valid
+      expect(result.path).toMatch(/^\/event\/2024casj/);
+    });
+
+    it('should redirect to event 2024mil', () => {
+      const result = getSearchRedirect(mockSearchIndex, '2024mil');
+      expect(result.type).toBe('event');
+      expect(result.path).toBe('/event/2024mil');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return no-results for empty query', () => {
+      const result = getSearchRedirect(mockSearchIndex, '');
+      expect(result.type).toBe('no-results');
+      expect(result.path).toBeUndefined();
+    });
+
+    it('should return no-results for whitespace-only query', () => {
+      const result = getSearchRedirect(mockSearchIndex, '   ');
+      expect(result.type).toBe('no-results');
+      expect(result.path).toBeUndefined();
+    });
+
+    it('should return no-results for query with no matches', () => {
+      const result = getSearchRedirect(mockSearchIndex, 'xyzabc123');
+      expect(result.type).toBe('no-results');
+      expect(result.path).toBeUndefined();
+    });
+
+    it('should preserve original query in result', () => {
+      const result = getSearchRedirect(mockSearchIndex, '  254  ');
+      expect(result.query).toBe('  254  ');
+    });
+  });
+
+  describe('priority logic', () => {
+    it('should prefer team when both team and event match', () => {
+      // When searching for something that could match both, teams should win
+      const result = getSearchRedirect(mockSearchIndex, '604');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/604');
+    });
+
+    it('should return team when only team matches', () => {
+      const emptyEvents: SearchIndex = {
+        teams: mockSearchIndex.teams,
+        events: [],
+      };
+      const result = getSearchRedirect(emptyEvents, '254');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/254');
+    });
+
+    it('should return event when only event matches', () => {
+      const emptyTeams: SearchIndex = {
+        teams: [],
+        events: mockSearchIndex.events,
+      };
+      const result = getSearchRedirect(emptyTeams, '2024casj');
+      expect(result.type).toBe('event');
+      expect(result.path).toBe('/event/2024casj');
+    });
+  });
+});

--- a/pwa/app/lib/search/searchRedirect.ts
+++ b/pwa/app/lib/search/searchRedirect.ts
@@ -1,0 +1,71 @@
+import { SearchIndex } from '~/api/tba/read';
+import FuzzysortFilterer from '~/lib/search/fuzzysortFilterer';
+
+export interface SearchRedirectResult {
+  type: 'team' | 'event' | 'no-results';
+  path?: string;
+  query: string;
+}
+
+/**
+ * Determines the best redirect target for a search query.
+ * Uses fuzzy search to find the top team and event matches,
+ * then redirects to whichever has the higher score.
+ * Teams win ties (common case: numeric searches match team numbers).
+ *
+ * @param searchIndex - The search index containing teams and events
+ * @param query - The search query string
+ * @returns A SearchRedirectResult indicating where to redirect (or no-results)
+ */
+export function getSearchRedirect(
+  searchIndex: SearchIndex,
+  query: string,
+): SearchRedirectResult {
+  // Normalize query
+  const normalizedQuery = query.trim();
+
+  // Return no-results if empty
+  if (!normalizedQuery) {
+    return { type: 'no-results', query };
+  }
+
+  // Use FuzzysortFilterer to search both teams and events
+  const filterer = new FuzzysortFilterer();
+  const results = filterer.filter(searchIndex, normalizedQuery);
+
+  const topTeam = results.teams[0];
+  const topEvent = results.events[0];
+
+  // If we have no matches, return no-results
+  if (!topTeam && !topEvent) {
+    return { type: 'no-results', query };
+  }
+
+  // If we only have a team match, redirect to it
+  if (topTeam && !topEvent) {
+    // Strip "frc" prefix from team key (e.g., "frc254" -> "254")
+    const teamNumber = topTeam.key.substring(3);
+    return {
+      type: 'team',
+      path: `/team/${teamNumber}`,
+      query,
+    };
+  }
+
+  // If we only have an event match, redirect to it
+  if (topEvent && !topTeam) {
+    return {
+      type: 'event',
+      path: `/event/${topEvent.key}`,
+      query,
+    };
+  }
+
+  // if we have both (we shouldn't), just redirect to the team
+  const teamNumber = topTeam.key.substring(3);
+  return {
+    type: 'team',
+    path: `/team/${teamNumber}`,
+    query,
+  };
+}

--- a/pwa/app/routeTree.gen.ts
+++ b/pwa/app/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ThanksRouteImport } from './routes/thanks'
+import { Route as SearchRouteImport } from './routes/search'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as Match_suggestionRouteImport } from './routes/match_suggestion'
 import { Route as GamedayRouteImport } from './routes/gameday'
@@ -37,6 +38,11 @@ import { Route as DistrictDistrictAbbreviationInsightsRouteImport } from './rout
 const ThanksRoute = ThanksRouteImport.update({
   id: '/thanks',
   path: '/thanks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SearchRoute = SearchRouteImport.update({
+  id: '/search',
+  path: '/search',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PrivacyRoute = PrivacyRouteImport.update({
@@ -171,6 +177,7 @@ export interface FileRoutesByFullPath {
   '/gameday': typeof GamedayRoute
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
+  '/search': typeof SearchRoute
   '/thanks': typeof ThanksRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs/v3': typeof ApidocsV3Route
@@ -180,7 +187,7 @@ export interface FileRoutesByFullPath {
   '/local/debug': typeof LocalDebugRoute
   '/match/$matchKey': typeof MatchMatchKeyRoute
   '/teams/{-$pgNum}': typeof TeamsChar123PgNumChar125Route
-  '/account': typeof AccountIndexRoute
+  '/account/': typeof AccountIndexRoute
   '/district/$districtAbbreviation/insights': typeof DistrictDistrictAbbreviationInsightsRoute
   '/district/$districtAbbreviation/{-$year}': typeof DistrictDistrictAbbreviationChar123YearChar125Route
   '/team/$teamNumber/history': typeof TeamTeamNumberHistoryRoute
@@ -197,6 +204,7 @@ export interface FileRoutesByTo {
   '/gameday': typeof GamedayRoute
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
+  '/search': typeof SearchRoute
   '/thanks': typeof ThanksRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs/v3': typeof ApidocsV3Route
@@ -224,6 +232,7 @@ export interface FileRoutesById {
   '/gameday': typeof GamedayRoute
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
+  '/search': typeof SearchRoute
   '/thanks': typeof ThanksRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs_/v3': typeof ApidocsV3Route
@@ -252,6 +261,7 @@ export interface FileRouteTypes {
     | '/gameday'
     | '/match_suggestion'
     | '/privacy'
+    | '/search'
     | '/thanks'
     | '/account/mytba'
     | '/apidocs/v3'
@@ -261,7 +271,7 @@ export interface FileRouteTypes {
     | '/local/debug'
     | '/match/$matchKey'
     | '/teams/{-$pgNum}'
-    | '/account'
+    | '/account/'
     | '/district/$districtAbbreviation/insights'
     | '/district/$districtAbbreviation/{-$year}'
     | '/team/$teamNumber/history'
@@ -278,6 +288,7 @@ export interface FileRouteTypes {
     | '/gameday'
     | '/match_suggestion'
     | '/privacy'
+    | '/search'
     | '/thanks'
     | '/account/mytba'
     | '/apidocs/v3'
@@ -304,6 +315,7 @@ export interface FileRouteTypes {
     | '/gameday'
     | '/match_suggestion'
     | '/privacy'
+    | '/search'
     | '/thanks'
     | '/account/mytba'
     | '/apidocs_/v3'
@@ -331,6 +343,7 @@ export interface RootRouteChildren {
   GamedayRoute: typeof GamedayRoute
   Match_suggestionRoute: typeof Match_suggestionRoute
   PrivacyRoute: typeof PrivacyRoute
+  SearchRoute: typeof SearchRoute
   ThanksRoute: typeof ThanksRoute
   AccountMytbaRoute: typeof AccountMytbaRoute
   ApidocsV3Route: typeof ApidocsV3Route
@@ -355,6 +368,13 @@ declare module '@tanstack/react-router' {
       path: '/thanks'
       fullPath: '/thanks'
       preLoaderRoute: typeof ThanksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search': {
+      id: '/search'
+      path: '/search'
+      fullPath: '/search'
+      preLoaderRoute: typeof SearchRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/privacy': {
@@ -423,7 +443,7 @@ declare module '@tanstack/react-router' {
     '/account/': {
       id: '/account/'
       path: '/account'
-      fullPath: '/account'
+      fullPath: '/account/'
       preLoaderRoute: typeof AccountIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -531,6 +551,7 @@ const rootRouteChildren: RootRouteChildren = {
   GamedayRoute: GamedayRoute,
   Match_suggestionRoute: Match_suggestionRoute,
   PrivacyRoute: PrivacyRoute,
+  SearchRoute: SearchRoute,
   ThanksRoute: ThanksRoute,
   AccountMytbaRoute: AccountMytbaRoute,
   ApidocsV3Route: ApidocsV3Route,

--- a/pwa/app/routes/search.tsx
+++ b/pwa/app/routes/search.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { z } from 'zod';
+
+import { getSearchIndexOptions } from '~/api/tba/read/@tanstack/react-query.gen';
+import { getSearchRedirect } from '~/lib/search/searchRedirect';
+import { publicCacheControlHeaders } from '~/lib/utils';
+
+const searchSchema = z.object({
+  q: z.string().optional().default(''),
+});
+
+export const Route = createFileRoute('/search')({
+  validateSearch: searchSchema,
+  beforeLoad: async ({ context: { queryClient }, search }) => {
+    const searchIndex = await queryClient.ensureQueryData(
+      getSearchIndexOptions({}),
+    );
+    // Tanstack may auto-parse '604' to a number, so just stringify it just in case
+    const result = getSearchRedirect(searchIndex, search.q.toString());
+
+    // If we found a team or event, redirect to it
+    if (result.type === 'team' || result.type === 'event') {
+      throw redirect({ to: result.path });
+    }
+
+    // Otherwise, pass query to component
+    return { query: search.q };
+  },
+  headers: publicCacheControlHeaders(),
+  head: () => ({
+    meta: [
+      { title: 'Search - The Blue Alliance' },
+      {
+        name: 'description',
+        content: 'Search for teams and events on The Blue Alliance',
+      },
+    ],
+  }),
+  component: SearchRoute,
+});
+
+function SearchRoute() {
+  const { query } = Route.useRouteContext();
+
+  return (
+    <div className="container max-w-2xl py-8">
+      <h1 className="mb-4 text-3xl font-medium">No Results Found</h1>
+      {query && (
+        <p className="mb-4 text-muted-foreground">
+          No results found for &quot;{query}&quot;
+        </p>
+      )}
+      <div className="rounded-lg border bg-muted/50 p-6">
+        <h2 className="mb-3 text-xl font-medium">Search Tips</h2>
+        <p className="mb-3">Try searching for:</p>
+        <ul className="list-inside list-disc space-y-1 text-muted-foreground">
+          <li>Team numbers (e.g., &quot;254&quot;, &quot;604&quot;)</li>
+          <li>
+            Team nicknames (e.g., &quot;Cheesy Poofs&quot;,
+            &quot;Quixilver&quot;)
+          </li>
+          <li>Event keys (e.g., &quot;2024casj&quot;, &quot;2024mil&quot;)</li>
+          <li>Event names (e.g., &quot;Silicon Valley Regional&quot;)</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/pwa/tests/routes.spec.ts
+++ b/pwa/tests/routes.spec.ts
@@ -20,7 +20,7 @@ function defineAllRoutes<T extends readonly RoutePath[]>(
 const allRoutes = defineAllRoutes([
   '/',
   '/about',
-  '/account',
+  '/account/',
   '/account/mytba',
   '/add-data',
   '/apidocs',
@@ -37,6 +37,7 @@ const allRoutes = defineAllRoutes([
   '/match_suggestion',
   '/match/$matchKey',
   '/privacy',
+  '/search',
   '/team/$teamNumber/{-$year}',
   '/team/$teamNumber/history',
   '/team/$teamNumber/stats',


### PR DESCRIPTION
Adds a search route for PWA. This can be installed as a custom search engine in browsers for easier searching.

For example, a Firefox bookmark search:

<img width="1036" height="607" alt="image" src="https://github.com/user-attachments/assets/3dab5201-a1cb-47ca-8f6f-cfccba4d5c3b" />

you would use this by typing `lh 604` into the address bar. I have a `tba ` search prefix for prod and it's useful, I wanted to add this for pwa as well.