### PR TITLE
PWA: Fix isEventWithinDays window end calculation

### DIFF
--- a/pwa/app/lib/eventUtils.test.ts
+++ b/pwa/app/lib/eventUtils.test.ts
@@ -170,6 +170,18 @@ describe('isEventWithinDays', () => {
     vi.useRealTimers();
   });
 
+  test('includes the full last day of the event with zero days after', () => {
+    // @ts-expect-error: Don't need to fill out all the fields
+    const event: Event = {
+      start_date: '2024-04-10',
+      end_date: '2024-04-12',
+    };
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-04-12T18:00:00Z'));
+    expect(isEventWithinDays(event, 0, 0)).toBe(true);
+    vi.useRealTimers();
+  });
+
   test('returns false when outside configured window', () => {
     // @ts-expect-error: Don't need to fill out all the fields
     const event: Event = {

--- a/pwa/app/lib/eventUtils.ts
+++ b/pwa/app/lib/eventUtils.ts
@@ -179,7 +179,9 @@ export function isEventWithinDays(
   const endDate = getLocalMidnightOnDate(event.end_date);
   const now = new Date();
   const windowStart = startDate.getTime() - negativeDaysBefore * DAY_IN_MS;
-  const windowEnd = endDate.getTime() + positiveDaysAfter * 2 * DAY_IN_MS;
+  // endDate is midnight at the start of the last day, so +1 day to include
+  // the full last day, then positiveDaysAfter additional days beyond that.
+  const windowEnd = endDate.getTime() + (1 + positiveDaysAfter) * DAY_IN_MS;
   return now.getTime() >= windowStart && now.getTime() <= windowEnd;
 }
 


### PR DESCRIPTION
## Summary
- Fix `isEventWithinDays` in `eventUtils.ts` — `endDate` is midnight at the start of the last day, so the window needs `+1` day to include the full last day, then `positiveDaysAfter` beyond that
- The old `positiveDaysAfter * 2` happened to produce the correct result when `positiveDaysAfter=1` (the only current caller), but was wrong in general (e.g. `positiveDaysAfter=0` couldn't detect an event on its own last day after midnight)
- Add a test that verifies the event is detected on its last day evening with `positiveDaysAfter=0`

## Test plan
- [ ] `npx vitest run app/lib/eventUtils.test.ts` — all 23 tests pass
- [ ] Visit events page during an active event — event should still highlight as live
- [ ] New test case covers the edge case that would have caught this bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)