### PR TITLE
Add 2026 ranking sort orders

### DIFF
--- a/src/backend/common/consts/ranking_sort_orders.py
+++ b/src/backend/common/consts/ranking_sort_orders.py
@@ -3,6 +3,12 @@ from typing import Dict, List
 from backend.common.models.ranking_sort_order_info import RankingSortOrderInfo
 
 SORT_ORDER_INFO: Dict[int, List[RankingSortOrderInfo]] = {
+    2026: [
+        {"name": "Ranking Score", "precision": 2},
+        {"name": "Avg Match", "precision": 2},
+        {"name": "Avg Auto Fuel", "precision": 2},
+        {"name": "Avg Tower", "precision": 2},
+    ],
     2025: [
         {"name": "Ranking Score", "precision": 2},
         {"name": "Avg Coop", "precision": 2},


### PR DESCRIPTION
As title, so rankings will render.

towards github.com/the-blue-alliance/the-blue-alliance/issues/9135