### PR TITLE
PWA: Add active state highlighting to navbar

### DIFF
--- a/pwa/app/components/tba/navigation/mobileMenu.tsx
+++ b/pwa/app/components/tba/navigation/mobileMenu.tsx
@@ -33,7 +33,6 @@ export function MobileMenu() {
               className="flex w-full animate-navigation-item-fade-in
                 items-center gap-3 py-4 opacity-0 hover:no-underline"
               activeProps={{ className: 'bg-white/15 rounded-md' }}
-              activeOptions={{ fuzzy: true }}
               style={{ animationDelay: `${index * 50}ms` }}
             >
               <Icon className="size-5 text-white/50" />

--- a/pwa/app/components/tba/navigation/navbar.tsx
+++ b/pwa/app/components/tba/navigation/navbar.tsx
@@ -74,7 +74,6 @@ export function Navbar() {
                           params={params}
                           className="hover:no-underline"
                           activeProps={{ className: 'bg-white/15' }}
-                          activeOptions={{ fuzzy: true }}
                         >
                           <Icon className="text-inherit" />
                           <span>{title}</span>


### PR DESCRIPTION
## Summary
- Highlight the active section in the navbar when navigating to Events, Teams, etc.
- Uses TanStack Router's `activeProps` with fuzzy matching so sub-pages (e.g. `/events/2025`) still highlight the parent nav item
- Applies to both desktop and mobile navigation menus
- Subtle `bg-white/15` highlight on the dark primary background

## Screenshots
<img width="941" height="224" alt="image" src="https://github.com/user-attachments/assets/48183372-9c5d-45e3-86f5-049e8c502de9" />


## Screenshot Pages

- /events Events Page
- /teams Teams Page
- /gameday GameDay Page

🤖 Generated with [Claude Code](https://claude.com/claude-code)