### PR TITLE
Remove APIv2 from APIDocs Sidebar

### DIFF
--- a/src/backend/web/templates/apidocs_overview.html
+++ b/src/backend/web/templates/apidocs_overview.html
@@ -19,8 +19,6 @@
               <li><a class="smooth-scroll" href="#trusted">Write API</a></li>
               <li><a class="smooth-scroll" href="#archives">Data Archives</a></li>
               <li><a class="smooth-scroll" href="#guidelines">Developer Guidelines</a></li>
-              <li><hr></li>
-              <li><a class="smooth-scroll" href="#apiv2">[Deprecated] Read API (v2)</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Description

Corrects a broken APIv2 navigation link by removing it. APIv2 docs were removed some time ago.

## Motivation and Context
Removing broken navigation link.

## How Has This Been Tested?
YOLO - 2 line HTML template change. Passed in-IDE HTML validation.

## Screenshots (if appropriate):
Before: 
<img width="409" height="488" alt="image" src="https://github.com/user-attachments/assets/ce0462d7-2f1d-4969-b7ee-693caf02b1b0" />

## Screenshot Pages

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
