### PR TITLE
PWA: Add match CSV export to event Results tab

### DIFF
--- a/pwa/app/lib/csvExport.ts
+++ b/pwa/app/lib/csvExport.ts
@@ -1,0 +1,70 @@
+import { Match } from '~/api/tba/read';
+
+function escapeCSV(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function generateMatchCSV(matches: Match[]): string {
+  const maxTeamsPerAlliance = Math.max(
+    ...matches.map((m) => m.alliances.red.team_keys.length),
+    ...matches.map((m) => m.alliances.blue.team_keys.length),
+    3,
+  );
+
+  const teamHeaders = [];
+  for (let i = 1; i <= maxTeamsPerAlliance; i++) {
+    teamHeaders.push(`Red ${i}`, `Blue ${i}`);
+  }
+
+  const headers = [
+    'Match',
+    'Comp Level',
+    'Set Number',
+    'Match Number',
+    ...teamHeaders,
+    'Red Score',
+    'Blue Score',
+    'Winning Alliance',
+  ];
+
+  const rows = matches.map((match) => {
+    const teamCols = [];
+    for (let i = 0; i < maxTeamsPerAlliance; i++) {
+      teamCols.push(
+        match.alliances.red.team_keys[i]?.substring(3) ?? '',
+        match.alliances.blue.team_keys[i]?.substring(3) ?? '',
+      );
+    }
+
+    return [
+      match.key,
+      match.comp_level,
+      String(match.set_number),
+      String(match.match_number),
+      ...teamCols,
+      String(match.alliances.red.score),
+      String(match.alliances.blue.score),
+      match.winning_alliance,
+    ];
+  });
+
+  const csvContent = [
+    headers.map(escapeCSV).join(','),
+    ...rows.map((row) => row.map(escapeCSV).join(',')),
+  ].join('\n');
+
+  return csvContent;
+}
+
+export function downloadCSV(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -8,6 +8,7 @@ import SourceIcon from '~icons/lucide/badge-check';
 import TeamsIcon from '~icons/lucide/bot';
 import DateIcon from '~icons/lucide/calendar-days';
 import StatbotIcon from '~icons/lucide/chart-spline';
+import DownloadIcon from '~icons/lucide/download';
 import WebsiteIcon from '~icons/lucide/globe';
 import RankingsIcon from '~icons/lucide/list-ordered';
 import LocationIcon from '~icons/lucide/map-pin';
@@ -103,6 +104,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { SEASON_EVENT_TYPES } from '~/lib/api/EventType';
 import { PlayoffType } from '~/lib/api/PlayoffType';
 import { sortAwardsComparator } from '~/lib/awardUtils';
+import { downloadCSV, generateMatchCSV } from '~/lib/csvExport';
 import {
   getCurrentWeekEvents,
   getEventDateString,
@@ -481,7 +483,22 @@ function ResultsTab({
 
   return (
     <>
-      <TableOfContents tocItems={tocItems} inView={inView} mobileOnly />
+      <div className="flex items-center justify-between">
+        <TableOfContents tocItems={tocItems} inView={inView} mobileOnly />
+        {sortedMatches.length > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const csv = generateMatchCSV(sortedMatches);
+              downloadCSV(csv, `${event.key}_matches.csv`);
+            }}
+          >
+            <DownloadIcon className="mr-1 size-4" />
+            Export CSV
+          </Button>
+        )}
+      </div>
 
       <div className="flex flex-wrap gap-4 lg:flex-nowrap">
         <TableOfContentsSection


### PR DESCRIPTION
## Summary
- Adds "Export CSV" button to the event Results tab
- Generates client-side CSV with match data (teams, scores, comp level)
- Downloads as `{eventKey}_matches.csv` file
- Reusable `generateMatchCSV` and `downloadCSV` utilities in `lib/csvExport.ts`

## Test plan
- [ ] Navigate to an event with matches (e.g., `/event/2024mil`)
- [ ] Click "Export CSV" button on the Results tab
- [ ] Verify downloaded CSV contains correct match data
- [ ] Open CSV in a spreadsheet app and verify formatting
- [ ] Run `npm run typecheck` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)