### PR TITLE
Fix: Can't Scroll in the Event Year List Dropdown

### DIFF
--- a/src/backend/web/static/css/less_css/less/tba/tba_dropdown_menu.less
+++ b/src/backend/web/static/css/less_css/less/tba/tba_dropdown_menu.less
@@ -13,6 +13,6 @@
     max-height: 500px;
   }
   @media (min-height: 750px) {
-    max-height: none;
+    max-height: 80vh;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the max-height for the .tba-dropdown-menu-limited class in large viewports (≥750px height) from none to 80vh, ensuring the dropdown never overflows the viewport.

## Motivation and Context
On taller screens, the year/event dropdown menu had no height limit (max-height: none), which could cause it to overflow the viewport bounds. This fix caps it at 80% of the viewport height, maintaining scrollability without overflow.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
