### PR TITLE
PWA: Add favorite button to match page

### DIFF
--- a/pwa/app/routes/match.$matchKey.tsx
+++ b/pwa/app/routes/match.$matchKey.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute, notFound } from '@tanstack/react-router';
 
 import { getEvent, getMatch } from '~/api/tba/read';
+import FavoriteButton from '~/components/tba/favoriteButton';
 import { EventLink } from '~/components/tba/links';
 import MatchDetails from '~/components/tba/match/matchDetails';
 import { PlayoffType } from '~/lib/api/PlayoffType';
 import { isValidMatchKey, matchTitleShort } from '~/lib/matchUtils';
-import { publicCacheControlHeaders } from '~/lib/utils';
+import { MODEL_TYPE, publicCacheControlHeaders } from '~/lib/utils';
 
 export const Route = createFileRoute('/match/$matchKey')({
   loader: async ({ params }) => {
@@ -63,14 +64,17 @@ function MatchPage() {
 
   return (
     <div>
-      <h1 className="mt-8 mb-4 text-4xl">
-        {matchTitleShort(match, event.playoff_type ?? PlayoffType.CUSTOM)}{' '}
-        <small className="text-xl">
-          <EventLink eventOrKey={event}>
-            {event.name} {event.year}
-          </EventLink>
-        </small>
-      </h1>
+      <div className="mt-8 mb-4 flex items-center gap-2">
+        <h1 className="text-4xl">
+          {matchTitleShort(match, event.playoff_type ?? PlayoffType.CUSTOM)}{' '}
+          <small className="text-xl">
+            <EventLink eventOrKey={event}>
+              {event.name} {event.year}
+            </EventLink>
+          </small>
+        </h1>
+        <FavoriteButton modelKey={match.key} modelType={MODEL_TYPE.MATCH} />
+      </div>
       <MatchDetails match={match} event={event} />
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds FavoriteButton component to the match detail page header
- Allows users to favorite/unfavorite individual matches from the match page
- Consistent with existing favorite buttons on event and team pages

## Test plan
- [ ] Navigate to a match page (e.g., `/match/2024mil_f1m2`)
- [ ] Verify the star button appears next to the match title
- [ ] Click the star to toggle favorite (requires sign-in)
- [ ] Verify sign-in prompt appears for unauthenticated users
- [ ] Run `npm run typecheck` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)