### PR TITLE
PWA: Add 4-team double elimination bracket visualization

### DIFF
--- a/pwa/app/components/tba/doubleElim4TeamBracket.tsx
+++ b/pwa/app/components/tba/doubleElim4TeamBracket.tsx
@@ -12,6 +12,13 @@ import {
 import PlayCircleIcon from '~icons/mdi/play-circle-outline';
 
 import { EliminationAlliance, Event, Match } from '~/api/tba/read';
+import {
+  EliminationBracketPaths,
+  type PlayoffMatchHandle,
+  type SeriesResult,
+  type WinnerLink,
+  useAdvancementPaths,
+} from '~/components/tba/eliminationBracketPaths';
 import { MatchLink, TeamLink } from '~/components/tba/links';
 import { Card, CardHeader, CardTitle } from '~/components/ui/card';
 import { EventType } from '~/lib/api/EventType';
@@ -27,34 +34,16 @@ type MatchLabel4 =
   | 'Match 5'
   | 'Finals';
 
-type MatchResult = {
-  score: number;
-  won: boolean;
-};
-
-type SeriesResult = {
-  redTeams: string[];
-  blueTeams: string[];
-  redAllianceNumber: number | null;
-  blueAllianceNumber: number | null;
-  redResults: MatchResult[];
-  blueResults: MatchResult[];
-  redWon: boolean;
-  blueWon: boolean;
-  matchRedTeams: string[];
-  matchBlueTeams: string[];
-};
-
-type MatchHandle = {
-  card: HTMLDivElement | null;
-  redRow: HTMLDivElement | null;
-  blueRow: HTMLDivElement | null;
-  redAlliance: number | null;
-  blueAlliance: number | null;
-};
+const WINNER_LINKS: WinnerLink[] = [
+  { from: 'Match 1', to: 'Match 4' },
+  { from: 'Match 2', to: 'Match 4' },
+  { from: 'Match 3', to: 'Match 5' },
+  { from: 'Match 4', to: 'Finals' },
+  { from: 'Match 5', to: 'Finals' },
+];
 
 const BracketMatch = forwardRef<
-  MatchHandle,
+  PlayoffMatchHandle,
   {
     matchLabel: MatchLabel4;
     matches: Match[] | undefined;
@@ -286,6 +275,15 @@ export default function DoubleElim4TeamBracket({
   event: Event;
 }): JSX.Element {
   const [hoveredAlliance, setHoveredAlliance] = useState<number | null>(null);
+  const matchRefs = useRef<Record<MatchLabel4, PlayoffMatchHandle | null>>({
+    'Match 1': null,
+    'Match 2': null,
+    'Match 3': null,
+    'Match 4': null,
+    'Match 5': null,
+    Finals: null,
+  });
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Group SF matches by set_number, Finals separately
   const matchesBySet = useMemo(() => {
@@ -376,6 +374,26 @@ export default function DoubleElim4TeamBracket({
     };
   };
 
+  const matchLookup: Record<string, Match[] | undefined> = useMemo(
+    () => ({
+      'Match 1': matchesBySet[1],
+      'Match 2': matchesBySet[2],
+      'Match 3': matchesBySet[3],
+      'Match 4': matchesBySet[4],
+      'Match 5': matchesBySet[5],
+      Finals: finalsMatches,
+    }),
+    [matchesBySet, finalsMatches],
+  );
+
+  const { paths, svgSize } = useAdvancementPaths({
+    containerRef,
+    matchRefs,
+    winnerLinks: WINNER_LINKS,
+    matchLookup,
+    getSeriesResult,
+  });
+
   if (alliances.length === 0 || matches.length === 0) {
     return <></>;
   }
@@ -387,115 +405,139 @@ export default function DoubleElim4TeamBracket({
       </CardHeader>
 
       <div className="overflow-x-auto overflow-y-hidden">
-        <div className="flex min-w-max items-start justify-start gap-6 px-4">
-          {/* Upper Bracket */}
-          <div className="space-y-4">
-            <h2 className="text-center text-xl font-medium">Upper Bracket</h2>
-            <div className="flex items-start gap-8">
-              {/* Round 1 */}
-              <div className="flex flex-col items-center">
-                <h3 className="mb-4 text-center">Round 1</h3>
-                <div className="space-y-4">
-                  <BracketMatch
-                    matchLabel="Match 1"
-                    matches={matchesBySet[1]}
-                    event={event}
-                    hoveredAlliance={hoveredAlliance}
-                    setHoveredAlliance={setHoveredAlliance}
-                    getSeriesResult={getSeriesResult}
-                    getAllianceDisplayName={getAllianceDisplayName}
-                    showFullAlliance
-                  />
-                  <BracketMatch
-                    matchLabel="Match 2"
-                    matches={matchesBySet[2]}
-                    event={event}
-                    hoveredAlliance={hoveredAlliance}
-                    setHoveredAlliance={setHoveredAlliance}
-                    getSeriesResult={getSeriesResult}
-                    getAllianceDisplayName={getAllianceDisplayName}
-                    showFullAlliance
-                  />
+        <div ref={containerRef} className="relative isolate min-w-max px-4">
+          <div className="relative z-1 space-y-4">
+            {/* Upper Bracket */}
+            <div className="space-y-4">
+              <h2 className="text-center text-xl font-medium">Upper Bracket</h2>
+              <div className="flex items-start gap-8">
+                {/* Round 1 */}
+                <div className="flex flex-col items-center">
+                  <h3 className="mb-4 text-center">Round 1</h3>
+                  <div className="space-y-4">
+                    <BracketMatch
+                      ref={(node) => {
+                        matchRefs.current['Match 1'] = node;
+                      }}
+                      matchLabel="Match 1"
+                      matches={matchesBySet[1]}
+                      event={event}
+                      hoveredAlliance={hoveredAlliance}
+                      setHoveredAlliance={setHoveredAlliance}
+                      getSeriesResult={getSeriesResult}
+                      getAllianceDisplayName={getAllianceDisplayName}
+                      showFullAlliance
+                    />
+                    <BracketMatch
+                      ref={(node) => {
+                        matchRefs.current['Match 2'] = node;
+                      }}
+                      matchLabel="Match 2"
+                      matches={matchesBySet[2]}
+                      event={event}
+                      hoveredAlliance={hoveredAlliance}
+                      setHoveredAlliance={setHoveredAlliance}
+                      getSeriesResult={getSeriesResult}
+                      getAllianceDisplayName={getAllianceDisplayName}
+                      showFullAlliance
+                    />
+                  </div>
+                </div>
+
+                {/* Round 2 - Upper */}
+                <div className="flex flex-col items-center">
+                  <h3 className="mb-4 text-center">Round 2</h3>
+                  <div className="space-y-4">
+                    <div className="h-8"></div>
+                    <BracketMatch
+                      ref={(node) => {
+                        matchRefs.current['Match 4'] = node;
+                      }}
+                      matchLabel="Match 4"
+                      matches={matchesBySet[4]}
+                      event={event}
+                      hoveredAlliance={hoveredAlliance}
+                      setHoveredAlliance={setHoveredAlliance}
+                      getSeriesResult={getSeriesResult}
+                      getAllianceDisplayName={getAllianceDisplayName}
+                    />
+                  </div>
+                </div>
+
+                <div className="w-16"></div>
+
+                {/* Finals */}
+                <div className="flex flex-col items-center">
+                  <h3 className="mb-4 text-center font-bold">Finals</h3>
+                  <div className="space-y-4">
+                    <div className="h-8"></div>
+                    <BracketMatch
+                      ref={(node) => {
+                        matchRefs.current.Finals = node;
+                      }}
+                      matchLabel="Finals"
+                      matches={finalsMatches}
+                      event={event}
+                      hoveredAlliance={hoveredAlliance}
+                      setHoveredAlliance={setHoveredAlliance}
+                      getSeriesResult={getSeriesResult}
+                      getAllianceDisplayName={getAllianceDisplayName}
+                    />
+                  </div>
                 </div>
               </div>
+            </div>
 
-              {/* Round 2 - Upper */}
-              <div className="flex flex-col items-center">
-                <h3 className="mb-4 text-center">Round 2</h3>
-                <div className="space-y-4">
-                  <div className="h-8"></div>
-                  <BracketMatch
-                    matchLabel="Match 4"
-                    matches={matchesBySet[4]}
-                    event={event}
-                    hoveredAlliance={hoveredAlliance}
-                    setHoveredAlliance={setHoveredAlliance}
-                    getSeriesResult={getSeriesResult}
-                    getAllianceDisplayName={getAllianceDisplayName}
-                  />
+            {/* Lower Bracket */}
+            <div className="space-y-4">
+              <h2 className="text-center text-xl font-medium">Lower Bracket</h2>
+              <div className="ml-16 flex items-start gap-8">
+                {/* Round 2 - Lower */}
+                <div className="flex flex-col items-center">
+                  <h3 className="mb-4 text-center">Round 2</h3>
+                  <div className="space-y-4">
+                    <BracketMatch
+                      ref={(node) => {
+                        matchRefs.current['Match 3'] = node;
+                      }}
+                      matchLabel="Match 3"
+                      matches={matchesBySet[3]}
+                      event={event}
+                      hoveredAlliance={hoveredAlliance}
+                      setHoveredAlliance={setHoveredAlliance}
+                      getSeriesResult={getSeriesResult}
+                      getAllianceDisplayName={getAllianceDisplayName}
+                    />
+                  </div>
                 </div>
-              </div>
 
-              <div className="w-16"></div>
-
-              {/* Finals */}
-              <div className="flex flex-col items-center">
-                <h3 className="mb-4 text-center font-bold">Finals</h3>
-                <div className="space-y-4">
-                  <div className="h-8"></div>
-                  <BracketMatch
-                    matchLabel="Finals"
-                    matches={finalsMatches}
-                    event={event}
-                    hoveredAlliance={hoveredAlliance}
-                    setHoveredAlliance={setHoveredAlliance}
-                    getSeriesResult={getSeriesResult}
-                    getAllianceDisplayName={getAllianceDisplayName}
-                  />
+                {/* Round 3 - Lower */}
+                <div className="flex flex-col items-center">
+                  <h3 className="mb-4 text-center">Round 3</h3>
+                  <div className="space-y-4">
+                    <BracketMatch
+                      ref={(node) => {
+                        matchRefs.current['Match 5'] = node;
+                      }}
+                      matchLabel="Match 5"
+                      matches={matchesBySet[5]}
+                      event={event}
+                      hoveredAlliance={hoveredAlliance}
+                      setHoveredAlliance={setHoveredAlliance}
+                      getSeriesResult={getSeriesResult}
+                      getAllianceDisplayName={getAllianceDisplayName}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
 
-        {/* Lower Bracket */}
-        <div className="mt-6 px-4">
-          <div className="space-y-4">
-            <h2 className="text-center text-xl font-medium">Lower Bracket</h2>
-            <div className="ml-16 flex items-start gap-8">
-              {/* Round 2 - Lower */}
-              <div className="flex flex-col items-center">
-                <h3 className="mb-4 text-center">Round 2</h3>
-                <div className="space-y-4">
-                  <BracketMatch
-                    matchLabel="Match 3"
-                    matches={matchesBySet[3]}
-                    event={event}
-                    hoveredAlliance={hoveredAlliance}
-                    setHoveredAlliance={setHoveredAlliance}
-                    getSeriesResult={getSeriesResult}
-                    getAllianceDisplayName={getAllianceDisplayName}
-                  />
-                </div>
-              </div>
-
-              {/* Round 3 - Lower */}
-              <div className="flex flex-col items-center">
-                <h3 className="mb-4 text-center">Round 3</h3>
-                <div className="space-y-4">
-                  <BracketMatch
-                    matchLabel="Match 5"
-                    matches={matchesBySet[5]}
-                    event={event}
-                    hoveredAlliance={hoveredAlliance}
-                    setHoveredAlliance={setHoveredAlliance}
-                    getSeriesResult={getSeriesResult}
-                    getAllianceDisplayName={getAllianceDisplayName}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
+          <EliminationBracketPaths
+            paths={paths}
+            svgSize={svgSize}
+            hoveredAlliance={hoveredAlliance}
+          />
         </div>
       </div>
     </Card>

--- a/pwa/app/components/tba/eliminationBracket.tsx
+++ b/pwa/app/components/tba/eliminationBracket.tsx
@@ -15,6 +15,8 @@ import { EliminationAlliance, Event, Match } from '~/api/tba/read';
 import {
   EliminationBracketPaths,
   PlayoffMatchHandle,
+  type SeriesResult,
+  type WinnerLink,
   useAdvancementPaths,
 } from '~/components/tba/eliminationBracketPaths';
 import { MatchLink, TeamLink } from '~/components/tba/links';
@@ -40,23 +42,21 @@ export type MatchLabel =
   | 'Match 13'
   | 'Finals';
 
-type MatchResult = {
-  score: number;
-  won: boolean;
-};
-
-export interface SeriesResult {
-  redTeams: string[];
-  blueTeams: string[];
-  redAllianceNumber: number | null;
-  blueAllianceNumber: number | null;
-  redResults: MatchResult[]; // For each match in the set
-  blueResults: MatchResult[]; // For each match in the set
-  redWon: boolean; // Overall winner of the series
-  blueWon: boolean; // Overall winner of the series
-  matchRedTeams: string[];
-  matchBlueTeams: string[];
-}
+const WINNER_LINKS: WinnerLink[] = [
+  { from: 'Match 1', to: 'Match 7' },
+  { from: 'Match 2', to: 'Match 7' },
+  { from: 'Match 3', to: 'Match 8' },
+  { from: 'Match 4', to: 'Match 8' },
+  { from: 'Match 5', to: 'Match 10' },
+  { from: 'Match 6', to: 'Match 9' },
+  { from: 'Match 7', to: 'Match 11' },
+  { from: 'Match 8', to: 'Match 11' },
+  { from: 'Match 9', to: 'Match 12' },
+  { from: 'Match 10', to: 'Match 12' },
+  { from: 'Match 12', to: 'Match 13' },
+  { from: 'Match 13', to: 'Finals' },
+  { from: 'Match 11', to: 'Finals' },
+];
 
 const PlayoffMatch = forwardRef<
   PlayoffMatchHandle,
@@ -415,11 +415,31 @@ export default function EliminationBracket({
     };
   };
 
+  const matchLookup: Record<string, Match[] | undefined> = useMemo(
+    () => ({
+      'Match 1': matchesBySet[1],
+      'Match 2': matchesBySet[2],
+      'Match 3': matchesBySet[3],
+      'Match 4': matchesBySet[4],
+      'Match 5': matchesBySet[5],
+      'Match 6': matchesBySet[6],
+      'Match 7': matchesBySet[7],
+      'Match 8': matchesBySet[8],
+      'Match 9': matchesBySet[9],
+      'Match 10': matchesBySet[10],
+      'Match 11': matchesBySet[11],
+      'Match 12': matchesBySet[12],
+      'Match 13': matchesBySet[13],
+      Finals: finalsMatches,
+    }),
+    [matchesBySet, finalsMatches],
+  );
+
   const { paths, svgSize } = useAdvancementPaths({
     containerRef,
     matchRefs,
-    matchesBySet,
-    finalsMatches,
+    winnerLinks: WINNER_LINKS,
+    matchLookup,
     getSeriesResult,
   });
 

--- a/pwa/app/components/tba/eliminationBracketPaths.tsx
+++ b/pwa/app/components/tba/eliminationBracketPaths.tsx
@@ -3,12 +3,30 @@ import {
   type MutableRefObject,
   type RefObject,
   useEffect,
-  useMemo,
   useState,
 } from 'react';
 
 import { Match } from '~/api/tba/read';
-import { MatchLabel, SeriesResult } from '~/components/tba/eliminationBracket';
+
+type MatchResult = {
+  score: number;
+  won: boolean;
+};
+
+export interface SeriesResult {
+  redTeams: string[];
+  blueTeams: string[];
+  redAllianceNumber: number | null;
+  blueAllianceNumber: number | null;
+  redResults: MatchResult[];
+  blueResults: MatchResult[];
+  redWon: boolean;
+  blueWon: boolean;
+  matchRedTeams: string[];
+  matchBlueTeams: string[];
+}
+
+export type WinnerLink = { from: string; to: string };
 
 export type PlayoffMatchHandle = {
   card: HTMLDivElement | null;
@@ -34,56 +52,21 @@ const desaturatedColors = {
   blue: 'var(--color-blue-300)',
 };
 
-const winnerLinks: { from: MatchLabel; to: MatchLabel }[] = [
-  { from: 'Match 1', to: 'Match 7' },
-  { from: 'Match 2', to: 'Match 7' },
-  { from: 'Match 3', to: 'Match 8' },
-  { from: 'Match 4', to: 'Match 8' },
-  { from: 'Match 5', to: 'Match 10' },
-  { from: 'Match 6', to: 'Match 9' },
-  { from: 'Match 7', to: 'Match 11' },
-  { from: 'Match 8', to: 'Match 11' },
-  { from: 'Match 9', to: 'Match 12' },
-  { from: 'Match 10', to: 'Match 12' },
-  { from: 'Match 12', to: 'Match 13' },
-  { from: 'Match 13', to: 'Finals' },
-  { from: 'Match 11', to: 'Finals' },
-];
-
 export function useAdvancementPaths({
   containerRef,
   matchRefs,
-  matchesBySet,
-  finalsMatches,
+  winnerLinks,
+  matchLookup,
   getSeriesResult,
 }: {
   containerRef: RefObject<HTMLDivElement | null>;
   matchRefs: MutableRefObject<Record<string, PlayoffMatchHandle | null>>;
-  matchesBySet: Record<number, Match[]>;
-  finalsMatches: Match[];
+  winnerLinks: WinnerLink[];
+  matchLookup: Record<string, Match[] | undefined>;
   getSeriesResult: (matches: Match[] | undefined) => SeriesResult | null;
 }): { paths: AdvancementPath[]; svgSize: { width: number; height: number } } {
   const [paths, setPaths] = useState<AdvancementPath[]>([]);
   const [svgSize, setSvgSize] = useState({ width: 0, height: 0 });
-  const matchLookup: Record<MatchLabel, Match[] | undefined> = useMemo(
-    () => ({
-      'Match 1': matchesBySet[1],
-      'Match 2': matchesBySet[2],
-      'Match 3': matchesBySet[3],
-      'Match 4': matchesBySet[4],
-      'Match 5': matchesBySet[5],
-      'Match 6': matchesBySet[6],
-      'Match 7': matchesBySet[7],
-      'Match 8': matchesBySet[8],
-      'Match 9': matchesBySet[9],
-      'Match 10': matchesBySet[10],
-      'Match 11': matchesBySet[11],
-      'Match 12': matchesBySet[12],
-      'Match 13': matchesBySet[13],
-      Finals: finalsMatches,
-    }),
-    [matchesBySet, finalsMatches],
-  );
 
   useEffect(() => {
     const computePaths = () => {
@@ -152,7 +135,7 @@ export function useAdvancementPaths({
     handle();
     window.addEventListener('resize', handle);
     return () => window.removeEventListener('resize', handle);
-  }, [containerRef, matchRefs, matchLookup, getSeriesResult]);
+  }, [containerRef, matchRefs, winnerLinks, matchLookup, getSeriesResult]);
 
   return { paths, svgSize };
 }


### PR DESCRIPTION
## Summary
- Adds `DoubleElim4TeamBracket` component for `DOUBLE_ELIM_4_TEAM` playoff format (used at district championships with 4 divisions)
- Shows upper bracket (matches 1-2, match 4), lower bracket (match 3, match 5), and best-of-3 finals
- Matches the backend `DOUBLE_ELIM_4_MAPPING` structure (sf set_number 1-5 + finals)
- Alliance highlighting on hover, team links, and match score display
- SVG Bezier curve line markers connecting match winners to their next match, matching the 8-team bracket style

## Changes
- **`eliminationBracketPaths.tsx`**: Refactored `useAdvancementPaths` to accept `winnerLinks` and `matchLookup` as parameters (instead of hardcoding them). Moved `SeriesResult` type here to break circular dependency. Exported `WinnerLink` type.
- **`eliminationBracket.tsx`**: Defines its own `WINNER_LINKS` array and builds `matchLookup` with `useMemo`, passing both to the refactored hook. Imports `SeriesResult` from the paths module.
- **`doubleElim4TeamBracket.tsx`**: Added line markers using the shared `useAdvancementPaths` hook. Replaced local duplicate types (`MatchHandle`, `SeriesResult`, `MatchResult`) with imports from `eliminationBracketPaths`. Both upper and lower brackets share a single `containerRef` so SVG paths can span across them.

## Test plan
- [ ] Verify bracket displays with line markers on a 4-team double elim event (e.g., `/event/2024oncmp1`)
- [ ] Verify alliance highlighting on hover lights up connecting lines
- [ ] Verify 8-team double elim bracket still works unchanged (e.g., `/event/2024mil`)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npx prettier --check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot Pages
- /event/2024oncmp1 District CMP with 4-Team Double Elim
- /event/2024mil 8-Team Double Elim (regression check)