### PR TITLE
Fix order of red/blue teams in scouting csv export

### DIFF
--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -271,6 +271,7 @@ def event_detail(event_key: EventKey) -> Response:
         )
         for i in range(max_teams):
             row[f"red{i + 1}"] = red_teams[i]
+        for i in range(max_teams):
             row[f"blue{i + 1}"] = blue_teams[i]
         row["red_score"] = str(red_score) if red_score >= 0 else ""
         row["blue_score"] = str(blue_score) if blue_score >= 0 else ""


### PR DESCRIPTION
IMO it should be red1,red2,red3,blue1,blue2,blue3. Currently it is red1,blue1,red2,blue2,red3,blue3