### PR TITLE
[pwa] Add score breakdown 2026

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -1192,6 +1192,7 @@ export type Match = {
     | MatchScoreBreakdown2023
     | MatchScoreBreakdown2024
     | MatchScoreBreakdown2025
+    | MatchScoreBreakdown2026
     | null;
   /**
    * Array of video objects associated with this match.

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -1360,6 +1360,7 @@ export const zMatch = z.object({
     zMatchScoreBreakdown2023,
     zMatchScoreBreakdown2024,
     zMatchScoreBreakdown2025,
+    zMatchScoreBreakdown2026,
     z.null(),
   ]),
   videos: z.array(

--- a/pwa/app/components/tba/match/matchDetails.tsx
+++ b/pwa/app/components/tba/match/matchDetails.tsx
@@ -7,6 +7,7 @@ import ScoreBreakdown2018 from '~/components/tba/match/scoreBreakdown2018';
 import ScoreBreakdown2023 from '~/components/tba/match/scoreBreakdown2023';
 import ScoreBreakdown2024 from '~/components/tba/match/scoreBreakdown2024';
 import ScoreBreakdown2025 from '~/components/tba/match/scoreBreakdown2025';
+import ScoreBreakdown2026 from '~/components/tba/match/scoreBreakdown2026';
 import { YoutubeEmbed } from '~/components/tba/videoEmbeds';
 import { Checkbox } from '~/components/ui/checkbox';
 import {
@@ -15,6 +16,7 @@ import {
   isScoreBreakdown2023,
   isScoreBreakdown2024,
   isScoreBreakdown2025,
+  isScoreBreakdown2026,
 } from '~/lib/rankingPoints';
 
 function formatMatchDate(timestamp: number, timezone: string): string {
@@ -93,6 +95,15 @@ export default function MatchDetails({
     match.actual_time ?? match.time ?? match.predicted_time;
 
   let sbDiv = null;
+
+  if (isScoreBreakdown2026(match.score_breakdown)) {
+    sbDiv = (
+      <ScoreBreakdown2026
+        scoreBreakdown={match.score_breakdown}
+        match={match}
+      />
+    );
+  }
 
   if (isScoreBreakdown2025(match.score_breakdown)) {
     sbDiv = (

--- a/pwa/app/components/tba/match/scoreBreakdown2026.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown2026.tsx
@@ -1,0 +1,511 @@
+import { Match, MatchScoreBreakdown2026, TowerRobot2026 } from '~/api/tba/read';
+import {
+  ConditionalBadge,
+  ConditionalRpAchieved,
+} from '~/components/tba/match/common';
+import {
+  ScoreBreakdownAllianceCell,
+  ScoreBreakdownLabelCell,
+  ScoreBreakdownRow,
+  ScoreBreakdownTable,
+} from '~/components/tba/match/scoreBreakdown';
+import { Badge } from '~/components/ui/badge';
+
+const TOWER_ROBOT_POINTS: Record<TowerRobot2026, number> = {
+  Level3: 15,
+  Level2: 10,
+  Level1: 6,
+  None: 0,
+};
+
+const TOWER_ROBOT_DISPLAY: Record<TowerRobot2026, string> = {
+  Level3: 'Level 3',
+  Level2: 'Level 2',
+  Level1: 'Level 1',
+  None: 'None',
+};
+
+function EndgameTowerCell({
+  endgame,
+  teamKey,
+}: {
+  endgame: TowerRobot2026;
+  teamKey: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <Badge variant="outline">{teamKey.substring(3)}</Badge>
+      <span>
+        {TOWER_ROBOT_DISPLAY[endgame]} (+{TOWER_ROBOT_POINTS[endgame]})
+      </span>
+    </div>
+  );
+}
+
+export default function ScoreBreakdown2026({
+  scoreBreakdown,
+  match,
+}: {
+  scoreBreakdown: MatchScoreBreakdown2026;
+  match: Match;
+}) {
+  return (
+    <ScoreBreakdownTable>
+      {/* Auto Tower */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.autoTowerPoints}
+        redValue={scoreBreakdown.red.autoTowerPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          <div className="flex flex-row items-center gap-1">
+            <div className="flex flex-col items-start justify-center gap-1">
+              <ConditionalBadge
+                condition={scoreBreakdown.red.autoTowerRobot1 !== 'None'}
+                teamKey={match.alliances.red.team_keys[0]}
+                alignIcon="left"
+              />
+              <ConditionalBadge
+                condition={scoreBreakdown.red.autoTowerRobot2 !== 'None'}
+                teamKey={match.alliances.red.team_keys[1]}
+                alignIcon="left"
+              />
+              <ConditionalBadge
+                condition={scoreBreakdown.red.autoTowerRobot3 !== 'None'}
+                teamKey={match.alliances.red.team_keys[2]}
+                alignIcon="left"
+              />
+            </div>
+            <div className="flex flex-1 justify-center">
+              {scoreBreakdown.red.autoTowerPoints}
+            </div>
+          </div>
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark">
+          Auto Tower
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          <div className="flex flex-row items-center gap-1">
+            <div className="flex flex-1 justify-center">
+              {scoreBreakdown.blue.autoTowerPoints}
+            </div>
+            <div className="flex flex-col items-end justify-center gap-1">
+              <ConditionalBadge
+                condition={scoreBreakdown.blue.autoTowerRobot1 !== 'None'}
+                teamKey={match.alliances.blue.team_keys[0]}
+                alignIcon="right"
+              />
+              <ConditionalBadge
+                condition={scoreBreakdown.blue.autoTowerRobot2 !== 'None'}
+                teamKey={match.alliances.blue.team_keys[1]}
+                alignIcon="right"
+              />
+              <ConditionalBadge
+                condition={scoreBreakdown.blue.autoTowerRobot3 !== 'None'}
+                teamKey={match.alliances.blue.team_keys[2]}
+                alignIcon="right"
+              />
+            </div>
+          </div>
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Total Auto */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.totalAutoPoints}
+        redValue={scoreBreakdown.red.totalAutoPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.totalAutoPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark" fontWeight="bold">
+          Total Auto
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.totalAutoPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Hub Score: Shift Counts */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.hubScore.shift1Count}
+        redValue={scoreBreakdown.red.hubScore.shift1Count}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          {scoreBreakdown.red.hubScore.shift1Count}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Shift 1 Count
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          {scoreBreakdown.blue.hubScore.shift1Count}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.hubScore.shift2Count}
+        redValue={scoreBreakdown.red.hubScore.shift2Count}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          {scoreBreakdown.red.hubScore.shift2Count}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Shift 2 Count
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          {scoreBreakdown.blue.hubScore.shift2Count}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.hubScore.shift3Count}
+        redValue={scoreBreakdown.red.hubScore.shift3Count}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          {scoreBreakdown.red.hubScore.shift3Count}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Shift 3 Count
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          {scoreBreakdown.blue.hubScore.shift3Count}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.hubScore.shift4Count}
+        redValue={scoreBreakdown.red.hubScore.shift4Count}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          {scoreBreakdown.red.hubScore.shift4Count}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Shift 4 Count
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          {scoreBreakdown.blue.hubScore.shift4Count}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Shift Points */}
+      <ScoreBreakdownRow
+        blueValue={
+          scoreBreakdown.blue.hubScore.shift1Points +
+          scoreBreakdown.blue.hubScore.shift2Points +
+          scoreBreakdown.blue.hubScore.shift3Points +
+          scoreBreakdown.blue.hubScore.shift4Points
+        }
+        redValue={
+          scoreBreakdown.red.hubScore.shift1Points +
+          scoreBreakdown.red.hubScore.shift2Points +
+          scoreBreakdown.red.hubScore.shift3Points +
+          scoreBreakdown.red.hubScore.shift4Points
+        }
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.hubScore.shift1Points} /{' '}
+          {scoreBreakdown.red.hubScore.shift2Points} /{' '}
+          {scoreBreakdown.red.hubScore.shift3Points} /{' '}
+          {scoreBreakdown.red.hubScore.shift4Points}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark">
+          Shift Points (1/2/3/4)
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.hubScore.shift1Points} /{' '}
+          {scoreBreakdown.blue.hubScore.shift2Points} /{' '}
+          {scoreBreakdown.blue.hubScore.shift3Points} /{' '}
+          {scoreBreakdown.blue.hubScore.shift4Points}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Teleop Count */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.hubScore.teleopCount}
+        redValue={scoreBreakdown.red.hubScore.teleopCount}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          {scoreBreakdown.red.hubScore.teleopCount}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Teleop Count
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          {scoreBreakdown.blue.hubScore.teleopCount}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Teleop Hub Points */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.hubScore.teleopPoints}
+        redValue={scoreBreakdown.red.hubScore.teleopPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.hubScore.teleopPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark">
+          Teleop Hub Points
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.hubScore.teleopPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Robot 1 Endgame */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell
+          color="red"
+          shade="light"
+          className="flex flex-col items-center gap-1"
+        >
+          <EndgameTowerCell
+            endgame={scoreBreakdown.red.endGameTowerRobot1}
+            teamKey={match.alliances.red.team_keys[0]}
+          />
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Robot 1 Endgame
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell
+          color="blue"
+          shade="light"
+          className="flex flex-col items-center gap-1"
+        >
+          <EndgameTowerCell
+            endgame={scoreBreakdown.blue.endGameTowerRobot1}
+            teamKey={match.alliances.blue.team_keys[0]}
+          />
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Robot 2 Endgame */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell
+          color="red"
+          shade="light"
+          className="flex flex-col items-center gap-1"
+        >
+          <EndgameTowerCell
+            endgame={scoreBreakdown.red.endGameTowerRobot2}
+            teamKey={match.alliances.red.team_keys[1]}
+          />
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Robot 2 Endgame
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell
+          color="blue"
+          shade="light"
+          className="flex flex-col items-center gap-1"
+        >
+          <EndgameTowerCell
+            endgame={scoreBreakdown.blue.endGameTowerRobot2}
+            teamKey={match.alliances.blue.team_keys[1]}
+          />
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Robot 3 Endgame */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell
+          color="red"
+          shade="light"
+          className="flex flex-col items-center gap-1"
+        >
+          <EndgameTowerCell
+            endgame={scoreBreakdown.red.endGameTowerRobot3}
+            teamKey={match.alliances.red.team_keys[2]}
+          />
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Robot 3 Endgame
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell
+          color="blue"
+          shade="light"
+          className="flex flex-col items-center gap-1"
+        >
+          <EndgameTowerCell
+            endgame={scoreBreakdown.blue.endGameTowerRobot3}
+            teamKey={match.alliances.blue.team_keys[2]}
+          />
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Endgame Tower Points */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.endGameTowerPoints}
+        redValue={scoreBreakdown.red.endGameTowerPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.endGameTowerPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark">
+          Endgame Tower Points
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.endGameTowerPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Total Tower Points */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.totalTowerPoints}
+        redValue={scoreBreakdown.red.totalTowerPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.totalTowerPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark">
+          Total Tower Points
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.totalTowerPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Total Teleop */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.totalTeleopPoints}
+        redValue={scoreBreakdown.red.totalTeleopPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.totalTeleopPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark" fontWeight="bold">
+          Total Teleop
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.totalTeleopPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Energized Bonus */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          <ConditionalRpAchieved
+            condition={scoreBreakdown.red.energizedAchieved}
+          />
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Energized Bonus
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          <ConditionalRpAchieved
+            condition={scoreBreakdown.blue.energizedAchieved}
+          />
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Supercharged Bonus */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          <ConditionalRpAchieved
+            condition={scoreBreakdown.red.superchargedAchieved}
+          />
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Supercharged Bonus
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          <ConditionalRpAchieved
+            condition={scoreBreakdown.blue.superchargedAchieved}
+          />
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Traversal Bonus */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          <ConditionalRpAchieved
+            condition={scoreBreakdown.red.traversalAchieved}
+          />
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Traversal Bonus
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          <ConditionalRpAchieved
+            condition={scoreBreakdown.blue.traversalAchieved}
+          />
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Fouls / Major Fouls */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          {scoreBreakdown.red.minorFoulCount} /{' '}
+          {scoreBreakdown.red.majorFoulCount}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">
+          Fouls / Major Fouls
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          {scoreBreakdown.blue.minorFoulCount} /{' '}
+          {scoreBreakdown.blue.majorFoulCount}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Foul Points */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.foulPoints}
+        redValue={scoreBreakdown.red.foulPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark">
+          {scoreBreakdown.red.foulPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark">
+          Foul Points
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark">
+          {scoreBreakdown.blue.foulPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Adjustments */}
+      {((scoreBreakdown.blue.adjustPoints ?? 0) !== 0 ||
+        (scoreBreakdown.red.adjustPoints ?? 0) !== 0) && (
+        <ScoreBreakdownRow
+          blueValue={scoreBreakdown.blue.adjustPoints}
+          redValue={scoreBreakdown.red.adjustPoints}
+        >
+          <ScoreBreakdownAllianceCell color="red" shade="light">
+            {scoreBreakdown.red.adjustPoints}
+          </ScoreBreakdownAllianceCell>
+          <ScoreBreakdownLabelCell shade="light">
+            Adjustments
+          </ScoreBreakdownLabelCell>
+          <ScoreBreakdownAllianceCell color="blue" shade="light">
+            {scoreBreakdown.blue.adjustPoints}
+          </ScoreBreakdownAllianceCell>
+        </ScoreBreakdownRow>
+      )}
+
+      {/* Total Score */}
+      <ScoreBreakdownRow
+        blueValue={scoreBreakdown.blue.totalPoints}
+        redValue={scoreBreakdown.red.totalPoints}
+      >
+        <ScoreBreakdownAllianceCell color="red" shade="dark" fontWeight="bold">
+          {scoreBreakdown.red.totalPoints}
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="dark" fontWeight="bold">
+          Total Score
+        </ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="dark" fontWeight="bold">
+          {scoreBreakdown.blue.totalPoints}
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+
+      {/* Ranking Points */}
+      <ScoreBreakdownRow>
+        <ScoreBreakdownAllianceCell color="red" shade="light">
+          +{scoreBreakdown.red.rp} RP
+        </ScoreBreakdownAllianceCell>
+        <ScoreBreakdownLabelCell shade="light">RP</ScoreBreakdownLabelCell>
+        <ScoreBreakdownAllianceCell color="blue" shade="light">
+          +{scoreBreakdown.blue.rp} RP
+        </ScoreBreakdownAllianceCell>
+      </ScoreBreakdownRow>
+    </ScoreBreakdownTable>
+  );
+}

--- a/pwa/app/lib/rankingPoints.test.ts
+++ b/pwa/app/lib/rankingPoints.test.ts
@@ -11,6 +11,8 @@ import {
   isScoreBreakdown2022Alliance,
   isScoreBreakdown2023Alliance,
   isScoreBreakdown2024Alliance,
+  isScoreBreakdown2025Alliance,
+  isScoreBreakdown2026Alliance,
 } from '~/lib/rankingPoints';
 
 describe('rankingPoints', () => {
@@ -111,6 +113,30 @@ describe('rankingPoints', () => {
   );
 
   test.each([
+    [{ coralBonusAchieved: true }, true],
+    [{ coralBonusAchieved: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2025Alliance (%#)',
+    (score_breakdown: Partial<MatchScoreBreakdownAlliance>, expected) => {
+      // @ts-expect-error - score_breakdown can be a partial for testing
+      expect(isScoreBreakdown2025Alliance(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
+    [{ energizedAchieved: true }, true],
+    [{ energizedAchieved: false }, true],
+    [{}, false],
+  ])(
+    'isScoreBreakdown2026Alliance (%#)',
+    (score_breakdown: Partial<MatchScoreBreakdownAlliance>, expected) => {
+      // @ts-expect-error - score_breakdown can be a partial for testing
+      expect(isScoreBreakdown2026Alliance(score_breakdown)).toBe(expected);
+    },
+  );
+
+  test.each([
     [{ teleopDefensesBreached: true }, [true, false]],
     [
       { teleopDefensesBreached: false, teleopTowerCaptured: true },
@@ -197,6 +223,36 @@ describe('rankingPoints', () => {
       [false, true],
     ],
     [{ melodyBonusAchieved: true, ensembleBonusAchieved: true }, [true, true]],
+
+    // 2025
+    [{ coralBonusAchieved: true }, [false, true, false]],
+    [
+      { autoBonusAchieved: true, coralBonusAchieved: false },
+      [true, false, false],
+    ],
+    [
+      {
+        autoBonusAchieved: true,
+        coralBonusAchieved: true,
+        bargeBonusAchieved: true,
+      },
+      [true, true, true],
+    ],
+
+    // 2026
+    [{ energizedAchieved: true }, [true, false, false]],
+    [
+      { energizedAchieved: false, superchargedAchieved: true },
+      [false, true, false],
+    ],
+    [
+      {
+        energizedAchieved: true,
+        superchargedAchieved: true,
+        traversalAchieved: true,
+      },
+      [true, true, true],
+    ],
   ])(
     `getBonusRankingPoints (%#)`,
     (score_breakdown: Partial<MatchScoreBreakdownAlliance>, expected) => {

--- a/pwa/app/lib/rankingPoints.ts
+++ b/pwa/app/lib/rankingPoints.ts
@@ -20,6 +20,8 @@ import {
   MatchScoreBreakdown2024Alliance,
   MatchScoreBreakdown2025,
   MatchScoreBreakdown2025Alliance,
+  MatchScoreBreakdown2026,
+  MatchScoreBreakdown2026Alliance,
 } from '~/api/tba/read';
 
 export const RANKING_POINT_LABELS: Record<number, string[]> = {
@@ -33,6 +35,7 @@ export const RANKING_POINT_LABELS: Record<number, string[]> = {
   2023: ['Sustainability Bonus', 'Activation Bonus'],
   2024: ['Melody Bonus', 'Ensemble Bonus'],
   2025: ['Auto Bonus', 'Coral Bonus', 'Barge Bonus'],
+  2026: ['Energized Bonus', 'Supercharged Bonus', 'Traversal Bonus'],
 };
 
 export type MatchScoreBreakdown = Match['score_breakdown'];
@@ -226,6 +229,25 @@ export function isScoreBreakdown2025Alliance(
   );
 }
 
+export function isScoreBreakdown2026(
+  scoreBreakdown: MatchScoreBreakdown,
+): scoreBreakdown is MatchScoreBreakdown2026 {
+  return (
+    scoreBreakdown !== null &&
+    (scoreBreakdown.red as MatchScoreBreakdown2026Alliance)
+      .energizedAchieved !== undefined
+  );
+}
+
+export function isScoreBreakdown2026Alliance(
+  scoreBreakdown: MatchScoreBreakdownAlliance,
+): scoreBreakdown is MatchScoreBreakdown2026Alliance {
+  return (
+    (scoreBreakdown as MatchScoreBreakdown2026Alliance).energizedAchieved !==
+    undefined
+  );
+}
+
 export function getBonusRankingPoints(
   scoreBreakdown: MatchScoreBreakdownAlliance,
 ): boolean[] {
@@ -290,6 +312,14 @@ export function getBonusRankingPoints(
       scoreBreakdown.autoBonusAchieved ?? false,
       scoreBreakdown.coralBonusAchieved ?? false,
       scoreBreakdown.bargeBonusAchieved ?? false,
+    ];
+  }
+
+  if (isScoreBreakdown2026Alliance(scoreBreakdown)) {
+    return [
+      scoreBreakdown.energizedAchieved ?? false,
+      scoreBreakdown.superchargedAchieved ?? false,
+      scoreBreakdown.traversalAchieved ?? false,
     ];
   }
 

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -7177,6 +7177,9 @@
               },
               {
                 "$ref": "#/components/schemas/Match_Score_Breakdown_2025"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2026"
               }
             ],
             "description": "Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null."


### PR DESCRIPTION
Also adds 2026 breakdown to the api spec since that was missing. And adds a missing test case for 2025.

<img width="1918" height="2159" alt="image" src="https://github.com/user-attachments/assets/fbe35fbc-dc4c-47e4-abed-a8b9498848bd" />
