### PR TITLE
Add beta/leave beta links to navbars

### DIFF
--- a/pwa/app/components/tba/navigation/navbar.tsx
+++ b/pwa/app/components/tba/navigation/navbar.tsx
@@ -82,6 +82,14 @@ export function Navbar() {
                   ))}
                 </ul>
                 <ul className="flex items-center gap-2">
+                  <a
+                    href="https://www.thebluealliance.com"
+                    className="rounded-md px-2.5 py-2 text-xs font-medium
+                      text-white hover:bg-black/20 hover:no-underline
+                      max-sm:hidden"
+                  >
+                    Leave beta
+                  </a>
                   <SearchModal />
                   <MobileMenu />
                 </ul>

--- a/src/backend/web/static/css/less_css/less/tba/tba_navbar.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_navbar.less
@@ -82,11 +82,9 @@
   }
 }
 
-@social-icon-size: 14px;
 .social-icons {
-  max-height: @social-icon-size;
   padding: 0;
-  margin-top: ((@navbar-height - @social-icon-size)/2 + 2);
+  margin-top: ((@navbar-height - 20px)/2);
   float: right;
 
   @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
@@ -99,18 +97,20 @@
     text-align: center;
     float: none;
   }
-}
 
-.social-icons img {
-  width: @social-icon-size;
-  height: @social-icon-size;
-  display: inline-block;
-  vertical-align: top;
-  margin: 0 4px 0px 4px;
+  a {
+    color: #fff;
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
 
-  @media (max-width: @screen-sm-max) {
-    margin: 0 15px;
-    text-align: center;
-    float: none;
+    &:hover {
+      text-decoration: underline;
+    }
+
+    sup {
+      font-size: 9px;
+      margin-left: 1px;
+    }
   }
 }

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -93,9 +93,7 @@
       <hr class="visible-xs" />
 
       <div class="social-icons">
-        <a href="https://www.facebook.com/thebluealliance" title="Like us on Facebook"><img src="/images/icons/facebook-white.svg" alt="Facebook" width="14" height="14"></a>
-        <a href="https://x.com/thebluealliance" title="Follow us on X"><img src="/images/icons/x-white.svg" alt="X" width="14" height="14"></a>
-        <a href="https://www.instagram.com/the_blue_alliance" title="Follow us on Instagram"><img src="/images/icons/instagram-white.svg" alt="Instagram" width="14" height="14"></a>
+        <a href="https://beta.thebluealliance.com" title="Try the beta version of The Blue Alliance">Try beta<sup>new!</sup></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace social media icons in the Jinja site navbar with a "Try beta" link to beta.thebluealliance.com
- Add a "Leave beta" link in the PWA navbar back to www.thebluealliance.com
- Update LESS styles to support the new text link in place of icon images

## Screenshot Pages
- /event/2024milac
- /team/254/2024

## Screenshots
<img width="1209" height="214" alt="image" src="https://github.com/user-attachments/assets/d706848c-4930-43ed-b14a-207875082045" />

<img width="1250" height="393" alt="image" src="https://github.com/user-attachments/assets/71f5d8b1-e228-4944-8677-2c0f87c0eb85" />


## Test plan
- [ ] Verify "Try beta" link appears in Jinja navbar and navigates to beta.thebluealliance.com
- [ ] Verify "Leave beta" link appears in PWA navbar and navigates to www.thebluealliance.com
- [ ] Check responsive behavior (link hides on mobile in PWA, centers on mobile in Jinja)
- [ ] Verify hover styles (underline on Jinja, rounded highlight on PWA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)