### PR TITLE
PWA: Add Schema.org structured data to event, match, and team pages

### DIFF
--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -172,14 +172,54 @@ export const Route = createFileRoute('/event/$eventKey')({
       };
     }
 
+    const event = loaderData.event;
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'SportsEvent',
+      name: `${event.name} ${event.year}`,
+      description: `${event.year} ${event.name} FIRST Robotics Competition`,
+      startDate: event.start_date,
+      endDate: event.end_date,
+      url: `https://www.thebluealliance.com/event/${event.key}`,
+      ...(event.lat &&
+        event.lng && {
+          location: {
+            '@type': 'Place',
+            name: event.location_name ?? event.name,
+            address: {
+              '@type': 'PostalAddress',
+              addressLocality: event.city,
+              addressRegion: event.state_prov,
+              addressCountry: event.country,
+            },
+            geo: {
+              '@type': 'GeoCoordinates',
+              latitude: event.lat,
+              longitude: event.lng,
+            },
+          },
+        }),
+      organizer: {
+        '@type': 'Organization',
+        name: 'FIRST',
+        url: 'https://www.firstinspires.org',
+      },
+    };
+
     return {
       meta: [
         {
-          title: `${loaderData.event.name} (${loaderData.event.year}) - The Blue Alliance`,
+          title: `${event.name} (${event.year}) - The Blue Alliance`,
         },
         {
           name: 'description',
-          content: `Videos and match results for the ${loaderData.event.year} ${loaderData.event.name} FIRST Robotics Competition.`,
+          content: `Videos and match results for the ${event.year} ${event.name} FIRST Robotics Competition.`,
+        },
+      ],
+      scripts: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify(jsonLd),
         },
       ],
     };

--- a/pwa/app/routes/team.$teamNumber.{-$year}.tsx
+++ b/pwa/app/routes/team.$teamNumber.{-$year}.tsx
@@ -179,16 +179,45 @@ export const Route = createFileRoute('/team/$teamNumber/{-$year}')({
       };
     }
 
+    const { team } = loaderData;
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'SportsTeam',
+      name: `Team ${team.team_number} - ${team.nickname}`,
+      url: `https://www.thebluealliance.com/team/${team.team_number}`,
+      location: {
+        '@type': 'Place',
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: team.city,
+          addressRegion: team.state_prov,
+          postalCode: team.postal_code,
+          addressCountry: team.country,
+        },
+      },
+      memberOf: {
+        '@type': 'SportsOrganization',
+        name: 'FIRST Robotics Competition',
+        url: 'https://www.firstinspires.org',
+      },
+    };
+
     return {
       meta: [
         {
-          title: `${loaderData.team.nickname} - Team ${loaderData.team.team_number} - The Blue Alliance`,
+          title: `${team.nickname} - Team ${team.team_number} - The Blue Alliance`,
         },
         {
           name: 'description',
           content:
-            `From ${loaderData.team.city}, ${loaderData.team.state_prov} ${loaderData.team.postal_code}, ${loaderData.team.country}.` +
+            `From ${team.city}, ${team.state_prov} ${team.postal_code}, ${team.country}.` +
             ' Team information, match results, and match videos from the FIRST Robotics Competition.',
+        },
+      ],
+      scripts: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify(jsonLd),
         },
       ],
     };


### PR DESCRIPTION
## Summary
- Adds JSON-LD structured data to event pages (Schema.org `SportsEvent` with location, dates, organizer)
- Adds JSON-LD to match pages (`SportsEvent` with competitors, team URLs, YouTube video links)
- Adds JSON-LD to team pages (`SportsTeam` with location, FIRST membership)
- Uses TanStack Start `head()` config `scripts` field for SSR-friendly injection

## Test plan
- [ ] View page source on event page — verify `<script type="application/ld+json">` with SportsEvent data
- [ ] View page source on match page — verify SportsEvent with competitor teams and video links
- [ ] View page source on team page — verify SportsTeam with location data
- [ ] Test with Google Rich Results Test tool
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)