### PR TITLE
Sort opr table by opr by default (not team #)

### DIFF
--- a/src/backend/web/templates/event_partials/event_copr_table.html
+++ b/src/backend/web/templates/event_partials/event_copr_table.html
@@ -189,7 +189,7 @@
         $("#coprTable").tablesorter({
             theme: 'bootstrap',
             headerTemplate: '{content}',
-            sortList: [[0,0]], // default sort by rank asc
+            sortList: [[1,1]], // default sort by OPR desc
             widgets: ['zebra']
         });
 


### PR DESCRIPTION
Despite the comment, this was sorting by team number first, which is a departure from the old opr table behavior. this restores it back to being sorted by opr