### PR TITLE
time predictions: preserve scheduled time for first match of the day

### DIFF
--- a/src/backend/common/helpers/match_time_prediction_helper.py
+++ b/src/backend/common/helpers/match_time_prediction_helper.py
@@ -227,10 +227,17 @@ class MatchTimePredictionHelper:
                 if i == 0:
                     write_logs = False
                 # Use predicted = scheduled once we exhaust all unplayed matches on this day or move to a new comp level
-                match.predicted_time = nexus_predicted_time or cls.as_utc(
-                    none_throws(cls.as_local(match.time, timezone))
-                    + first_unplayed_timedelta
-                )
+                # Only use nexus prediction if we have actual match data from the current day to calibrate against.
+                if average_cycle_time is not None:
+                    match.predicted_time = nexus_predicted_time or cls.as_utc(
+                        none_throws(cls.as_local(match.time, timezone))
+                        + first_unplayed_timedelta
+                    )
+                else:
+                    # When no matches have been played today, use just the scheduled time
+                    match.predicted_time = cls.as_utc(
+                        none_throws(cls.as_local(match.time, timezone))
+                    )
                 continue
 
             # For the first iteration, base the predictions off the newest known actual start time
@@ -254,11 +261,15 @@ class MatchTimePredictionHelper:
                     seconds=int(average_cycle_time)
                 )
             else:
-                # Shift predicted time by the amouont the first match is behind
-                predicted = (
-                    none_throws(cls.as_local(match.time, timezone))
-                    + first_unplayed_timedelta
-                )
+                # When no matches have been played today, use just the scheduled time
+                # Otherwise, shift predicted time by the amount the first match is behind
+                if average_cycle_time is not None:
+                    predicted = (
+                        none_throws(cls.as_local(match.time, timezone))
+                        + first_unplayed_timedelta
+                    )
+                else:
+                    predicted = none_throws(cls.as_local(match.time, timezone))
 
             # Never predict a match to happen more than 15 minutes ahead of schedule or in the past
             # Except for playoff matches, which we allow to be any amount early (since all schedule

--- a/src/backend/common/helpers/tests/match_time_prediction_helper_test.py
+++ b/src/backend/common/helpers/tests/match_time_prediction_helper_test.py
@@ -111,8 +111,10 @@ def test_nexus_prediction_ignored_when_no_matches_played_today(
     }
 
     # Predict times with no matches played yet
+    # Use is_live=True to properly exercise the buggy code path where
+    # first_unplayed_timedelta is computed based on current time
     MatchTimePredictionHelper.predict_future_matches(
-        "2019nyny", [], matches, timezone, False, nexus_queue_info
+        "2019nyny", [], matches, timezone, True, nexus_queue_info
     )
 
     # The predicted time should equal the scheduled time (or very close to it),


### PR DESCRIPTION
For the first match, if nexus hits "on field" before opening ceremonies, the predictive time can be super early.

This diff fixes the bug where we keep the scheduled time for the first match of the day