### PR TITLE
Add oEmbed API test page and bump FB Graph API to v25.0

### DIFF
--- a/src/backend/web/handlers/embed.py
+++ b/src/backend/web/handlers/embed.py
@@ -17,6 +17,7 @@ from backend.common.models.media import Media
 from backend.common.models.team import Team
 from backend.common.profiler import Span
 from backend.common.sitevars.instagram_api_secret import InstagramApiSecret
+from backend.web.profiled_render import render_template
 
 
 @cached_public(ttl=timedelta(hours=6), cache_redirects=True)
@@ -50,9 +51,9 @@ def instagram_oembed(media_key: str):
     except Exception:
         return abort(400)
 
-    with Span("GET: https://graph.facebook.com/v14.0/instagram_oembed"):
+    with Span("GET: https://graph.facebook.com/v25.0/instagram_oembed"):
         response = requests.get(
-            "https://graph.facebook.com/v14.0/instagram_oembed"
+            "https://graph.facebook.com/v25.0/instagram_oembed"
             + f"?url={urllib.parse.quote_plus(instagram_url)}"
             + f"&maxwidth={width}"
             + f"&access_token={InstagramApiSecret.get()['api_key']}"
@@ -65,6 +66,57 @@ def instagram_oembed(media_key: str):
         return redirect("/images/instagram_blank.png")
 
     return redirect(response.json()["thumbnail_url"])
+
+
+def oembed_test():
+    access_token = InstagramApiSecret.get()["api_key"]
+    instagram_url = "https://www.instagram.com/p/CbAabcyNUda/"
+    facebook_url = "https://www.facebook.com/thebluealliance/posts/pfbid0yVvTAw61qYufQZ1Pg288ioN6P3JAfCFMvgs5Cij6d7Ld2xSwVomxKRgR2CHM6bwVl"
+
+    instagram_html = None
+    instagram_error = None
+    facebook_html = None
+    facebook_error = None
+
+    try:
+        ig_response = requests.get(
+            "https://graph.facebook.com/v25.0/instagram_oembed",
+            params={
+                "url": instagram_url,
+                "access_token": access_token,
+            },
+        )
+        if ig_response.status_code == 200:
+            instagram_html = ig_response.json().get("html", "")
+        else:
+            instagram_error = f"HTTP {ig_response.status_code}: {ig_response.text}"
+    except Exception as e:
+        instagram_error = str(e)
+
+    try:
+        fb_response = requests.get(
+            "https://graph.facebook.com/v25.0/oembed_post",
+            params={
+                "url": facebook_url,
+                "access_token": access_token,
+            },
+        )
+        if fb_response.status_code == 200:
+            facebook_html = fb_response.json().get("html", "")
+        else:
+            facebook_error = f"HTTP {fb_response.status_code}: {fb_response.text}"
+    except Exception as e:
+        facebook_error = str(e)
+
+    return render_template(
+        "local/oembed_test.html",
+        {
+            "instagram_html": instagram_html,
+            "instagram_error": instagram_error,
+            "facebook_html": facebook_html,
+            "facebook_error": facebook_error,
+        },
+    )
 
 
 @cached_public(ttl=timedelta(hours=24))

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -23,7 +23,7 @@ from backend.web.handlers.ajax import (
 )
 from backend.web.handlers.apidocs import blueprint as apidocs_blueprint
 from backend.web.handlers.district import district_detail, regional_detail
-from backend.web.handlers.embed import avatar_png, instagram_oembed
+from backend.web.handlers.embed import avatar_png, instagram_oembed, oembed_test
 from backend.web.handlers.error import handle_404, handle_500
 from backend.web.handlers.event import (
     event_agenda,
@@ -193,6 +193,7 @@ app.add_url_rule("/_/playoff_types", view_func=playoff_types_handler)
 app.add_url_rule("/_/typeahead/<search_key>", view_func=typeahead_handler)
 app.add_url_rule("/instagram_oembed/<media_key>", view_func=instagram_oembed)
 app.add_url_rule("/avatar/<int:year>/<team_key>.png", view_func=avatar_png)
+app.add_url_rule("/_test/oembed_api", view_func=oembed_test)
 
 app.register_blueprint(apidocs_blueprint)
 app.register_blueprint(admin_blueprint)

--- a/src/backend/web/templates/local/oembed_test.html
+++ b/src/backend/web/templates/local/oembed_test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>oEmbed API Test</title>
+    <meta name="robots" content="noindex, nofollow">
+    <style>
+        body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; }
+        h1 { color: #333; }
+        h2 { color: #555; margin-top: 40px; }
+        .embed-container { border: 1px solid #ddd; padding: 20px; border-radius: 8px; margin: 10px 0; }
+        .error { color: red; background: #fff0f0; padding: 10px; border-radius: 4px; }
+        .meta { font-size: 12px; color: #888; margin-bottom: 10px; }
+    </style>
+</head>
+<body>
+    <h1>oEmbed API Test</h1>
+    <p class="meta">Using access token from <code>instagram.secrets</code> sitevar</p>
+
+    <h2>Instagram (@thebluealliance)</h2>
+    <div class="embed-container">
+        {% if instagram_error %}
+            <div class="error">{{ instagram_error }}</div>
+        {% else %}
+            {{ instagram_html | safe }}
+        {% endif %}
+    </div>
+
+    <h2>Facebook (/thebluealliance)</h2>
+    <div class="embed-container">
+        {% if facebook_error %}
+            <div class="error">{{ facebook_error }}</div>
+        {% else %}
+            {{ facebook_html | safe }}
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a test page at `/_test/oembed_api` that renders Instagram and Facebook oEmbed embeds, for Meta app verification
- Bump Facebook Graph API from v14.0 to v25.0 for the existing `instagram_oembed` handler
- Uses existing `instagram.secrets` sitevar for the access token

## Test plan
- [x] Verified locally at `http://localhost:8080/_test/oembed_api`
- [ ] Deploy and verify embeds render on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)