### PR TITLE
[pwa] Add gameday redirect for event specific urls

### DIFF
--- a/pwa/app/lib/gameday/context.tsx
+++ b/pwa/app/lib/gameday/context.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
 } from 'react';
 
+import { getBestLayoutForCount } from '~/lib/gameday/layouts';
 import {
   type GamedayState,
   gamedayReducer,
@@ -37,11 +38,19 @@ const GamedayContext = createContext<{
 } | null>(null);
 
 // Provider
-export function GamedayProvider({ children }: { children: React.ReactNode }) {
+export function GamedayProvider({
+  children,
+  initialEventCode,
+}: {
+  children: React.ReactNode;
+  initialEventCode?: string;
+}) {
   const [state, dispatch] = useReducer(gamedayReducer, initialState);
 
   // Track if we've restored URL state
   const hasRestoredUrlState = useRef(false);
+  // Track if we've loaded webcasts for the initial event code
+  const hasLoadedEventWebcasts = useRef(false);
 
   // Subscribe to Firebase and sync webcasts into state
   const { webcasts: firebaseWebcasts, isLoading } = useFirebaseWebcasts();
@@ -57,8 +66,11 @@ export function GamedayProvider({ children }: { children: React.ReactNode }) {
   // Check if we have URL state to restore (computed synchronously)
   const hasUrlState = hasUrlStateToRestore(initialUrlState);
 
-  // We're initializing if we have URL state to restore but haven't done so yet
-  const isInitializing = hasUrlState && !hasRestoredUrlState.current;
+  // We're initializing if restoring URL state, or if waiting for Firebase to
+  // load webcasts for an event code (prevents flash of the layout selector)
+  const isInitializing =
+    (hasUrlState && !hasRestoredUrlState.current) ||
+    (!!initialEventCode && isLoading && !hasUrlState);
 
   // Restore state from URL after webcasts are loaded (so webcast IDs are valid)
   useEffect(() => {
@@ -80,6 +92,31 @@ export function GamedayProvider({ children }: { children: React.ReactNode }) {
       });
     }
   }, [firebaseWebcasts, isLoading]);
+
+  // Auto-load all webcasts for the initial event code once Firebase is ready
+  useEffect(() => {
+    if (
+      isLoading ||
+      !initialEventCode ||
+      hasLoadedEventWebcasts.current ||
+      hasUrlStateToRestore(initialUrlState)
+    )
+      return;
+
+    const eventWebcasts = Object.values(state.webcastsById)
+      .filter((w) => !w.isSpecial && w.id.startsWith(`${initialEventCode}-`))
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    if (eventWebcasts.length === 0) return;
+
+    hasLoadedEventWebcasts.current = true;
+    const layoutId = getBestLayoutForCount(eventWebcasts.length);
+    dispatch({
+      type: 'LOAD_EVENT_WEBCASTS',
+      webcasts: eventWebcasts,
+      layoutId,
+    });
+  }, [isLoading, initialEventCode, state.webcastsById, initialUrlState]);
 
   // Selectors
   const displayedWebcasts = useMemo(

--- a/pwa/app/lib/gameday/layouts.test.ts
+++ b/pwa/app/lib/gameday/layouts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import { Layout, getBestLayoutForCount } from '~/lib/gameday/layouts';
+
+describe.concurrent('getBestLayoutForCount', () => {
+  test('returns single view for 0 or 1 webcasts', () => {
+    expect(getBestLayoutForCount(0)).toBe(Layout.SINGLE_VIEW);
+    expect(getBestLayoutForCount(1)).toBe(Layout.SINGLE_VIEW);
+  });
+
+  test('returns vertical split for 2 webcasts', () => {
+    expect(getBestLayoutForCount(2)).toBe(Layout.VERTICAL_SPLIT);
+  });
+
+  test('returns 1+2 view for 3 webcasts', () => {
+    expect(getBestLayoutForCount(3)).toBe(Layout.ONE_PLUS_TWO);
+  });
+
+  test('returns quad view for 4 webcasts', () => {
+    expect(getBestLayoutForCount(4)).toBe(Layout.QUAD_VIEW);
+  });
+
+  test('returns 1+4 view for 5 webcasts', () => {
+    expect(getBestLayoutForCount(5)).toBe(Layout.ONE_PLUS_FOUR);
+  });
+
+  test('returns hex view for 6 webcasts', () => {
+    expect(getBestLayoutForCount(6)).toBe(Layout.HEX_VIEW);
+  });
+
+  test('returns octo-view for 7 or 8 webcasts', () => {
+    expect(getBestLayoutForCount(7)).toBe(Layout.OCTO_VIEW);
+    expect(getBestLayoutForCount(8)).toBe(Layout.OCTO_VIEW);
+  });
+
+  test('returns nona-view for 9+ webcasts', () => {
+    expect(getBestLayoutForCount(9)).toBe(Layout.NONA_VIEW);
+    expect(getBestLayoutForCount(100)).toBe(Layout.NONA_VIEW);
+  });
+});

--- a/pwa/app/lib/gameday/layouts.ts
+++ b/pwa/app/lib/gameday/layouts.ts
@@ -131,9 +131,40 @@ const LAYOUTS: LayoutConfig[] = [
 ];
 
 /**
+ * Named indices into the LAYOUTS array
+ */
+export const Layout = {
+  SINGLE_VIEW: 0,
+  VERTICAL_SPLIT: 1,
+  ONE_PLUS_TWO: 2,
+  QUAD_VIEW: 3,
+  ONE_PLUS_THREE: 4,
+  ONE_PLUS_FOUR: 5,
+  HEX_VIEW: 6,
+  OCTO_VIEW: 7,
+  NONA_VIEW: 8,
+  HORIZONTAL_SPLIT: 9,
+  ONE_PLUS_SIX: 10,
+  OCTO_VIEW_VERTICAL: 11,
+} as const;
+
+/**
  * Order in which layouts should be displayed in the selection UI
  */
-export const LAYOUT_DISPLAY_ORDER = [0, 1, 9, 2, 3, 4, 5, 6, 10, 7, 11, 8];
+export const LAYOUT_DISPLAY_ORDER = [
+  Layout.SINGLE_VIEW,
+  Layout.VERTICAL_SPLIT,
+  Layout.HORIZONTAL_SPLIT,
+  Layout.ONE_PLUS_TWO,
+  Layout.QUAD_VIEW,
+  Layout.ONE_PLUS_THREE,
+  Layout.ONE_PLUS_FOUR,
+  Layout.HEX_VIEW,
+  Layout.ONE_PLUS_SIX,
+  Layout.OCTO_VIEW,
+  Layout.OCTO_VIEW_VERTICAL,
+  Layout.NONA_VIEW,
+];
 
 /**
  * Get a layout by its index
@@ -149,4 +180,18 @@ export function getLayoutById(id: number | null): LayoutConfig | undefined {
 export function getNumViewsForLayout(layoutId: number): number {
   const layout = getLayoutById(layoutId);
   return layout?.numViews ?? 1;
+}
+
+/**
+ * Pick the best layout index to display a given number of webcasts
+ */
+export function getBestLayoutForCount(count: number): number {
+  if (count <= 1) return Layout.SINGLE_VIEW;
+  if (count <= 2) return Layout.VERTICAL_SPLIT;
+  if (count <= 3) return Layout.ONE_PLUS_TWO;
+  if (count <= 4) return Layout.QUAD_VIEW;
+  if (count <= 5) return Layout.ONE_PLUS_FOUR;
+  if (count <= 6) return Layout.HEX_VIEW;
+  if (count <= 8) return Layout.OCTO_VIEW;
+  return Layout.NONA_VIEW;
 }

--- a/pwa/app/lib/gameday/reducer.test.ts
+++ b/pwa/app/lib/gameday/reducer.test.ts
@@ -433,6 +433,52 @@ describe.concurrent('RESTORE_URL_STATE action', () => {
   });
 });
 
+describe.concurrent('LOAD_EVENT_WEBCASTS', () => {
+  test('sets layout and populates positions with event webcasts', () => {
+    const webcasts = [
+      createMockWebcast('2026tuis-0'),
+      createMockWebcast('2026tuis-1'),
+    ];
+    const state = gamedayReducer(initialState, {
+      type: 'LOAD_EVENT_WEBCASTS',
+      webcasts,
+      layoutId: 1, // Vertical Split (2 views)
+    });
+    expect(state.layoutId).toBe(1);
+    expect(state.positionToWebcast[0]).toBe('2026tuis-0');
+    expect(state.positionToWebcast[1]).toBe('2026tuis-1');
+    expect(state.positionToWebcast[2]).toBeNull();
+  });
+
+  test('caps webcasts at layout capacity', () => {
+    const webcasts = [
+      createMockWebcast('2026tuis-0'),
+      createMockWebcast('2026tuis-1'),
+      createMockWebcast('2026tuis-2'),
+    ];
+    // Layout 0 = Single View (1 view)
+    const state = gamedayReducer(initialState, {
+      type: 'LOAD_EVENT_WEBCASTS',
+      webcasts,
+      layoutId: 0,
+    });
+    expect(state.layoutId).toBe(0);
+    expect(state.positionToWebcast[0]).toBe('2026tuis-0');
+    expect(state.positionToWebcast[1]).toBeNull();
+  });
+
+  test('fills remaining positions with null', () => {
+    const webcasts = [createMockWebcast('2026tuis-0')];
+    const state = gamedayReducer(initialState, {
+      type: 'LOAD_EVENT_WEBCASTS',
+      webcasts,
+      layoutId: 0,
+    });
+    expect(state.positionToWebcast).toHaveLength(MAX_VIEWS);
+    expect(state.positionToWebcast.filter((p) => p !== null)).toHaveLength(1);
+  });
+});
+
 describe.concurrent('default case', () => {
   test('returns unchanged state for unknown action', () => {
     const unknownAction = {

--- a/pwa/app/lib/gameday/reducer.ts
+++ b/pwa/app/lib/gameday/reducer.ts
@@ -34,7 +34,12 @@ export type GamedayAction =
   | { type: 'RESET_WEBCASTS' }
   | { type: 'TOGGLE_CHAT_SIDEBAR' }
   | { type: 'SET_CURRENT_CHAT'; channel: string }
-  | { type: 'RESTORE_URL_STATE'; urlState: GamedayUrlState };
+  | { type: 'RESTORE_URL_STATE'; urlState: GamedayUrlState }
+  | {
+      type: 'LOAD_EVENT_WEBCASTS';
+      webcasts: WebcastWithMeta[];
+      layoutId: number;
+    };
 
 // Reducer
 export function gamedayReducer(
@@ -154,6 +159,20 @@ export function gamedayReducer(
       }
 
       return newState;
+    }
+
+    case 'LOAD_EVENT_WEBCASTS': {
+      const { webcasts, layoutId } = action;
+      const numViews = getNumViewsForLayout(layoutId);
+      const positionToWebcast = createEmptyPositionArray();
+      webcasts.slice(0, numViews).forEach((w, i) => {
+        positionToWebcast[i] = w.id;
+      });
+      return {
+        ...state,
+        layoutId,
+        positionToWebcast,
+      };
     }
 
     default:

--- a/pwa/app/routeTree.gen.ts
+++ b/pwa/app/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as TeamsChar123PgNumChar125RouteImport } from './routes/teams.{-$
 import { Route as MatchMatchKeyRouteImport } from './routes/match.$matchKey'
 import { Route as LocalDebugRouteImport } from './routes/local.debug'
 import { Route as InsightsChar123YearChar125RouteImport } from './routes/insights.{-$year}'
+import { Route as GamedayEventCodeRouteImport } from './routes/gameday.$eventCode'
 import { Route as EventsChar123YearChar125RouteImport } from './routes/events.{-$year}'
 import { Route as EventEventKeyRouteImport } from './routes/event.$eventKey'
 import { Route as DistrictsChar123YearChar125RouteImport } from './routes/districts.{-$year}'
@@ -130,6 +131,11 @@ const InsightsChar123YearChar125Route =
     path: '/insights/{-$year}',
     getParentRoute: () => rootRouteImport,
   } as any)
+const GamedayEventCodeRoute = GamedayEventCodeRouteImport.update({
+  id: '/$eventCode',
+  path: '/$eventCode',
+  getParentRoute: () => GamedayRoute,
+} as any)
 const EventsChar123YearChar125Route =
   EventsChar123YearChar125RouteImport.update({
     id: '/events/{-$year}',
@@ -193,7 +199,7 @@ export interface FileRoutesByFullPath {
   '/apidocs': typeof ApidocsRoute
   '/contact': typeof ContactRoute
   '/donate': typeof DonateRoute
-  '/gameday': typeof GamedayRoute
+  '/gameday': typeof GamedayRouteWithChildren
   '/hall-of-fame': typeof HallOfFameRoute
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
@@ -205,6 +211,7 @@ export interface FileRoutesByFullPath {
   '/districts/{-$year}': typeof DistrictsChar123YearChar125Route
   '/event/$eventKey': typeof EventEventKeyRoute
   '/events/{-$year}': typeof EventsChar123YearChar125Route
+  '/gameday/$eventCode': typeof GamedayEventCodeRoute
   '/insights/{-$year}': typeof InsightsChar123YearChar125Route
   '/local/debug': typeof LocalDebugRoute
   '/match/$matchKey': typeof MatchMatchKeyRoute
@@ -223,7 +230,7 @@ export interface FileRoutesByTo {
   '/apidocs': typeof ApidocsRoute
   '/contact': typeof ContactRoute
   '/donate': typeof DonateRoute
-  '/gameday': typeof GamedayRoute
+  '/gameday': typeof GamedayRouteWithChildren
   '/hall-of-fame': typeof HallOfFameRoute
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
@@ -235,6 +242,7 @@ export interface FileRoutesByTo {
   '/districts/{-$year}': typeof DistrictsChar123YearChar125Route
   '/event/$eventKey': typeof EventEventKeyRoute
   '/events/{-$year}': typeof EventsChar123YearChar125Route
+  '/gameday/$eventCode': typeof GamedayEventCodeRoute
   '/insights/{-$year}': typeof InsightsChar123YearChar125Route
   '/local/debug': typeof LocalDebugRoute
   '/match/$matchKey': typeof MatchMatchKeyRoute
@@ -254,7 +262,7 @@ export interface FileRoutesById {
   '/apidocs': typeof ApidocsRoute
   '/contact': typeof ContactRoute
   '/donate': typeof DonateRoute
-  '/gameday': typeof GamedayRoute
+  '/gameday': typeof GamedayRouteWithChildren
   '/hall-of-fame': typeof HallOfFameRoute
   '/match_suggestion': typeof Match_suggestionRoute
   '/privacy': typeof PrivacyRoute
@@ -266,6 +274,7 @@ export interface FileRoutesById {
   '/districts/{-$year}': typeof DistrictsChar123YearChar125Route
   '/event/$eventKey': typeof EventEventKeyRoute
   '/events/{-$year}': typeof EventsChar123YearChar125Route
+  '/gameday/$eventCode': typeof GamedayEventCodeRoute
   '/insights/{-$year}': typeof InsightsChar123YearChar125Route
   '/local/debug': typeof LocalDebugRoute
   '/match/$matchKey': typeof MatchMatchKeyRoute
@@ -298,6 +307,7 @@ export interface FileRouteTypes {
     | '/districts/{-$year}'
     | '/event/$eventKey'
     | '/events/{-$year}'
+    | '/gameday/$eventCode'
     | '/insights/{-$year}'
     | '/local/debug'
     | '/match/$matchKey'
@@ -328,6 +338,7 @@ export interface FileRouteTypes {
     | '/districts/{-$year}'
     | '/event/$eventKey'
     | '/events/{-$year}'
+    | '/gameday/$eventCode'
     | '/insights/{-$year}'
     | '/local/debug'
     | '/match/$matchKey'
@@ -358,6 +369,7 @@ export interface FileRouteTypes {
     | '/districts/{-$year}'
     | '/event/$eventKey'
     | '/events/{-$year}'
+    | '/gameday/$eventCode'
     | '/insights/{-$year}'
     | '/local/debug'
     | '/match/$matchKey'
@@ -377,7 +389,7 @@ export interface RootRouteChildren {
   ApidocsRoute: typeof ApidocsRoute
   ContactRoute: typeof ContactRoute
   DonateRoute: typeof DonateRoute
-  GamedayRoute: typeof GamedayRoute
+  GamedayRoute: typeof GamedayRouteWithChildren
   HallOfFameRoute: typeof HallOfFameRoute
   Match_suggestionRoute: typeof Match_suggestionRoute
   PrivacyRoute: typeof PrivacyRoute
@@ -529,6 +541,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InsightsChar123YearChar125RouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/gameday/$eventCode': {
+      id: '/gameday/$eventCode'
+      path: '/$eventCode'
+      fullPath: '/gameday/$eventCode'
+      preLoaderRoute: typeof GamedayEventCodeRouteImport
+      parentRoute: typeof GamedayRoute
+    }
     '/events/{-$year}': {
       id: '/events/{-$year}'
       path: '/events/{-$year}'
@@ -602,6 +621,17 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface GamedayRouteChildren {
+  GamedayEventCodeRoute: typeof GamedayEventCodeRoute
+}
+
+const GamedayRouteChildren: GamedayRouteChildren = {
+  GamedayEventCodeRoute: GamedayEventCodeRoute,
+}
+
+const GamedayRouteWithChildren =
+  GamedayRoute._addFileChildren(GamedayRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
@@ -609,7 +639,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApidocsRoute: ApidocsRoute,
   ContactRoute: ContactRoute,
   DonateRoute: DonateRoute,
-  GamedayRoute: GamedayRoute,
+  GamedayRoute: GamedayRouteWithChildren,
   HallOfFameRoute: HallOfFameRoute,
   Match_suggestionRoute: Match_suggestionRoute,
   PrivacyRoute: PrivacyRoute,

--- a/pwa/app/routes/gameday.$eventCode.tsx
+++ b/pwa/app/routes/gameday.$eventCode.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/gameday/$eventCode')({
+  beforeLoad: ({ params: { eventCode } }) => {
+    throw redirect({
+      to: '/gameday',
+      search: { event: eventCode },
+    });
+  },
+});

--- a/pwa/app/routes/gameday.tsx
+++ b/pwa/app/routes/gameday.tsx
@@ -8,6 +8,7 @@ import { publicCacheControlHeaders } from '~/lib/utils';
 // Search params schema for gameday URL state
 const gamedaySearchSchema = z.object({
   layout: z.coerce.number().int().optional(),
+  event: z.string().optional(),
   view_0: z.string().optional(),
   view_1: z.string().optional(),
   view_2: z.string().optional(),
@@ -39,8 +40,9 @@ export const Route = createFileRoute('/gameday')({
 });
 
 function GamedayRoute() {
+  const { event } = Route.useSearch();
   return (
-    <GamedayProvider>
+    <GamedayProvider initialEventCode={event}>
       <GamedayFrame />
     </GamedayProvider>
   );

--- a/pwa/tests/routes.spec.ts
+++ b/pwa/tests/routes.spec.ts
@@ -33,6 +33,7 @@ const allRoutes = defineAllRoutes([
   '/event/$eventKey',
   '/events/{-$year}',
   '/gameday',
+  '/gameday/$eventCode',
   '/hall-of-fame',
   '/insights/{-$year}',
   '/local/debug',
@@ -52,6 +53,7 @@ const allRoutes = defineAllRoutes([
 // Only need to specify values for parameters, not list out every route manually
 const parameterValues: Record<string, string[]> = {
   $eventKey: ['2024mil'],
+  $eventCode: ['2024mil'],
   '{-$year}': ['', '2024'],
   $matchKey: ['2024mil_f1m2'],
   '{-$pgNum}': ['', '1'],


### PR DESCRIPTION
Tested locally on 2026tuis links from the homepage.

<img width="1918" height="1077" alt="image" src="https://github.com/user-attachments/assets/f83781e2-2397-4343-8ea4-5749872e042d" />

Tested changing layouts and stuff, url update works correctly, etc.