### PR TITLE
PWA screenshots: opt-in only, no default pages

### DIFF
--- a/.github/workflows/pwa_screenshots.yml
+++ b/.github/workflows/pwa_screenshots.yml
@@ -27,10 +27,10 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # --- Parse extra screenshot pages from PR description ---
+      # --- Parse screenshot pages from PR description ---
       - name: Parse screenshot pages from PR body
         if: steps.check-key.outputs.skip != 'true'
-        id: extra-pages
+        id: pages
         uses: actions/github-script@v8
         with:
           script: |
@@ -51,7 +51,7 @@ jobs:
             const section = stripped.match(/## Screenshot Pages\s*\n([\s\S]*?)(?:\n##|\n\n---|\s*$)/);
             if (!section) {
               core.setOutput('json', '[]');
-              core.info('No "## Screenshot Pages" section found in PR body');
+              core.info('No "## Screenshot Pages" section found in PR body — skipping screenshots');
               return;
             }
 
@@ -67,21 +67,25 @@ jobs:
             }
 
             core.setOutput('json', JSON.stringify(pages));
-            core.info(`Found ${pages.length} extra page(s): ${pages.map(p => p.path).join(', ')}`);
+            if (pages.length === 0) {
+              core.info('## Screenshot Pages section found but no pages listed — skipping screenshots');
+            } else {
+              core.info(`Found ${pages.length} page(s): ${pages.map(p => p.path).join(', ')}`);
+            }
 
       # --- Setup toolchain ---
       - name: Checkout PR branch
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: pnpm/action-setup@v4
         with:
           version: "10.24.0"
 
       - name: Set up Node
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -89,7 +93,7 @@ jobs:
           cache-dependency-path: "pwa/pnpm-lock.yaml"
 
       - name: Cache Playwright browsers
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
@@ -98,16 +102,16 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install dependencies
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         run: pnpm --dir pwa install --frozen-lockfile
 
       - name: Install Playwright browsers
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         run: pnpm --dir pwa exec playwright install --with-deps chromium
 
       # --- Build and screenshot PR branch ---
       - name: Create dotenv (PR)
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         run: ./ops/pwa/create_dotenv.sh --env
         env:
           TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
@@ -115,11 +119,11 @@ jobs:
           GCLOUD_PROJECT_ID: demo-test
 
       - name: Build PWA (PR branch)
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         run: pnpm --dir pwa run build
 
       - name: Take PR screenshots
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         working-directory: pwa
         run: |
           node ./server.js &
@@ -136,17 +140,17 @@ jobs:
         env:
           NODE_ENV: production
           SCREENSHOT_DIR: ${{ github.workspace }}/screenshots-after
-          EXTRA_PAGES: ${{ steps.extra-pages.outputs.json }}
+          PAGES: ${{ steps.pages.outputs.json }}
 
       # --- Save scripts and switch to base branch ---
       - name: Save scripts for base branch
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         run: |
           cp ops/pwa/take-screenshots.mjs /tmp/take-screenshots.mjs
           cp ops/pwa/generate-screenshot-comment.mjs /tmp/generate-screenshot-comment.mjs
 
       - name: Checkout base branch
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -154,13 +158,13 @@ jobs:
 
       # --- Build and screenshot base branch ---
       - name: Install dependencies (base)
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         id: base-deps
         continue-on-error: true
         run: pnpm --dir pwa install --frozen-lockfile
 
       - name: Create dotenv (base)
-        if: steps.check-key.outputs.skip != 'true' && steps.base-deps.outcome == 'success'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]' && steps.base-deps.outcome == 'success'
         run: ./ops/pwa/create_dotenv.sh --env
         env:
           TBA_API_READ_KEY: ${{ secrets.TBA_API_READ_KEY }}
@@ -168,13 +172,13 @@ jobs:
           GCLOUD_PROJECT_ID: demo-test
 
       - name: Build PWA (base branch)
-        if: steps.check-key.outputs.skip != 'true' && steps.base-deps.outcome == 'success'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]' && steps.base-deps.outcome == 'success'
         id: base-build
         continue-on-error: true
         run: pnpm --dir pwa run build
 
       - name: Take base screenshots
-        if: steps.check-key.outputs.skip != 'true' && steps.base-build.outcome == 'success'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]' && steps.base-build.outcome == 'success'
         continue-on-error: true
         working-directory: pwa
         run: |
@@ -192,11 +196,11 @@ jobs:
         env:
           NODE_ENV: production
           SCREENSHOT_DIR: ${{ github.workspace }}/screenshots-before
-          EXTRA_PAGES: ${{ steps.extra-pages.outputs.json }}
+          PAGES: ${{ steps.pages.outputs.json }}
 
       # --- Generate comment and post ---
       - name: Generate screenshot comment
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         run: node /tmp/generate-screenshot-comment.mjs
         env:
           BEFORE_DIR: ${{ github.workspace }}/screenshots-before
@@ -206,7 +210,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Post comment on PR
-        if: steps.check-key.outputs.skip != 'true'
+        if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: actions/github-script@v8
         with:
           script: |

--- a/ops/pwa/take-screenshots.mjs
+++ b/ops/pwa/take-screenshots.mjs
@@ -1,13 +1,14 @@
 /**
  * PWA Screenshot Capture Script
  *
- * Takes full-page screenshots of canonical PWA pages using Playwright.
+ * Takes full-page screenshots of PWA pages using Playwright.
+ * Pages to screenshot are specified via the PAGES env var (JSON array).
  * Designed to run against a built & running PWA server.
  *
  * Environment variables:
  *   BASE_URL       - Server URL (default: http://localhost:3000)
  *   SCREENSHOT_DIR - Output directory for screenshots (default: screenshots)
- *   EXTRA_PAGES    - JSON array of {name, path} objects for additional pages
+ *   PAGES          - JSON array of {name, path} objects for pages to screenshot
  */
 
 import { mkdirSync } from "fs";
@@ -26,26 +27,21 @@ const { chromium } = await import(pwPath);
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || "screenshots";
 
-// Canonical pages — small set that covers key page types
-const CANONICAL_PAGES = [
-  { name: "Homepage", path: "/" },
-  { name: "Team 604 (2024)", path: "/team/604/2024" },
-  { name: "Event 2024mil", path: "/event/2024mil" },
-];
-
-// Merge canonical pages with any extra pages from EXTRA_PAGES env var
-// EXTRA_PAGES should be a JSON array of {name, path} objects
-let extraPages = [];
-if (process.env.EXTRA_PAGES) {
+// Pages to screenshot, specified via PAGES env var (JSON array of {name, path})
+let PAGES = [];
+if (process.env.PAGES) {
   try {
-    extraPages = JSON.parse(process.env.EXTRA_PAGES);
-    console.log(`Adding ${extraPages.length} extra page(s) from PR description`);
+    PAGES = JSON.parse(process.env.PAGES);
+    console.log(`Screenshotting ${PAGES.length} page(s) from PR description`);
   } catch (err) {
-    console.warn(`Failed to parse EXTRA_PAGES: ${err.message}`);
+    console.warn(`Failed to parse PAGES: ${err.message}`);
   }
 }
 
-const PAGES = [...CANONICAL_PAGES, ...extraPages];
+if (PAGES.length === 0) {
+  console.log("No pages to screenshot. Add a ## Screenshot Pages section to the PR description.");
+  process.exit(0);
+}
 
 function toFilename(name) {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-") + ".png";

--- a/pwa/AGENTS.md
+++ b/pwa/AGENTS.md
@@ -86,9 +86,7 @@ npx playwright test  # E2E tests
 
 ## PR Screenshots
 
-PRs that touch `pwa/` files automatically get before/after screenshots posted as a comment. By default, the Homepage, a Team page, and an Event page are captured.
-
-To request screenshots of additional pages, add a `## Screenshot Pages` section to the PR description with bullet-pointed paths:
+PRs that touch `pwa/` files can get before/after screenshots posted as a comment. To request screenshots, add a `## Screenshot Pages` section to the PR description:
 
 ```markdown
 ## Screenshot Pages
@@ -98,4 +96,4 @@ To request screenshots of additional pages, add a `## Screenshot Pages` section 
 - /gameday
 ```
 
-Each line is `- /path` optionally followed by a display name. If no name is given, the path is used.
+Each line is `- /path` optionally followed by a display name. If no name is given, the path is used. If no pages are listed, the workflow skips screenshot capture.

--- a/pwa/README.md
+++ b/pwa/README.md
@@ -155,9 +155,7 @@ Unfortunately, Iconify wants you to get the icons from their API, but we'd rathe
 
 ## PR Screenshots
 
-PRs that touch `pwa/` files automatically get before/after screenshots posted as a PR comment (via the `PWA Screenshots` workflow). By default, the Homepage, a Team page, and an Event page are captured.
-
-To request screenshots of additional pages, add a `## Screenshot Pages` section to your PR description:
+PRs that touch `pwa/` files can get before/after screenshots posted as a PR comment (via the `PWA Screenshots` workflow). To request screenshots, add a `## Screenshot Pages` section to your PR description:
 
 ```markdown
 ## Screenshot Pages
@@ -167,7 +165,7 @@ To request screenshots of additional pages, add a `## Screenshot Pages` section 
 - /gameday
 ```
 
-Each line is `- /path` optionally followed by a display name. The workflow parses this section and adds those pages to the screenshot set.
+Each line is `- /path` optionally followed by a display name. If no pages are listed, the workflow skips screenshot capture.
 
 > **Note:** Screenshots require the `TBA_API_READ_KEY` secret, which is only available for same-repo branches (not fork PRs). Fork PRs will gracefully skip screenshot capture.
 


### PR DESCRIPTION
## Summary

Makes PWA screenshot capture fully opt-in. No pages are screenshotted by default — only pages listed in the `## Screenshot Pages` section of the PR description are captured. If no pages are listed, the workflow skips entirely (no build, no Playwright install).

This reduces noise from the screenshot workflow on PRs that don't need visual review.

## Screenshot Pages
- /team/604/2024 Team Page

## Test plan
- [ ] Verify the workflow captures only the page listed above
- [ ] Verify PRs without a `## Screenshot Pages` section skip the workflow entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)