### PR TITLE
dbquery: attempt to self-heal broken CachedQueryResult

### DIFF
--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -64,13 +64,16 @@ class CachedQueryResult(ndb.Model):
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True)
 
-    def _validate_result_properties(self) -> None:
+    def _validate_result_properties(self) -> bool:
         """
         Validates that all required properties on models in the result field are set.
         Logs an error with stack trace and model key if validation fails.
+
+        Returns True when one or more models have missing required properties,
+        otherwise False.
         """
         if self.result is None:
-            return
+            return False
 
         # Handle both single model and list of models
         models_to_check = []
@@ -108,6 +111,9 @@ class CachedQueryResult(ndb.Model):
                     f"CachedQueryResult key: {cached_result_key}\n"
                     f"Stack trace:\n{stack_trace}"
                 )
+                return True
+
+        return False
 
     def _pre_put_hook(self) -> None:
         """

--- a/src/backend/common/models/tests/cached_query_result_test.py
+++ b/src/backend/common/models/tests/cached_query_result_test.py
@@ -24,9 +24,10 @@ def test_validate_result_properties_all_set(ndb_stub, caplog) -> None:
             required_int=42,
         )
         result = CachedQueryResult(id="test_result", result=model)
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # No errors should be logged
+    assert has_missing_required_properties is False
     assert len(caplog.records) == 0
 
 
@@ -36,9 +37,10 @@ def test_validate_result_properties_missing(ndb_stub, caplog) -> None:
         model = DummyModelWithRequiredProps(id="test_model", required_prop="value")
         # required_int is not set (None)
         result = CachedQueryResult(id="test_result", result=model)
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # Should log an error for missing required_int
+    assert has_missing_required_properties is True
     assert len(caplog.records) == 1
     error_message = caplog.records[0].message
     assert "Required properties not set" in error_message
@@ -65,9 +67,10 @@ def test_validate_result_properties_list_all_valid(ndb_stub, caplog) -> None:
             ),
         ]
         result = CachedQueryResult(id="test_result", result=models)
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # No errors should be logged
+    assert has_missing_required_properties is False
     assert len(caplog.records) == 0
 
 
@@ -83,9 +86,10 @@ def test_validate_result_properties_list_with_invalid(ndb_stub, caplog) -> None:
             DummyModelWithRequiredProps(id="model2", required_prop="value2"),
         ]
         result = CachedQueryResult(id="test_result", result=models)
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # Should log an error for the invalid model
+    assert has_missing_required_properties is True
     assert len(caplog.records) == 1
     error_message = caplog.records[0].message
     assert "required_int" in error_message
@@ -95,9 +99,10 @@ def test_validate_result_properties_none_result(ndb_stub, caplog) -> None:
     """Test validation handles None result gracefully."""
     with caplog.at_level(logging.ERROR):
         result = CachedQueryResult(id="test_result", result=None)
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # No errors should be logged for None result
+    assert has_missing_required_properties is False
     assert len(caplog.records) == 0
 
 
@@ -161,9 +166,10 @@ def test_validate_result_properties_non_cached_model(ndb_stub, caplog) -> None:
     with caplog.at_level(logging.ERROR):
         # Store a plain dict (not a model) in result
         result = CachedQueryResult(id="test_result", result={"key": "value"})
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # No errors should be logged (non-models are skipped)
+    assert has_missing_required_properties is False
     assert len(caplog.records) == 0
 
 
@@ -179,7 +185,8 @@ def test_validate_result_properties_mixed_types(ndb_stub, caplog) -> None:
             {"key": "value"},  # Non-model object
         ]
         result = CachedQueryResult(id="test_result", result=models)
-        result._validate_result_properties()
+        has_missing_required_properties = result._validate_result_properties()
 
     # No errors should be logged (only valid models are checked)
+    assert has_missing_required_properties is False
     assert len(caplog.records) == 0

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -126,6 +126,19 @@ class CachedDatabaseQuery(
         with Span("{}._do_query".format(self.__class__.__name__)):
             cache_key = self.cache_key
             cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+
+            # Validate cached result for corruption and treat as cache miss if corrupted
+            if (
+                cached_query_result is not None
+                and cached_query_result._validate_result_properties()
+            ):
+                logging.error(
+                    "Corrupted cached result detected in _do_query; treating as cache miss. "
+                    "cache_key=%s",
+                    cache_key,
+                )
+                cached_query_result = None
+
             if cached_query_result is None:
                 query_result = yield self._query_async(*args, **kwargs)
                 if self.CACHE_WRITES_ENABLED:
@@ -139,6 +152,7 @@ class CachedDatabaseQuery(
                         )
                         logging.exception(e)
                 return query_result
+
             return cached_query_result.result
 
     @ndb.tasklet

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -6,12 +6,18 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.models.cached_model import CachedModel
 from backend.common.models.cached_query_result import CachedQueryResult
 from backend.common.queries.database_query import CachedDatabaseQuery, DatabaseQuery
 from backend.common.queries.dict_converters.converter_base import ConverterBase
 
 
 class DummyModel(ndb.Model):
+    int_prop = ndb.IntegerProperty()
+
+
+class DummyModelWithRequiredProp(CachedModel):
+    required_prop = ndb.StringProperty(required=True)
     int_prop = ndb.IntegerProperty()
 
 
@@ -69,6 +75,26 @@ class CachedDummyModelRangeQuery(
         models: Iterable[DummyModel] = yield DummyModel.query(
             DummyModel.int_prop >= min, DummyModel.int_prop <= max
         ).fetch_async()
+        return list(models)
+
+
+class CachedDummyModelWithRequiredPropQuery(
+    CachedDatabaseQuery[List[DummyModelWithRequiredProp], None]
+):
+    CACHE_KEY_FORMAT = "test_required_query_{min}_{max}"
+    DICT_CONVERTER = None
+    CACHE_WRITES_ENABLED = True
+
+    @ndb.tasklet
+    def _query_async(
+        self, min: int, max: int
+    ) -> Generator[Any, Any, List[DummyModelWithRequiredProp]]:
+        models: Iterable[DummyModelWithRequiredProp] = (
+            yield DummyModelWithRequiredProp.query(
+                DummyModelWithRequiredProp.int_prop >= min,
+                DummyModelWithRequiredProp.int_prop <= max,
+            ).fetch_async()
+        )
         return list(models)
 
 
@@ -267,3 +293,47 @@ def test_cached_dict_query_put_exception_logs_cache_key(caplog) -> None:
             result = query.fetch_dict(ApiMajorVersion.API_V3)
     assert len(result) == 3
     assert query.dict_cache_key(ApiMajorVersion.API_V3) in caplog.text
+
+
+def test_cached_query_corrupt_cache_treated_as_miss(caplog, monkeypatch) -> None:
+    # Create valid models in datastore
+    keys = ndb.put_multi(
+        [
+            DummyModelWithRequiredProp(
+                id=f"{i}", required_prop=f"value_{i}", int_prop=i
+            )
+            for i in range(0, 5)
+        ]
+    )
+    assert len(keys) == 5
+
+    query = CachedDummyModelWithRequiredPropQuery(min=0, max=2)
+    cache_key = query.cache_key
+
+    # First, populate the cache with valid data
+    result = query.fetch()
+    assert len(result) == 3
+
+    # Verify cache was populated
+    cached_result = CachedQueryResult.get_by_id(cache_key)
+    assert cached_result is not None
+
+    # Mock _validate_result_properties to return True (simulating corruption)
+    def mock_validate_corrupt(self):
+        return True
+
+    monkeypatch.setattr(
+        CachedQueryResult, "_validate_result_properties", mock_validate_corrupt
+    )
+
+    # Now fetch the query - should detect corruption and treat as cache miss
+    with caplog.at_level(logging.WARNING):
+        result = query.fetch()
+
+    # Should log a warning about corruption
+    assert "Corrupted cached result detected" in caplog.text
+    assert cache_key in caplog.text
+
+    # Should have refetched valid data from datastore
+    assert len(result) == 3
+    assert all(model.required_prop is not None for model in result)


### PR DESCRIPTION
Another case where we might encounter broken data, and try to self-heal it by treating it as a miss