### PR TITLE
trustedapi: log requests to cloud storage for recordkeeping

### DIFF
--- a/src/backend/api/handlers/tests/trustedapi_auth_test.py
+++ b/src/backend/api/handlers/tests/trustedapi_auth_test.py
@@ -5,7 +5,7 @@ import json
 import random
 import string
 from typing import List, Optional, Tuple
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from freezegun import freeze_time
@@ -1088,3 +1088,154 @@ def test_error_message_without_all_official_events(
     assert resp.status_code == 401
     assert "Error" in resp.json
     assert resp.json["Error"] == "Only allowed to edit events: 2019other"
+
+
+@freeze_time("2019-06-01")
+def test_successful_request_logs_to_storage(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test that successful requests are logged to cloud storage"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, is_admin=True)
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_TEAMS],
+    )
+
+    request_data = json.dumps([])
+    request_path = "/api/trusted/v1/event/2019nyny/team_list/update"
+
+    with patch("backend.common.helpers.trusted_api_logger.storage_write") as mock_write:
+        with api_client.application.test_request_context():  # pyre-ignore[16]
+            resp = api_client.post(
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, request_data
+                    ),
+                },
+                data=request_data,
+            )
+
+    assert resp.status_code == 200
+    # Verify storage_write was called
+    mock_write.assert_called_once()
+
+    # Verify the call arguments
+    call_args = mock_write.call_args
+    storage_path = call_args[0][0]
+    content = call_args[0][1]
+    bucket = call_args[1]["bucket"]
+    metadata = call_args[1]["metadata"]
+
+    # Check storage path structure
+    assert storage_path.startswith("api/trusted/v1/event/2019nyny/team_list/update/")
+    assert storage_path.endswith(".json")
+
+    # Check bucket name
+    assert bucket.endswith("-trustedapi-requests")
+
+    # Check content
+    assert content == request_data.encode()
+
+    # Check metadata
+    assert metadata["X-TBA-Auth-Id"] == auth_id
+    assert metadata["method"] == "POST"
+    assert metadata["status_code"] == "200"
+
+
+@freeze_time("2019-06-01")
+def test_failed_request_does_not_log_to_storage(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test that failed requests are not logged to cloud storage"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, permissions=[])
+    auth_id, auth_secret = setup_api_auth(
+        "2019other",  # Different event, should fail auth
+        auth_types=[AuthType.EVENT_TEAMS],
+    )
+
+    request_data = json.dumps([])
+    request_path = "/api/trusted/v1/event/2019nyny/team_list/update"
+
+    with patch("backend.common.helpers.trusted_api_logger.storage_write") as mock_write:
+        with api_client.application.test_request_context():  # pyre-ignore[16]
+            resp = api_client.post(
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, request_data
+                    ),
+                },
+                data=request_data,
+            )
+
+    assert resp.status_code == 401
+    # Verify storage_write was NOT called for failed request
+    mock_write.assert_not_called()
+
+
+@freeze_time("2019-06-01")
+def test_get_request_does_not_log_to_storage(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test that GET requests are not logged to cloud storage"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, is_admin=True)
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_INFO],
+    )
+
+    request_path = "/api/trusted/v1/event/2019nyny/info"
+
+    with patch("backend.common.helpers.trusted_api_logger.storage_write") as mock_write:
+        with api_client.application.test_request_context():  # pyre-ignore[16]
+            resp = api_client.get(
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, ""
+                    ),
+                },
+            )
+
+    assert resp.status_code == 200
+    # Verify storage_write was NOT called for GET request
+    mock_write.assert_not_called()
+
+
+@freeze_time("2019-06-01")
+def test_empty_request_body_does_not_log_to_storage(
+    monkeypatch: MonkeyPatch, ndb_stub, api_client: Client
+) -> None:
+    """Test that requests with empty body are not logged to cloud storage"""
+    setup_event(event_type=EventType.OFFSEASON)
+    setup_user(monkeypatch, is_admin=True)
+    auth_id, auth_secret = setup_api_auth(
+        "2019nyny",
+        auth_types=[AuthType.EVENT_TEAMS],
+    )
+
+    request_path = "/api/trusted/v1/event/2019nyny/team_list/update"
+
+    with patch("backend.common.helpers.trusted_api_logger.storage_write") as mock_write:
+        with api_client.application.test_request_context():  # pyre-ignore[16]
+            _resp = api_client.post(  # noqa: F841
+                request_path,
+                headers={
+                    "X-TBA-Auth-Id": auth_id,
+                    "X-TBA-Auth-Sig": TrustedApiAuthHelper.compute_auth_signature(
+                        auth_secret, request_path, ""
+                    ),
+                },
+                data="",
+            )
+
+    # Request might succeed or fail, but either way empty body should not log
+    # Verify storage_write was NOT called for empty request body
+    mock_write.assert_not_called()

--- a/src/backend/api/trusted_api_main.py
+++ b/src/backend/api/trusted_api_main.py
@@ -1,6 +1,6 @@
 from json import JSONDecodeError
 
-from flask import Blueprint, make_response, Response
+from flask import Blueprint, make_response, request, Response
 from flask_cors import CORS
 
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
@@ -20,6 +20,7 @@ from backend.api.handlers.trusted import (
     update_teams,
 )
 from backend.common.datafeed_parsers.exceptions import ParserInputException
+from backend.common.helpers.trusted_api_logger import TrustedApiLogger
 
 # Trusted API
 trusted_api = Blueprint("trusted_api", __name__, url_prefix="/api/trusted/v1")
@@ -94,6 +95,13 @@ trusted_api.add_url_rule(
     methods=["POST"],
     view_func=add_match_zebra_motionworks_info,
 )
+
+
+@trusted_api.after_request
+def log_request_to_storage(response: Response) -> Response:
+    """Log successful trusted API requests to cloud storage for audit purposes."""
+    TrustedApiLogger.log_request(request, response)
+    return response
 
 
 @trusted_api.errorhandler(JSONDecodeError)

--- a/src/backend/common/helpers/tests/trusted_api_logger_test.py
+++ b/src/backend/common/helpers/tests/trusted_api_logger_test.py
@@ -1,0 +1,196 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Flask, Request, Response
+
+from backend.common.helpers.trusted_api_logger import TrustedApiLogger
+
+
+@pytest.fixture
+def app():
+    """Create a test Flask app."""
+    return Flask(__name__)
+
+
+def create_mock_request(
+    method: str = "POST",
+    path: str = "/api/trusted/v1/event/2019nyny/team_list/update",
+    data: bytes = b'{"test": "data"}',
+    auth_id: str = "test_auth_id",
+) -> Request:
+    """Create a mock Flask request."""
+    mock_request = Mock(spec=Request)
+    mock_request.method = method
+    mock_request.path = path
+    mock_request.get_data.return_value = data
+    mock_request.headers = {"X-TBA-Auth-Id": auth_id}
+    return mock_request
+
+
+def create_mock_response(status_code: int = 200) -> Response:
+    """Create a mock Flask response."""
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = status_code
+    return mock_response
+
+
+class TestTrustedApiLogger:
+    def test_get_bucket(self) -> None:
+        """Test getting the bucket name."""
+        with patch(
+            "backend.common.helpers.trusted_api_logger.Environment.project"
+        ) as mock_project:
+            mock_project.return_value = "test-project"
+            bucket = TrustedApiLogger.get_bucket()
+            assert bucket == "test-project-trustedapi-requests"
+
+    def test_should_log_request_success(self) -> None:
+        """Test that successful POST requests should be logged."""
+        request = create_mock_request(method="POST", data=b'{"test": "data"}')
+        response = create_mock_response(status_code=200)
+
+        assert TrustedApiLogger.should_log_request(request, response) is True
+
+    def test_should_log_request_patch(self) -> None:
+        """Test that successful PATCH requests should be logged."""
+        request = create_mock_request(method="PATCH", data=b'{"test": "data"}')
+        response = create_mock_response(status_code=200)
+
+        assert TrustedApiLogger.should_log_request(request, response) is True
+
+    def test_should_log_request_delete(self) -> None:
+        """Test that successful DELETE requests should be logged."""
+        request = create_mock_request(method="DELETE", data=b'{"test": "data"}')
+        response = create_mock_response(status_code=200)
+
+        assert TrustedApiLogger.should_log_request(request, response) is True
+
+    def test_should_not_log_get_request(self) -> None:
+        """Test that GET requests should not be logged."""
+        request = create_mock_request(method="GET", data=b"")
+        response = create_mock_response(status_code=200)
+
+        assert TrustedApiLogger.should_log_request(request, response) is False
+
+    def test_should_not_log_failed_request(self) -> None:
+        """Test that failed requests should not be logged."""
+        request = create_mock_request(method="POST", data=b'{"test": "data"}')
+        response = create_mock_response(status_code=401)
+
+        assert TrustedApiLogger.should_log_request(request, response) is False
+
+    def test_should_not_log_empty_body(self) -> None:
+        """Test that requests with empty body should not be logged."""
+        request = create_mock_request(method="POST", data=b"")
+        response = create_mock_response(status_code=200)
+
+        assert TrustedApiLogger.should_log_request(request, response) is False
+
+    def test_log_request_success(self) -> None:
+        """Test successfully logging a request."""
+        request = create_mock_request(
+            method="POST",
+            path="/api/trusted/v1/event/2019nyny/team_list/update",
+            data=b'{"test": "data"}',
+            auth_id="test_auth_id",
+        )
+        response = create_mock_response(status_code=200)
+
+        with patch(
+            "backend.common.helpers.trusted_api_logger.storage_write"
+        ) as mock_write:
+            with patch(
+                "backend.common.helpers.trusted_api_logger.Environment.project"
+            ) as mock_project:
+                with patch(
+                    "backend.common.helpers.trusted_api_logger.current_user"
+                ) as mock_user:
+                    mock_project.return_value = "test-project"
+                    mock_user.return_value = None
+
+                    storage_path = TrustedApiLogger.log_request(request, response)
+
+                    assert storage_path is not None
+                    assert storage_path.startswith(
+                        "api/trusted/v1/event/2019nyny/team_list/update/"
+                    )
+                    assert storage_path.endswith(".json")
+
+                    # Verify storage_write was called
+                    mock_write.assert_called_once()
+                    call_args = mock_write.call_args
+
+                    # Check storage path
+                    assert call_args[0][0] == storage_path
+
+                    # Check content
+                    assert call_args[0][1] == b'{"test": "data"}'
+
+                    # Check bucket
+                    assert call_args[1]["bucket"] == "test-project-trustedapi-requests"
+
+                    # Check content type
+                    assert call_args[1]["content_type"] == "application/json"
+
+                    # Check metadata
+                    metadata = call_args[1]["metadata"]
+                    assert metadata["X-TBA-Auth-Id"] == "test_auth_id"
+                    assert metadata["method"] == "POST"
+                    assert metadata["status_code"] == "200"
+
+    def test_log_request_with_user(self) -> None:
+        """Test logging a request with authenticated user."""
+        request = create_mock_request(method="POST", data=b'{"test": "data"}')
+        response = create_mock_response(status_code=200)
+
+        mock_user = Mock()
+        mock_user.uid = "user123"
+        mock_user.email = "test@example.com"
+
+        with patch(
+            "backend.common.helpers.trusted_api_logger.storage_write"
+        ) as mock_write:
+            with patch(
+                "backend.common.helpers.trusted_api_logger.Environment.project"
+            ) as mock_project:
+                with patch(
+                    "backend.common.helpers.trusted_api_logger.current_user"
+                ) as mock_current_user:
+                    mock_project.return_value = "test-project"
+                    mock_current_user.return_value = mock_user
+
+                    storage_path = TrustedApiLogger.log_request(request, response)
+
+                    assert storage_path is not None
+
+                    # Check metadata includes user info
+                    metadata = mock_write.call_args[1]["metadata"]
+                    assert metadata["X-TBA-Auth-User"] == "user123"
+                    assert metadata["X-TBA-Auth-User-Email"] == "test@example.com"
+
+    def test_log_request_skips_non_loggable(self) -> None:
+        """Test that non-loggable requests return None without calling storage."""
+        request = create_mock_request(method="GET", data=b"")
+        response = create_mock_response(status_code=200)
+
+        with patch(
+            "backend.common.helpers.trusted_api_logger.storage_write"
+        ) as mock_write:
+            storage_path = TrustedApiLogger.log_request(request, response)
+
+            assert storage_path is None
+            mock_write.assert_not_called()
+
+    def test_log_request_handles_exception(self) -> None:
+        """Test that exceptions during logging are handled gracefully."""
+        request = create_mock_request(method="POST", data=b'{"test": "data"}')
+        response = create_mock_response(status_code=200)
+
+        with patch(
+            "backend.common.helpers.trusted_api_logger.storage_write"
+        ) as mock_write:
+            mock_write.side_effect = Exception("Storage error")
+
+            # Should return None instead of raising exception
+            storage_path = TrustedApiLogger.log_request(request, response)
+            assert storage_path is None

--- a/src/backend/common/helpers/trusted_api_logger.py
+++ b/src/backend/common/helpers/trusted_api_logger.py
@@ -1,0 +1,103 @@
+import datetime
+import logging
+from typing import Optional
+
+from flask import Request, Response
+
+from backend.common.auth import current_user
+from backend.common.environment import Environment
+from backend.common.storage import write as storage_write
+
+
+class TrustedApiLogger:
+    """Helper class for logging Trusted API requests to cloud storage."""
+
+    BUCKET_TEMPLATE = "{project_id}-trustedapi-requests"
+
+    @staticmethod
+    def get_bucket() -> str:
+        """Get the Trusted API request logging bucket name."""
+        project = Environment.project()
+        return TrustedApiLogger.BUCKET_TEMPLATE.format(project_id=project)
+
+    @staticmethod
+    def should_log_request(request: Request, response: Response) -> bool:
+        """Determine if a request should be logged to storage.
+
+        Args:
+            request: The Flask request object
+            response: The Flask response object
+
+        Returns:
+            True if the request should be logged, False otherwise
+        """
+        # Only log successful requests (2xx status codes)
+        if not (200 <= response.status_code < 300):
+            return False
+
+        # Only log requests with a body (POST, PATCH, DELETE methods)
+        if request.method not in ["POST", "PATCH", "DELETE"]:
+            return False
+
+        # Only log if there's a request body
+        request_body = request.get_data()
+        if not request_body:
+            return False
+
+        return True
+
+    @staticmethod
+    def log_request(request: Request, response: Response) -> Optional[str]:
+        """Log a Trusted API request to cloud storage.
+
+        Args:
+            request: The Flask request object
+            response: The Flask response object
+
+        Returns:
+            The storage path if successful, None if logging failed
+        """
+        if not TrustedApiLogger.should_log_request(request, response):
+            return None
+
+        try:
+            # Get request body
+            request_body = request.get_data()
+
+            # Prepare storage path
+            bucket = TrustedApiLogger.get_bucket()
+
+            # Use URL path as directory
+            # For example: /api/trusted/v1/event/2024casj/matches/update/{timestamp}.json
+            url_path = request.path.strip("/")
+            timestamp = datetime.datetime.now(
+                datetime.timezone.utc  # pyre-ignore[16]
+            ).isoformat()
+            storage_path = f"{url_path}/{timestamp}.json"
+
+            # Prepare metadata
+            user = current_user()
+            metadata = {
+                "X-TBA-Auth-User": str(user.uid) if user else None,
+                "X-TBA-Auth-User-Email": user.email if user else None,
+                "X-TBA-Auth-Id": request.headers.get("X-TBA-Auth-Id"),
+                "method": request.method,
+                "status_code": str(response.status_code),
+            }
+
+            # Write to storage
+            storage_write(
+                storage_path,
+                request_body,
+                bucket=bucket,
+                content_type="application/json",
+                metadata=metadata,
+            )
+
+            logging.info(f"Logged trusted API request to {bucket}/{storage_path}")
+            return storage_path
+
+        except Exception as e:
+            # Don't fail the request if logging fails
+            logging.exception(f"Failed to log trusted API request to storage: {e}")
+            return None

--- a/src/backend/web/handlers/admin/api_history.py
+++ b/src/backend/web/handlers/admin/api_history.py
@@ -8,6 +8,7 @@ from backend.common.consts.fms_report_type import FMSReportType
 from backend.common.environment import Environment
 from backend.common.helpers.fms_companion_helper import FMSCompanionHelper
 from backend.common.helpers.fms_report_helper import FMSReportHelper
+from backend.common.helpers.trusted_api_logger import TrustedApiLogger
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey
 from backend.common.storage import get_files
@@ -17,7 +18,7 @@ from backend.web.profiled_render import render_template
 def api_history(event_key: EventKey) -> str:
     """
     Display API response history for an event from Cloud Storage.
-    Shows FRC API, FMS Reports, and Companion DB tabs.
+    Shows FRC API, FMS Reports, Companion DB, and Trusted API tabs.
     """
     event = Event.get_by_id(event_key)
     if not event:
@@ -101,11 +102,20 @@ def api_history(event_key: EventKey) -> str:
         FMSCompanionHelper.get_bucket(),
     )
 
+    # Get Trusted API request logs from trustedapi-requests bucket
+    trusted_api_bucket = TrustedApiLogger.get_bucket()
+    trusted_api_data = _get_storage_files(
+        event,
+        f"api/trusted/v1/event/{event_key}/",
+        trusted_api_bucket,
+    )
+
     template_values = {
         "event": event,
         "frc_api_data": frc_api_data,
         "fms_reports_data": fms_reports_data,
         "companion_db_data": companion_db_data,
+        "trusted_api_data": trusted_api_data,
     }
 
     return render_template("admin/api_history.html", template_values)

--- a/src/backend/web/handlers/admin/tests/api_history_test.py
+++ b/src/backend/web/handlers/admin/tests/api_history_test.py
@@ -67,6 +67,16 @@ def test_api_history_with_files(
             else:
                 return []
 
+        # Check Trusted API bucket
+        if bucket == "testbed-test-trustedapi-requests":
+            if "api/trusted/v1/event/2020nyny" in path:
+                return [
+                    "api/trusted/v1/event/2020nyny/team_list/update/2020-03-15T11:00:00.000000+00:00.json",
+                    "api/trusted/v1/event/2020nyny/matches/update/2020-03-15T12:00:00.000000+00:00.json",
+                ]
+            else:
+                return []
+
         # FRC API paths (no bucket or default bucket)
         if "alliances" in path:
             return [
@@ -115,6 +125,9 @@ def test_api_history_with_files(
     # Check that Companion DB section header is present
     assert "FMS Companion Database" in content
 
+    # Check that Trusted API section header is present
+    assert "Trusted API Request Logs" in content
+
     # Check that timestamps are displayed for alliance files
     assert "2020-03-15 12:45:00" in content
     assert "2020-03-15 10:30:00" in content
@@ -126,6 +139,10 @@ def test_api_history_with_files(
     # Check that Companion DB timestamps are displayed
     assert "2020-03-15T14:30:00" in content
     assert "2020-03-14T09:15:00" in content
+
+    # Check that Trusted API timestamps are displayed
+    assert "2020-03-15T11:00:00.000000+00:00" in content
+    assert "2020-03-15T12:00:00.000000+00:00" in content
 
     # Check that production GCS URLs are present
     assert (
@@ -140,10 +157,14 @@ def test_api_history_with_files(
         "https://storage.googleapis.com/testbed-test-eventwizard-fms-companion/fms_companion/2020nyny/fms_companion.2020-03-15T14:30:00.db"
         in content
     )
+    assert (
+        "https://storage.googleapis.com/testbed-test-trustedapi-requests/api/trusted/v1/event/2020nyny/team_list/update/2020-03-15T11:00:00.000000+00:00.json"
+        in content
+    )
 
     # Verify get_files was called multiple times for different endpoints
-    # 7 FRC API endpoints + 7 FMS Reports + 1 Companion DB = 15
-    assert mock_get_files.call_count == 15
+    # 7 FRC API endpoints + 7 FMS Reports + 1 Companion DB + 1 Trusted API = 16
+    assert mock_get_files.call_count == 16
 
 
 @patch("backend.web.handlers.admin.api_history.Environment.project")
@@ -235,7 +256,7 @@ def test_api_history_storage_error(
 
 
 def test_api_history_has_tabs(web_client: Client, login_gae_admin) -> None:
-    """Test that all three tabs are present in the template"""
+    """Test that all four tabs are present in the template"""
     helpers.preseed_event("2020nyny")
 
     resp = web_client.get("/admin/api_history/2020nyny")
@@ -245,3 +266,4 @@ def test_api_history_has_tabs(web_client: Client, login_gae_admin) -> None:
     assert "FRC API" in content
     assert "FMS Reports" in content
     assert "Companion DB" in content
+    assert "Trusted API" in content

--- a/src/backend/web/templates/admin/api_history.html
+++ b/src/backend/web/templates/admin/api_history.html
@@ -24,6 +24,7 @@
       <li class="active"><a href="#frc-api" data-toggle="tab">FRC API</a></li>
       <li><a href="#fms-reports" data-toggle="tab">FMS Reports</a></li>
       <li><a href="#companion-db" data-toggle="tab">Companion DB</a></li>
+      <li><a href="#trusted-api" data-toggle="tab">Trusted API</a></li>
     </ul>
   </div>
 </div>
@@ -164,6 +165,17 @@
       "FMS Companion Database",
       companion_db_data,
       "Database files from the FMS Companion application"
+    ) }}
+
+  </div>
+
+  <!-- Trusted API Tab -->
+  <div class="tab-pane" id="trusted-api">
+    
+    {{ render_api_section(
+      "Trusted API Request Logs",
+      trusted_api_data,
+      "Logged requests to the Trusted API for this event"
     ) }}
 
   </div>


### PR DESCRIPTION
This will help us keep track of the requests that are made, similar to how we log frc api responses.

Additionally, this will give us the ability to replace requests, to re-link webcasts, for example, should we need to delete & recreate matches due to data corruption