### PR TITLE
PWA: Add district list page

### DIFF
--- a/pwa/app/components/tba/links.tsx
+++ b/pwa/app/components/tba/links.tsx
@@ -171,4 +171,34 @@ const MatchLink = forwardRef<
 });
 MatchLink.displayName = 'MatchLink';
 
-export { EventLink, EventLocationLink, TeamLocationLink, MatchLink, TeamLink };
+const DistrictLink = forwardRef<
+  HTMLAnchorElement,
+  PropsWithChildren<
+    {
+      districtAbbreviation: string;
+      year?: number;
+    } & AnchorHTMLAttributes<HTMLAnchorElement>
+  >
+>(({ districtAbbreviation, year, ...props }, ref) => {
+  return (
+    <Link
+      to="/district/$districtAbbreviation/{-$year}"
+      params={{
+        districtAbbreviation,
+        year: year?.toString(),
+      }}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+DistrictLink.displayName = 'DistrictLink';
+
+export {
+  DistrictLink,
+  EventLink,
+  EventLocationLink,
+  MatchLink,
+  TeamLink,
+  TeamLocationLink,
+};

--- a/pwa/app/routeTree.gen.ts
+++ b/pwa/app/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as LocalDebugRouteImport } from './routes/local.debug'
 import { Route as InsightsChar123YearChar125RouteImport } from './routes/insights.{-$year}'
 import { Route as EventsChar123YearChar125RouteImport } from './routes/events.{-$year}'
 import { Route as EventEventKeyRouteImport } from './routes/event.$eventKey'
+import { Route as DistrictsChar123YearChar125RouteImport } from './routes/districts.{-$year}'
 import { Route as ApidocsV3RouteImport } from './routes/apidocs_.v3'
 import { Route as AccountMytbaRouteImport } from './routes/account.mytba'
 import { Route as TeamTeamNumberChar123YearChar125RouteImport } from './routes/team.$teamNumber.{-$year}'
@@ -122,6 +123,12 @@ const EventEventKeyRoute = EventEventKeyRouteImport.update({
   path: '/event/$eventKey',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DistrictsChar123YearChar125Route =
+  DistrictsChar123YearChar125RouteImport.update({
+    id: '/districts/{-$year}',
+    path: '/districts/{-$year}',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApidocsV3Route = ApidocsV3RouteImport.update({
   id: '/apidocs_/v3',
   path: '/apidocs/v3',
@@ -174,6 +181,7 @@ export interface FileRoutesByFullPath {
   '/thanks': typeof ThanksRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs/v3': typeof ApidocsV3Route
+  '/districts/{-$year}': typeof DistrictsChar123YearChar125Route
   '/event/$eventKey': typeof EventEventKeyRoute
   '/events/{-$year}': typeof EventsChar123YearChar125Route
   '/insights/{-$year}': typeof InsightsChar123YearChar125Route
@@ -200,6 +208,7 @@ export interface FileRoutesByTo {
   '/thanks': typeof ThanksRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs/v3': typeof ApidocsV3Route
+  '/districts/{-$year}': typeof DistrictsChar123YearChar125Route
   '/event/$eventKey': typeof EventEventKeyRoute
   '/events/{-$year}': typeof EventsChar123YearChar125Route
   '/insights/{-$year}': typeof InsightsChar123YearChar125Route
@@ -227,6 +236,7 @@ export interface FileRoutesById {
   '/thanks': typeof ThanksRoute
   '/account/mytba': typeof AccountMytbaRoute
   '/apidocs_/v3': typeof ApidocsV3Route
+  '/districts/{-$year}': typeof DistrictsChar123YearChar125Route
   '/event/$eventKey': typeof EventEventKeyRoute
   '/events/{-$year}': typeof EventsChar123YearChar125Route
   '/insights/{-$year}': typeof InsightsChar123YearChar125Route
@@ -255,6 +265,7 @@ export interface FileRouteTypes {
     | '/thanks'
     | '/account/mytba'
     | '/apidocs/v3'
+    | '/districts/{-$year}'
     | '/event/$eventKey'
     | '/events/{-$year}'
     | '/insights/{-$year}'
@@ -281,6 +292,7 @@ export interface FileRouteTypes {
     | '/thanks'
     | '/account/mytba'
     | '/apidocs/v3'
+    | '/districts/{-$year}'
     | '/event/$eventKey'
     | '/events/{-$year}'
     | '/insights/{-$year}'
@@ -307,6 +319,7 @@ export interface FileRouteTypes {
     | '/thanks'
     | '/account/mytba'
     | '/apidocs_/v3'
+    | '/districts/{-$year}'
     | '/event/$eventKey'
     | '/events/{-$year}'
     | '/insights/{-$year}'
@@ -334,6 +347,7 @@ export interface RootRouteChildren {
   ThanksRoute: typeof ThanksRoute
   AccountMytbaRoute: typeof AccountMytbaRoute
   ApidocsV3Route: typeof ApidocsV3Route
+  DistrictsChar123YearChar125Route: typeof DistrictsChar123YearChar125Route
   EventEventKeyRoute: typeof EventEventKeyRoute
   EventsChar123YearChar125Route: typeof EventsChar123YearChar125Route
   InsightsChar123YearChar125Route: typeof InsightsChar123YearChar125Route
@@ -469,6 +483,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventEventKeyRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/districts/{-$year}': {
+      id: '/districts/{-$year}'
+      path: '/districts/{-$year}'
+      fullPath: '/districts/{-$year}'
+      preLoaderRoute: typeof DistrictsChar123YearChar125RouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/apidocs_/v3': {
       id: '/apidocs_/v3'
       path: '/apidocs/v3'
@@ -534,6 +555,7 @@ const rootRouteChildren: RootRouteChildren = {
   ThanksRoute: ThanksRoute,
   AccountMytbaRoute: AccountMytbaRoute,
   ApidocsV3Route: ApidocsV3Route,
+  DistrictsChar123YearChar125Route: DistrictsChar123YearChar125Route,
   EventEventKeyRoute: EventEventKeyRoute,
   EventsChar123YearChar125Route: EventsChar123YearChar125Route,
   InsightsChar123YearChar125Route: InsightsChar123YearChar125Route,

--- a/pwa/app/routes/districts.{-$year}.tsx
+++ b/pwa/app/routes/districts.{-$year}.tsx
@@ -1,0 +1,141 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router';
+import { useMemo } from 'react';
+
+import { getDistrictsByYearOptions } from '~/api/tba/read/@tanstack/react-query.gen';
+import { DistrictLink } from '~/components/tba/links';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
+import {
+  parseParamsForYearElseDefault,
+  publicCacheControlHeaders,
+  useValidYears,
+} from '~/lib/utils';
+
+export const Route = createFileRoute('/districts/{-$year}')({
+  loader: async ({ params, context: { queryClient } }) => {
+    const year = await parseParamsForYearElseDefault(queryClient, params);
+    if (year === undefined) {
+      throw notFound();
+    }
+
+    await queryClient.ensureQueryData(
+      getDistrictsByYearOptions({ path: { year } }),
+    );
+
+    return { year };
+  },
+  headers: publicCacheControlHeaders(),
+  head: ({ loaderData }) => {
+    if (!loaderData) {
+      return {
+        meta: [
+          { title: 'FIRST Robotics Districts - The Blue Alliance' },
+          {
+            name: 'description',
+            content: 'District list for the FIRST Robotics Competition.',
+          },
+        ],
+      };
+    }
+
+    return {
+      meta: [
+        {
+          title: `${loaderData.year} FIRST Robotics Districts - The Blue Alliance`,
+        },
+        {
+          name: 'description',
+          content: `District list for the ${loaderData.year} FIRST Robotics Competition.`,
+        },
+      ],
+    };
+  },
+  component: DistrictsPage,
+});
+
+function DistrictsPage() {
+  const { year } = Route.useLoaderData();
+  const { data: districts } = useSuspenseQuery({
+    ...getDistrictsByYearOptions({ path: { year } }),
+  });
+  const validYears = useValidYears();
+  const navigate = useNavigate();
+
+  const sortedDistricts = useMemo(
+    () =>
+      [...districts].sort((a, b) =>
+        a.display_name.localeCompare(b.display_name),
+      ),
+    [districts],
+  );
+
+  return (
+    <div className="py-8">
+      <div className="mb-4 flex items-center gap-4">
+        <h1 className="text-3xl font-medium">
+          {year} <i>FIRST</i> Robotics Competition Districts{' '}
+          <small className="text-xl text-muted-foreground">
+            {districts.length} Districts
+          </small>
+        </h1>
+        <Select
+          value={String(year)}
+          onValueChange={(value) => {
+            void navigate({ to: `/districts/${value}` });
+          }}
+        >
+          <SelectTrigger className="w-[120px]">
+            <SelectValue placeholder={year} />
+          </SelectTrigger>
+          <SelectContent className="max-h-[30vh] overflow-y-auto">
+            {validYears.map((y) => (
+              <SelectItem key={y} value={`${y}`}>
+                {y}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>District</TableHead>
+            <TableHead>Key</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sortedDistricts.map((district) => (
+            <TableRow key={district.key}>
+              <TableCell>
+                <DistrictLink
+                  districtAbbreviation={district.abbreviation}
+                  year={year}
+                >
+                  {district.display_name}
+                </DistrictLink>
+              </TableCell>
+              <TableCell className="font-mono text-muted-foreground">
+                {district.abbreviation}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/pwa/tests/routes.spec.ts
+++ b/pwa/tests/routes.spec.ts
@@ -28,6 +28,7 @@ const allRoutes = defineAllRoutes([
   '/contact',
   '/district/$districtAbbreviation/{-$year}',
   '/district/$districtAbbreviation/insights',
+  '/districts/{-$year}',
   '/donate',
   '/event/$eventKey',
   '/events/{-$year}',


### PR DESCRIPTION
## Summary
- Adds `/districts/{year}` route displaying all FRC districts for a given year
- Sortable table with district names and links to individual district pages
- Year selector consistent with existing events/teams pages
- Adds reusable `DistrictLink` component to the shared links module

## Test plan
- [ ] Navigate to `/districts` and verify current year's districts load
- [ ] Switch years via the year selector
- [ ] Click a district name and verify it links to the correct district page
- [ ] Run `npm run typecheck` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot Pages
- /districts Districts List
- /districts/2024 2024 Districts