### PR TITLE
PWA: Add screenshot comparison workflow for PRs

### DIFF
--- a/.github/workflows/pwa_screenshots.yml
+++ b/.github/workflows/pwa_screenshots.yml
@@ -1,0 +1,201 @@
+name: PWA Screenshots
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "pwa/**"
+      - "ops/pwa/**"
+      - ".github/workflows/pwa_screenshots.yml"
+  workflow_dispatch:
+
+jobs:
+  pwa-screenshots:
+    name: "PWA Screenshots"
+    runs-on: ubuntu-24.04
+    # Skip if TBA API key is not available (e.g. fork PRs without secrets)
+    env:
+      TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
+    steps:
+      - name: Check for API key
+        id: check-key
+        run: |
+          if [ -z "$TBA_API_READ_KEY" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "TBA_API_READ_KEY not available (expected for fork PRs). Skipping screenshots."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # --- Setup toolchain ---
+      - name: Checkout PR branch
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        if: steps.check-key.outputs.skip != 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.24.0"
+
+      - name: Set up Node
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pwa/pnpm-lock.yaml"
+
+      - name: Cache Playwright browsers
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pwa/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install dependencies
+        if: steps.check-key.outputs.skip != 'true'
+        run: pnpm --dir pwa install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        if: steps.check-key.outputs.skip != 'true'
+        run: pnpm --dir pwa exec playwright install --with-deps chromium
+
+      # --- Build and screenshot PR branch ---
+      - name: Create dotenv (PR)
+        if: steps.check-key.outputs.skip != 'true'
+        run: ./ops/pwa/create_dotenv.sh --env
+        env:
+          TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
+
+      - name: Build PWA (PR branch)
+        if: steps.check-key.outputs.skip != 'true'
+        run: pnpm --dir pwa run build
+
+      - name: Take PR screenshots
+        if: steps.check-key.outputs.skip != 'true'
+        working-directory: pwa
+        run: |
+          node ./server.js &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Server is ready"
+              break
+            fi
+            sleep 2
+          done
+          node ../ops/pwa/take-screenshots.mjs
+          kill $SERVER_PID 2>/dev/null || true
+        env:
+          NODE_ENV: production
+          SCREENSHOT_DIR: ${{ github.workspace }}/screenshots-after
+
+      # --- Save scripts and switch to base branch ---
+      - name: Save scripts for base branch
+        if: steps.check-key.outputs.skip != 'true'
+        run: |
+          cp ops/pwa/take-screenshots.mjs /tmp/take-screenshots.mjs
+          cp ops/pwa/generate-screenshot-comment.mjs /tmp/generate-screenshot-comment.mjs
+
+      - name: Checkout base branch
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          clean: false
+
+      # --- Build and screenshot base branch ---
+      - name: Install dependencies (base)
+        if: steps.check-key.outputs.skip != 'true'
+        id: base-deps
+        continue-on-error: true
+        run: pnpm --dir pwa install --frozen-lockfile
+
+      - name: Create dotenv (base)
+        if: steps.check-key.outputs.skip != 'true' && steps.base-deps.outcome == 'success'
+        run: ./ops/pwa/create_dotenv.sh --env
+        env:
+          TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
+
+      - name: Build PWA (base branch)
+        if: steps.check-key.outputs.skip != 'true' && steps.base-deps.outcome == 'success'
+        id: base-build
+        continue-on-error: true
+        run: pnpm --dir pwa run build
+
+      - name: Take base screenshots
+        if: steps.check-key.outputs.skip != 'true' && steps.base-build.outcome == 'success'
+        continue-on-error: true
+        working-directory: pwa
+        run: |
+          node ./server.js &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Server is ready"
+              break
+            fi
+            sleep 2
+          done
+          node /tmp/take-screenshots.mjs
+          kill $SERVER_PID 2>/dev/null || true
+        env:
+          NODE_ENV: production
+          SCREENSHOT_DIR: ${{ github.workspace }}/screenshots-before
+
+      # --- Generate comment and post ---
+      - name: Generate screenshot comment
+        if: steps.check-key.outputs.skip != 'true'
+        run: node /tmp/generate-screenshot-comment.mjs
+        env:
+          BEFORE_DIR: ${{ github.workspace }}/screenshots-before
+          AFTER_DIR: ${{ github.workspace }}/screenshots-after
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Post comment on PR
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '${{ github.workspace }}/pwa_screenshots_message.md';
+
+            if (!fs.existsSync(path)) {
+              core.warning('No screenshot comment file found');
+              return;
+            }
+
+            const body = fs.readFileSync(path, 'utf8');
+            const marker = '<!-- pwa-screenshots-comment -->';
+            const fullBody = `${marker}\n${body}`;
+
+            // Find and update existing comment, or create new one
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+              core.info(`Updated comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ github.event.pull_request.number }},
+                body: fullBody,
+              });
+              core.info('Created new comment');
+            }

--- a/ops/pwa/generate-screenshot-comment.mjs
+++ b/ops/pwa/generate-screenshot-comment.mjs
@@ -1,0 +1,206 @@
+/**
+ * PWA Screenshot Comment Generator
+ *
+ * Reads before/after screenshots, uploads them to the ci-screenshots branch
+ * via the GitHub API, and generates a markdown PR comment comparing them.
+ *
+ * Environment variables:
+ *   BEFORE_DIR       - Directory with base branch screenshots (default: screenshots-before)
+ *   AFTER_DIR        - Directory with PR branch screenshots (default: screenshots-after)
+ *   PR_NUMBER        - Pull request number (required)
+ *   GITHUB_TOKEN     - GitHub token for API access (required)
+ *   GITHUB_REPOSITORY - owner/repo (required)
+ *   OUTPUT_FILE      - Output markdown file (default: pwa_screenshots_message.md)
+ */
+
+import { readFileSync, readdirSync, existsSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const BEFORE_DIR = process.env.BEFORE_DIR || "screenshots-before";
+const AFTER_DIR = process.env.AFTER_DIR || "screenshots-after";
+const PR_NUMBER = process.env.PR_NUMBER;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+const OUTPUT_FILE = process.env.OUTPUT_FILE || "pwa_screenshots_message.md";
+
+const BRANCH_NAME = "ci-screenshots";
+const API_BASE = "https://api.github.com";
+const BOT_AUTHOR = {
+  name: "github-actions[bot]",
+  email: "github-actions[bot]@users.noreply.github.com",
+};
+
+function apiHeaders() {
+  return {
+    Accept: "application/vnd.github.v3+json",
+    Authorization: `Bearer ${GITHUB_TOKEN}`,
+  };
+}
+
+/** Ensure the ci-screenshots branch exists. */
+async function ensureBranch() {
+  const refUrl = `${API_BASE}/repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}`;
+  const res = await fetch(refUrl, { headers: apiHeaders() });
+  if (res.ok) return;
+
+  console.log(`Creating orphan branch "${BRANCH_NAME}"...`);
+  // Get the default branch SHA to base the new branch on
+  const repoRes = await fetch(`${API_BASE}/repos/${GITHUB_REPOSITORY}`, {
+    headers: apiHeaders(),
+  });
+  const repoData = await repoRes.json();
+  const defaultBranch = repoData.default_branch;
+
+  const defaultRef = await fetch(
+    `${API_BASE}/repos/${GITHUB_REPOSITORY}/git/ref/heads/${defaultBranch}`,
+    { headers: apiHeaders() }
+  );
+  const defaultRefData = await defaultRef.json();
+
+  await fetch(`${API_BASE}/repos/${GITHUB_REPOSITORY}/git/refs`, {
+    method: "POST",
+    headers: apiHeaders(),
+    body: JSON.stringify({
+      ref: `refs/heads/${BRANCH_NAME}`,
+      sha: defaultRefData.object.sha,
+    }),
+  });
+}
+
+/** Upload a single image file to the ci-screenshots branch. Returns the raw URL or null. */
+async function uploadImage(branchPath, localPath) {
+  const content = readFileSync(localPath).toString("base64");
+  const url = `${API_BASE}/repos/${GITHUB_REPOSITORY}/contents/${branchPath}`;
+
+  // Try to create the file
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: apiHeaders(),
+    body: JSON.stringify({
+      message: `[CI] PWA screenshot for PR #${PR_NUMBER}`,
+      content,
+      branch: BRANCH_NAME,
+      author: BOT_AUTHOR,
+      committer: BOT_AUTHOR,
+    }),
+  });
+
+  if (res.ok) {
+    const rawUrl = `https://github.com/${GITHUB_REPOSITORY}/raw/${BRANCH_NAME}/${branchPath}`;
+    console.log(`  Uploaded ${branchPath}`);
+    return rawUrl;
+  }
+
+  // File might already exist — get its SHA and update
+  if (res.status === 422) {
+    const getRes = await fetch(`${url}?ref=${BRANCH_NAME}`, {
+      headers: apiHeaders(),
+    });
+    if (getRes.ok) {
+      const existing = await getRes.json();
+      const updateRes = await fetch(url, {
+        method: "PUT",
+        headers: apiHeaders(),
+        body: JSON.stringify({
+          message: `[CI] PWA screenshot for PR #${PR_NUMBER}`,
+          content,
+          branch: BRANCH_NAME,
+          sha: existing.sha,
+          author: BOT_AUTHOR,
+          committer: BOT_AUTHOR,
+        }),
+      });
+      if (updateRes.ok) {
+        const rawUrl = `https://github.com/${GITHUB_REPOSITORY}/raw/${BRANCH_NAME}/${branchPath}`;
+        console.log(`  Updated ${branchPath}`);
+        return rawUrl;
+      }
+    }
+  }
+
+  const body = await res.text();
+  console.error(`  Failed to upload ${branchPath}: ${res.status} ${body}`);
+  return null;
+}
+
+/** Human-readable name from a screenshot filename like "homepage.png" → "Homepage" */
+function filenameToName(filename) {
+  return filename
+    .replace(/\.png$/, "")
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+async function main() {
+  if (!PR_NUMBER || !GITHUB_TOKEN || !GITHUB_REPOSITORY) {
+    console.error(
+      "Required env vars: PR_NUMBER, GITHUB_TOKEN, GITHUB_REPOSITORY"
+    );
+    process.exit(1);
+  }
+
+  await ensureBranch();
+
+  const hasBeforeDir = existsSync(BEFORE_DIR);
+  const hasAfterDir = existsSync(AFTER_DIR);
+
+  if (!hasAfterDir) {
+    console.error(`After directory "${AFTER_DIR}" not found`);
+    process.exit(1);
+  }
+
+  const afterFiles = readdirSync(AFTER_DIR).filter((f) => f.endsWith(".png"));
+  const beforeFiles = hasBeforeDir
+    ? readdirSync(BEFORE_DIR).filter((f) => f.endsWith(".png"))
+    : [];
+
+  const timestamp = Date.now();
+  const rows = [];
+
+  for (const filename of afterFiles) {
+    const name = filenameToName(filename);
+    const afterPath = join(AFTER_DIR, filename);
+    const branchAfterPath = `pwa/pr-${PR_NUMBER}/${timestamp}/after/${filename}`;
+
+    console.log(`Processing ${name}...`);
+    const afterUrl = await uploadImage(branchAfterPath, afterPath);
+
+    let beforeUrl = null;
+    if (beforeFiles.includes(filename)) {
+      const beforePath = join(BEFORE_DIR, filename);
+      const branchBeforePath = `pwa/pr-${PR_NUMBER}/${timestamp}/before/${filename}`;
+      beforeUrl = await uploadImage(branchBeforePath, beforePath);
+    }
+
+    rows.push({ name, beforeUrl, afterUrl });
+  }
+
+  // Generate markdown
+  let message = "## PWA Screenshots\n\n";
+  message +=
+    "Visual comparison of PWA pages between the base branch and this PR.\n\n";
+
+  for (const { name, beforeUrl, afterUrl } of rows) {
+    if (!afterUrl) continue;
+
+    message += `### ${name}\n\n`;
+
+    if (beforeUrl) {
+      message += "| Before | After |\n";
+      message += "|--------|-------|\n";
+      message += `| ![Before](${beforeUrl}) | ![After](${afterUrl}) |\n\n`;
+    } else {
+      message += `*New page (no base branch screenshot)*\n\n`;
+      message += `![After](${afterUrl})\n\n`;
+    }
+  }
+
+  writeFileSync(OUTPUT_FILE, message);
+  console.log(`\nComment markdown written to ${OUTPUT_FILE}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/ops/pwa/take-screenshots.mjs
+++ b/ops/pwa/take-screenshots.mjs
@@ -1,0 +1,85 @@
+/**
+ * PWA Screenshot Capture Script
+ *
+ * Takes full-page screenshots of canonical PWA pages using Playwright.
+ * Designed to run against a built & running PWA server.
+ *
+ * Environment variables:
+ *   BASE_URL       - Server URL (default: http://localhost:3000)
+ *   SCREENSHOT_DIR - Output directory for screenshots (default: screenshots)
+ */
+
+import { chromium } from "playwright";
+import { mkdirSync } from "fs";
+import { join } from "path";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || "screenshots";
+
+// Canonical pages using historical data that won't change
+const PAGES = [
+  { name: "Homepage", path: "/" },
+  { name: "Team 604 (2024)", path: "/team/604/2024" },
+  { name: "Event 2024mil", path: "/event/2024mil" },
+  { name: "Match 2024mil_f1m2", path: "/match/2024mil_f1m2" },
+  { name: "Teams List", path: "/teams" },
+  { name: "Events 2024", path: "/events/2024" },
+  { name: "GameDay", path: "/gameday" },
+  { name: "About", path: "/about" },
+  { name: "API Docs", path: "/apidocs" },
+];
+
+function toFilename(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-") + ".png";
+}
+
+async function main() {
+  mkdirSync(SCREENSHOT_DIR, { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+  });
+
+  let captured = 0;
+  let failed = 0;
+
+  for (const page of PAGES) {
+    const url = `${BASE_URL}${page.path}`;
+    const filename = toFilename(page.name);
+    const tab = await context.newPage();
+
+    try {
+      console.log(`Capturing ${page.name} (${url})...`);
+      await tab.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
+      // Brief extra wait for any client-side rendering to settle
+      await tab.waitForTimeout(1000);
+      await tab.screenshot({
+        path: join(SCREENSHOT_DIR, filename),
+        fullPage: true,
+      });
+      console.log(`  Saved ${filename}`);
+      captured++;
+    } catch (err) {
+      console.warn(`  Failed to capture ${page.name}: ${err.message}`);
+      failed++;
+    }
+
+    await tab.close();
+  }
+
+  await browser.close();
+
+  console.log(
+    `\nDone: ${captured} captured, ${failed} failed out of ${PAGES.length} pages`
+  );
+
+  if (captured === 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds CI infrastructure to automatically capture before/after screenshots of canonical PWA pages and post them as a PR comment, making visual changes easy to review.

- **`ops/pwa/take-screenshots.mjs`** — Playwright script that screenshots 9 canonical pages (Homepage, Team 604, Event 2024mil, Match, Teams List, Events 2024, GameDay, About, API Docs) at 1280x720
- **`ops/pwa/generate-screenshot-comment.mjs`** — Uploads screenshots to the `ci-screenshots` branch via GitHub API and generates a markdown before/after comparison
- **`.github/workflows/pwa_screenshots.yml`** — Workflow triggered on PRs touching `pwa/`, `ops/pwa/`, or the workflow file itself; builds both PR and base branches, takes screenshots, and posts a side-by-side comparison comment

### How it works

1. Workflow triggers on `pull_request` events that touch PWA files
2. Builds the PR branch PWA with a real TBA API key, starts the server, and takes screenshots via Playwright
3. Saves the screenshot script to `/tmp`, checks out the base branch
4. Builds the base branch PWA, takes screenshots
5. Uploads all images to the `ci-screenshots` branch and posts/updates a comparison comment on the PR

### Graceful degradation

- **Fork PRs**: `TBA_API_READ_KEY` secret is unavailable — workflow detects this and skips (no failure)
- **Base branch failures**: `continue-on-error` on base branch steps — if the base doesn't have a PWA or build fails, only "after" screenshots are shown
- **Page failures**: Individual page errors are logged but don't fail the workflow

### Note on this PR

This PR touches `ops/pwa/` and `.github/workflows/` but the screenshot workflow should trigger since the path filter includes those paths. Since this is a fork PR, the `TBA_API_READ_KEY` secret won't be available and the workflow will skip with a message. To fully test, the workflow can be triggered manually via `workflow_dispatch` from a branch with access to repo secrets.

## Test plan

- [ ] Verify the workflow triggers on this PR (should show "skipping" due to missing API key for fork PR)
- [ ] After merge, open a PR from a same-repo branch touching `pwa/` files to verify full screenshot capture
- [ ] Verify before/after screenshots appear as a PR comment
- [ ] Verify the workflow skips gracefully for non-PWA PRs
- [ ] Test `workflow_dispatch` manual trigger


🤖 Generated with [Claude Code](https://claude.com/claude-code)