### PR TITLE
Show webcast links on event pages before matches are posted

### DIFF
--- a/src/backend/web/jinja2_filters.py
+++ b/src/backend/web/jinja2_filters.py
@@ -139,6 +139,12 @@ def match_short(match_key: MatchKey) -> str:
     return match_id.replace("m", "-").upper()
 
 
+def format_date_string(date_str: str, formatstr: str = "%a, %b %d") -> str:
+    """Parses a YYYY-MM-DD string and formats it."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return strftime(dt, formatstr)
+
+
 def sort_by(values, prop):
     return sorted(values, key=lambda item: getattr(item, prop))
 
@@ -168,6 +174,7 @@ _filters = {
     "get_item": get_item,
     "pprint_json": pprint_json,
     "from_ms_timestamp": from_ms_timestamp,
+    "format_date_string": format_date_string,
 }
 
 

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -85,6 +85,11 @@
         {% if event.website %}<br><span class="glyphicon glyphicon-link"></span> <a href="{{ event.website }}" title="{{ event.name }}" target="_blank" rel="noopener noreferrer">{{ event.website }}</a>{% endif %}
         {% if event.first_eid or event.official %}{% if not event.website %}<br><span class="glyphicon glyphicon-info-sign"></span>{% else %} - {% endif %} details on <a href="{% if event.first_eid %}https://www.firstinspires.org/event-detail?eventId={{event.first_eid}}{%elif event.official %}https://frc-events.firstinspires.org/{{event.year}}/{{event.first_api_code}}{%endif%}" target="_blank" rel="noopener noreferrer">firstinspires.org</a>{% endif %}
         {% if event.year == 2022 %}{% if event.official %}<br><span class="glyphicon glyphicon-plus"></span> <a href="https://www.firstinspires.org/sites/default/files/uploads/frc/{{event.year}}-events/{{event.year}}_{{event.first_api_code}}_SiteInfo.pdf" target="_blank" rel="noopener noreferrer">COVID-19 Site Information</a>{% endif %}{% endif %}
+        {% if event.webcast and match_count == 0 %}
+          {% for webcast in event.webcast %}
+            <br><span class="glyphicon glyphicon-facetime-video"></span> <a href="{{event.gameday_url}}" target="_blank" rel="noopener noreferrer">Watch webcast{% if webcast.date %} ({{ webcast.date|format_date_string }}){% endif %}</a>
+          {% endfor %}
+        {% endif %}
         {% if event.facebook_eid %}<br><span class="glyphicon glyphicon-thumbs-up"></span> <a href="{{ event.facebook_event_url }}" title="Facebook Event" target="_blank" rel="noopener noreferrer">RSVP on Facebook</a><br>{% endif %}
       </p>
     </div>


### PR DESCRIPTION
## Summary
- Webcast links were invisible on event pages when no matches had been posted yet, because the webcast button was nested inside a `match_count > 0` gate in the Results tab
- Adds webcast links (linking to GameDay) in the always-visible event info section when `match_count == 0`
- Once matches are posted, these links hide and the existing "Event in progress" panel with Watch Now/Offline status takes over
- Adds a `format_date_string` Jinja2 filter for optional per-day webcast date display

## Test plan
- [ ] Verify an event with webcasts but no matches (e.g. `2026cisw0`) shows GameDay link(s) in the event info section
- [ ] Verify an event with no webcasts doesn't show a spurious link
- [ ] Verify once matches are posted, the info-section links disappear and the Results tab "Event in progress" panel shows instead
- [ ] Verify the GameDay link opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)