### PR TITLE
PWA: Add edit profile and delete account

### DIFF
--- a/pwa/app/routes/account.index.tsx
+++ b/pwa/app/routes/account.index.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link, createFileRoute } from '@tanstack/react-router';
+import { deleteUser, updateProfile } from 'firebase/auth';
 import { Mail, User } from 'lucide-react';
+import { useState } from 'react';
 
 import { listFavorites, listSubscriptions } from '~/api/tba/mobile/sdk.gen';
 import { useAuth } from '~/components/tba/auth/auth';
@@ -13,6 +15,16 @@ import {
   CardHeader,
   CardTitle,
 } from '~/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog';
+import { Input } from '~/components/ui/input';
 
 export const Route = createFileRoute('/account/')({
   component: Account,
@@ -82,14 +94,17 @@ function Account() {
             </div>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row">
-            <a href="#todo">
-              <Button size="sm">Edit Profile</Button>
-            </a>
-            <a href="#todo">
-              <Button size="sm" variant="destructive">
-                Delete Account
-              </Button>
-            </a>
+            <EditProfileDialog
+              displayName={user.displayName ?? ''}
+              onSave={async (newDisplayName) => {
+                await updateProfile(user, { displayName: newDisplayName });
+              }}
+            />
+            <DeleteAccountDialog
+              onConfirm={async () => {
+                await deleteUser(user);
+              }}
+            />
           </div>
         </CardContent>
       </Card>
@@ -123,5 +138,156 @@ function Account() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+function EditProfileDialog({
+  displayName,
+  onSave,
+}: {
+  displayName: string;
+  onSave: (newDisplayName: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(displayName);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError('Display name cannot be empty.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(name.trim());
+      setOpen(false);
+    } catch {
+      setError('Failed to update profile. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+        if (isOpen) {
+          setName(displayName);
+          setError(null);
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm">Edit Profile</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Profile</DialogTitle>
+          <DialogDescription>Update your display name.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <span className="text-sm font-medium">Display Name</span>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter your display name"
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteAccountDialog({
+  onConfirm,
+}: {
+  onConfirm: () => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      await onConfirm();
+      setOpen(false);
+    } catch {
+      setError(
+        'Failed to delete account. You may need to sign in again before deleting.',
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+        if (isOpen) {
+          setConfirmText('');
+          setError(null);
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm" variant="destructive">
+          Delete Account
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Account</DialogTitle>
+          <DialogDescription>
+            This action is permanent and cannot be undone. All your data,
+            favorites, and subscriptions will be deleted.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <span className="text-sm font-medium">
+              Type <strong>DELETE</strong> to confirm
+            </span>
+            <Input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE"
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => void handleDelete()}
+            disabled={confirmText !== 'DELETE' || deleting}
+          >
+            {deleting ? 'Deleting...' : 'Delete Account'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces placeholder `#todo` links with working Edit Profile and Delete Account dialogs
- Edit Profile dialog allows updating display name via Firebase `updateProfile()`
- Delete Account dialog requires typing "DELETE" to confirm, uses Firebase `deleteUser()`
- Both dialogs include loading states and error handling

## Test plan
- [ ] Sign in and click "Edit Profile" - verify dialog opens with current display name
- [ ] Change display name and save - verify it updates
- [ ] Click "Delete Account" - verify confirmation dialog requires typing DELETE
- [ ] Verify delete button is disabled until DELETE is typed
- [ ] Run `npm run typecheck` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)