### PR TITLE
Downsize district info on team page

### DIFF
--- a/pwa/app/components/tba/teamPageTeamInfo.tsx
+++ b/pwa/app/components/tba/teamPageTeamInfo.tsx
@@ -1,7 +1,7 @@
 import SponsorsIcon from '~icons/lucide/anchor';
 import SourceIcon from '~icons/lucide/badge-check';
 import StatbotIcon from '~icons/lucide/chart-spline';
-import DistrictIcon from '~icons/lucide/globe';
+import DistrictIcon from '~icons/lucide/map';
 import LocationIcon from '~icons/lucide/map-pin';
 import RookieIcon from '~icons/lucide/sprout';
 

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -34,7 +34,6 @@
           <img class="team-avatar single blue" src='{{avatar.avatar_image_url}}'/>
         {% endif %}
         Team {{team.team_number}}{% if team.nickname %} - {{team.nickname}}{% endif %}</h2>
-        {% if district_name %}<blockquote class="visible-xs"><em>Part of the <a href="/events/{{district_abbrev}}/{{year}}">{{district_name}} District</a></em></blockquote>{% endif %}
 
         <div class="tba-sidebar">
           <ul class="nav tba-sidenav">

--- a/src/backend/web/templates/team_partials/team_info.html
+++ b/src/backend/web/templates/team_partials/team_info.html
@@ -8,13 +8,13 @@
       <img class="team-avatar single blue" src='{{avatar.avatar_image_url}}'/>
     {% endif %}
     Team {{team.team_number}}{% if team.nickname %} - {{team.nickname}}{% endif %}</h2>
-    {% if district_name %}<blockquote id="team-district"><em>Part of the <a href="/events/{{district_abbrev}}/{{year}}">{{district_name}} District</a></em></blockquote>{% endif %}
   </div>
 </div>
 
 <div class="row">
   <div class="col-sm-6">
     <p>
+      {% if district_name %}<span class="glyphicon glyphicon-globe"></span> Part of the <a id="team-district" href="/events/{{district_abbrev}}/{{year}}">{{district_name}} District</a><br>{% endif %}
       {% if team.city_state_country %}
         <span class="glyphicon glyphicon-map-marker"></span> From
         <a id="team-location" href="//maps.google.com/maps?q={{ team.city_state_country|urlencode }}" target="_blank" rel="noopener noreferrer">{{team.city_state_country}}</a>


### PR DESCRIPTION
## Summary
- Replace the prominent `<blockquote>` district display on team pages with a regular inline info item (glyphicon-globe icon), matching the style of location, rookie year, and other team details
- Remove duplicate mobile-only blockquote in `team_details.html`
- Update PWA district icon from globe to map to match the Android app

## Screenshot Pages

- /team/177 Team 177 (New England District)
- /team/254/2025 Team 254 (non-district)

🤖 Generated with [Claude Code](https://claude.com/claude-code)