### PR TITLE
PWA: Add webcasts list page

### DIFF
--- a/pwa/app/routeTree.gen.ts
+++ b/pwa/app/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as WebcastsRouteImport } from './routes/webcasts'
 import { Route as ThanksRouteImport } from './routes/thanks'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as Match_suggestionRouteImport } from './routes/match_suggestion'
@@ -34,6 +35,11 @@ import { Route as TeamTeamNumberHistoryRouteImport } from './routes/team.$teamNu
 import { Route as DistrictDistrictAbbreviationChar123YearChar125RouteImport } from './routes/district.$districtAbbreviation.{-$year}'
 import { Route as DistrictDistrictAbbreviationInsightsRouteImport } from './routes/district.$districtAbbreviation.insights'
 
+const WebcastsRoute = WebcastsRouteImport.update({
+  id: '/webcasts',
+  path: '/webcasts',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ThanksRoute = ThanksRouteImport.update({
   id: '/thanks',
   path: '/thanks',
@@ -172,6 +178,7 @@ export interface FileRoutesByFullPath {
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
   '/thanks': typeof ThanksRoute
+  '/webcasts': typeof WebcastsRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs/v3': typeof ApidocsV3Route
   '/event/$eventKey': typeof EventEventKeyRoute
@@ -198,6 +205,7 @@ export interface FileRoutesByTo {
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
   '/thanks': typeof ThanksRoute
+  '/webcasts': typeof WebcastsRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs/v3': typeof ApidocsV3Route
   '/event/$eventKey': typeof EventEventKeyRoute
@@ -225,6 +233,7 @@ export interface FileRoutesById {
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
   '/thanks': typeof ThanksRoute
+  '/webcasts': typeof WebcastsRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs_/v3': typeof ApidocsV3Route
   '/event/$eventKey': typeof EventEventKeyRoute
@@ -253,6 +262,7 @@ export interface FileRouteTypes {
     | '/match_suggestion'
     | '/privacy'
     | '/thanks'
+    | '/webcasts'
     | '/account/mytba'
     | '/apidocs/v3'
     | '/event/$eventKey'
@@ -279,6 +289,7 @@ export interface FileRouteTypes {
     | '/match_suggestion'
     | '/privacy'
     | '/thanks'
+    | '/webcasts'
     | '/account/mytba'
     | '/apidocs/v3'
     | '/event/$eventKey'
@@ -305,6 +316,7 @@ export interface FileRouteTypes {
     | '/match_suggestion'
     | '/privacy'
     | '/thanks'
+    | '/webcasts'
     | '/account/mytba'
     | '/apidocs_/v3'
     | '/event/$eventKey'
@@ -332,6 +344,7 @@ export interface RootRouteChildren {
   Match_suggestionRoute: typeof Match_suggestionRoute
   PrivacyRoute: typeof PrivacyRoute
   ThanksRoute: typeof ThanksRoute
+  WebcastsRoute: typeof WebcastsRoute
   AccountMytbaRoute: typeof AccountMytbaRoute
   ApidocsV3Route: typeof ApidocsV3Route
   EventEventKeyRoute: typeof EventEventKeyRoute
@@ -350,6 +363,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/webcasts': {
+      id: '/webcasts'
+      path: '/webcasts'
+      fullPath: '/webcasts'
+      preLoaderRoute: typeof WebcastsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/thanks': {
       id: '/thanks'
       path: '/thanks'
@@ -532,6 +552,7 @@ const rootRouteChildren: RootRouteChildren = {
   Match_suggestionRoute: Match_suggestionRoute,
   PrivacyRoute: PrivacyRoute,
   ThanksRoute: ThanksRoute,
+  WebcastsRoute: WebcastsRoute,
   AccountMytbaRoute: AccountMytbaRoute,
   ApidocsV3Route: ApidocsV3Route,
   EventEventKeyRoute: EventEventKeyRoute,

--- a/pwa/app/routes/webcasts.tsx
+++ b/pwa/app/routes/webcasts.tsx
@@ -1,0 +1,208 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import { useMemo } from 'react';
+
+import { Event } from '~/api/tba/read';
+import {
+  getEventsByYearOptions,
+  getStatusOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
+import { EventLink, EventLocationLink } from '~/components/tba/links';
+import { WebcastIcon } from '~/components/tba/socialBadges';
+import { Badge } from '~/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card';
+import { getEventDateString, getEventWeekString } from '~/lib/eventUtils';
+import { publicCacheControlHeaders } from '~/lib/utils';
+
+export const Route = createFileRoute('/webcasts')({
+  loader: async ({ context: { queryClient } }) => {
+    const status = await queryClient.ensureQueryData(getStatusOptions());
+    const year = status.current_season;
+
+    await queryClient.ensureQueryData(
+      getEventsByYearOptions({ path: { year } }),
+    );
+
+    return { year };
+  },
+  headers: publicCacheControlHeaders(),
+  head: () => ({
+    meta: [
+      { title: 'Live Webcasts - The Blue Alliance' },
+      {
+        name: 'description',
+        content:
+          'Watch live webcasts from FIRST Robotics Competition events on The Blue Alliance.',
+      },
+    ],
+  }),
+  component: WebcastsPage,
+});
+
+interface EventGroup {
+  label: string;
+  events: Event[];
+}
+
+function groupEventsByWeek(events: Event[]): EventGroup[] {
+  const groups = new Map<string, EventGroup>();
+
+  for (const event of events) {
+    const weekStr = getEventWeekString(event) ?? 'Other';
+    const existing = groups.get(weekStr);
+    if (existing) {
+      existing.events.push(event);
+    } else {
+      groups.set(weekStr, { label: weekStr, events: [event] });
+    }
+  }
+
+  return Array.from(groups.values());
+}
+
+function WebcastsPage() {
+  const { year } = Route.useLoaderData();
+  const { data: allEvents } = useSuspenseQuery({
+    ...getEventsByYearOptions({ path: { year } }),
+  });
+
+  const eventsWithWebcasts = useMemo(
+    () => allEvents.filter((event) => event.webcasts.length > 0),
+    [allEvents],
+  );
+
+  const now = useMemo(() => new Date(), []);
+
+  const currentEvents = useMemo(
+    () =>
+      eventsWithWebcasts.filter((event) => {
+        const start = new Date(event.start_date);
+        const end = new Date(event.end_date);
+        end.setDate(end.getDate() + 1);
+        return now >= start && now <= end;
+      }),
+    [eventsWithWebcasts, now],
+  );
+
+  const upcomingEvents = useMemo(
+    () =>
+      eventsWithWebcasts.filter((event) => {
+        const start = new Date(event.start_date);
+        return start > now;
+      }),
+    [eventsWithWebcasts, now],
+  );
+
+  const pastEvents = useMemo(
+    () =>
+      eventsWithWebcasts.filter((event) => {
+        const end = new Date(event.end_date);
+        end.setDate(end.getDate() + 1);
+        return end < now;
+      }),
+    [eventsWithWebcasts, now],
+  );
+
+  const upcomingGroups = groupEventsByWeek(upcomingEvents);
+  const pastGroups = groupEventsByWeek(pastEvents).reverse();
+
+  return (
+    <div className="py-8">
+      <h1 className="mb-4 text-3xl font-medium">
+        {year} Webcasts{' '}
+        <small className="text-xl text-muted-foreground">
+          {eventsWithWebcasts.length} Events with Webcasts
+        </small>
+      </h1>
+
+      {currentEvents.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-2xl font-medium">Live Now</h2>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {currentEvents.map((event) => (
+              <EventWebcastCard key={event.key} event={event} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {upcomingGroups.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-2xl font-medium">Upcoming</h2>
+          {upcomingGroups.map((group) => (
+            <div key={group.label} className="mb-4">
+              <h3 className="mb-2 text-lg font-medium text-muted-foreground">
+                {group.label}
+              </h3>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {group.events.map((event) => (
+                  <EventWebcastCard key={event.key} event={event} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {pastGroups.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-2xl font-medium">Past</h2>
+          {pastGroups.map((group) => (
+            <div key={group.label} className="mb-4">
+              <h3 className="mb-2 text-lg font-medium text-muted-foreground">
+                {group.label}
+              </h3>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {group.events.map((event) => (
+                  <EventWebcastCard key={event.key} event={event} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {eventsWithWebcasts.length === 0 && (
+        <p className="text-muted-foreground">
+          No events with webcasts found for {year}.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function EventWebcastCard({ event }: { event: Event }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">
+          <EventLink eventOrKey={event}>{event.name}</EventLink>
+        </CardTitle>
+        <CardDescription>
+          <EventLocationLink event={event} hideUSA hideVenue />
+          {event.week !== null && (
+            <Badge variant="secondary" className="ml-2">
+              Week {event.week + 1}
+            </Badge>
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="text-xs text-muted-foreground">
+          {getEventDateString(event, 'short')}
+        </div>
+        <div className="mt-2 flex flex-wrap gap-1">
+          {event.webcasts.map((webcast) => (
+            <WebcastIcon key={webcast.channel} webcast={webcast} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/tests/routes.spec.ts
+++ b/pwa/tests/routes.spec.ts
@@ -42,6 +42,7 @@ const allRoutes = defineAllRoutes([
   '/team/$teamNumber/stats',
   '/teams/{-$pgNum}',
   '/thanks',
+  '/webcasts',
 ] as const);
 
 // Define test data for dynamic route parameters


### PR DESCRIPTION
## Summary
- Adds `/webcasts` route showing all events with webcasts for the current season
- Groups events into "Live Now", "Upcoming", and "Past" sections
- Upcoming and Past sections are further grouped by competition week
- Each event card shows event name, location, dates, and webcast badges

## Test plan
- [ ] Navigate to `/webcasts` and verify events with webcasts are listed
- [ ] Verify "Live Now" section appears during active competition weeks
- [ ] Verify webcasts link to correct YouTube/Twitch URLs
- [ ] Run `npm run typecheck` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)