### PR TITLE
PWA: Hide stats section on team page when no matches played

### DIFF
--- a/pwa/app/routes/team.$teamNumber.{-$year}.tsx
+++ b/pwa/app/routes/team.$teamNumber.{-$year}.tsx
@@ -371,8 +371,6 @@ function TeamPage(): React.JSX.Element {
             </div>
           </div>
 
-          <Separator className="my-4" />
-
           <StatsSection
             events={sortedEvents}
             team={team}
@@ -493,8 +491,13 @@ function StatsSection({
     [officialMatches, team.key],
   );
 
+  if (matches.length === 0) {
+    return null;
+  }
+
   return (
     <>
+      <Separator className="my-4" />
       <div className="">
         Team {team.team_number} was{' '}
         <span className="font-semibold">


### PR DESCRIPTION
## Summary
- Hide the "Team X was 0-0 in official play and 0-0 overall in YEAR" stats section when a team has played 0 matches in a season
- Move the separator into `StatsSection` so two consecutive separators don't appear when the section is hidden

## Screenshot Pages

- /team/177/2026 Team with no matches
- /team/254/2025 Team with matches

## Test plan
- [ ] Visit a team page for a team with no matches in the current season (e.g. `/team/177/2026`) — stats section should be hidden, no double separators
- [ ] Visit a team page for a team with matches (e.g. `/team/254/2025`) — stats section renders as before with separator above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)