### PR TITLE
Update 2026 Match Breakdown GUI

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2026.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2026.html
@@ -1,8 +1,8 @@
 {% macro tower_status(team, tower_result) %}
-{% if tower_result == 'Yes' %}
-<span class="glyphicon glyphicon-ok" rel="tooltip" title="{{team|digits}}"></span>
-{% else %}
+{% if tower_result == 'None' %}
 <span class="glyphicon glyphicon-remove" rel="tooltip" title="{{team|digits}}"></span>
+{% else %}
+<span class="glyphicon glyphicon-ok" rel="tooltip" title="{{team|digits}}"></span>
 {% endif %}
 {% endmacro %}
 
@@ -65,27 +65,17 @@
 
     {% if "hubScore" in match.score_breakdown.red %}
     <tr>
-        <td class="redScore" colspan="2">
+        <td class="red" colspan="2">
             {{match.score_breakdown.red.hubScore.autoPoints}}
         </td>
         <td>Auto Fuel</td>
-        <td class="blueScore" colspan="2">
+        <td class="blue" colspan="2">
             {{match.score_breakdown.blue.hubScore.autoPoints}}
         </td>
     </tr>
     {% endif %}
 
-    {% if "autoPoints" in match.score_breakdown.red %}
-    <tr>
-        <td class="red" colspan="2">
-            <b>{{match.score_breakdown.red.autoPoints}}</b>
-        </td>
-        <th>Auto Fuel</th>
-        <td class="blue" colspan="2">
-            <b>{{match.score_breakdown.blue.autoPoints}}</b>
-        </td>
-    </tr>
-    {% endif %}
+
     {% if "totalAutoPoints" in match.score_breakdown.red %}
     <tr class="key">
         <td class="redScore" colspan="2">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the GUI added in #9151 for the 2026 game





## Motivation and Context
Primarily because endgame climbing was always rendered as an X regardless of the actual status, but I found the old UI showed redundant fields (as fuel score is always equal to fuel count) and think it makes more sense to keep everything in one table to minimize confusion.

It's not entirely clear what possible values exist for the auto tower breakdown (no week0 match had an auto climb), so I wrote it to show a checkmark for any non "None" value

## How Has This Been Tested?
Ran locally in container with week0 data

## Screenshots (if appropriate):

<table>
<tr>
 <td>
Old
</td>
 <td>
Updated
</td>
</tr>
<tr>
 <td>
<img width="568" height="1177" alt="image" src="https://github.com/user-attachments/assets/2475a47f-a9d3-44b7-8a5c-3556e5ecfbeb" />
</td>
 <td>
<img width="586" height="1139" alt="image" src="https://github.com/user-attachments/assets/7e692f23-606f-45eb-bb15-909285633cbe" />
</td>
</table>

## Screenshot Pages
<!--- For PRs that touch pwa/ files, list additional pages to screenshot. -->
<!--- Each line: - /path Optional Display Name -->
<!--- Example: - /match/2024mil_f1m2 Match Page -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
