### PR TITLE
Fix notification times displaying UTC instead of local timezone

### DIFF
--- a/src/backend/common/models/notifications/event_level.py
+++ b/src/backend/common/models/notifications/event_level.py
@@ -21,18 +21,21 @@ class EventLevelNotification(Notification):
     @property
     def fcm_notification(self) -> Optional[Any]:
         if self.match.time:
-            time = self.match.time.strftime("%H:%M")
-            # Add timezone, if possible
+            # Convert UTC time to event local time, if possible
             if self.event.timezone_id:
                 try:
                     import pytz
 
                     timezone = pytz.timezone(self.event.timezone_id)
-                    time += timezone.localize(self.match.time).strftime(" %Z")
+                    local_time = pytz.utc.localize(self.match.time).astimezone(timezone)
+                    time = local_time.strftime("%-H:%M %Z")
                 except Exception as e:
                     logging.warning(
-                        f"Unable to add timezone to event level notification: {e}"
+                        f"Unable to convert timezone for event level notification: {e}"
                     )
+                    time = self.match.time.strftime("%-H:%M")
+            else:
+                time = self.match.time.strftime("%-H:%M")
             ending = f"scheduled for {time}."
         else:
             ending = "starting."

--- a/src/backend/common/models/notifications/event_schedule.py
+++ b/src/backend/common/models/notifications/event_schedule.py
@@ -30,18 +30,23 @@ class EventScheduleNotification(Notification):
     def fcm_notification(self) -> Optional[Any]:
         body = f"The {self.event.normalized_name} match schedule has been updated."
         if self.next_match and self.next_match.time:
-            time = self.next_match.time.strftime("%H:%M")
-            # Add timezone, if possible
+            # Convert UTC time to event local time, if possible
             if self.event.timezone_id:
                 try:
                     import pytz
 
                     timezone = pytz.timezone(self.event.timezone_id)
-                    time += timezone.localize(self.next_match.time).strftime(" %Z")
+                    local_time = pytz.utc.localize(self.next_match.time).astimezone(
+                        timezone
+                    )
+                    time = local_time.strftime("%-H:%M %Z")
                 except Exception as e:
                     logging.warning(
-                        f"Unable to add timezone to match schedule notification: {e}"
+                        f"Unable to convert timezone for match schedule notification: {e}"
                     )
+                    time = self.next_match.time.strftime("%-H:%M")
+            else:
+                time = self.next_match.time.strftime("%-H:%M")
 
             body += f" The next match starts at {time}."
 

--- a/src/backend/common/models/notifications/match_upcoming.py
+++ b/src/backend/common/models/notifications/match_upcoming.py
@@ -37,18 +37,21 @@ class MatchUpcomingNotification(Notification):
             else self.match.predicted_time
         )
         if scheduled_time:
-            time = scheduled_time.strftime("%H:%M")
-            # Add timezone, if possible
+            # Convert UTC time to event local time, if possible
             if self.event.timezone_id:
                 try:
                     import pytz
 
                     timezone = pytz.timezone(self.event.timezone_id)
-                    time += timezone.localize(scheduled_time).strftime(" %Z")
+                    local_time = pytz.utc.localize(scheduled_time).astimezone(timezone)
+                    time = local_time.strftime("%-H:%M %Z")
                 except Exception as e:
                     logging.warning(
-                        f"Unable to add timezone to event level notification: {e}"
+                        f"Unable to convert timezone for upcoming match notification: {e}"
                     )
+                    time = scheduled_time.strftime("%-H:%M")
+            else:
+                time = scheduled_time.strftime("%-H:%M")
             ending = ", scheduled for {}.".format(time)
         else:
             ending = "."

--- a/src/backend/common/models/notifications/tests/event_level_test.py
+++ b/src/backend/common/models/notifications/tests/event_level_test.py
@@ -72,6 +72,7 @@ class TestEventLevelNotification(unittest.TestCase):
 
     def test_fcm_notification_scheduled_time_timezone(self):
         self.notification.event.timezone_id = "America/Detroit"
+        # 13:30 UTC = 8:30 EST
         self.notification.match.time = datetime(2017, 11, 28, 13, 30, 59)
 
         assert self.notification.fcm_notification is not None
@@ -81,7 +82,7 @@ class TestEventLevelNotification(unittest.TestCase):
         )
         assert (
             self.notification.fcm_notification.body
-            == "Qualification matches at the Present Test Event are scheduled for 13:30 EST."
+            == "Qualification matches at the Present Test Event are scheduled for 8:30 EST."
         )
 
     def test_fcm_notification_short_name_scheduled_time(self):

--- a/src/backend/common/models/notifications/tests/event_schedule_test.py
+++ b/src/backend/common/models/notifications/tests/event_schedule_test.py
@@ -78,7 +78,7 @@ class TestEventScheduleNotification(unittest.TestCase):
         self._setup_notification()
 
         self.event.timezone_id = "America/Detroit"
-        # Set constant scheduled time for testing
+        # Set constant scheduled time for testing (13:30 UTC = 08:30 EST)
         self.notification.next_match.time = datetime(2017, 11, 28, 13, 30, 59)
 
         assert self.notification.fcm_notification is not None
@@ -87,7 +87,7 @@ class TestEventScheduleNotification(unittest.TestCase):
         )
         assert (
             self.notification.fcm_notification.body
-            == "The Present Test Event match schedule has been updated. The next match starts at 13:30 EST."
+            == "The Present Test Event match schedule has been updated. The next match starts at 8:30 EST."
         )
 
     def test_fcm_notification_short_name(self):

--- a/src/backend/common/models/notifications/tests/match_upcoming_test.py
+++ b/src/backend/common/models/notifications/tests/match_upcoming_test.py
@@ -41,7 +41,7 @@ class TestMatchUpcomingNotification(unittest.TestCase):
         assert match is not None
 
     def test_fcm_notification_predicted_time(self):
-        # Set times for testing
+        # Set times for testing (13:30 UTC = 8:30 EST)
         self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
         self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
         self.notification.event.timezone_id = "America/New_York"
@@ -51,7 +51,7 @@ class TestMatchUpcomingNotification(unittest.TestCase):
             self.notification.fcm_notification.title == "TESTPRESENT Q1 Starting Soon"
         )
         match_regex = re.compile(
-            r"^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:30 EST.$"
+            r"^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 8:30 EST.$"
         )
         match = re.match(match_regex, self.notification.fcm_notification.body)
         assert match is not None
@@ -73,7 +73,7 @@ class TestMatchUpcomingNotification(unittest.TestCase):
         assert match is not None
 
     def test_fcm_notification_time(self):
-        # Set times for testing
+        # Set times for testing (13:00 UTC = 5:00 PST)
         self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
         self.notification.event.timezone_id = "America/Los_Angeles"
 
@@ -82,7 +82,7 @@ class TestMatchUpcomingNotification(unittest.TestCase):
             self.notification.fcm_notification.title == "TESTPRESENT Q1 Starting Soon"
         )
         match_regex = re.compile(
-            r"^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:00 PST.$"
+            r"^Present Test Event Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 5:00 PST.$"
         )
         match = re.match(match_regex, self.notification.fcm_notification.body)
         assert match is not None
@@ -119,7 +119,7 @@ class TestMatchUpcomingNotification(unittest.TestCase):
 
     def test_fcm_notification_short_name_predicted_time(self):
         self.notification.event.short_name = "Arizona North"
-        # Set times for testing
+        # Set times for testing (13:30 UTC = 6:30 MST)
         self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
         self.notification.match.predicted_time = datetime(2017, 11, 28, 13, 30, 59)
         self.notification.event.timezone_id = "America/Phoenix"
@@ -129,14 +129,14 @@ class TestMatchUpcomingNotification(unittest.TestCase):
             self.notification.fcm_notification.title == "TESTPRESENT Q1 Starting Soon"
         )
         match_regex = re.compile(
-            r"^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:30 MST.$"
+            r"^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 6:30 MST.$"
         )
         match = re.match(match_regex, self.notification.fcm_notification.body)
         assert match is not None
 
     def test_fcm_notification_short_name_time(self):
         self.notification.event.short_name = "Arizona North"
-        # Set times for testing
+        # Set times for testing (13:00 UTC = 6:00 MST)
         self.notification.match.time = datetime(2017, 11, 28, 13, 00, 59)
         self.notification.event.timezone_id = "America/Phoenix"
 
@@ -145,7 +145,7 @@ class TestMatchUpcomingNotification(unittest.TestCase):
             self.notification.fcm_notification.title == "TESTPRESENT Q1 Starting Soon"
         )
         match_regex = re.compile(
-            r"^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 13:00 MST.$"
+            r"^Arizona North Regional Quals 1: \d+, \d+, \d+ will play \d+, \d+, \d+, scheduled for 6:00 MST.$"
         )
         match = re.match(match_regex, self.notification.fcm_notification.body)
         assert match is not None


### PR DESCRIPTION
## Summary
- Notification times (schedule updated, event level starting, match upcoming) were displaying the raw UTC time but labeling it with the event's local timezone abbreviation
- For example, a match at 14:55 UTC at an event in CST would show "14:55 CST" instead of "08:55 CST"
- Now properly converts UTC to local time using `pytz.utc.localize().astimezone()` before formatting
- Fixed in all three notification types: `EventScheduleNotification`, `EventLevelNotification`, `MatchUpcomingNotification`

## Test plan
- [x] Updated existing timezone tests to assert correct UTC→local conversion
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)