### PR TITLE
Add Android Digital Asset Links for deep linking

### DIFF
--- a/src/backend/web/static/well-known/assetlinks.json
+++ b/src/backend/web/static/well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.thebluealliance.androidclient",
+      "sha256_cert_fingerprints": [
+        "65:01:22:67:93:F4:30:84:E0:8E:BA:24:82:19:4F:22:BF:C4:5F:A3:8F:27:77:A1:2F:4A:AB:8C:73:EA:09:E0"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `/.well-known/assetlinks.json` to enable Android App Links for `com.thebluealliance.androidclient`
- Uses the existing `web.yaml` handler that already serves `/.well-known/` files (same mechanism as `apple-app-site-association`)
- Fixes deep linking from Google Play Console

## Test plan
- [ ] After deploy, verify `https://thebluealliance.com/.well-known/assetlinks.json` returns correct JSON
- [ ] Validate with [Google's Digital Asset Links tool](https://developers.google.com/digital-asset-links/tools/generator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)