### PR TITLE
Revert "dbquery: when falling back to datastore, skip cache"

### DIFF
--- a/src/backend/common/queries/account_query.py
+++ b/src/backend/common/queries/account_query.py
@@ -12,8 +12,4 @@ class AccountQuery(DatabaseQuery[Optional[Account], None]):
     def _query_async(self, email: str) -> Generator[Any, Any, Optional[Account]]:
         if not email:
             return None
-        return (
-            yield Account.query(Account.email == email).get_async(
-                use_cache=False, use_memcache=False
-            )
-        )
+        return (yield Account.query(Account.email == email).get_async())

--- a/src/backend/common/queries/api_auth_access_query.py
+++ b/src/backend/common/queries/api_auth_access_query.py
@@ -15,9 +15,5 @@ class ApiAuthAccessQuery(DatabaseQuery[List[ApiAuthAccess], None]):
     @typed_tasklet
     def _query_async(self, owner: Account) -> Generator[Any, Any, List[ApiAuthAccess]]:
         return (
-            yield (
-                ApiAuthAccess.query(ApiAuthAccess.owner == owner.key).fetch_async(
-                    use_cache=False, use_memcache=False
-                )
-            )
+            yield (ApiAuthAccess.query(ApiAuthAccess.owner == owner.key).fetch_async())
         )

--- a/src/backend/common/queries/award_query.py
+++ b/src/backend/common/queries/award_query.py
@@ -28,7 +28,7 @@ class EventAwardsQuery(CachedDatabaseQuery[List[Award], List[AwardDict]]):
     def _query_async(self, event_key: EventKey) -> Generator[Any, Any, List[Award]]:
         awards = yield Award.query(
             Award.event == ndb.Key(Event, event_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return awards
 
 
@@ -44,7 +44,7 @@ class TeamAwardsQuery(CachedDatabaseQuery[List[Award], List[AwardDict]]):
     def _query_async(self, team_key: TeamKey) -> Generator[Any, Any, List[Award]]:
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return awards
 
 
@@ -62,7 +62,7 @@ class TeamYearAwardsQuery(CachedDatabaseQuery[List[Award], List[AwardDict]]):
     ) -> Generator[Any, Any, List[Award]]:
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key), Award.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return awards
 
 
@@ -81,7 +81,7 @@ class TeamEventAwardsQuery(CachedDatabaseQuery[List[Award], List[AwardDict]]):
         awards = yield Award.query(
             Award.team_list == ndb.Key(Team, team_key),
             Award.event == ndb.Key(Event, event_key),
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return awards
 
 
@@ -107,5 +107,5 @@ class TeamEventTypeAwardsQuery(CachedDatabaseQuery[List[Award], List[AwardDict]]
             Award.team_list == ndb.Key(Team, team_key),
             Award.event_type_enum == event_type,
             Award.award_type_enum == award_type,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return awards

--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -29,11 +29,7 @@ class DistrictQuery(CachedDatabaseQuery[Optional[District], Optional[DistrictDic
     ) -> Generator[Any, Any, Optional[District]]:
         # Fetch all equivalent keys
         keys = RenamedDistricts.get_equivalent_keys(district_key)
-        districts = yield ndb.get_multi_async(
-            [ndb.Key(District, key) for key in keys],
-            use_cache=False,
-            use_memcache=False,
-        )
+        districts = yield ndb.get_multi_async([ndb.Key(District, key) for key in keys])
         for district in districts:
             if district:
                 # Return first key that exists
@@ -52,11 +48,9 @@ class DistrictsInYearQuery(CachedDatabaseQuery[List[District], List[DistrictDict
     @typed_tasklet
     def _query_async(self, year: Year) -> Generator[Any, Any, List[District]]:
         district_keys = yield District.query(District.year == year).fetch_async(
-            keys_only=True, use_cache=False, use_memcache=False
+            keys_only=True
         )
-        districts = yield ndb.get_multi_async(
-            district_keys, use_cache=False, use_memcache=False
-        )
+        districts = yield ndb.get_multi_async(district_keys)
         return list(districts)
 
 
@@ -76,10 +70,8 @@ class DistrictHistoryQuery(CachedDatabaseQuery[List[District], List[DistrictDict
             District.abbreviation.IN(
                 RenamedDistricts.get_equivalent_codes(abbreviation)
             )
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
-        districts = yield ndb.get_multi_async(
-            district_keys, use_cache=False, use_memcache=False
-        )
+        ).fetch_async(keys_only=True)
+        districts = yield ndb.get_multi_async(district_keys)
         return list(districts)
 
 
@@ -95,11 +87,9 @@ class TeamDistrictsQuery(CachedDatabaseQuery[List[District], List[DistrictDict]]
     def _query_async(self, team_key: TeamKey) -> Generator[Any, Any, List[District]]:
         district_team_keys = yield DistrictTeam.query(
             DistrictTeam.team == ndb.Key(Team, team_key)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
+        ).fetch_async(keys_only=True)
         districts = yield ndb.get_multi_async(
-            [ndb.Key(District, dtk.id().split("_")[0]) for dtk in district_team_keys],
-            use_cache=False,
-            use_memcache=False,
+            [ndb.Key(District, dtk.id().split("_")[0]) for dtk in district_team_keys]
         )
         return list(filter(lambda x: x is not None, districts))
 
@@ -122,9 +112,7 @@ class DistrictAbbreviationQuery(
 
         district_keys = yield District.query(
             District.abbreviation.IN(all_abbreviations)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
-        districts = yield ndb.get_multi_async(
-            district_keys, use_cache=False, use_memcache=False
-        )
+        ).fetch_async(keys_only=True)
+        districts = yield ndb.get_multi_async(district_keys)
 
         return list(sorted(districts, key=lambda x: x.year))

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -44,9 +44,7 @@ class EventListQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
 
     @typed_tasklet
     def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
-        events = yield Event.query(Event.year == year).fetch_async(
-            use_cache=False, use_memcache=False
-        )
+        events = yield Event.query(Event.year == year).fetch_async()
         return events
 
 
@@ -64,7 +62,7 @@ class DistrictEventsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
     ) -> Generator[Any, Any, List[Event]]:
         events = yield Event.query(
             Event.district_key == ndb.Key(District, district_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return events
 
 
@@ -80,7 +78,7 @@ class RegionalEventsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
     def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
         events = yield Event.query(
             Event.event_type_enum == EventType.REGIONAL, Event.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return events
 
 
@@ -96,10 +94,8 @@ class DistrictChampsInYearQuery(CachedDatabaseQuery[List[Event], List[EventDict]
     def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
         all_cmp_event_keys = yield Event.query(
             Event.year == year, Event.event_type_enum == EventType.DISTRICT_CMP
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
-        events = yield ndb.get_multi_async(
-            all_cmp_event_keys, use_cache=False, use_memcache=False
-        )
+        ).fetch_async(keys_only=True)
+        events = yield ndb.get_multi_async(all_cmp_event_keys)
         return list(events)
 
 
@@ -115,10 +111,8 @@ class CmpDivisionsInYearQuery(CachedDatabaseQuery[List[Event], List[EventDict]])
     def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
         all_cmp_event_keys = yield Event.query(
             Event.year == year, Event.event_type_enum == EventType.CMP_DIVISION
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
-        events = yield ndb.get_multi_async(
-            all_cmp_event_keys, use_cache=False, use_memcache=False
-        )
+        ).fetch_async(keys_only=True)
+        events = yield ndb.get_multi_async(all_cmp_event_keys)
         return list(events)
 
 
@@ -134,11 +128,9 @@ class TeamEventsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
     def _query_async(self, team_key: TeamKey) -> Generator[Any, Any, List[Event]]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         event_keys = map(lambda event_team: event_team.event, event_teams)
-        events = yield ndb.get_multi_async(
-            event_keys, use_cache=False, use_memcache=False
-        )
+        events = yield ndb.get_multi_async(event_keys)
         return list(events)
 
 
@@ -156,11 +148,9 @@ class TeamYearEventsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
     ) -> Generator[Any, Any, List[Event]]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key), EventTeam.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         event_keys = map(lambda event_team: event_team.event, event_teams)
-        events = yield ndb.get_multi_async(
-            event_keys, use_cache=False, use_memcache=False
-        )
+        events = yield ndb.get_multi_async(event_keys)
         return list(events)
 
 
@@ -178,7 +168,7 @@ class TeamYearEventTeamsQuery(CachedDatabaseQuery[List[EventTeam], None]):
     ) -> Generator[Any, Any, List[EventTeam]]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key), EventTeam.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return event_teams
 
 
@@ -192,14 +182,10 @@ class EventDivisionsQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
 
     @typed_tasklet
     def _query_async(self, event_key: EventKey) -> Generator[Any, Any, List[Event]]:
-        event = yield Event.get_by_id_async(
-            event_key, use_cache=False, use_memcache=False
-        )
+        event = yield Event.get_by_id_async(event_key)
         if event is None:
             return []
-        divisions = yield ndb.get_multi_async(
-            event.divisions, use_cache=False, use_memcache=False
-        )
+        divisions = yield ndb.get_multi_async(event.divisions)
         return list(divisions)
 
 
@@ -218,7 +204,7 @@ class LastSeasonEventQuery(CachedDatabaseQuery[Optional[Event], Optional[EventDi
                 Event.year == year, Event.event_type_enum.IN(SEASON_EVENT_TYPES)
             )
             .order(-Event.end_date)
-            .fetch_async(1, use_cache=False, use_memcache=False)
+            .fetch_async(1)
         )
         events = list(events)
         if not events:

--- a/src/backend/common/queries/favorite_query.py
+++ b/src/backend/common/queries/favorite_query.py
@@ -17,10 +17,4 @@ class FavoriteQuery(DatabaseQuery[List[Favorite], None]):
         self, account: Account, keys_only: bool = False
     ) -> Generator[Any, Any, List[Favorite]]:
         favorite_query = Favorite.query(ancestor=account.key)
-        return (
-            yield (
-                favorite_query.fetch_async(
-                    keys_only=keys_only, use_cache=False, use_memcache=False
-                )
-            )
-        )
+        return (yield (favorite_query.fetch_async(keys_only=keys_only)))

--- a/src/backend/common/queries/insight_query.py
+++ b/src/backend/common/queries/insight_query.py
@@ -29,7 +29,7 @@ class InsightsLeaderboardsYearQuery(
         insights = yield Insight.query(
             Insight.name.IN(insight_names),
             Insight.year == year,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return insights
 
 
@@ -50,7 +50,7 @@ class InsightsNotablesYearQuery(CachedDatabaseQuery[List[Insight], List[InsightD
         insights = yield Insight.query(
             Insight.name.IN(insight_names),
             Insight.year == year,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return insights
 
 
@@ -76,6 +76,6 @@ class DistrictInsightQuery(CachedDatabaseQuery[Insight, InsightDict]):
             Insight.name == insight_name,
             Insight.year == year,
             Insight.district_abbreviation == district_abbreviation,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
 
         return insight

--- a/src/backend/common/queries/match_query.py
+++ b/src/backend/common/queries/match_query.py
@@ -40,7 +40,7 @@ class EventMatchesQuery(CachedDatabaseQuery[List[Match], List[MatchDict]]):
     def _query_async(self, event_key: EventKey) -> Generator[Any, Any, List[Match]]:
         matches = yield Match.query(
             Match.event == ndb.Key(Event, event_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return matches
 
 
@@ -58,10 +58,8 @@ class TeamEventMatchesQuery(CachedDatabaseQuery[List[Match], List[MatchDict]]):
     ) -> Generator[Any, Any, List[Match]]:
         match_keys = yield Match.query(
             Match.team_key_names == team_key, Match.event == ndb.Key(Event, event_key)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
-        matches = yield ndb.get_multi_async(
-            match_keys, use_cache=False, use_memcache=False
-        )
+        ).fetch_async(keys_only=True)
+        matches = yield ndb.get_multi_async(match_keys)
         return list(filter(None, matches))
 
 
@@ -79,8 +77,6 @@ class TeamYearMatchesQuery(CachedDatabaseQuery[List[Match], List[MatchDict]]):
     ) -> Generator[Any, Any, List[Match]]:
         match_keys = yield Match.query(
             Match.team_key_names == team_key, Match.year == year
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
-        matches = yield ndb.get_multi_async(
-            match_keys, use_cache=False, use_memcache=False
-        )
+        ).fetch_async(keys_only=True)
+        matches = yield ndb.get_multi_async(match_keys)
         return list(filter(None, matches))

--- a/src/backend/common/queries/media_query.py
+++ b/src/backend/common/queries/media_query.py
@@ -30,7 +30,7 @@ class TeamSocialMediaQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key),
             Media.year == None,  # noqa: E711
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -46,7 +46,7 @@ class TeamMediaQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
     def _query_async(self, team_key: TeamKey) -> Generator[Any, Any, List[Media]]:
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -64,7 +64,7 @@ class TeamYearMediaQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
     ) -> Generator[Any, Any, List[Media]]:
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key), Media.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -81,7 +81,7 @@ class EventTeamsMediasQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
         year = int(event_key[:4])
         event_team_keys = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
+        ).fetch_async(keys_only=True)
         if not event_team_keys:
             return []
         team_keys = list(
@@ -92,7 +92,7 @@ class EventTeamsMediasQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
         )
         medias = yield Media.query(
             cast(ndb.KeyProperty, Media.references).IN(team_keys), Media.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -109,7 +109,7 @@ class EventTeamsPreferredMediasQuery(CachedDatabaseQuery[List[Media], List[Media
         year = int(event_key[:4])
         event_team_keys = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
+        ).fetch_async(keys_only=True)
         if not event_team_keys:
             return []
         team_keys = list(
@@ -121,7 +121,7 @@ class EventTeamsPreferredMediasQuery(CachedDatabaseQuery[List[Media], List[Media
         medias = yield Media.query(
             cast(ndb.KeyProperty, Media.preferred_references).IN(team_keys),
             Media.year == year,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -137,7 +137,7 @@ class EventMediasQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
     def _query_async(self, event_key: EventKey) -> Generator[Any, Any, List[Media]]:
         medias = yield Media.query(
             Media.references == ndb.Key(Event, event_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -156,7 +156,7 @@ class TeamTagMediasQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
         medias = yield Media.query(
             Media.references == ndb.Key(Team, team_key),
             Media.media_tag_enum == media_tag,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -177,7 +177,7 @@ class TeamYearTagMediasQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
             Media.references == team_ndb_key,
             Media.year == year,
             Media.media_tag_enum == media_tag,
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias
 
 
@@ -195,5 +195,5 @@ class MediaTypeYearQuery(CachedDatabaseQuery[List[Media], List[MediaDict]]):
     ) -> Generator[Any, Any, List[Media]]:
         medias = yield Media.query(
             Media.media_type_enum == media_type, Media.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return medias

--- a/src/backend/common/queries/mobile_client_query.py
+++ b/src/backend/common/queries/mobile_client_query.py
@@ -38,9 +38,7 @@ class MobileClientQuery(DatabaseQuery[List[MobileClient], None]):
             mobile_clients_query = mobile_clients_query.filter(
                 MobileClient.verified == True  # noqa: E712
             )
-        clients = yield mobile_clients_query.fetch_async(
-            use_cache=False, use_memcache=False
-        )
+        clients = yield mobile_clients_query.fetch_async()
         return list(clients)
 
     @staticmethod
@@ -51,6 +49,6 @@ class MobileClientQuery(DatabaseQuery[List[MobileClient], None]):
             messaging_id (string): The messaging_id to filter for.
         """
         to_delete = MobileClient.query(MobileClient.messaging_id == messaging_id).fetch(
-            keys_only=True, use_cache=False, use_memcache=False
+            keys_only=True
         )
         ndb.delete_multi(to_delete)

--- a/src/backend/common/queries/robot_query.py
+++ b/src/backend/common/queries/robot_query.py
@@ -23,7 +23,5 @@ class TeamRobotsQuery(CachedDatabaseQuery[List[Robot], List[RobotDict]]):
 
     @typed_tasklet
     def _query_async(self, team_key: TeamKey) -> Generator[Any, Any, List[Robot]]:
-        robots = yield Robot.query(Robot.team == ndb.Key(Team, team_key)).fetch_async(
-            use_cache=False, use_memcache=False
-        )
+        robots = yield Robot.query(Robot.team == ndb.Key(Team, team_key)).fetch_async()
         return robots

--- a/src/backend/common/queries/subscription_query.py
+++ b/src/backend/common/queries/subscription_query.py
@@ -17,10 +17,4 @@ class SubscriptionQuery(DatabaseQuery[List[Subscription], None]):
         self, account: Account, keys_only: bool = False
     ) -> Generator[Any, Any, List[Subscription]]:
         subscription_query = Subscription.query(ancestor=account.key)
-        return (
-            yield (
-                subscription_query.fetch_async(
-                    keys_only=keys_only, use_cache=False, use_memcache=False
-                )
-            )
-        )
+        return (yield (subscription_query.fetch_async(keys_only=keys_only)))

--- a/src/backend/common/queries/suggestion_query.py
+++ b/src/backend/common/queries/suggestion_query.py
@@ -37,10 +37,4 @@ class SuggestionQuery(DatabaseQuery[List[Suggestion], None]):
             params.append(Suggestion.author == author.key)
         if reviewer:
             params.append(Suggestion.reviewer == reviewer.key)
-        return (
-            yield (
-                Suggestion.query(*params).fetch_async(
-                    keys_only=keys_only, use_cache=False, use_memcache=False
-                )
-            )
-        )
+        return (yield (Suggestion.query(*params).fetch_async(keys_only=keys_only)))

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -52,7 +52,7 @@ class TeamListQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
         teams = (
             yield Team.query(Team.team_number >= start, Team.team_number < end)
             .order(Team.team_number)
-            .fetch_async(use_cache=False, use_memcache=False)
+            .fetch_async()
         )
         return list(teams)
 
@@ -68,7 +68,7 @@ class TeamListYearQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
     @typed_tasklet
     def _query_async(self, year: Year, page: int) -> List[Team]:
         event_team_keys_future = EventTeam.query(EventTeam.year == year).fetch_async(
-            keys_only=True, use_cache=False, use_memcache=False
+            keys_only=True
         )
         teams_future = TeamListQuery(page=page).fetch_async()
 
@@ -97,11 +97,9 @@ class DistrictTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
     ) -> Generator[Any, Any, List[Team]]:
         district_teams = yield DistrictTeam.query(
             DistrictTeam.district_key == ndb.Key(District, district_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         team_keys = map(lambda district_team: district_team.team, district_teams)
-        teams = yield ndb.get_multi_async(
-            team_keys, use_cache=False, use_memcache=False
-        )
+        teams = yield ndb.get_multi_async(team_keys)
         return list(teams)
 
 
@@ -117,7 +115,7 @@ class RegionalTeamsQuery(CachedDatabaseQuery[List[ndb.Key], List[str]]):
     def _query_async(self, year: Year) -> Generator[Any, Any, List[ndb.Key]]:
         regional_teams = yield RegionalPoolTeam.query(
             RegionalPoolTeam.year == year
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         team_keys = map(lambda t: t.team, regional_teams)
         return list(team_keys)
 
@@ -134,14 +132,12 @@ class EventTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
     def _query_async(self, event_key: EventKey) -> Generator[Any, Any, List[Team]]:
         event_team_keys = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
+        ).fetch_async(keys_only=True)
         team_keys = map(
             lambda event_team_key: ndb.Key(Team, event_team_key.id().split("_")[1]),
             event_team_keys,
         )
-        teams = yield ndb.get_multi_async(
-            team_keys, use_cache=False, use_memcache=False
-        )
+        teams = yield ndb.get_multi_async(team_keys)
         return list(teams)
 
 
@@ -157,7 +153,7 @@ class EventEventTeamsQuery(CachedDatabaseQuery[List[EventTeam], None]):
     def _query_async(self, event_key: EventKey) -> Generator[Any, Any, List[EventTeam]]:
         event_teams = yield EventTeam.query(
             EventTeam.event == ndb.Key(Event, event_key)
-        ).fetch_async(use_cache=False, use_memcache=False)
+        ).fetch_async()
         return event_teams
 
 
@@ -173,6 +169,6 @@ class TeamParticipationQuery(CachedDatabaseQuery[Set[Year], None]):
     def _query_async(self, team_key: TeamKey) -> Generator[Any, Any, Set[Year]]:
         event_teams = yield EventTeam.query(
             EventTeam.team == ndb.Key(Team, team_key)
-        ).fetch_async(keys_only=True, use_cache=False, use_memcache=False)
+        ).fetch_async(keys_only=True)
         years = map(lambda event_team: int(event_team.id()[:4]), event_teams)
         return set(years)


### PR DESCRIPTION
Reverts the-blue-alliance/the-blue-alliance#9280

Now that we have https://github.com/the-blue-alliance/the-blue-alliance/pull/9287, I don't think we actually need this (since this was an incorrect theory)