### PR TITLE
PWA: Add score breakdowns for 2016, 2017, 2019, 2020

### DIFF
--- a/pwa/app/components/tba/match/matchDetails.tsx
+++ b/pwa/app/components/tba/match/matchDetails.tsx
@@ -3,7 +3,11 @@ import { useState } from 'react';
 import { Event, Match } from '~/api/tba/read';
 import { SimpleMatchRow } from '~/components/tba/match/matchRows';
 import { ScoreBreakdown2015 } from '~/components/tba/match/scoreBreakdown2015';
+import ScoreBreakdown2016 from '~/components/tba/match/scoreBreakdown2016';
+import ScoreBreakdown2017 from '~/components/tba/match/scoreBreakdown2017';
 import ScoreBreakdown2018 from '~/components/tba/match/scoreBreakdown2018';
+import ScoreBreakdown2019 from '~/components/tba/match/scoreBreakdown2019';
+import ScoreBreakdown2020 from '~/components/tba/match/scoreBreakdown2020';
 import ScoreBreakdown2023 from '~/components/tba/match/scoreBreakdown2023';
 import ScoreBreakdown2024 from '~/components/tba/match/scoreBreakdown2024';
 import ScoreBreakdown2025 from '~/components/tba/match/scoreBreakdown2025';
@@ -11,7 +15,11 @@ import { YoutubeEmbed } from '~/components/tba/videoEmbeds';
 import { Checkbox } from '~/components/ui/checkbox';
 import {
   isScoreBreakdown2015,
+  isScoreBreakdown2016,
+  isScoreBreakdown2017,
   isScoreBreakdown2018,
+  isScoreBreakdown2019,
+  isScoreBreakdown2020,
   isScoreBreakdown2023,
   isScoreBreakdown2024,
   isScoreBreakdown2025,
@@ -121,9 +129,45 @@ export default function MatchDetails({
     );
   }
 
+  if (isScoreBreakdown2020(match.score_breakdown)) {
+    sbDiv = (
+      <ScoreBreakdown2020
+        scoreBreakdown={match.score_breakdown}
+        match={match}
+      />
+    );
+  }
+
+  if (isScoreBreakdown2019(match.score_breakdown)) {
+    sbDiv = (
+      <ScoreBreakdown2019
+        scoreBreakdown={match.score_breakdown}
+        match={match}
+      />
+    );
+  }
+
   if (isScoreBreakdown2018(match.score_breakdown)) {
     sbDiv = (
       <ScoreBreakdown2018
+        scoreBreakdown={match.score_breakdown}
+        match={match}
+      />
+    );
+  }
+
+  if (isScoreBreakdown2017(match.score_breakdown)) {
+    sbDiv = (
+      <ScoreBreakdown2017
+        scoreBreakdown={match.score_breakdown}
+        match={match}
+      />
+    );
+  }
+
+  if (isScoreBreakdown2016(match.score_breakdown)) {
+    sbDiv = (
+      <ScoreBreakdown2016
         scoreBreakdown={match.score_breakdown}
         match={match}
       />

--- a/pwa/app/components/tba/match/scoreBreakdown2016.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown2016.tsx
@@ -1,0 +1,311 @@
+import { Match, MatchScoreBreakdown2016 } from '~/api/tba/read';
+import {
+  ConditionalCheckmark,
+  ConditionalRpAchieved,
+  FoulDisplay,
+} from '~/components/tba/match/common';
+import { Table, TableBody, TableCell, TableRow } from '~/components/ui/table';
+import { POINTS_PER_FOUL, POINTS_PER_TECH_FOUL } from '~/lib/pointValues';
+
+export default function ScoreBreakdown2016({
+  scoreBreakdown,
+  match,
+}: {
+  scoreBreakdown: MatchScoreBreakdown2016;
+  match: Match;
+}) {
+  return (
+    <Table className="table-fixed overflow-hidden rounded-lg text-center">
+      <colgroup>
+        <col />
+        <col className="w-[45%]" />
+        <col />
+      </colgroup>
+      <TableBody>
+        {/* Auto Reach/Cross */}
+        <TableRow>
+          <TableCell
+            className="bg-alliance-red-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.red.robot1Auto === 'Crossed' ||
+                scoreBreakdown.red.robot1Auto === 'Reached'
+              }
+              teamKey={match.alliances.red.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.red.robot2Auto === 'Crossed' ||
+                scoreBreakdown.red.robot2Auto === 'Reached'
+              }
+              teamKey={match.alliances.red.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.red.robot3Auto === 'Crossed' ||
+                scoreBreakdown.red.robot3Auto === 'Reached'
+              }
+              teamKey={match.alliances.red.team_keys[2].substring(3)}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Auto Reach/Cross
+          </TableCell>
+          <TableCell
+            className="bg-alliance-blue-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.blue.robot1Auto === 'Crossed' ||
+                scoreBreakdown.blue.robot1Auto === 'Reached'
+              }
+              teamKey={match.alliances.blue.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.blue.robot2Auto === 'Crossed' ||
+                scoreBreakdown.blue.robot2Auto === 'Reached'
+              }
+              teamKey={match.alliances.blue.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.blue.robot3Auto === 'Crossed' ||
+                scoreBreakdown.blue.robot3Auto === 'Reached'
+              }
+              teamKey={match.alliances.blue.team_keys[2].substring(3)}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Reach Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoReachPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Reach Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoReachPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Crossing Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoCrossingPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Crossing Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoCrossingPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Boulders */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            H: {scoreBreakdown.red.autoBouldersHigh ?? 0} / L:{' '}
+            {scoreBreakdown.red.autoBouldersLow ?? 0} (+
+            {scoreBreakdown.red.autoBoulderPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Boulders
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            H: {scoreBreakdown.blue.autoBouldersHigh ?? 0} / L:{' '}
+            {scoreBreakdown.blue.autoBouldersLow ?? 0} (+
+            {scoreBreakdown.blue.autoBoulderPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Total Auto */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.autoPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Auto
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.autoPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Crossing Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopCrossingPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Crossing Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopCrossingPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Boulders */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            H: {scoreBreakdown.red.teleopBouldersHigh} / L:{' '}
+            {scoreBreakdown.red.teleopBouldersLow} (+
+            {scoreBreakdown.red.teleopBoulderPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Boulders
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            H: {scoreBreakdown.blue.teleopBouldersHigh} / L:{' '}
+            {scoreBreakdown.blue.teleopBouldersLow} (+
+            {scoreBreakdown.blue.teleopBoulderPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Challenge/Scale Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopChallengePoints +
+              scoreBreakdown.red.teleopScalePoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Tower Challenge/Scale
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopChallengePoints +
+              scoreBreakdown.blue.teleopScalePoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Teleop */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.teleopPoints ?? 0}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Teleop
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.teleopPoints ?? 0}
+          </TableCell>
+        </TableRow>
+
+        {/* Breached RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.teleopDefensesBreached}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Defenses Breached
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.teleopDefensesBreached}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Tower Captured RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.teleopTowerCaptured}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Tower Captured
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.teleopTowerCaptured}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Breach / Capture Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.breachPoints} /{' '}
+            {scoreBreakdown.red.capturePoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Breach / Capture Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.breachPoints} /{' '}
+            {scoreBreakdown.blue.capturePoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Fouls / Tech Fouls */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.red.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2016]}
+              techFoulsReceived={scoreBreakdown.red.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2016]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Fouls / Tech Fouls
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.blue.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2016]}
+              techFoulsReceived={scoreBreakdown.blue.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2016]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Adjustments */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.adjustPoints ?? 0}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Adjustments
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.adjustPoints ?? 0}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Score */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.totalPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Score
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.totalPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            +{scoreBreakdown.red.tba_rpEarned ?? 0} RP
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            RP
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            +{scoreBreakdown.blue.tba_rpEarned ?? 0} RP
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}

--- a/pwa/app/components/tba/match/scoreBreakdown2017.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown2017.tsx
@@ -1,0 +1,402 @@
+import { Match, MatchScoreBreakdown2017 } from '~/api/tba/read';
+import {
+  ConditionalCheckmark,
+  ConditionalRpAchieved,
+  FoulDisplay,
+} from '~/components/tba/match/common';
+import { Badge } from '~/components/ui/badge';
+import { Table, TableBody, TableCell, TableRow } from '~/components/ui/table';
+import { POINTS_PER_FOUL, POINTS_PER_TECH_FOUL } from '~/lib/pointValues';
+
+export default function ScoreBreakdown2017({
+  scoreBreakdown,
+  match,
+}: {
+  scoreBreakdown: MatchScoreBreakdown2017;
+  match: Match;
+}) {
+  return (
+    <Table className="table-fixed overflow-hidden rounded-lg text-center">
+      <colgroup>
+        <col />
+        <col className="w-[45%]" />
+        <col />
+      </colgroup>
+      <TableBody>
+        {/* Auto Mobility */}
+        <TableRow>
+          <TableCell
+            className="bg-alliance-red-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={scoreBreakdown.red.robot1Auto === 'Mobility'}
+              teamKey={match.alliances.red.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.red.robot2Auto === 'Mobility'}
+              teamKey={match.alliances.red.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.red.robot3Auto === 'Mobility'}
+              teamKey={match.alliances.red.team_keys[2].substring(3)}
+            />
+            (+{scoreBreakdown.red.autoMobilityPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Auto Mobility
+          </TableCell>
+          <TableCell
+            className="bg-alliance-blue-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={scoreBreakdown.blue.robot1Auto === 'Mobility'}
+              teamKey={match.alliances.blue.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.blue.robot2Auto === 'Mobility'}
+              teamKey={match.alliances.blue.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.blue.robot3Auto === 'Mobility'}
+              teamKey={match.alliances.blue.team_keys[2].substring(3)}
+            />
+            (+{scoreBreakdown.blue.autoMobilityPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Fuel High */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoFuelHigh}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Fuel High
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoFuelHigh}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Fuel Low */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoFuelLow}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Fuel Low
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoFuelLow}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Fuel Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.autoFuelPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Auto Fuel Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.autoFuelPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Rotors */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <RotorDisplay
+              rotor1={scoreBreakdown.red.rotor1Auto}
+              rotor2={scoreBreakdown.red.rotor2Auto}
+            />
+            (+{scoreBreakdown.red.autoRotorPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Rotors
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <RotorDisplay
+              rotor1={scoreBreakdown.blue.rotor1Auto}
+              rotor2={scoreBreakdown.blue.rotor2Auto}
+            />
+            (+{scoreBreakdown.blue.autoRotorPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Total Auto */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.autoPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Auto
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.autoPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Fuel High */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopFuelHigh}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Fuel High
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopFuelHigh}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Fuel Low */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopFuelLow}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Fuel Low
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopFuelLow}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Fuel Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.teleopFuelPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Teleop Fuel Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.teleopFuelPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Rotors */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <RotorDisplay
+              rotor1={scoreBreakdown.red.rotor1Engaged}
+              rotor2={scoreBreakdown.red.rotor2Engaged}
+              rotor3={scoreBreakdown.red.rotor3Engaged}
+              rotor4={scoreBreakdown.red.rotor4Engaged}
+            />
+            (+{scoreBreakdown.red.teleopRotorPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Rotors
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <RotorDisplay
+              rotor1={scoreBreakdown.blue.rotor1Engaged}
+              rotor2={scoreBreakdown.blue.rotor2Engaged}
+              rotor3={scoreBreakdown.blue.rotor3Engaged}
+              rotor4={scoreBreakdown.blue.rotor4Engaged}
+            />
+            (+{scoreBreakdown.blue.teleopRotorPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Takeoff Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <TouchpadDisplay
+              near={scoreBreakdown.red.touchpadNear}
+              middle={scoreBreakdown.red.touchpadMiddle}
+              far={scoreBreakdown.red.touchpadFar}
+              teamKeys={match.alliances.red.team_keys}
+            />
+            (+{scoreBreakdown.red.teleopTakeoffPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Takeoff
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <TouchpadDisplay
+              near={scoreBreakdown.blue.touchpadNear}
+              middle={scoreBreakdown.blue.touchpadMiddle}
+              far={scoreBreakdown.blue.touchpadFar}
+              teamKeys={match.alliances.blue.team_keys}
+            />
+            (+{scoreBreakdown.blue.teleopTakeoffPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Total Teleop */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.teleopPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Teleop
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.teleopPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* kPa Bonus RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.kPaRankingPointAchieved}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Pressure Reached
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.kPaRankingPointAchieved}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Rotor Bonus RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.rotorRankingPointAchieved}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            All Rotors Engaged
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.rotorRankingPointAchieved}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Fouls / Tech Fouls */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.red.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2017]}
+              techFoulsReceived={scoreBreakdown.red.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2017]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Fouls / Tech Fouls
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.blue.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2017]}
+              techFoulsReceived={scoreBreakdown.blue.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2017]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Adjustments */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.adjustPoints ?? 0}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Adjustments
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.adjustPoints ?? 0}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Score */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.totalPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Score
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.totalPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            +{scoreBreakdown.red.tba_rpEarned ?? 0} RP
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            RP
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            +{scoreBreakdown.blue.tba_rpEarned ?? 0} RP
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}
+
+function RotorDisplay({
+  rotor1,
+  rotor2,
+  rotor3,
+  rotor4,
+}: {
+  rotor1: boolean;
+  rotor2: boolean;
+  rotor3?: boolean;
+  rotor4?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-1">
+      <Badge variant={rotor1 ? 'secondary' : 'outline'}>R1</Badge>
+      <Badge variant={rotor2 ? 'secondary' : 'outline'}>R2</Badge>
+      {rotor3 !== undefined && (
+        <Badge variant={rotor3 ? 'secondary' : 'outline'}>R3</Badge>
+      )}
+      {rotor4 !== undefined && (
+        <Badge variant={rotor4 ? 'secondary' : 'outline'}>R4</Badge>
+      )}
+    </div>
+  );
+}
+
+function TouchpadDisplay({
+  near,
+  middle,
+  far,
+  teamKeys,
+}: {
+  near?: string;
+  middle?: string;
+  far?: string;
+  teamKeys: string[];
+}) {
+  return (
+    <div className="flex items-center justify-center gap-1">
+      <Badge
+        variant={near === 'ReadyForTakeoff' ? 'secondary' : 'outline'}
+        title={teamKeys[0]?.substring(3)}
+      >
+        {teamKeys[0]?.substring(3)}
+      </Badge>
+      <Badge
+        variant={middle === 'ReadyForTakeoff' ? 'secondary' : 'outline'}
+        title={teamKeys[1]?.substring(3)}
+      >
+        {teamKeys[1]?.substring(3)}
+      </Badge>
+      <Badge
+        variant={far === 'ReadyForTakeoff' ? 'secondary' : 'outline'}
+        title={teamKeys[2]?.substring(3)}
+      >
+        {teamKeys[2]?.substring(3)}
+      </Badge>
+    </div>
+  );
+}

--- a/pwa/app/components/tba/match/scoreBreakdown2019.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown2019.tsx
@@ -1,0 +1,323 @@
+import { Match, MatchScoreBreakdown2019 } from '~/api/tba/read';
+import {
+  ConditionalCheckmark,
+  ConditionalRpAchieved,
+  FoulDisplay,
+} from '~/components/tba/match/common';
+import { Badge } from '~/components/ui/badge';
+import { Table, TableBody, TableCell, TableRow } from '~/components/ui/table';
+import { POINTS_PER_FOUL, POINTS_PER_TECH_FOUL } from '~/lib/pointValues';
+
+const ENDGAME_2019_POINTS: Record<string, number> = {
+  HabLevel3: 6,
+  HabLevel2: 3,
+  HabLevel1: 3,
+  None: 0,
+  Unknown: 0,
+};
+
+export default function ScoreBreakdown2019({
+  scoreBreakdown,
+  match,
+}: {
+  scoreBreakdown: MatchScoreBreakdown2019;
+  match: Match;
+}) {
+  return (
+    <Table className="table-fixed overflow-hidden rounded-lg text-center">
+      <colgroup>
+        <col />
+        <col className="w-[45%]" />
+        <col />
+      </colgroup>
+      <TableBody>
+        {/* Sandstorm / HAB Line */}
+        <TableRow>
+          <TableCell
+            className="bg-alliance-red-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.red.habLineRobot1 === 'CrossedHabLineInSandstorm'
+              }
+              teamKey={match.alliances.red.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.red.habLineRobot2 === 'CrossedHabLineInSandstorm'
+              }
+              teamKey={match.alliances.red.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.red.habLineRobot3 === 'CrossedHabLineInSandstorm'
+              }
+              teamKey={match.alliances.red.team_keys[2].substring(3)}
+            />
+            (+{scoreBreakdown.red.sandStormBonusPoints})
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Sandstorm Bonus
+          </TableCell>
+          <TableCell
+            className="bg-alliance-blue-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.blue.habLineRobot1 ===
+                'CrossedHabLineInSandstorm'
+              }
+              teamKey={match.alliances.blue.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.blue.habLineRobot2 ===
+                'CrossedHabLineInSandstorm'
+              }
+              teamKey={match.alliances.blue.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={
+                scoreBreakdown.blue.habLineRobot3 ===
+                'CrossedHabLineInSandstorm'
+              }
+              teamKey={match.alliances.blue.team_keys[2].substring(3)}
+            />
+            (+{scoreBreakdown.blue.sandStormBonusPoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Hatch Panel Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.hatchPanelPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Hatch Panel Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.hatchPanelPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Cargo Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.cargoPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Cargo Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.cargoPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Robot 1 Endgame */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.red.endgameRobot1}
+              teamKey={match.alliances.red.team_keys[0]}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Robot 1 Endgame
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.blue.endgameRobot1}
+              teamKey={match.alliances.blue.team_keys[0]}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Robot 2 Endgame */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.red.endgameRobot2}
+              teamKey={match.alliances.red.team_keys[1]}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Robot 2 Endgame
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.blue.endgameRobot2}
+              teamKey={match.alliances.blue.team_keys[1]}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Robot 3 Endgame */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.red.endgameRobot3}
+              teamKey={match.alliances.red.team_keys[2]}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Robot 3 Endgame
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.blue.endgameRobot3}
+              teamKey={match.alliances.blue.team_keys[2]}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* HAB Climb Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.habClimbPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            HAB Climb Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.habClimbPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Teleop */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.teleopPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Teleop
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.teleopPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Complete Rocket RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.completeRocketRankingPoint}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Complete Rocket
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.completeRocketRankingPoint}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* HAB Docking RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.habDockingRankingPoint}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            HAB Docking
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.habDockingRankingPoint}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Fouls / Tech Fouls */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.red.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2019]}
+              techFoulsReceived={scoreBreakdown.red.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2019]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Fouls / Tech Fouls
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.blue.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2019]}
+              techFoulsReceived={scoreBreakdown.blue.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2019]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Adjustments */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.adjustPoints ?? 0}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Adjustments
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.adjustPoints ?? 0}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Score */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.totalPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Score
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.totalPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            +{scoreBreakdown.red.rp} RP
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            RP
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            +{scoreBreakdown.blue.rp} RP
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}
+
+function EndgameRobotCell({
+  endgame,
+  teamKey,
+}: {
+  endgame: MatchScoreBreakdown2019['red']['endgameRobot1'];
+  teamKey: string;
+}) {
+  const points = ENDGAME_2019_POINTS[endgame] ?? 0;
+  const displayMap: Record<string, string> = {
+    HabLevel3: 'HAB 3',
+    HabLevel2: 'HAB 2',
+    HabLevel1: 'HAB 1',
+    None: 'None',
+    Unknown: 'Unknown',
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <Badge variant="outline">{teamKey.substring(3)}</Badge>
+      {displayMap[endgame] ?? endgame} (+{points})
+    </div>
+  );
+}

--- a/pwa/app/components/tba/match/scoreBreakdown2020.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown2020.tsx
@@ -1,0 +1,454 @@
+import { Match, MatchScoreBreakdown2020 } from '~/api/tba/read';
+import {
+  ConditionalCheckmark,
+  ConditionalRpAchieved,
+  FoulDisplay,
+} from '~/components/tba/match/common';
+import { Badge } from '~/components/ui/badge';
+import { Table, TableBody, TableCell, TableRow } from '~/components/ui/table';
+import { POINTS_PER_FOUL, POINTS_PER_TECH_FOUL } from '~/lib/pointValues';
+
+const ENDGAME_2020_POINTS: Record<string, number> = {
+  Hang: 25,
+  Park: 5,
+  None: 0,
+};
+
+export default function ScoreBreakdown2020({
+  scoreBreakdown,
+  match,
+}: {
+  scoreBreakdown: MatchScoreBreakdown2020;
+  match: Match;
+}) {
+  return (
+    <Table className="table-fixed overflow-hidden rounded-lg text-center">
+      <colgroup>
+        <col />
+        <col className="w-[45%]" />
+        <col />
+      </colgroup>
+      <TableBody>
+        {/* Initiation Line */}
+        <TableRow>
+          <TableCell
+            className="bg-alliance-red-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={scoreBreakdown.red.initLineRobot1 === 'Exited'}
+              teamKey={match.alliances.red.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.red.initLineRobot2 === 'Exited'}
+              teamKey={match.alliances.red.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.red.initLineRobot3 === 'Exited'}
+              teamKey={match.alliances.red.team_keys[2].substring(3)}
+            />
+            (+{scoreBreakdown.red.autoInitLinePoints})
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Initiation Line
+          </TableCell>
+          <TableCell
+            className="bg-alliance-blue-dark whitespace-nowrap *:align-middle"
+          >
+            <ConditionalCheckmark
+              condition={scoreBreakdown.blue.initLineRobot1 === 'Exited'}
+              teamKey={match.alliances.blue.team_keys[0].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.blue.initLineRobot2 === 'Exited'}
+              teamKey={match.alliances.blue.team_keys[1].substring(3)}
+            />
+            <ConditionalCheckmark
+              condition={scoreBreakdown.blue.initLineRobot3 === 'Exited'}
+              teamKey={match.alliances.blue.team_keys[2].substring(3)}
+            />
+            (+{scoreBreakdown.blue.autoInitLinePoints})
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Power Cells Bottom */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoCellsBottom}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Bottom Port
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoCellsBottom}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Power Cells Outer */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoCellsOuter}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Outer Port
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoCellsOuter}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Power Cells Inner */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.autoCellsInner}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Auto Inner Port
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.autoCellsInner}
+          </TableCell>
+        </TableRow>
+
+        {/* Auto Cell Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.autoCellPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Auto Cell Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.autoCellPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Auto */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.autoPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Auto
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.autoPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Power Cells Bottom */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopCellsBottom}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Bottom Port
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopCellsBottom}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Power Cells Outer */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopCellsOuter}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Outer Port
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopCellsOuter}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Power Cells Inner */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.teleopCellsInner}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Teleop Inner Port
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.teleopCellsInner}
+          </TableCell>
+        </TableRow>
+
+        {/* Teleop Cell Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.teleopCellPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Teleop Cell Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.teleopCellPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Control Panel */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ControlPanelCell
+              stage1Activated={scoreBreakdown.red.stage1Activated}
+              stage2Activated={scoreBreakdown.red.stage2Activated}
+              stage3Activated={scoreBreakdown.red.stage3Activated}
+              controlPanelPoints={scoreBreakdown.red.controlPanelPoints}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Control Panel
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ControlPanelCell
+              stage1Activated={scoreBreakdown.blue.stage1Activated}
+              stage2Activated={scoreBreakdown.blue.stage2Activated}
+              stage3Activated={scoreBreakdown.blue.stage3Activated}
+              controlPanelPoints={scoreBreakdown.blue.controlPanelPoints}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Robot 1 Endgame */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.red.endgameRobot1}
+              teamKey={match.alliances.red.team_keys[0]}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Robot 1 Endgame
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.blue.endgameRobot1}
+              teamKey={match.alliances.blue.team_keys[0]}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Robot 2 Endgame */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.red.endgameRobot2}
+              teamKey={match.alliances.red.team_keys[1]}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Robot 2 Endgame
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.blue.endgameRobot2}
+              teamKey={match.alliances.blue.team_keys[1]}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Robot 3 Endgame */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.red.endgameRobot3}
+              teamKey={match.alliances.red.team_keys[2]}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Robot 3 Endgame
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <EndgameRobotCell
+              endgame={scoreBreakdown.blue.endgameRobot3}
+              teamKey={match.alliances.blue.team_keys[2]}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Rung Level */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.endgameRungIsLevel === 'IsLevel'}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Rung Level
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.endgameRungIsLevel === 'IsLevel'}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Endgame Points */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.endgamePoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Endgame Points
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.endgamePoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Teleop */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.teleopPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Teleop
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.teleopPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* Shield Operational RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.shieldOperationalRankingPoint}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Shield Operational
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.shieldOperationalRankingPoint}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Shield Energized RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.red.shieldEnergizedRankingPoint}
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Shield Energized
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <ConditionalRpAchieved
+              condition={scoreBreakdown.blue.shieldEnergizedRankingPoint}
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Fouls / Tech Fouls */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.red.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2020]}
+              techFoulsReceived={scoreBreakdown.red.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2020]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Fouls / Tech Fouls
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            <FoulDisplay
+              foulsReceived={scoreBreakdown.blue.foulCount}
+              pointsPerFoul={POINTS_PER_FOUL[2020]}
+              techFoulsReceived={scoreBreakdown.blue.techFoulCount}
+              pointsPerTechFoul={POINTS_PER_TECH_FOUL[2020]}
+              techOrMajor="tech"
+            />
+          </TableCell>
+        </TableRow>
+
+        {/* Adjustments */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            {scoreBreakdown.red.adjustPoints ?? 0}
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            Adjustments
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            {scoreBreakdown.blue.adjustPoints ?? 0}
+          </TableCell>
+        </TableRow>
+
+        {/* Total Score */}
+        <TableRow className="font-bold">
+          <TableCell className="bg-alliance-red-dark">
+            {scoreBreakdown.red.totalPoints}
+          </TableCell>
+          <TableCell className="bg-neutral-200 dark:bg-neutral-800">
+            Total Score
+          </TableCell>
+          <TableCell className="bg-alliance-blue-dark">
+            {scoreBreakdown.blue.totalPoints}
+          </TableCell>
+        </TableRow>
+
+        {/* RP */}
+        <TableRow>
+          <TableCell className="bg-alliance-red-light">
+            +{scoreBreakdown.red.rp ?? 0} RP
+          </TableCell>
+          <TableCell className="bg-neutral-50 dark:bg-neutral-950">
+            RP
+          </TableCell>
+          <TableCell className="bg-alliance-blue-light">
+            +{scoreBreakdown.blue.rp ?? 0} RP
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}
+
+interface ControlPanelCellProps {
+  stage1Activated: boolean;
+  stage2Activated: boolean;
+  stage3Activated: boolean;
+  controlPanelPoints: number;
+}
+
+function ControlPanelCell({
+  stage1Activated,
+  stage2Activated,
+  stage3Activated,
+  controlPanelPoints,
+}: ControlPanelCellProps) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="flex items-center gap-2">
+        <Badge variant={stage1Activated ? 'secondary' : 'outline'}>S1</Badge>
+        <Badge variant={stage2Activated ? 'secondary' : 'outline'}>S2</Badge>
+        <Badge variant={stage3Activated ? 'secondary' : 'outline'}>S3</Badge>
+      </div>
+      <span>(+{controlPanelPoints})</span>
+    </div>
+  );
+}
+
+interface EndgameRobotCellProps {
+  endgame: MatchScoreBreakdown2020['red']['endgameRobot1'];
+  teamKey: string;
+}
+
+function EndgameRobotCell({ endgame, teamKey }: EndgameRobotCellProps) {
+  const points = ENDGAME_2020_POINTS[endgame] ?? 0;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <Badge variant={'outline'}>{teamKey.substring(3)}</Badge>
+      {endgame} (+{points})
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds match score breakdown components for 2016 (STRONGHOLD), 2017 (STEAMWORKS), 2019 (Destination: Deep Space), and 2020 (Infinite Recharge)
- Wires all four into `matchDetails.tsx` dispatch chain using existing type guards from `rankingPoints.ts`
- Follows the established pattern from existing score breakdown components (2015, 2018, 2022-2025)

## Test plan
- [ ] Verify 2016 match page shows defense crossings, boulders, tower challenge/scale breakdown
- [ ] Verify 2017 match page shows fuel counts, rotors, touchpad takeoff breakdown
- [ ] Verify 2019 match page shows hatch panels, cargo, HAB climb breakdown
- [ ] Verify 2020 match page shows power cells, control panel stages, endgame hang breakdown
- [ ] Verify existing score breakdowns (2015, 2018, 2022-2025) are unaffected
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)