### PR TITLE
Add 2026 coprs. Improve copr table styling

### DIFF
--- a/src/backend/common/helpers/matchstats_helper.py
+++ b/src/backend/common/helpers/matchstats_helper.py
@@ -178,6 +178,65 @@ MANUAL_COMPONENTS = {
             ]
         ),
     },
+    2026: {
+        "Hub Auto Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("autoCount", 0),
+        "Hub Auto Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("autoPoints", 0),
+        "Hub Endgame Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("endgameCount", 0),
+        "Hub Endgame Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("endgamePoints", 0),
+        "Hub Shift 1 Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift1Count", 0),
+        "Hub Shift 1 Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift1Points", 0),
+        "Hub Shift 2 Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift2Count", 0),
+        "Hub Shift 2 Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift2Points", 0),
+        "Hub Shift 3 Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift3Count", 0),
+        "Hub Shift 3 Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift3Points", 0),
+        "Hub Shift 4 Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift4Count", 0),
+        "Hub Shift 4 Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("shift4Points", 0),
+        "Hub Teleop Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("teleopCount", 0),
+        "Hub Teleop Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("teleopPoints", 0),
+        "Hub Total Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("totalCount", 0),
+        "Hub Total Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("totalPoints", 0),
+        "Hub Transition Count": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("transitionCount", 0),
+        "Hub Transition Points": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("transitionPoints", 0),
+        "Hub Uncounted": lambda match, color: match.score_breakdown[color][
+            "hubScore"
+        ].get("uncounted", 0),
+    },
 }
 
 
@@ -299,24 +358,25 @@ class MatchstatsHelper(object):
     @classmethod
     def calculate_coprs(cls, matches: List[Match], year: Year) -> EventComponentOPRs:
         coprs: OrderedDict[Component, TeamStatMap] = OrderedDict()
+        matches_with_score_breakdown = [
+            match for match in matches if match.score_breakdown is not None
+        ]
 
-        if matches is None or len(matches) == 0:
+        if len(matches_with_score_breakdown) == 0:
             return coprs
 
-        first_match = matches[0]
-        if first_match.score_breakdown is None:
-            return coprs
+        first_match = matches_with_score_breakdown[0]
 
-        team_list, team_id_map = cls.build_team_mapping(matches)
+        team_list, team_id_map = cls.build_team_mapping(matches_with_score_breakdown)
         if not team_list:
             return {}
 
-        Minv = cls.build_Minv_matrix(matches, team_id_map)
+        Minv = cls.build_Minv_matrix(matches_with_score_breakdown, team_id_map)
 
         if year in MANUAL_COMPONENTS.keys():
             for name, accessor in MANUAL_COMPONENTS[year].items():
                 coprs[name] = cls.calc_stat(
-                    matches, team_list, team_id_map, Minv, accessor
+                    matches_with_score_breakdown, team_list, team_id_map, Minv, accessor
                 )
 
         # For each k-v in score_breakdown, attempt to convert v to a float.
@@ -332,7 +392,7 @@ class MatchstatsHelper(object):
                 pass
             else:
                 coprs[component] = cls.calc_stat(
-                    matches,
+                    matches_with_score_breakdown,
                     team_list,
                     team_id_map,
                     Minv,

--- a/src/backend/web/templates/event_partials/event_copr_table.html
+++ b/src/backend/web/templates/event_partials/event_copr_table.html
@@ -6,14 +6,14 @@
                         aria-expanded="false">
             <span id="coprSelector">Statistics</span> <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu" style="min-width: 260px;">
             <li>
                     <a href="#" id="copr_clear">Clear (reset to OPR)</a>
             </li>
             <li role="separator" class="divider"></li>
             {% for copr_item in copr_items %}
                     <li>
-                            <label class="copr-select" data-key="{{ copr_item[0] }}" data-name="{{ copr_item[2] }}" for="checkbox_{{ copr_item[1] }}" style="display:block; padding:3px 12px; cursor:pointer;">
+                            <label class="copr-select" data-key="{{ copr_item[0] }}" data-name="{{ copr_item[2] }}" for="checkbox_{{ copr_item[1] }}" style="display:block; padding:1px 12px; cursor:pointer; font-weight: normal;">
                                     <input type="checkbox" id="checkbox_{{ copr_item[1] }}" style="margin-right:6px;">{{ copr_item[2] }}
                             </label>
                     </li>
@@ -139,6 +139,11 @@
     }
 
     document.addEventListener("DOMContentLoaded", function() {
+        // Prevent dropdown from closing when clicking checkboxes/labels inside it
+        $(document).on('click.dropdown-persist', '.dropdown-menu', function(e) {
+            e.stopPropagation();
+        });
+
         // Initialize: wire up checkboxes and derive initial selection from current DOM state
         const checkboxNodes = document.querySelectorAll('.copr-select');
 


### PR DESCRIPTION
- Adds 2026 component OPRs which are nested inside a `hubScore` object
- Fixes error when trying to calculate cOPRs with unplayed matches. Didn't affect calculations, just clogs up console logs.
- Slightly improves styling for cOPR selection dropdown.
- Selection dropdown will no longer auto close when you select a component. It will close if you click away from it.
- 
<img width="1918" height="2159" alt="image" src="https://github.com/user-attachments/assets/8ec00d1d-9da8-46ad-b671-715b487c61df" />

<img width="1918" height="2159" alt="image" src="https://github.com/user-attachments/assets/66c62587-b3a2-4850-bc8e-bda787c64145" />
