### PR TITLE
PWA: Fix loading progress bar visibility in dark mode

### DIFF
--- a/pwa/app/components/tba/globalLoadingProgress.tsx
+++ b/pwa/app/components/tba/globalLoadingProgress.tsx
@@ -47,7 +47,8 @@ export default function GlobalLoadingProgress() {
   }
   return (
     <Progress
-      className="fixed top-0 z-20 h-0.5 rounded-none"
+      className="fixed top-0 z-20 h-0.5 rounded-none
+        [&_[data-slot=progress-indicator]]:dark:bg-secondary-foreground"
       value={progress}
     />
   );


### PR DESCRIPTION
## Summary
- The navigation loading progress bar uses `bg-secondary` for the indicator, which is nearly black in dark mode — invisible against the dark navbar
- Override to `bg-secondary-foreground` in dark mode so it stays light, matching the light mode appearance

## Screenshot Pages

- /events Events Page
- /team/177 Team 177

🤖 Generated with [Claude Code](https://claude.com/claude-code)