### PR TITLE
Fix admin media 404 for keys containing slashes

### DIFF
--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -345,17 +345,17 @@ admin_routes.add_url_rule(
 admin_routes.add_url_rule("/media", view_func=media_dashboard)
 admin_routes.add_url_rule("/media/add_media", methods=["POST"], view_func=media_add)
 admin_routes.add_url_rule(
-    "/media/delete_reference/<media_key_name>",
+    "/media/delete_reference/<path:media_key_name>",
     methods=["POST"],
     view_func=media_delete_reference,
 )
 admin_routes.add_url_rule(
-    "/media/make_preferred/<media_key_name>",
+    "/media/make_preferred/<path:media_key_name>",
     methods=["POST"],
     view_func=media_make_preferred,
 )
 admin_routes.add_url_rule(
-    "/media/remove_preferred/<media_key_name>",
+    "/media/remove_preferred/<path:media_key_name>",
     methods=["POST"],
     view_func=media_remove_preferred,
 )

--- a/src/backend/web/handlers/admin/tests/media_test.py
+++ b/src/backend/web/handlers/admin/tests/media_test.py
@@ -1,6 +1,7 @@
 from pyre_extensions import none_throws
 from werkzeug.test import Client
 
+from backend.common.consts.media_type import MediaType
 from backend.common.models.media import Media
 from backend.common.suggestions.media_parser import MediaParser
 
@@ -60,6 +61,37 @@ def test_delete_reference(
     assert media.preferred_references == []
 
 
+def test_delete_reference_key_with_slash(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    media_reference = Media.create_reference("team", "frc1124")
+    # YouTube channel keys can contain slashes (e.g. channel/UCxxx)
+    foreign_key = "channel/UCxxx"
+    media = Media(
+        id=Media.render_key_name(MediaType.YOUTUBE_CHANNEL, foreign_key),
+        foreign_key=foreign_key,
+        media_type_enum=MediaType.YOUTUBE_CHANNEL,
+        year=2010,
+        references=[media_reference],
+    )
+    media.put()
+
+    resp = web_client.post(
+        f"/admin/media/delete_reference/{media.key_name}",
+        data={
+            "reference_type": "team",
+            "reference_key_name": "frc1124",
+            "originating_url": "/admin/team/1124",
+        },
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/admin/team/1124"
+
+    media = Media.get_by_id(media.key_name)
+    assert media is not None
+    assert media.references == []
+
+
 def test_make_preferred_no_media(
     web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
 ) -> None:
@@ -107,6 +139,36 @@ def test_make_preferred(
     media = Media.get_by_id(media.key_name)
     assert media is not None
     assert media.references == [media_reference]
+    assert media.preferred_references == [media_reference]
+
+
+def test_make_preferred_key_with_slash(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    media_reference = Media.create_reference("team", "frc1124")
+    foreign_key = "channel/UCxxx"
+    media = Media(
+        id=Media.render_key_name(MediaType.YOUTUBE_CHANNEL, foreign_key),
+        foreign_key=foreign_key,
+        media_type_enum=MediaType.YOUTUBE_CHANNEL,
+        year=2010,
+        references=[media_reference],
+    )
+    media.put()
+
+    resp = web_client.post(
+        f"/admin/media/make_preferred/{media.key_name}",
+        data={
+            "reference_type": "team",
+            "reference_key_name": "frc1124",
+            "originating_url": "/admin/team/1124",
+        },
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/admin/team/1124"
+
+    media = Media.get_by_id(media.key_name)
+    assert media is not None
     assert media.preferred_references == [media_reference]
 
 
@@ -158,6 +220,37 @@ def test_remove_preferred(
     media = Media.get_by_id(media.key_name)
     assert media is not None
     assert media.references == [media_reference]
+    assert media.preferred_references == []
+
+
+def test_remove_preferred_key_with_slash(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    media_reference = Media.create_reference("team", "frc1124")
+    foreign_key = "channel/UCxxx"
+    media = Media(
+        id=Media.render_key_name(MediaType.YOUTUBE_CHANNEL, foreign_key),
+        foreign_key=foreign_key,
+        media_type_enum=MediaType.YOUTUBE_CHANNEL,
+        year=2010,
+        references=[media_reference],
+        preferred_references=[media_reference],
+    )
+    media.put()
+
+    resp = web_client.post(
+        f"/admin/media/remove_preferred/{media.key_name}",
+        data={
+            "reference_type": "team",
+            "reference_key_name": "frc1124",
+            "originating_url": "/admin/team/1124",
+        },
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/admin/team/1124"
+
+    media = Media.get_by_id(media.key_name)
+    assert media is not None
     assert media.preferred_references == []
 
 


### PR DESCRIPTION
## Summary
- Admin media operations (delete reference, make/remove preferred) return 404 for media whose key names contain a `/` (e.g. `youtube-channel_channel/UCxxx` from YouTube channel URLs)
- Changed `<media_key_name>` to `<path:media_key_name>` in the three affected Flask routes so they match key names with slashes
- Added tests for each operation using a media key with a slash

## Test plan
- [x] All existing admin media tests pass (13/13)
- [x] New tests verify delete_reference, make_preferred, and remove_preferred work with slash-containing keys (return 302 instead of 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)