### PR TITLE
PWA: Fix winner highlight readability in dark mode

### DIFF
--- a/pwa/app/components/tba/allianceSelectionTable.tsx
+++ b/pwa/app/components/tba/allianceSelectionTable.tsx
@@ -20,7 +20,7 @@ const rowVariants = cva('text-center', {
   variants: {
     variant: {
       winner: `bg-yellow-100 font-bold shadow-inner shadow-yellow-200
-      dark:bg-yellow-800`,
+      dark:bg-yellow-500/15 dark:shadow-yellow-500/10`,
       finalist: 'bg-neutral-100 shadow-inner shadow-border dark:bg-neutral-800',
       default: '',
     },

--- a/pwa/app/components/tba/rankingsTable.tsx
+++ b/pwa/app/components/tba/rankingsTable.tsx
@@ -102,8 +102,10 @@ export default function RankingsTable({
       data={rankings.rankings}
       conditionalRowStyling={(row) =>
         cn({
-          'bg-yellow-100 font-bold shadow-inner shadow-yellow-200':
-            winners.includes(row.original.team_key),
+          [`bg-yellow-100 font-bold shadow-inner shadow-yellow-200
+          dark:bg-yellow-500/15 dark:shadow-yellow-500/10`]: winners.includes(
+            row.original.team_key,
+          ),
         })
       }
     />


### PR DESCRIPTION
## Summary
- Winner highlighting in rankings and alliance selection tables used opaque yellow backgrounds that made white text unreadable in dark mode
- Replace `bg-yellow-800` with `bg-yellow-500/15` (subtle tint) in dark mode, matching the `/15` opacity pattern used for alliance colors elsewhere
- Light mode unchanged

## Screenshot Pages

- /event/2026week0 Week 0 Event (Rankings tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)