### PR TITLE
Fix navbar vertical alignment of link text

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_navbar.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_navbar.less
@@ -21,8 +21,8 @@
 .tba-navbar-nav {
   margin: 0;
   > li > a {
-    padding-top: ((@navbar-height - @line-height-computed) / 2);
-    padding-bottom: ((@navbar-height - @line-height-computed) / 2);
+    padding-top: ((@navbar-height - @line-height-computed) / 2 - 2);
+    padding-bottom: ((@navbar-height - @line-height-computed) / 2 + 2);
 
     padding-left: 5px;
     padding-right: 5px;


### PR DESCRIPTION
## Summary
- The navbar link text ("Teams", "Events", etc.) had uneven visual spacing above and below the cap height
- The existing formula `(@navbar-height - @line-height-computed) / 2` gives equal 15px top/bottom padding, but the font's line-height includes more space above the cap height (ascenders) than below the baseline (descenders), making text appear to sit slightly low
- Shifts 2px from `padding-top` to `padding-bottom` (13px/17px instead of 15px/15px) to visually center the text

## Test plan
- [ ] Visually verify the navbar text appears vertically centered in the bar
- [ ] Check at multiple breakpoints (xs, sm, md, lg) since horizontal padding varies
- [ ] Verify the logo and social icons still align properly with the nav links

🤖 Generated with [Claude Code](https://claude.com/claude-code)