### PR TITLE
PWA: Enhance media type coverage with unified URL helpers

### DIFF
--- a/pwa/app/components/tba/teamRobotPicsCarousel.tsx
+++ b/pwa/app/components/tba/teamRobotPicsCarousel.tsx
@@ -8,6 +8,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from '~/components/ui/carousel';
+import { getMediaImageUrl, getMediaLinkUrl } from '~/lib/mediaUtils';
 
 export default function TeamRobotPicsCarousel({
   media,
@@ -17,17 +18,33 @@ export default function TeamRobotPicsCarousel({
   return (
     <Carousel className="w-full max-w-xs" plugins={[Autoplay({ delay: 5000 })]}>
       <CarouselContent className="items-center">
-        {media.map((m, index) => (
-          <CarouselItem key={index}>
-            <div className="rounded-lg border-2 border-neutral-300">
-              <img
-                className="max-h-[250px] w-full rounded object-contain"
-                src={m.direct_url}
-                alt={''}
-              />
-            </div>
-          </CarouselItem>
-        ))}
+        {media.map((m, index) => {
+          const imageUrl = getMediaImageUrl(m);
+          const linkUrl = getMediaLinkUrl(m);
+          if (!imageUrl) return null;
+
+          const img = (
+            <img
+              className="max-h-[250px] w-full rounded object-contain"
+              src={imageUrl}
+              alt=""
+            />
+          );
+
+          return (
+            <CarouselItem key={index}>
+              <div className="rounded-lg border-2 border-neutral-300">
+                {linkUrl ? (
+                  <a href={linkUrl} target="_blank" rel="noreferrer">
+                    {img}
+                  </a>
+                ) : (
+                  img
+                )}
+              </div>
+            </CarouselItem>
+          );
+        })}
       </CarouselContent>
       {media.length > 1 && (
         <div className="mt-1 flex justify-center gap-2">

--- a/pwa/app/lib/mediaUtils.ts
+++ b/pwa/app/lib/mediaUtils.ts
@@ -1,30 +1,105 @@
 import { Media } from '~/api/tba/read';
 
+/** Media types that represent displayable images. */
+export const IMAGE_MEDIA_TYPES: ReadonlySet<Media['type']> = new Set([
+  'imgur',
+  'cdphotothread',
+  'instagram-image',
+  'external-link',
+]);
+
+/** Media types that represent CAD models. */
+export const CAD_MEDIA_TYPES: ReadonlySet<Media['type']> = new Set([
+  'grabcad',
+  'onshape',
+]);
+
+/** Returns the image URL for a media item, handling type-specific URL formats. */
+export function getMediaImageUrl(media: Media): string | undefined {
+  switch (media.type) {
+    case 'imgur':
+      return `https://i.imgur.com/${media.foreign_key}m.jpg`;
+    case 'cdphotothread':
+      return media.direct_url;
+    case 'instagram-image':
+      return `https://www.thebluealliance.com/instagram_oembed/${media.foreign_key}`;
+    case 'external-link':
+      return media.direct_url;
+    default:
+      return media.direct_url;
+  }
+}
+
+/** Returns the full-size image URL (for lightbox/detail views). */
+export function getMediaImageUrlFull(media: Media): string | undefined {
+  switch (media.type) {
+    case 'imgur':
+      return `https://i.imgur.com/${media.foreign_key}h.jpg`;
+    case 'cdphotothread':
+      return media.direct_url;
+    case 'instagram-image':
+      return `https://www.thebluealliance.com/instagram_oembed/${media.foreign_key}`;
+    case 'external-link':
+      return media.direct_url;
+    default:
+      return media.direct_url;
+  }
+}
+
+/** Returns the link URL for a media item (where clicking should navigate). */
+export function getMediaLinkUrl(media: Media): string | undefined {
+  switch (media.type) {
+    case 'imgur':
+      return `https://imgur.com/${media.foreign_key}`;
+    case 'cdphotothread': {
+      const details = media.details as { image_partial?: string } | undefined;
+      return details?.image_partial
+        ? `https://www.chiefdelphi.com/media/img/${details.image_partial}`
+        : undefined;
+    }
+    case 'instagram-image':
+      return `https://www.instagram.com/p/${media.foreign_key}`;
+    case 'grabcad':
+      return `https://grabcad.com/library/${media.foreign_key}`;
+    case 'onshape':
+      return `https://cad.onshape.com/documents/${media.foreign_key}`;
+    case 'external-link':
+      return media.foreign_key;
+    default:
+      return undefined;
+  }
+}
+
+/** Returns the display name for a CAD model media item. */
+export function getCadModelName(media: Media): string {
+  if (media.type === 'grabcad') {
+    const details = media.details as { model_name?: string } | undefined;
+    return details?.model_name ?? 'GrabCAD Model';
+  }
+  return 'CAD Model';
+}
+
+/** Returns all image-type media, sorted with preferred first. */
+export function getImageMedia(media: Media[]): Media[] {
+  return media
+    .filter((m) => IMAGE_MEDIA_TYPES.has(m.type))
+    .sort((a, b) => {
+      if (a.preferred && !b.preferred) return -1;
+      if (!a.preferred && b.preferred) return 1;
+      return 0;
+    });
+}
+
 export function getTeamPreferredRobotPicMedium(
   media: Media[],
 ): string | undefined {
   const maybePreferredImg = media.filter(
-    (m) =>
-      ['imgur', 'cdphotothread', 'instagram-image', 'external-link'].includes(
-        m.type,
-      ) && m.preferred,
+    (m) => IMAGE_MEDIA_TYPES.has(m.type) && m.preferred,
   );
 
   if (maybePreferredImg.length === 0) {
     return undefined;
   }
 
-  function imageUrl(media: Media) {
-    if (media.type === 'imgur') {
-      return `https://i.imgur.com/${media.foreign_key}m.jpg`;
-    }
-
-    if (media.type === 'instagram-image') {
-      return `https://www.thebluealliance.com/instagram_oembed/${media.foreign_key}`;
-    }
-
-    return media.direct_url;
-  }
-
-  return imageUrl(maybePreferredImg[0]);
+  return getMediaImageUrl(maybePreferredImg[0]);
 }

--- a/pwa/app/routes/team.$teamNumber.{-$year}.tsx
+++ b/pwa/app/routes/team.$teamNumber.{-$year}.tsx
@@ -61,6 +61,7 @@ import {
   calculateTeamRecordsFromMatches,
   getTeamsUnpenalizedHighScore,
 } from '~/lib/matchUtils';
+import { getImageMedia } from '~/lib/mediaUtils';
 import {
   MODEL_TYPE,
   addRecords,
@@ -259,22 +260,7 @@ function TeamPage(): React.JSX.Element {
 
   yearsParticipated.sort((a, b) => b - a);
 
-  const robotPics = useMemo(
-    () =>
-      media
-        .filter((m) => m.type === 'imgur')
-        .sort((a, b) => {
-          if (a.preferred) {
-            return -1;
-          }
-          if (b.preferred) {
-            return 1;
-          }
-
-          return 0;
-        }),
-    [media],
-  );
+  const robotPics = useMemo(() => getImageMedia(media), [media]);
 
   const maybeAvatar = useMemo(
     () => media.find((m) => m.type === 'avatar'),


### PR DESCRIPTION
## Summary
- Expands team robot pictures from imgur-only to include Chief Delphi photos, Instagram images, and external links
- Adds `getMediaImageUrl`, `getMediaImageUrlFull`, `getMediaLinkUrl`, `getImageMedia` helpers to `mediaUtils.ts`
- Carousel images now link to their source (Imgur page, CD thread, Instagram post)
- Adds `IMAGE_MEDIA_TYPES` and `CAD_MEDIA_TYPES` constants for consistent type checking
- Refactors `getTeamPreferredRobotPicMedium` to use the new shared helpers

## Test plan
- [ ] Team pages with imgur photos continue to display correctly
- [ ] Team pages with Chief Delphi photos now show in the carousel
- [ ] Clicking a carousel image opens the source page in a new tab
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)