### PR TITLE
fix type hints for cached API responses

### DIFF
--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from flask import Response
+from flask import abort, Response
 
 from backend.api.handlers.decorators import api_authenticated, validate_keys
 from backend.api.handlers.helpers.model_properties import (
@@ -89,6 +89,8 @@ def district_rankings(district_key: DistrictKey) -> Response:
     track_call_after_response("district/rankings", district_key)
 
     district = DistrictQuery(district_key=district_key).fetch()
+    if district is None:
+        abort(404)
     return profiled_jsonify(district.rankings)
 
 
@@ -142,6 +144,8 @@ def district_advancement(district_key: DistrictKey) -> Response:
     track_call_after_response("district/advancement", district_key)
 
     district = DistrictQuery(district_key=district_key).fetch()
+    if district is None:
+        abort(404)
     return profiled_jsonify(district.advancement)
 
 

--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from flask import Response
+from flask import abort, Response
 
 from backend.api.handlers.decorators import api_authenticated, validate_keys
 from backend.api.handlers.helpers.add_alliance_status import add_alliance_status
@@ -39,6 +39,8 @@ def event(event_key: EventKey, model_type: Optional[ModelType] = None) -> Respon
     track_call_after_response("event", event_key, model_type)
 
     event = EventQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
+    if event is None:
+        abort(404)
     if model_type is not None:
         event = filter_event_properties([event], model_type)[0]
     return profiled_jsonify(event)
@@ -161,14 +163,17 @@ def event_teams_statuses(event_key: EventKey) -> Response:
         status = event_team.status
         if status is not None:
             status_strings = event_team.status_strings
-            status.update(
-                {
+            status_dict = status.copy()
+            status_dict.update(
+                {  # pyre-ignore[55]
                     "alliance_status_str": status_strings["alliance"],
                     "playoff_status_str": status_strings["playoff"],
                     "overall_status_str": status_strings["overall"],
                 }
             )
-        statuses[event_team.team.id()] = status
+            statuses[event_team.team.id()] = status_dict
+        else:
+            statuses[event_team.team.id()] = status
     return profiled_jsonify(statuses)
 
 
@@ -228,6 +233,8 @@ def event_playoff_advancement(event_key: EventKey) -> Response:
     event_future = EventQuery(event_key).fetch_async()
     matches_future = EventMatchesQuery(event_key).fetch_async()
     event = event_future.get_result()
+    if event is None:
+        abort(404)
     event.prep_details()
     matches = matches_future.get_result()
 

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from flask import Response
+from flask import abort, Response
 
 from backend.api.handlers.decorators import api_authenticated, validate_keys
 from backend.api.handlers.helpers.model_properties import (
@@ -26,6 +26,8 @@ def match(match_key: MatchKey, model_type: Optional[ModelType] = None) -> Respon
     track_call_after_response("match", match_key, model_type)
 
     match = MatchQuery(match_key=match_key).fetch_dict(ApiMajorVersion.API_V3)
+    if match is None:
+        abort(404)
     if model_type is not None:
         match = filter_match_properties([match], model_type)[0]
     return profiled_jsonify(match)

--- a/src/backend/api/handlers/team.py
+++ b/src/backend/api/handlers/team.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from flask import Response
+from flask import abort, Response
 
 from backend.api.handlers.decorators import (
     api_authenticated,
@@ -62,6 +62,8 @@ def team(team_key: TeamKey, model_type: Optional[ModelType] = None) -> Response:
     track_call_after_response("team", team_key, model_type)
 
     team = TeamQuery(team_key=team_key).fetch_dict(ApiMajorVersion.API_V3)
+    if team is None:
+        abort(404)
     if model_type is not None:
         team = filter_team_properties([team], model_type)[0]
     return profiled_jsonify(team)
@@ -190,14 +192,17 @@ def team_events_statuses_year(team_key: TeamKey, year: int) -> Response:
         status = event_team.status
         if status is not None:
             status_strings = event_team.status_strings
-            status.update(
-                {
+            status_dict = status.copy()
+            status_dict.update(
+                {  # pyre-ignore[55]
                     "alliance_status_str": status_strings["alliance"],
                     "playoff_status_str": status_strings["playoff"],
                     "overall_status_str": status_strings["overall"],
                 }
             )
-        statuses[event_team.event.id()] = status
+            statuses[event_team.event.id()] = status_dict
+        else:
+            statuses[event_team.event.id()] = status
     return profiled_jsonify(statuses)
 
 

--- a/src/backend/common/helpers/insights_districts_helper.py
+++ b/src/backend/common/helpers/insights_districts_helper.py
@@ -292,11 +292,11 @@ class InsightsDistrictsHelper:
         )
 
 
-def get_state_or_country_if_international(team: Team) -> str:
-    if team.country not in ["USA", "Canada"]:
-        return team.country
+def get_state_or_country_if_international(team_or_event: Team | Event) -> str:
+    if team_or_event.country not in ["USA", "Canada"]:
+        return team_or_event.country
 
-    return state_short_code_to_full_name(team.state_prov)
+    return state_short_code_to_full_name(team_or_event.state_prov)
 
 
 def state_short_code_to_full_name(state_short_code: str) -> str:

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -56,7 +56,8 @@ class DatabaseQuery(abc.ABC, Generic[QueryReturn, DictQueryReturn]):
             return query_result
 
     def fetch_dict(self, version: ApiMajorVersion) -> DictQueryReturn:
-        return self.fetch_dict_async(version).get_result()
+        fut: TypedFuture[DictQueryReturn] = self.fetch_dict_async(version)
+        return fut.get_result()
 
     @ndb.tasklet
     def fetch_dict_async(
@@ -68,7 +69,9 @@ class DatabaseQuery(abc.ABC, Generic[QueryReturn, DictQueryReturn]):
 
 
 class CachedDatabaseQuery(
-    DatabaseQuery, Generic[QueryReturn, DictQueryReturn], metaclass=abc.ABCMeta
+    DatabaseQuery[QueryReturn, DictQueryReturn],
+    Generic[QueryReturn, DictQueryReturn],
+    metaclass=abc.ABCMeta,
 ):
     DATABASE_QUERY_VERSION = 5
     BASE_CACHE_KEY_FORMAT: str = (

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -66,21 +66,16 @@ class TeamListYearQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):
         super().__init__(year=year, page=page)
 
     @typed_tasklet
-    def _query_async(self, year: Year, page: int) -> List[Team]:
-        event_team_keys_future = EventTeam.query(EventTeam.year == year).fetch_async(
-            keys_only=True
+    def _query_async(self, year: Year, page: int) -> Generator[Any, Any, List[Team]]:
+        event_team_keys, teams = yield (
+            EventTeam.query(EventTeam.year == year).fetch_async(keys_only=True),
+            TeamListQuery(page=page).fetch_async(),
         )
-        teams_future = TeamListQuery(page=page).fetch_async()
 
-        year_team_keys = set()
-        for et_key in event_team_keys_future.get_result():
-            team_key = et_key.id().split("_")[1]
-            year_team_keys.add(team_key)
+        year_team_keys = {et_key.id().split("_")[1] for et_key in event_team_keys}
 
-        teams = filter(
-            lambda team: team.key.id() in year_team_keys, teams_future.get_result()
-        )
-        return list(teams)
+        filtered_teams = filter(lambda team: team.key.id() in year_team_keys, teams)
+        return list(filtered_teams)
 
 
 class DistrictTeamsQuery(CachedDatabaseQuery[List[Team], List[TeamDict]]):

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -218,7 +218,8 @@ def get_team_info(resp_data: str) -> TeamInfo:
     home_cmp = soup.find(id="team-home-cmp")
     hof = soup.find(id="team-hof")
     district = soup.find(id="team-district")
-    district = district.find("a") if district else None
+    if district is not None and district.name != "a":
+        district = district.find("a")
     social_media = soup.find(id="team-social-media")
     social_media = (
         [


### PR DESCRIPTION
This was a bug in how the DB query types would get propagated, resulting in some query return values coming back as `Any`.

This will fix up the type propagation and the resulting errors that were exposed.