### PR TITLE
RFP: Make api-track-call queue resilient to instance scaling spikes

### DIFF
--- a/src/queue.yaml
+++ b/src/queue.yaml
@@ -9,8 +9,11 @@ queue:
 
 - name: api-track-call
   rate: 500/s
+  max_concurrent_requests: 5
   retry_parameters:
-    task_retry_limit: 0
+    task_age_limit: 1h
+    min_backoff_seconds: 10
+    max_backoff_seconds: 300
 
 - name: datafeed
   rate: 5/s


### PR DESCRIPTION
## Summary
- Add `max_concurrent_requests: 5` so tasks sit in the queue instead of being dispatched to unavailable instances
- Replace `task_retry_limit: 0` with `task_age_limit: 1h` so failed tasks retry instead of being permanently dropped
- Add exponential backoff (10s min, 300s max) for retries

## Problem
During traffic spikes, `api-track-call` dispatches up to 500 tasks/sec with no concurrency limit. When `py3-tasks-io` can't scale fast enough, GAE's router rejects tasks with "Request was aborted after waiting too long to attempt to service your request" (500). With `task_retry_limit: 0`, these tasks are permanently lost.

This also generates alert noise — the 500s are infrastructure-level (the request never reaches application code), but they still show up in error logs.

## Solution
- **`max_concurrent_requests: 5`** — Only 5 tracking tasks in-flight at once. The rest queue up. This leaves headroom for other queues (`datafeed`, `nexus_queue_status`, etc.) that share `py3-tasks-io` (which has `max_concurrent_requests: 10` per instance, currently 3 instances = 30 total capacity).
- **`task_age_limit: 1h`** — Retry failed tasks for up to 1 hour with exponential backoff, then drop. No retry count limit.
- **Backoff 10s→300s** — Gives instances time to scale up between retries.

## RFP
Looking for review from someone familiar with Cloud Tasks queue configuration. Questions to consider:
- Is `max_concurrent_requests: 5` the right balance, given other queues on `py3-tasks-io`?
- Is 1h age limit appropriate for tracking data?
- Any concern about queue depth during sustained high API traffic?

## Test plan
- [ ] Deploy queue config and monitor during peak traffic
- [ ] Verify 500s on `deferred_track_call_apiv3` decrease
- [ ] Verify tracking data is not lost during scaling events

🤖 Generated with [Claude Code](https://claude.com/claude-code)