### PR TITLE
PWA: Fix COPR scatterplot tooltip contrast in dark mode

### DIFF
--- a/pwa/app/components/tba/charts/coprScatterChart.tsx
+++ b/pwa/app/components/tba/charts/coprScatterChart.tsx
@@ -282,7 +282,10 @@ const CustomTooltip = ({
     ).teamKey.substring(3);
 
     return (
-      <div className="flex flex-col rounded-md bg-white shadow-xl">
+      <div
+        className="flex flex-col rounded-md bg-background text-foreground
+          shadow-xl"
+      >
         <div className="flex flex-col p-4">
           <div className="pb-2 text-xl">{teamKey}</div>
           <div className="">


### PR DESCRIPTION
## Summary
- The Component OPRs scatterplot tooltip on event Insights used hardcoded `bg-white` with no text color, resulting in white-on-white text in dark mode
- Replace with theme-aware `bg-background text-foreground` so the tooltip adapts to both light and dark modes

## Screenshot Pages

- /event/2026week0 Week 0 Event (Insights tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)