### PR TITLE
ra: Fix calculation of rookie bonuses

### DIFF
--- a/src/backend/common/helpers/regional_champs_pool_helper.py
+++ b/src/backend/common/helpers/regional_champs_pool_helper.py
@@ -221,8 +221,12 @@ class RegionalChampsPoolHelper(DistrictHelper):
                 team = team_f
             bonus = cls._get_rookie_bonus(year, team.rookie_year)
 
-            team_totals[team.key_name]["rookie_bonus"] = bonus
-            team_totals[team.key_name]["point_total"] += bonus
+            # Rookie bonus is applied per event attended (up to 2 events)
+            num_events_attended = len(team_totals[team.key_name]["event_points"])
+            total_rookie_bonus = bonus * num_events_attended
+
+            team_totals[team.key_name]["rookie_bonus"] = total_rookie_bonus
+            team_totals[team.key_name]["point_total"] += total_rookie_bonus
 
             # For other adjustments made by HQ
             if adjustments and (team_adjustment := adjustments.get(team.key_name)):

--- a/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
+++ b/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
@@ -9,6 +9,7 @@ from backend.common.helpers.regional_champs_pool_helper import (
     RegionalChampsPoolTiebreakers,
 )
 from backend.common.models.event import Event
+from backend.common.models.event_details import EventDetails
 from backend.common.models.event_district_points import TeamAtEventDistrictPoints
 from backend.common.models.team import Team
 
@@ -161,3 +162,67 @@ def test_hq_adjustments(setup_full_event) -> None:
             best_qual_points=21,
         ),
     )
+
+
+def test_rookie_bonus_per_event(setup_full_event) -> None:
+    """Test that rookie bonus is applied per event attended, not just once."""
+    setup_full_event("2025mndu")
+    setup_full_event("2025mndu2")
+
+    events = [
+        none_throws(Event.get_by_id("2025mndu")),
+        none_throws(Event.get_by_id("2025mndu2")),
+    ]
+
+    # Set up event points for rookie teams that attend events
+    # Rookie team attending both events
+    event1_details = EventDetails.get_by_id("2025mndu")
+    if event1_details and event1_details.regional_champs_pool_points:
+        event1_details.regional_champs_pool_points["points"]["frc9001"] = (
+            TeamAtEventDistrictPoints(
+                alliance_points=10,
+                award_points=0,
+                elim_points=0,
+                qual_points=15,
+                total=25,
+            )
+        )
+        event1_details.put()
+
+    event2_details = EventDetails.get_by_id("2025mndu2")
+    if event2_details and event2_details.regional_champs_pool_points:
+        event2_details.regional_champs_pool_points["points"]["frc9001"] = (
+            TeamAtEventDistrictPoints(
+                alliance_points=12,
+                award_points=0,
+                elim_points=0,
+                qual_points=18,
+                total=30,
+            )
+        )
+        event2_details.put()
+
+    # Reload events to get updated points
+    events = [
+        none_throws(Event.get_by_id("2025mndu")),
+        none_throws(Event.get_by_id("2025mndu2")),
+    ]
+    for event in events:
+        event.prep_details()
+
+    # Create rookie team
+    rookie_two_events = Team(
+        id="frc9001",
+        team_number=9001,
+        rookie_year=2025,  # Current year rookie gets 10 points per event
+    )
+    rookie_two_events.put()
+
+    teams = [rookie_two_events]
+
+    rankings = RegionalChampsPoolHelper.calculate_rankings(events, teams, 2025, None)
+
+    # Rookie team attending 2 events should get 10 points per event = 20
+    assert rankings["frc9001"]["rookie_bonus"] == 20
+    # Total: 25 (event1) + 30 (event2) + 20 (rookie bonus) = 75
+    assert rankings["frc9001"]["point_total"] == 75


### PR DESCRIPTION
A great catch in https://github.com/the-blue-alliance/the-blue-alliance/issues/8158

For regionals, we need to be applying the rookie bonus *per event*, not once overall.

Fixes #8158 