### PR TITLE
PWA: Fix getCurrentWeekEvents to use Monday-based weeks

### DIFF
--- a/pwa/app/lib/eventUtils.test.ts
+++ b/pwa/app/lib/eventUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { Event } from '~/api/tba/read';
 import {
+  getCurrentWeekEvents,
   getEventDateString,
   getEventWeekString,
   isEventWithinDays,
@@ -179,6 +180,41 @@ describe('isEventWithinDays', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-04-15T12:00:00Z'));
     expect(isEventWithinDays(event, 1, 1)).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
+describe('getCurrentWeekEvents', () => {
+  test('excludes previous Sunday but includes same-week events', () => {
+    // Set to Thursday April 11 at noon local time
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 3, 11, 12, 0, 0));
+
+    // Sunday April 7 — before Monday week start
+    const sundayBeforeEvent = {
+      start_date: '2024-04-07',
+      end_date: '2024-04-07',
+    } as Event;
+    // Thursday April 11 — clearly within the week
+    const thursdayEvent = {
+      start_date: '2024-04-11',
+      end_date: '2024-04-11',
+    } as Event;
+    // Next Wednesday April 17 — clearly after the Mon-Sun week
+    const nextWeekEvent = {
+      start_date: '2024-04-17',
+      end_date: '2024-04-17',
+    } as Event;
+
+    const result = getCurrentWeekEvents([
+      sundayBeforeEvent,
+      thursdayEvent,
+      nextWeekEvent,
+    ]);
+
+    expect(result).toContain(thursdayEvent);
+    expect(result).not.toContain(sundayBeforeEvent);
+    expect(result).not.toContain(nextWeekEvent);
     vi.useRealTimers();
   });
 });

--- a/pwa/app/lib/eventUtils.ts
+++ b/pwa/app/lib/eventUtils.ts
@@ -111,9 +111,9 @@ export function getCurrentWeekEvents(events: Event[]) {
   const now = new Date();
   const filteredEvents = [];
 
-  const diffFromWeekStart = now.getDay();
+  const diffFromMonday = (now.getDay() + 6) % 7;
   const closestStartMonday = new Date(now).setDate(
-    now.getDate() - diffFromWeekStart,
+    now.getDate() - diffFromMonday,
   );
 
   for (const event of events) {


### PR DESCRIPTION
## Summary
- Fix `getCurrentWeekEvents` to use Monday-based weeks instead of Sunday-based
- The variable was named `closestStartMonday` but `getDay()` returns 0 for Sunday, so weeks actually ran Sun-Sat
- Use `(getDay() + 6) % 7` to get a 0=Monday offset, making weeks run Mon-Sun
- FRC events run Wed/Thu-Sat, so Monday-Sunday weeks are a better fit

## Test plan
- [ ] `npx vitest run app/lib/eventUtils.test.ts` — all 23 tests pass
- [ ] New test verifies Sunday events are excluded from the current week window
- [ ] Visit homepage during competition season — "This Week" events should use Mon-Sun grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)