### PR TITLE
manipulator: fix corrupted models by treating them as missing

### DIFF
--- a/src/backend/common/manipulators/manipulator_base.py
+++ b/src/backend/common/manipulators/manipulator_base.py
@@ -205,12 +205,32 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
     @classmethod
     def findOrSpawn(cls, new_models, auto_union=True, update_manual_attrs=True) -> Any:
         new_models = listify(new_models)
-        old_models = ndb.get_multi(
+        old_models: List[Optional[TModel]] = ndb.get_multi(
             [model.key for model in new_models], use_cache=False, use_memcache=False
         )
+
+        validated_old_models: List[Optional[TModel]] = []
+        for old_model in old_models:
+            if old_model is None:
+                validated_old_models.append(None)
+                continue
+
+            if old_model._validate_required_properties():
+                model_key = old_model.key.urlsafe() if old_model.key else "No key"
+                logging.error(
+                    "Corrupted model detected in findOrSpawn; treating existing model as missing. "
+                    "model_class=%s model_key=%s",
+                    old_model.__class__.__name__,
+                    model_key,
+                )
+                validated_old_models.append(None)
+                continue
+
+            validated_old_models.append(old_model)
+
         updated_models = [
             cls.updateMergeBase(new_model, old_model, auto_union, update_manual_attrs)
-            for (new_model, old_model) in zip(new_models, old_models)
+            for (new_model, old_model) in zip(new_models, validated_old_models)
         ]
         return delistify(updated_models)
 

--- a/src/backend/common/manipulators/tests/base_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/base_manipulator_test.py
@@ -116,6 +116,42 @@ class DummyManipulator(ManipulatorBase[DummyModel]):
         return old_model
 
 
+class DummyModelWithRequiredProp(CachedModel):
+    required_prop: Optional[str] = ndb.StringProperty(required=True)
+
+    _mutable_attrs: Set[str] = {
+        "required_prop",
+    }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._affected_references = {
+            "key": set(),
+        }
+
+
+class DummyRequiredManipulator(ManipulatorBase[DummyModelWithRequiredProp]):
+    update_merge_calls = 0
+
+    @classmethod
+    def getCacheKeysAndQueries(
+        cls, affected_refs: TAffectedReferences
+    ) -> List[TCacheKeyAndQuery]:
+        return []
+
+    @classmethod
+    def updateMerge(
+        cls,
+        new_model: DummyModelWithRequiredProp,
+        old_model: DummyModelWithRequiredProp,
+        auto_union: bool,
+        update_manual_attrs: bool,
+    ) -> DummyModelWithRequiredProp:
+        cls.update_merge_calls += 1
+        cls._update_attrs(new_model, old_model, auto_union, update_manual_attrs)
+        return old_model
+
+
 @DummyManipulator.register_post_delete_hook
 def post_delete_hook(models: List[DummyModel]) -> None:
     DummyManipulator.delete_calls += 1
@@ -139,6 +175,7 @@ def reset_hook_call_counts():
     DummyManipulator.delete_hook_extra = None
     DummyManipulator.update_calls = 0
     DummyManipulator.update_hook_extra = None
+    DummyRequiredManipulator.update_merge_calls = 0
 
 
 def test_create_new_model(ndb_context, taskqueue_stub) -> None:
@@ -177,6 +214,30 @@ def test_update_model(ndb_context, taskqueue_stub) -> None:
 
     check = DummyModel.get_by_id("test")
     assert check == expected
+
+
+def test_find_or_spawn_corrupt_old_model_treated_as_create(
+    ndb_context, monkeypatch, taskqueue_stub
+) -> None:
+    new_model = DummyModelWithRequiredProp(id="test", required_prop="new-value")
+    corrupt_old_model = DummyModelWithRequiredProp(id="test")
+
+    monkeypatch.setattr(
+        ndb,
+        "get_multi",
+        lambda *_args, **_kwargs: [corrupt_old_model],
+    )
+
+    result = DummyRequiredManipulator.createOrUpdate(new_model)
+
+    assert result == new_model
+    assert result._is_new is True
+    assert result._dirty is False
+    assert DummyRequiredManipulator.update_merge_calls == 0
+
+    saved = DummyModelWithRequiredProp.get_by_id("test")
+    assert saved is not None
+    assert saved.required_prop == "new-value"
 
 
 def test_update_model_leaves_unknown_attrs(ndb_context, taskqueue_stub) -> None:

--- a/src/backend/common/models/cached_model.py
+++ b/src/backend/common/models/cached_model.py
@@ -48,14 +48,17 @@ class CachedModel(ndb.Model):
         # constructors, so make sure we have a common set of properties defined
         self._fix_up_properties()
 
-    def _validate_required_properties(self) -> None:
+    def _validate_required_properties(self) -> bool:
         """
         Validates that all required properties on the model are set.
         Logs an error with stack trace and model key if validation fails.
+
+        Returns True when one or more required properties are missing,
+        otherwise False.
         """
         # Skip validation if model doesn't have _properties attribute
         if not hasattr(self, "_properties"):
-            return
+            return False
 
         missing_properties: List[str] = []
 
@@ -78,6 +81,9 @@ class CachedModel(ndb.Model):
                 f"Model key: {model_key}\n"
                 f"Stack trace:\n{stack_trace}"
             )
+            return True
+
+        return False
 
     def _pre_put_hook(self) -> None:
         """

--- a/src/backend/common/models/tests/cached_model_test.py
+++ b/src/backend/common/models/tests/cached_model_test.py
@@ -22,9 +22,10 @@ def test_validate_required_properties_all_set(ndb_stub, caplog) -> None:
             required_prop="value",
             required_int=42,
         )
-        model._validate_required_properties()
+        has_missing_required_properties = model._validate_required_properties()
 
     # No errors should be logged
+    assert has_missing_required_properties is False
     assert len(caplog.records) == 0
 
 
@@ -33,9 +34,10 @@ def test_validate_required_properties_missing(ndb_stub, caplog) -> None:
     with caplog.at_level(logging.ERROR):
         model = DummyModelWithRequiredProps(id="test_model", required_prop="value")
         # required_int is not set (None)
-        model._validate_required_properties()
+        has_missing_required_properties = model._validate_required_properties()
 
     # Should log an error for missing required_int
+    assert has_missing_required_properties is True
     assert len(caplog.records) == 1
     error_message = caplog.records[0].message
     assert "Required properties not set" in error_message
@@ -50,9 +52,10 @@ def test_validate_required_properties_multiple_missing(ndb_stub, caplog) -> None
     with caplog.at_level(logging.ERROR):
         model = DummyModelWithRequiredProps(id="test_model")
         # Both required_prop and required_int are not set
-        model._validate_required_properties()
+        has_missing_required_properties = model._validate_required_properties()
 
     # Should log an error listing both missing properties
+    assert has_missing_required_properties is True
     assert len(caplog.records) == 1
     error_message = caplog.records[0].message
     assert "Required properties not set" in error_message
@@ -139,9 +142,10 @@ def test_validation_with_no_key(ndb_stub, caplog) -> None:
     """Test validation works even when model has no key (unsaved)."""
     with caplog.at_level(logging.ERROR):
         model = DummyModelWithRequiredProps(required_prop="value")
-        model._validate_required_properties()
+        has_missing_required_properties = model._validate_required_properties()
 
     # Should log error with "No key (unsaved model)"
+    assert has_missing_required_properties is True
     assert len(caplog.records) == 1
     error_message = caplog.records[0].message
     assert "No key (unsaved model)" in error_message


### PR DESCRIPTION
Now that we have a way to identify corrupt models in the datastore (although the "how" is still a baffling mystery to me), this will teach the manipulators to try and self-heal.  If we load a corrupt model (defined as missing a required property) in `findOrSpawn`, then treat it as missing. This way, if we write the "old" model, we should be able to try and recover.