### PR TITLE
Fix social media icons invisible in dark mode

### DIFF
--- a/pwa/app/components/tba/navigation/footer.tsx
+++ b/pwa/app/components/tba/navigation/footer.tsx
@@ -3,7 +3,7 @@ import { MoonIcon, SunIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Fragment } from 'react/jsx-runtime';
 
-import GithubIcon from '~icons/logos/github-icon';
+import GithubIcon from '~icons/simple-icons/github';
 
 import andymarkLogo from '~/images/images/andymark-logo.png';
 import { useTheme } from '~/lib/theme';

--- a/pwa/app/components/tba/socialBadges.tsx
+++ b/pwa/app/components/tba/socialBadges.tsx
@@ -1,10 +1,10 @@
-import LogosFacebook from '~icons/logos/facebook';
-import LogosGithubIcon from '~icons/logos/github-icon';
-import LogosGitlab from '~icons/logos/gitlab';
-import LogosInstagramIcon from '~icons/logos/instagram-icon';
 import LogosTwitch from '~icons/logos/twitch';
 import LogosYoutubeIcon from '~icons/logos/youtube-icon';
 import MdiVideoOutline from '~icons/mdi/video-outline';
+import SimpleIconsFacebook from '~icons/simple-icons/facebook';
+import SimpleIconsGithub from '~icons/simple-icons/github';
+import SimpleIconsGitlab from '~icons/simple-icons/gitlab';
+import SimpleIconsInstagram from '~icons/simple-icons/instagram';
 import SimpleIconsX from '~icons/simple-icons/x';
 
 import { Media, Webcast } from '~/api/tba/read';
@@ -53,7 +53,7 @@ export function MediaIcon({
       return (
         <MediaBadge
           className={className}
-          icon={<LogosFacebook />}
+          icon={<SimpleIconsFacebook />}
           href={`https://www.facebook.com/${media.foreign_key}`}
           label={media.foreign_key}
         />
@@ -62,7 +62,7 @@ export function MediaIcon({
       return (
         <MediaBadge
           className={className}
-          icon={<LogosGithubIcon />}
+          icon={<SimpleIconsGithub />}
           href={`https://github.com/${media.foreign_key}`}
           label={media.foreign_key}
         />
@@ -71,7 +71,7 @@ export function MediaIcon({
       return (
         <MediaBadge
           className={className}
-          icon={<LogosInstagramIcon />}
+          icon={<SimpleIconsInstagram />}
           href={`https://www.instagram.com/${media.foreign_key}`}
           label={media.foreign_key}
         />
@@ -89,7 +89,7 @@ export function MediaIcon({
       return (
         <MediaBadge
           className={className}
-          icon={<LogosGitlab />}
+          icon={<SimpleIconsGitlab />}
           href={`https://gitlab.com/${media.foreign_key}`}
           label={media.foreign_key}
         />


### PR DESCRIPTION
## Summary
- Switch GitHub, Instagram, Facebook, and GitLab icons from `logos/` collection (hardcoded brand colors) to `simple-icons/` collection (monochrome, uses `currentColor`)
- Icons now adapt to text color and are visible in both light and dark mode
- Applies to both social badges on team pages and the GitHub link in the footer

## Screenshot Pages
- /team/254/2024 Team 254 (has social links)
- /team/1678/2024 Team 1678 (has social links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)