### PR TITLE
Add official district dcmp/cmp slot allocations

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -112,6 +112,19 @@ export type District = {
    * Year this district participated.
    */
   year: number;
+  /**
+   * The number of teams advancing to DCMP and CMP from this district, as specified in the FIRST manual.
+   */
+  official_advancement_counts: {
+    /**
+     * Number of teams advancing to the District Championship.
+     */
+    dcmp: number;
+    /**
+     * Number of teams advancing to the Championship.
+     */
+    cmp: number;
+  };
 };
 
 export type DistrictInsightRegionData = {

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -52,6 +52,10 @@ export const zDistrict = z.object({
   display_name: z.string(),
   key: z.string(),
   year: z.int(),
+  official_advancement_counts: z.object({
+    dcmp: z.int(),
+    cmp: z.int(),
+  }),
 });
 
 export const zDistrictInsightRegionData = z.object({

--- a/src/backend/api/handlers/tests/district_test.py
+++ b/src/backend/api/handlers/tests/district_test.py
@@ -145,12 +145,14 @@ def test_district_events(ndb_stub, api_client: Client) -> None:
             "abbreviation": "fim",
             "display_name": "Michigan",
             "key": "2019fim",
+            "official_advancement_counts": {"dcmp": 160, "cmp": 87},
             "year": 2019,
         },
         {
             "abbreviation": "fim",
             "display_name": "Michigan",
             "key": "2020fim",
+            "official_advancement_counts": {"dcmp": 200, "cmp": 90},
             "year": 2020,
         },
     ]
@@ -173,12 +175,14 @@ def test_district_events(ndb_stub, api_client: Client) -> None:
             "abbreviation": "mar",
             "display_name": "Mid-Atlantic",
             "key": "2014mar",
+            "official_advancement_counts": {"dcmp": 55, "cmp": 18},
             "year": 2014,
         },
         {
             "abbreviation": "fma",
             "display_name": "Mid-Atlantic",
             "key": "2024fma",
+            "official_advancement_counts": {"dcmp": 60, "cmp": 22},
             "year": 2024,
         },
     ]
@@ -194,12 +198,14 @@ def test_district_events(ndb_stub, api_client: Client) -> None:
             "abbreviation": "mar",
             "display_name": "Mid-Atlantic",
             "key": "2014mar",
+            "official_advancement_counts": {"dcmp": 55, "cmp": 18},
             "year": 2014,
         },
         {
             "abbreviation": "fma",
             "display_name": "Mid-Atlantic",
             "key": "2024fma",
+            "official_advancement_counts": {"dcmp": 60, "cmp": 22},
             "year": 2024,
         },
     ]
@@ -338,6 +344,8 @@ def test_district_list_year(ndb_stub, api_client: Client) -> None:
     district_keys = set([d["key"] for d in resp.json])
     assert "2020ne" in district_keys
     assert "2020fim" in district_keys
+    for d in resp.json:
+        assert "official_advancement_counts" in d
 
 
 def test_district_awards(ndb_stub, api_client: Client) -> None:

--- a/src/backend/common/consts/district_advancements.py
+++ b/src/backend/common/consts/district_advancements.py
@@ -1,0 +1,185 @@
+from typing import Dict
+
+from backend.common.models.district_advancement import AdvancementCounts
+from backend.common.models.keys import DistrictAbbreviation, Year
+
+# Number of teams per district that qualify for DCMP/WCMP, as specified in the FIRST manual.
+# This is NOT guaranteed to be the number of teams that *actually* attended the events from each district.
+# There are other factors that can affect the real number, such as late drops, CMP waitlist additions, pre-qualification, etc.
+FIRST_MANUAL_DISTRICT_ADVANCEMENT_COUNTS: Dict[
+    Year, Dict[DistrictAbbreviation, AdvancementCounts]
+] = {
+    # https://www.chiefdelphi.com/t/new-first-competition-structure-in-michigan/90414/67
+    2009: {"fim": {"dcmp": 64, "cmp": 18}},
+    # https://web.archive.org/web/20100301091136/http://www.firstinmichigan.org/filemgmt_data/files/FiM_Rules_Supplement_2010_rev4.pdf
+    2010: {"fim": {"dcmp": 64, "cmp": 18}},
+    # https://web.archive.org/web/20150316061757/http://firstinmichigan.org/FRC_2011/2011_Rules_Supplement.pdf
+    2011: {"fim": {"dcmp": 64, "cmp": 18}},
+    2012: {
+        # https://web.archive.org/web/20120316080915/http://firstinmichigan.org/FRC_2012/2012_Rules_Supplement.pdf
+        "fim": {"dcmp": 64, "cmp": 18},
+        # https://docs.google.com/spreadsheets/d/1s087OqNmn4xS_coJCsqX8bFfSPTKDocORiikkBvkXiE/edit?gid=595085150#gid=595085150
+        "fma": {"dcmp": 53, "cmp": 12},
+    },
+    2013: {
+        # https://web.archive.org/web/20130903031011/http://firstinmichigan.org/FRC_2013/2013_Rules_Supplement.pdf
+        "fim": {"dcmp": 64, "cmp": 27},
+        # https://docs.google.com/spreadsheets/d/1s087OqNmn4xS_coJCsqX8bFfSPTKDocORiikkBvkXiE/edit?gid=595085150#gid=595085150
+        "fma": {"dcmp": 49, "cmp": 14},
+    },
+    # https://web.archive.org/web/20140727170559/http://www.usfirst.org/roboticsprograms/frc/blog-standard-district-points-ranking-system%E2%80%93more-info
+    2014: {
+        "fim": {"dcmp": 64, "cmp": 32},
+        "fma": {"dcmp": 55, "cmp": 18},
+        "ne": {"dcmp": 53, "cmp": 24},
+        "pnw": {"dcmp": 63, "cmp": 24},
+    },
+    # From the manual
+    2015: {
+        "fim": {"dcmp": 102, "cmp": 68},
+        "fin": {"dcmp": 32, "cmp": 10},
+        "fma": {"dcmp": 55, "cmp": 25},
+        "ne": {"dcmp": 60, "cmp": 35},
+        "pnw": {"dcmp": 64, "cmp": 31},
+    },
+    # From the manual
+    2016: {
+        "fch": {"dcmp": 58, "cmp": 25},
+        "fim": {"dcmp": 102, "cmp": 76},
+        "fin": {"dcmp": 32, "cmp": 9},
+        "fma": {"dcmp": 60, "cmp": 22},
+        "fnc": {"dcmp": 32, "cmp": 10},
+        "ne": {"dcmp": 64, "cmp": 34},
+        "pch": {"dcmp": 45, "cmp": 12},
+        "pnw": {"dcmp": 64, "cmp": 30},
+    },
+    # From the manual
+    2017: {
+        "fch": {"dcmp": 58, "cmp": 23},
+        "fim": {"dcmp": 160, "cmp": 82},
+        "fin": {"dcmp": 32, "cmp": 10},
+        "fma": {"dcmp": 60, "cmp": 22},
+        "fnc": {"dcmp": 32, "cmp": 15},
+        "isr": {"dcmp": 45, "cmp": 16},
+        "ne": {"dcmp": 64, "cmp": 37},
+        "ont": {"dcmp": 60, "cmp": 29},
+        "pch": {"dcmp": 45, "cmp": 18},
+        "pnw": {"dcmp": 64, "cmp": 39},
+    },
+    # From the manual
+    2018: {
+        "fch": {"dcmp": 60, "cmp": 21},
+        "fim": {"dcmp": 160, "cmp": 89},
+        "fin": {"dcmp": 32, "cmp": 9},
+        "fma": {"dcmp": 60, "cmp": 22},
+        "fnc": {"dcmp": 32, "cmp": 14},
+        "isr": {"dcmp": 45, "cmp": 15},
+        "ne": {"dcmp": 64, "cmp": 37},
+        "ont": {"dcmp": 80, "cmp": 29},
+        "pch": {"dcmp": 45, "cmp": 16},
+        "pnw": {"dcmp": 64, "cmp": 32},
+    },
+    # From the manual
+    2019: {
+        "fch": {"dcmp": 58, "cmp": 21},
+        "fim": {"dcmp": 160, "cmp": 87},
+        "fin": {"dcmp": 32, "cmp": 10},
+        "fit": {"dcmp": 64, "cmp": 38},
+        "fma": {"dcmp": 60, "cmp": 21},
+        "fnc": {"dcmp": 32, "cmp": 15},
+        "isr": {"dcmp": 45, "cmp": 11},
+        "ne": {"dcmp": 64, "cmp": 33},
+        "ont": {"dcmp": 80, "cmp": 29},
+        "pch": {"dcmp": 45, "cmp": 17},
+        "pnw": {"dcmp": 64, "cmp": 31},
+    },
+    # From the manual
+    2020: {
+        "fch": {"dcmp": 80, "cmp": 20},
+        "fim": {"dcmp": 200, "cmp": 90},
+        "fin": {"dcmp": 32, "cmp": 10},
+        "fit": {"dcmp": 64, "cmp": 37},
+        "fma": {"dcmp": 60, "cmp": 21},
+        "fnc": {"dcmp": 32, "cmp": 14},
+        "isr": {"dcmp": 45, "cmp": 13},
+        "ne": {"dcmp": 64, "cmp": 33},
+        "ont": {"dcmp": 80, "cmp": 27},
+        "pch": {"dcmp": 45, "cmp": 16},
+        "pnw": {"dcmp": 64, "cmp": 28},
+    },
+    # From the manual and also
+    # web.archive.org/web/20220818200443/https://www.firstinspires.org/resource-library/frc/championship-eligibility-criteria
+    2022: {
+        "fch": {"dcmp": 60, "cmp": 16},
+        "fim": {"dcmp": 160, "cmp": 64},
+        "fin": {"dcmp": 32, "cmp": 8},
+        "fit": {"dcmp": 80, "cmp": 23},
+        "fma": {"dcmp": 60, "cmp": 18},
+        "fnc": {"dcmp": 32, "cmp": 10},
+        "isr": {"dcmp": 40, "cmp": 9},
+        "ne": {"dcmp": 80, "cmp": 25},
+        "ont": {"dcmp": 80, "cmp": 11},
+        "pch": {"dcmp": 32, "cmp": 10},
+        "pnw": {"dcmp": 50, "cmp": 18},
+    },
+    # From the manual
+    2023: {
+        "fch": {"dcmp": 60, "cmp": 19},
+        "fim": {"dcmp": 160, "cmp": 82},
+        "fin": {"dcmp": 32, "cmp": 10},
+        "fit": {"dcmp": 80, "cmp": 30},
+        "fma": {"dcmp": 60, "cmp": 23},
+        "fnc": {"dcmp": 40, "cmp": 14},
+        "isr": {"dcmp": 40, "cmp": 11},
+        "ne": {"dcmp": 90, "cmp": 32},
+        "ont": {"dcmp": 80, "cmp": 23},
+        "pch": {"dcmp": 50, "cmp": 17},
+        "pnw": {"dcmp": 50, "cmp": 22},
+    },
+    # From the manual
+    2024: {
+        "fch": {"dcmp": 54, "cmp": 17},
+        "fim": {"dcmp": 160, "cmp": 86},
+        "fin": {"dcmp": 38, "cmp": 11},
+        "fit": {"dcmp": 86, "cmp": 29},
+        "fma": {"dcmp": 60, "cmp": 22},
+        "fnc": {"dcmp": 40, "cmp": 13},
+        "isr": {"dcmp": 45, "cmp": 11},
+        "ne": {"dcmp": 96, "cmp": 31},
+        "ont": {"dcmp": 100, "cmp": 23},
+        "pch": {"dcmp": 50, "cmp": 16},
+        "pnw": {"dcmp": 50, "cmp": 22},
+    },
+    # From the manual
+    2025: {
+        "fch": {"dcmp": 54, "cmp": 17},
+        "fim": {"dcmp": 160, "cmp": 80},
+        "fin": {"dcmp": 38, "cmp": 12},
+        "fit": {"dcmp": 90, "cmp": 28},
+        "fma": {"dcmp": 60, "cmp": 23},
+        "fnc": {"dcmp": 40, "cmp": 14},
+        "fsc": {"dcmp": 28, "cmp": 5},
+        "isr": {"dcmp": 45, "cmp": 10},
+        "ne": {"dcmp": 96, "cmp": 31},
+        "ont": {"dcmp": 100, "cmp": 22},
+        "pch": {"dcmp": 45, "cmp": 12},
+        "pnw": {"dcmp": 50, "cmp": 22},
+    },
+    # From the manual
+    2026: {
+        "ca": {"dcmp": 120, "cmp": 46},  # NorCal (60) + SoCal (60)
+        "fch": {"dcmp": 54, "cmp": 19},
+        "fim": {"dcmp": 160, "cmp": 83},
+        "fin": {"dcmp": 38, "cmp": 12},
+        "fit": {"dcmp": 90, "cmp": 28},
+        "fma": {"dcmp": 66, "cmp": 23},
+        "fnc": {"dcmp": 50, "cmp": 15},
+        "fsc": {"dcmp": 32, "cmp": 7},
+        "isr": {"dcmp": 42, "cmp": 12},
+        "ne": {"dcmp": 100, "cmp": 32},
+        "ont": {"dcmp": 100, "cmp": 21},
+        "pch": {"dcmp": 45, "cmp": 13},
+        "pnw": {"dcmp": 50, "cmp": 21},
+        "win": {"dcmp": 36, "cmp": 12},
+    },
+}

--- a/src/backend/common/consts/renamed_districts.py
+++ b/src/backend/common/consts/renamed_districts.py
@@ -1,9 +1,30 @@
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator, List, Set
 
 from google.appengine.ext import ndb
 
-from backend.common.models.district import ALL_KNOWN_DISTRICT_ABBREVIATIONS
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey
+
+ALL_KNOWN_DISTRICT_ABBREVIATIONS: Set[DistrictAbbreviation] = {
+    "chs",
+    "fch",
+    "fim",
+    "fit",
+    "tx",
+    "in",
+    "fin",
+    "isr",
+    "mar",
+    "fma",
+    "nc",
+    "fnc",
+    "fsc",
+    "ne",
+    "ont",
+    "pnw",
+    "pch",
+    "ca",
+    "win",
+}
 
 OLD_TO_NEW_CODE_MAP: Dict[DistrictAbbreviation, DistrictAbbreviation] = {
     # Old to new
@@ -52,6 +73,10 @@ class RenamedDistricts:
             seen.add(OLD_TO_NEW_CODE_MAP.get(abbr, abbr))
 
         return list(seen)
+
+    @classmethod
+    def get_latest_code(cls, code: DistrictAbbreviation) -> DistrictAbbreviation:
+        return OLD_TO_NEW_CODE_MAP.get(code, code)
 
     @classmethod
     @ndb.tasklet

--- a/src/backend/common/models/district.py
+++ b/src/backend/common/models/district.py
@@ -4,32 +4,17 @@ from typing import Dict, List, Set
 from google.appengine.ext import ndb
 from pyre_extensions import safe_cast
 
+from backend.common.consts.district_advancements import (
+    FIRST_MANUAL_DISTRICT_ADVANCEMENT_COUNTS,
+)
+from backend.common.consts.renamed_districts import RenamedDistricts
 from backend.common.models.cached_model import CachedModel
-from backend.common.models.district_advancement import DistrictAdvancement
+from backend.common.models.district_advancement import (
+    AdvancementCounts,
+    DistrictAdvancement,
+)
 from backend.common.models.district_ranking import DistrictRanking
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey, TeamKey, Year
-
-ALL_KNOWN_DISTRICT_ABBREVIATIONS: Set[DistrictAbbreviation] = {
-    "chs",
-    "fch",
-    "fim",
-    "fit",
-    "tx",
-    "in",
-    "fin",
-    "isr",
-    "mar",
-    "fma",
-    "nc",
-    "fnc",
-    "fsc",
-    "ne",
-    "ont",
-    "pnw",
-    "pch",
-    "ca",
-    "win",
-}
 
 
 class District(CachedModel):
@@ -85,6 +70,16 @@ class District(CachedModel):
     @property
     def render_name(self) -> str:
         return self.display_name if self.display_name else self.abbreviation.upper()
+
+    @property
+    def official_advancement_counts(self) -> AdvancementCounts:
+        # Returns the advancement counts as specified in the FIRST manual for the district
+        # If the district/year is not found, returns 0 for both dcmp and cmp
+
+        latest_code = RenamedDistricts.get_latest_code(self.abbreviation)
+        return FIRST_MANUAL_DISTRICT_ADVANCEMENT_COUNTS.get(self.year, {}).get(
+            latest_code, AdvancementCounts(dcmp=0, cmp=0)
+        )
 
     @classmethod
     def validate_key_name(self, district_key: str) -> bool:

--- a/src/backend/common/models/district_advancement.py
+++ b/src/backend/common/models/district_advancement.py
@@ -9,3 +9,8 @@ class TeamDistrictAdvancement(TypedDict):
 
 
 DistrictAdvancement = Dict[TeamKey, TeamDistrictAdvancement]
+
+
+class AdvancementCounts(TypedDict):
+    dcmp: int
+    cmp: int

--- a/src/backend/common/queries/dict_converters/district_converter.py
+++ b/src/backend/common/queries/dict_converters/district_converter.py
@@ -33,6 +33,7 @@ class DistrictConverter(ConverterBase):
                 "year": district.year,
                 "abbreviation": district.abbreviation,
                 "display_name": district.display_name,
+                "official_advancement_counts": district.official_advancement_counts,
             }
         )
 

--- a/src/backend/common/queries/dict_converters/tests/district_converter_test.py
+++ b/src/backend/common/queries/dict_converters/tests/district_converter_test.py
@@ -1,0 +1,89 @@
+from backend.common.models.district import District
+from backend.common.models.district_advancement import AdvancementCounts
+from backend.common.queries.dict_converters.district_converter import DistrictConverter
+
+
+def test_districtConverter_v3_basic(ndb_context) -> None:
+    district = District(
+        id="2025ne",
+        year=2025,
+        abbreviation="ne",
+        display_name="New England",
+    )
+
+    converted = DistrictConverter.districtConverter_v3(district)
+
+    assert converted["key"] == "2025ne"
+    assert converted["year"] == 2025
+    assert converted["abbreviation"] == "ne"
+    assert converted["display_name"] == "New England"
+
+
+def test_districtConverter_v3_with_known_advancement_counts(ndb_context) -> None:
+    district = District(
+        id="2025ne",
+        year=2025,
+        abbreviation="ne",
+        display_name="New England",
+    )
+
+    converted = DistrictConverter.districtConverter_v3(district)
+
+    assert converted["official_advancement_counts"] == AdvancementCounts(
+        dcmp=96, cmp=31
+    )
+
+
+def test_districtConverter_v3_unknown_year_returns_zero_counts(ndb_context) -> None:
+    district = District(
+        id="2000ne",
+        year=2000,
+        abbreviation="ne",
+        display_name="New England",
+    )
+
+    converted = DistrictConverter.districtConverter_v3(district)
+
+    assert converted["official_advancement_counts"] == AdvancementCounts(dcmp=0, cmp=0)
+
+
+def test_districtConverter_v3_unknown_abbreviation_returns_zero_counts(
+    ndb_context,
+) -> None:
+    district = District(
+        id="2025xyz",
+        year=2025,
+        abbreviation="xyz",
+        display_name="Unknown District",
+    )
+
+    converted = DistrictConverter.districtConverter_v3(district)
+
+    assert converted["official_advancement_counts"] == AdvancementCounts(dcmp=0, cmp=0)
+
+
+def test_districtConverter_v3_advancement_works_for_old_and_new_district_names(
+    ndb_context,
+) -> None:
+    old_district = District(
+        id="2012mar",
+        year=2012,
+        abbreviation="mar",
+        display_name="Mid Atlantic",
+    )
+    new_district = District(
+        id="2013fma",
+        year=2013,
+        abbreviation="fma",
+        display_name="Mid Atlantic",
+    )
+
+    converted_old = DistrictConverter.districtConverter_v3(old_district)
+    converted_new = DistrictConverter.districtConverter_v3(new_district)
+
+    assert converted_old["official_advancement_counts"] == AdvancementCounts(
+        dcmp=53, cmp=12
+    )
+    assert converted_new["official_advancement_counts"] == AdvancementCounts(
+        dcmp=49, cmp=14
+    )

--- a/src/backend/web/local/bootstrap.py
+++ b/src/backend/web/local/bootstrap.py
@@ -4,6 +4,7 @@ from typing import Any, cast, Dict, List, Optional, Union
 import requests
 from google.appengine.ext import ndb
 
+from backend.common.consts.renamed_districts import ALL_KNOWN_DISTRICT_ABBREVIATIONS
 from backend.common.helpers.deferred import defer_safe
 from backend.common.manipulators.award_manipulator import AwardManipulator
 from backend.common.manipulators.district_manipulator import DistrictManipulator
@@ -19,7 +20,7 @@ from backend.common.manipulators.match_manipulator import MatchManipulator
 from backend.common.manipulators.media_manipulator import MediaManipulator
 from backend.common.manipulators.team_manipulator import TeamManipulator
 from backend.common.models.award import Award
-from backend.common.models.district import ALL_KNOWN_DISTRICT_ABBREVIATIONS, District
+from backend.common.models.district import District
 from backend.common.models.district_ranking import DistrictRanking
 from backend.common.models.district_team import DistrictTeam
 from backend.common.models.event import Event

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -5137,7 +5137,8 @@
           "abbreviation",
           "display_name",
           "key",
-          "year"
+          "year",
+          "official_advancement_counts"
         ],
         "type": "object",
         "properties": {
@@ -5156,6 +5157,24 @@
           "year": {
             "type": "integer",
             "description": "Year this district participated."
+          },
+          "official_advancement_counts": {
+            "type": "object",
+            "description": "The number of teams advancing to DCMP and CMP from this district, as specified in the FIRST manual.",
+            "required": [
+              "dcmp",
+              "cmp"
+            ],
+            "properties": {
+              "dcmp": {
+                "type": "integer",
+                "description": "Number of teams advancing to the District Championship."
+              },
+              "cmp": {
+                "type": "integer",
+                "description": "Number of teams advancing to the Championship."
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Adds official DCMP/CMP slot allocations per district since 2009 to the District model in the api. Doesn't save anything to the db, it's just a property that then calls into a dict that will need to be manually updated year over year. For the very old stuff I linked to sources. For 2012-14 DCMP sizes (excluding FIM), I just used the number of teams that played a match at that DCMP. Everything else is according to the manual or old official publications.

Old FMA slots I could not find, but Scott Meredith maintained a big spreadsheet of stats about FMA and it had the old CMP slot allocations. I couldn't find sources for 2012/13 FMA other than that.

Had to move `ALL_KNOWN_DISTRICT_ABBREVIATIONS` to avoid circular imports.