### PR TITLE
PWA: Add Favorite Teams section to teams list page

### DIFF
--- a/pwa/app/components/tba/favoriteTeamsSection.tsx
+++ b/pwa/app/components/tba/favoriteTeamsSection.tsx
@@ -1,0 +1,19 @@
+import TeamListTable from '~/components/tba/teamListTable';
+import { Separator } from '~/components/ui/separator';
+import { useFavoriteTeams } from '~/lib/hooks/useFavoriteTeams';
+
+export default function FavoriteTeamsSection() {
+  const { favoriteTeams, isLoading } = useFavoriteTeams();
+
+  if (isLoading || favoriteTeams.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <h1 className="mb-3 text-3xl font-medium">Favorite Teams</h1>
+      <TeamListTable teams={favoriteTeams} />
+      <Separator className="my-6" />
+    </>
+  );
+}

--- a/pwa/app/lib/hooks/useFavoriteTeams.ts
+++ b/pwa/app/lib/hooks/useFavoriteTeams.ts
@@ -1,0 +1,49 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+
+import { listFavorites } from '~/api/tba/mobile/sdk.gen';
+import type { TeamSimple } from '~/api/tba/read';
+import { getTeamSimpleOptions } from '~/api/tba/read/@tanstack/react-query.gen';
+import { useAuth } from '~/components/tba/auth/auth';
+import { MODEL_TYPE } from '~/lib/utils';
+
+interface UseFavoriteTeamsResult {
+  favoriteTeams: TeamSimple[];
+  isLoading: boolean;
+}
+
+export function useFavoriteTeams(): UseFavoriteTeamsResult {
+  const { user } = useAuth();
+
+  const { data: favorites, isLoading: isFavoritesLoading } = useQuery({
+    queryKey: ['favorites', user?.uid],
+    queryFn: async () => {
+      if (!user) throw new Error('User not authenticated');
+      const token = await user.getIdToken();
+      const response = await listFavorites({ auth: token });
+      return response.data;
+    },
+    enabled: !!user,
+  });
+
+  const teamKeys = (favorites?.favorites ?? [])
+    .filter((f) => f.model_type === MODEL_TYPE.TEAM)
+    .map((f) => f.model_key);
+
+  const favoriteTeams = useQueries({
+    queries: teamKeys.map((key) =>
+      getTeamSimpleOptions({ path: { team_key: key } }),
+    ),
+    combine: (results) => ({
+      data: results
+        .map((r) => r.data)
+        .filter((t): t is TeamSimple => t !== undefined)
+        .sort((a, b) => a.team_number - b.team_number),
+      isLoading: results.some((r) => r.isLoading),
+    }),
+  });
+
+  return {
+    favoriteTeams: favoriteTeams.data,
+    isLoading: isFavoritesLoading || favoriteTeams.isLoading,
+  };
+}

--- a/pwa/app/routes/teams.{-$pgNum}.tsx
+++ b/pwa/app/routes/teams.{-$pgNum}.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router';
 
 import { getTeamsSimple } from '~/api/tba/read';
 import { getStatusOptions } from '~/api/tba/read/@tanstack/react-query.gen';
+import FavoriteTeamsSection from '~/components/tba/favoriteTeamsSection';
 import TeamListTable from '~/components/tba/teamListTable';
 import {
   Select,
@@ -95,11 +96,9 @@ function TeamsPage() {
         </div>
       </div>
       <div className="basis-full overflow-x-auto lg:basis-5/6 lg:py-8">
+        {pageNum === 1 && <FavoriteTeamsSection />}
         <h1 className="mb-3 text-3xl font-medium">
-          <i>FIRST</i> Robotics Teams {TeamPageNumberToRange(pageNum)}{' '}
-          <small className="text-xl text-muted-foreground">
-            {teams.length} Teams
-          </small>
+          <i>FIRST</i> Robotics Teams {TeamPageNumberToRange(pageNum)}
         </h1>
         <TeamListTable teams={teams} />
       </div>


### PR DESCRIPTION
## Summary

- Adds a "Favorite Teams" section at the top of the `/teams` page (page 1 only) for signed-in users
- Fetches the user's favorited teams via the existing favorites API and displays them using the same `TeamListTable` component
- Non-authenticated users or users with zero favorites see no extra UI (zero layout shift)

## Screenshot
<img width="1225" height="486" alt="image" src="https://github.com/user-attachments/assets/18522520-e7a0-45a9-bac1-1d108d206347" />

## Details

**New files:**
- `useFavoriteTeams.ts` — hook that fetches favorites, filters to teams, fetches `TeamSimple` for each in parallel via `useQueries`, and returns sorted results
- `favoriteTeamsSection.tsx` — renders the "Favorite Teams" header + table + separator, or `null` if loading/empty

**Modified:**
- `teams.{-$pgNum}.tsx` — adds `<FavoriteTeamsSection />` conditionally on page 1, removes team count from heading

Shares the same `['favorites', user?.uid]` query cache key as `useMyTBA`, so favoriting/unfavoriting a team on its detail page is immediately reflected when navigating back.

## Screenshot Pages

- /teams

## Test plan

- [ ] Not signed in → no favorites section visible on `/teams`
- [x] Signed in with 0 favorite teams → no favorites section
- [x] Signed in with favorites → "Favorite Teams" section appears on page 1 with correct teams
- [x] Navigate to `/teams/2` → no favorites section
- [x] Favorite/unfavorite a team on its detail page, return to `/teams` → section updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)