### PR TITLE
Improve reliability of api spec for openapi client generators

### DIFF
--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -947,10 +947,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_District_Points",
-                  "type": [
-                    "null",
-                    "object"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_District_Points"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ]
                 }
               }
@@ -1131,11 +1134,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "$ref": "#/components/schemas/Event_COPRs"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_COPRs"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -1193,10 +1199,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_District_Points",
-                  "type": [
-                    "null",
-                    "object"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_District_Points"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ]
                 }
               }
@@ -1254,10 +1263,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_Insights",
-                  "type": [
-                    "null",
-                    "object"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_Insights"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ]
                 }
               }
@@ -1561,11 +1573,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "$ref": "#/components/schemas/Event_OPRs"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_OPRs"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -1622,10 +1637,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_Predictions",
-                  "type": [
-                    "null",
-                    "object"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_Predictions"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ]
                 }
               }
@@ -1683,10 +1701,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Event_Ranking",
-                  "type": [
-                    "null",
-                    "object"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_Ranking"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ]
                 }
               }
@@ -1744,11 +1765,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "$ref": "#/components/schemas/Event_District_Points"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Event_District_Points"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -2109,10 +2133,13 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/Team_Event_Status",
-                    "type": [
-                      "null",
-                      "object"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/Team_Event_Status"
+                      },
+                      {
+                        "type": "null"
+                      }
                     ]
                   },
                   "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
@@ -3442,11 +3469,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "$ref": "#/components/schemas/Team_Event_Status"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Team_Event_Status"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -3886,11 +3916,14 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": {
-                    "type": [
-                      "null",
-                      "object"
-                    ],
-                    "$ref": "#/components/schemas/Team_Event_Status"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/Team_Event_Status"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
                 }
@@ -5506,20 +5539,26 @@
                 "description": "Match level, qm/ef/qf/sf/f."
               },
               "record": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "$ref": "#/components/schemas/WLT_Record",
-                "description": "W-L-T record for the alliance, may be null."
+                "description": "W-L-T record for the alliance, may be null.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/WLT_Record"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "current_level_record": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "$ref": "#/components/schemas/WLT_Record",
-                "description": "W-L-T record for the alliance at the current level, may be null."
+                "description": "W-L-T record for the alliance at the current level, may be null.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/WLT_Record"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "status": {
                 "type": "string",
@@ -5759,10 +5798,13 @@
             "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py#L8"
           },
           "district": {
-            "$ref": "#/components/schemas/District",
-            "type": [
-              "null",
-              "object"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/District"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "city": {
@@ -6808,11 +6850,14 @@
                   "description": "Additional year-specific information. See parent `sort_order_info` for details."
                 },
                 "record": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "$ref": "#/components/schemas/WLT_Record"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/WLT_Record"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "rank": {
                   "type": "integer",
@@ -6909,10 +6954,13 @@
             "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py#L8"
           },
           "district": {
-            "$ref": "#/components/schemas/District",
-            "type": [
-              "null",
-              "object"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/District"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "city": {
@@ -7143,10 +7191,6 @@
             "format": "int64"
           },
           "score_breakdown": {
-            "type": [
-              "object",
-              "null"
-            ],
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Match_Score_Breakdown_2015"
@@ -7180,6 +7224,9 @@
               },
               {
                 "$ref": "#/components/schemas/Match_Score_Breakdown_2026"
+              },
+              {
+                "type": "null"
               }
             ],
             "description": "Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null."
@@ -10038,24 +10085,33 @@
         "type": "object",
         "properties": {
           "qual": {
-            "$ref": "#/components/schemas/Team_Event_Status_rank",
-            "type": [
-              "null",
-              "object"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Team_Event_Status_rank"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "alliance": {
-            "$ref": "#/components/schemas/Team_Event_Status_alliance",
-            "type": [
-              "null",
-              "object"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Team_Event_Status_alliance"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "playoff": {
-            "$ref": "#/components/schemas/Team_Event_Status_playoff",
-            "type": [
-              "null",
-              "object"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Team_Event_Status_playoff"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "alliance_status_str": {
@@ -10140,18 +10196,24 @@
             "$ref": "#/components/schemas/Comp_Level"
           },
           "current_level_record": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "$ref": "#/components/schemas/WLT_Record"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "record": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "$ref": "#/components/schemas/WLT_Record"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "type": "string",
@@ -10210,10 +10272,13 @@
                 }
               },
               "record": {
-                "$ref": "#/components/schemas/WLT_Record",
-                "type": [
-                  "null",
-                  "object"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/WLT_Record"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "rank": {


### PR DESCRIPTION
In openapi 3.1, you are allowed to specify sibling elements next to `$ref`. We do this with `type` to specify nullability. This works with our pwa typescript client generator. Unfortunately not every "3.1 compliant" client generator actually follows this the same way (even official ones, lol).

This makes null a oneof type. No change to pwa, but improves client generation for other ecosystems (e.g. python which i'm using for some random other thing)

Maybe its worth having some more stern ci checks for our openapi spec, but yolo