### PR TITLE
Link FIRST Sync Code to frc-events on offseason review page

### DIFF
--- a/src/backend/web/templates/event_partials/suggest_event_info.html
+++ b/src/backend/web/templates/event_partials/suggest_event_info.html
@@ -9,7 +9,7 @@
             <td><p><strong>Example:</strong><br>nyny</p></td>
         </tr>
         <tr>
-            <td>FIRST Sync Code</td>
+            <td>FIRST Sync Code{% if event.first_code %} (<a href="https://frc-events.firstinspires.org/{{ event.year }}/{{ event.first_code }}" target="_blank">{{ event.first_code }}</a>){% endif %}</td>
             <td><input type="text" name="first_code" {% if event.first_code%}value="{{ event.first_code }}{% endif %}"/></td>
             <td><p><strong>Example:</strong><br>IRI</p></td>
         </tr>


### PR DESCRIPTION
## Summary
- On the offseason event suggestion review page (`/suggest/offseason/review`), the FIRST Sync Code label now shows the user-submitted code in parentheses, linked to `frc-events.firstinspires.org/{year}/{code}`
- Helps reviewing admins quickly verify the offseason is the correct one before accepting
- When no code is submitted, the label displays as before with no link

## Test plan
- [ ] Submit an offseason event suggestion with a FIRST Sync Code
- [ ] Visit `/suggest/offseason/review` and verify the code appears as a clickable link next to the label
- [ ] Verify the link opens the correct frc-events page in a new tab
- [ ] Submit a suggestion without a FIRST Sync Code and verify the label shows plain "FIRST Sync Code" with no parentheses

🤖 Generated with [Claude Code](https://claude.com/claude-code)