### PR TITLE
PWA: Add District Points tab to event page

### DIFF
--- a/pwa/app/lib/api/EventType.ts
+++ b/pwa/app/lib/api/EventType.ts
@@ -19,6 +19,12 @@ export const CMP_EVENT_TYPES = new Set([
   EventType.CMP_FINALS,
 ]);
 
+export const DISTRICT_EVENT_TYPES = new Set([
+  EventType.DISTRICT,
+  EventType.DISTRICT_CMP_DIVISION,
+  EventType.DISTRICT_CMP,
+]);
+
 export const SEASON_EVENT_TYPES = new Set([
   EventType.REGIONAL,
   EventType.DISTRICT,

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -103,7 +103,7 @@ import {
   TableRow,
 } from '~/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
-import { SEASON_EVENT_TYPES } from '~/lib/api/EventType';
+import { DISTRICT_EVENT_TYPES, SEASON_EVENT_TYPES } from '~/lib/api/EventType';
 import { PlayoffType } from '~/lib/api/PlayoffType';
 import { sortAwardsComparator } from '~/lib/awardUtils';
 import {
@@ -356,14 +356,15 @@ function EventPage() {
                 </InlineIcon>
               </TabsTrigger>
             )}
-          {districtPointsQuery.data && (
-            <TabsTrigger value="district-points">
-              <InlineIcon>
-                <DistrictPointsIcon />
-                District Points
-              </InlineIcon>
-            </TabsTrigger>
-          )}
+          {districtPointsQuery.data &&
+            DISTRICT_EVENT_TYPES.has(event.event_type) && (
+              <TabsTrigger value="district-points">
+                <InlineIcon>
+                  <DistrictPointsIcon />
+                  District Points
+                </InlineIcon>
+              </TabsTrigger>
+            )}
           <TabsTrigger value="media">
             <InlineIcon>
               <MediaIcon />
@@ -428,14 +429,15 @@ function EventPage() {
           )}
         </TabsContent>
 
-        {districtPointsQuery.data && (
-          <TabsContent value="district-points">
-            <DistrictPointsTab
-              districtPoints={districtPointsQuery.data}
-              year={event.year}
-            />
-          </TabsContent>
-        )}
+        {districtPointsQuery.data &&
+          DISTRICT_EVENT_TYPES.has(event.event_type) && (
+            <TabsContent value="district-points">
+              <DistrictPointsTab
+                districtPoints={districtPointsQuery.data}
+                year={event.year}
+              />
+            </TabsContent>
+          )}
 
         <TabsContent value="media">
           <MediaTab webcasts={event.webcasts} eventKey={event.key} />


### PR DESCRIPTION
## Summary
- Adds "District Points" tab to the event detail page
- Sortable table showing qual, elim, alliance, award, and total district points per team
- Tab only appears when district points data is available from the API
- Uses existing `DataTable` component for sorting

## Test plan
- [ ] Navigate to a district event (e.g., `/event/2024miket`) and verify District Points tab appears
- [ ] Verify table is sortable by clicking column headers
- [ ] Navigate to a regional event and verify District Points tab does NOT appear (or shows calculated points)
- [ ] Run `npm run typecheck` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot Pages
- /event/2024oncmp1 District Event with Points