### PR TITLE
pwa: Add zebra striping to tables

### DIFF
--- a/pwa/app/components/ui/table.tsx
+++ b/pwa/app/components/ui/table.tsx
@@ -62,7 +62,7 @@ const TableRow = forwardRef<
   <tr
     ref={ref}
     className={cn(
-      `border-b transition-colors hover:bg-muted/50
+      `border-b transition-colors odd:bg-muted/30 hover:bg-muted/50
       data-[state=selected]:bg-muted`,
       className,
     )}


### PR DESCRIPTION
## Summary

- Adds subtle alternating row backgrounds (`odd:bg-muted/30`) to the shared `TableRow` component
- Hover effect (`hover:bg-muted/50`) remains visible on both odd and even rows
- Applies automatically to all tables using the shared UI component (rankings, event lists, team lists, etc.)

## Screenshot Pages

- /events/2024
- /event/2024mil
- /team/254/2024

## Test plan

- [ ] Verify zebra striping is visible on event list, rankings, and team list tables
- [ ] Verify hover effect is still noticeable on both striped and non-striped rows
- [ ] Verify dark mode looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)