### PR TITLE
Pass keys instead of full models for tbans

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -97,16 +97,17 @@ class TBANSHelper:
     """
 
     @classmethod
-    def alliance_selection(cls, event: Event, user_id: str | None = None) -> None:
+    def alliance_selection(cls, event_key: str) -> None:
+        event = Event.get_by_id(event_key)
+        if event is None:
+            return
+
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.ALLIANCE_SELECTION in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], AllianceSelectionNotification(event))
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    event, NotificationType.ALLIANCE_SELECTION
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                event, NotificationType.ALLIANCE_SELECTION
+            )
 
         # Send to Team subscribers
         # Key is a team key, value is a future
@@ -118,14 +119,11 @@ class TBANSHelper:
                 except Exception:
                     continue
 
-                if user_id:
-                    cls._send([user_id], AllianceSelectionNotification(event, team))
-                else:
-                    team_subscriptions_futures[team_key] = (
-                        Subscription.subscriptions_for_team(
-                            team, NotificationType.ALLIANCE_SELECTION
-                        )
+                team_subscriptions_futures[team_key] = (
+                    Subscription.subscriptions_for_team(
+                        team, NotificationType.ALLIANCE_SELECTION
                     )
+                )
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
@@ -144,28 +142,18 @@ class TBANSHelper:
                 AllianceSelectionNotification(event, team),
             )
 
-    """
-    Dispatch Awards notifications to users subscribed to Event or Team Award notifications.
-
-    Args:
-        event (models.event.Event): The Event to query Subscriptions for.
-        user_id (string): A user ID to only send notifications for - used ONLY for TBANS Admin testing.
-
-    Returns:
-        list (string): List of user IDs with Subscriptions to the given Event/notification type.
-    """
-
     @classmethod
-    def awards(cls, event: Event, user_id: str | None = None) -> None:
+    def awards(cls, event_key: str) -> None:
+        event = Event.get_by_id(event_key)
+        if event is None:
+            return
+
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.AWARDS in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], AwardsNotification(event))
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    event, NotificationType.AWARDS
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                event, NotificationType.AWARDS
+            )
         # Send to Team subscribers
         # Key is a team key, value is a future
         team_subscriptions_futures = {}
@@ -177,9 +165,7 @@ class TBANSHelper:
                 if not team:
                     continue
 
-                if user_id:
-                    cls._send([user_id], AwardsNotification(event, team))
-                elif team.key_name:
+                if team.key_name:
                     team_subscriptions_futures[team.key_name] = (
                         Subscription.subscriptions_for_team(
                             team, NotificationType.AWARDS
@@ -231,16 +217,17 @@ class TBANSHelper:
                     cls._defer_webhook(client, notification)
 
     @classmethod
-    def event_level(cls, match: Match, user_id: str | None = None) -> None:
+    def event_level(cls, match_key: str) -> None:
+        match = Match.get_by_id(match_key)
+        if match is None:
+            return
+
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.LEVEL_STARTING in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], EventLevelNotification(match))
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    match.event.get(), NotificationType.LEVEL_STARTING
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                match.event.get(), NotificationType.LEVEL_STARTING
+            )
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
@@ -248,16 +235,17 @@ class TBANSHelper:
             )
 
     @classmethod
-    def event_schedule(cls, event: Event, user_id: str | None = None) -> None:
+    def event_schedule(cls, event_key: str) -> None:
+        event = Event.get_by_id(event_key)
+        if event is None:
+            return
+
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.SCHEDULE_UPDATED in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], EventScheduleNotification(event))
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    event, NotificationType.SCHEDULE_UPDATED
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                event, NotificationType.SCHEDULE_UPDATED
+            )
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
@@ -269,7 +257,6 @@ class TBANSHelper:
     def match_score(
         cls,
         match_key: str,
-        user_id: str | None = None,
         is_score_breakdown_update: bool = False,
     ) -> None:
         """Dispatch match score notifications.
@@ -280,7 +267,6 @@ class TBANSHelper:
 
         Args:
             match_key: The string key name of the Match (e.g. "2024ct_qm1").
-            user_id: Optional user ID to restrict notifications to (for testing).
             is_score_breakdown_update: When True, this notification is being sent
                 because a score breakdown was added to a match whose score was
                 already sent. Only webhook clients are notified and upcoming
@@ -288,7 +274,6 @@ class TBANSHelper:
         """
         match = Match.get_by_id(match_key)
         if match is None:
-            logging.warning(f"match_score: Match {match_key} not found in Datastore")
             return
 
         event = match.event.get()
@@ -304,12 +289,9 @@ class TBANSHelper:
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.MATCH_SCORE in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], MatchScoreNotification(match), mode)
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    event, NotificationType.MATCH_SCORE
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                event, NotificationType.MATCH_SCORE
+            )
 
         # Send to Team subscribers
         # Key is a team key, value is a future
@@ -320,9 +302,7 @@ class TBANSHelper:
                 if not team:
                     continue
 
-                if user_id:
-                    cls._send([user_id], MatchScoreNotification(match, team), mode)
-                elif team.key_name:
+                if team.key_name:
                     team_subscriptions_futures[team.key_name] = (
                         Subscription.subscriptions_for_team(
                             team, NotificationType.MATCH_SCORE
@@ -332,12 +312,9 @@ class TBANSHelper:
         # Send to Match subscribers
         match_subscriptions_future = None
         if NotificationType.MATCH_SCORE in ENABLED_MATCH_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], MatchScoreNotification(match), mode)
-            else:
-                match_subscriptions_future = Subscription.subscriptions_for_match(
-                    match, NotificationType.MATCH_SCORE
-                )
+            match_subscriptions_future = Subscription.subscriptions_for_match(
+                match, NotificationType.MATCH_SCORE
+            )
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
@@ -397,19 +374,20 @@ class TBANSHelper:
             return
 
         next_match = next_matches.pop()
-        cls.schedule_upcoming_match(next_match, user_id)
+        cls.schedule_upcoming_match(next_match.key_name)
 
     @classmethod
-    def match_upcoming(cls, match: Match, user_id: str | None = None) -> None:
+    def match_upcoming(cls, match_key: str) -> None:
+        match = Match.get_by_id(match_key)
+        if match is None:
+            return
+
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.UPCOMING_MATCH in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], MatchUpcomingNotification(match))
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    match.event.get(), NotificationType.UPCOMING_MATCH
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                match.event.get(), NotificationType.UPCOMING_MATCH
+            )
 
         # Send to Team subscribers
         # Key is a team key, value is a future
@@ -420,9 +398,7 @@ class TBANSHelper:
                 if not team:
                     continue
 
-                if user_id:
-                    cls._send([user_id], MatchUpcomingNotification(match, team))
-                elif team.key_name:
+                if team.key_name:
                     team_subscriptions_futures[team.key_name] = (
                         Subscription.subscriptions_for_team(
                             team, NotificationType.UPCOMING_MATCH
@@ -432,12 +408,9 @@ class TBANSHelper:
         # Send to Match subscribers
         match_subscriptions_future = None
         if NotificationType.UPCOMING_MATCH in ENABLED_MATCH_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], MatchUpcomingNotification(match))
-            else:
-                match_subscriptions_future = Subscription.subscriptions_for_match(
-                    match, NotificationType.UPCOMING_MATCH
-                )
+            match_subscriptions_future = Subscription.subscriptions_for_match(
+                match, NotificationType.UPCOMING_MATCH
+            )
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
@@ -464,19 +437,20 @@ class TBANSHelper:
 
         # Send LEVEL_STARTING for the first match of a new type
         if match.set_number == 1 and match.match_number == 1:
-            cls.event_level(match, user_id)
+            cls.event_level(match_key)
 
     @classmethod
-    def match_video(cls, match: Match, user_id: str | None = None) -> None:
+    def match_video(cls, match_key: str) -> None:
+        match = Match.get_by_id(match_key)
+        if match is None:
+            return
+
         # Send to Event subscribers
         event_subscriptions_future = None
         if NotificationType.MATCH_VIDEO in ENABLED_EVENT_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], MatchVideoNotification(match))
-            else:
-                event_subscriptions_future = Subscription.subscriptions_for_event(
-                    match.event.get(), NotificationType.MATCH_VIDEO
-                )
+            event_subscriptions_future = Subscription.subscriptions_for_event(
+                match.event.get(), NotificationType.MATCH_VIDEO
+            )
 
         # Send to Team subscribers
         # Key is a team key, value is a future
@@ -487,9 +461,7 @@ class TBANSHelper:
                 if not team:
                     continue
 
-                if user_id:
-                    cls._send([user_id], MatchVideoNotification(match, team))
-                elif team.key_name:
+                if team.key_name:
                     team_subscriptions_futures[team.key_name] = (
                         Subscription.subscriptions_for_team(
                             team, NotificationType.MATCH_VIDEO
@@ -499,12 +471,9 @@ class TBANSHelper:
         # Send to Match subscribers
         match_subscriptions_future = None
         if NotificationType.MATCH_VIDEO in ENABLED_MATCH_NOTIFICATIONS:
-            if user_id:
-                cls._send([user_id], MatchVideoNotification(match))
-            else:
-                match_subscriptions_future = Subscription.subscriptions_for_match(
-                    match, NotificationType.MATCH_VIDEO
-                )
+            match_subscriptions_future = Subscription.subscriptions_for_match(
+                match, NotificationType.MATCH_VIDEO
+            )
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
@@ -582,15 +551,16 @@ class TBANSHelper:
         return webhook_request.send()
 
     @classmethod
-    def schedule_upcoming_match(cls, match: Match, user_id: str | None = None) -> None:
+    def schedule_upcoming_match(cls, match_key: str) -> None:
         from google.appengine.api import taskqueue
+
+        match = Match.get_by_id(match_key)
+        if match is None:
+            return
 
         queue = taskqueue.Queue("push-notifications")
 
-        if not match.key_name:
-            return
-
-        task_name = "{}_match_upcoming".format(match.key_name)
+        task_name = "{}_match_upcoming".format(match_key)
         # Cancel any previously-scheduled `match_upcoming` notifications for this match
         queue.delete_tasks(taskqueue.Task(name=task_name))
 
@@ -600,13 +570,12 @@ class TBANSHelper:
         # If we know when our match is starting, schedule to send Xmins before start of match.
         # Otherwise, send immediately.
         if match.time is None or match.time + MATCH_UPCOMING_MINUTES <= now:
-            cls.match_upcoming(match, user_id)
+            cls.match_upcoming(match_key)
         else:
             try:
                 defer_safe(
                     cls.match_upcoming,
-                    match,
-                    user_id,
+                    match_key,
                     _name=task_name,
                     _target="py3-tasks-io",
                     _queue="push-notifications",
@@ -617,9 +586,11 @@ class TBANSHelper:
                 pass
 
     @classmethod
-    def schedule_upcoming_matches(
-        cls, event: Event, user_id: str | None = None
-    ) -> None:
+    def schedule_upcoming_matches(cls, event_key: str) -> None:
+        event = Event.get_by_id(event_key)
+        if event is None:
+            return
+
         # Schedule `match_upcoming` notifications for Match 1 and Match 2
         # Match 3 (and onward) will be dispatched after Match 1 (or Match N - 2) has been played
         if not event.matches:
@@ -638,7 +609,7 @@ class TBANSHelper:
             return
 
         for match in next_matches:
-            cls.schedule_upcoming_match(match, user_id)
+            cls.schedule_upcoming_match(match.key_name)
 
     @staticmethod
     def verify_webhook(url: str, secret: str) -> str:

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -144,19 +144,16 @@ class TestTBANSHelper(unittest.TestCase):
         # Should be the same object
         assert app_one == app_two
 
+    def test_alliance_selection_event_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.alliance_selection("2020nonexistent")
+            mock_send.assert_not_called()
+
     def test_alliance_selection_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.alliance_selection(self.event)
+            TBANSHelper.alliance_selection(self.event.key_name)
             mock_send.assert_not_called()
-
-    def test_alliance_selection_user_id(self):
-        # Test send called with user id
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.alliance_selection(self.event, "user_id")
-            mock_send.assert_called_once()
-            user_id = mock_send.call_args[0][0]
-            assert user_id == ["user_id"]
 
     def test_alliance_selection(self):
         # Insert a Subscription for this Event and these Teams so we call to send
@@ -188,7 +185,7 @@ class TestTBANSHelper(unittest.TestCase):
             alliance_selections=[{"declines": [], "picks": ["frc7332"]}],
         ).put()
 
-        TBANSHelper.alliance_selection(self.event)
+        TBANSHelper.alliance_selection(self.event.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 2
 
@@ -214,19 +211,16 @@ class TestTBANSHelper(unittest.TestCase):
             assert team_notification.event == self.event
             assert team_notification.team == self.team
 
+    def test_awards_event_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.awards("2020nonexistent")
+            mock_send.assert_not_called()
+
     def test_awards_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.awards(self.event)
+            TBANSHelper.awards(self.event.key_name)
             mock_send.assert_not_called()
-
-    def test_awards_user_id(self):
-        # Test send called with user id
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.awards(self.event, "user_id")
-            mock_send.assert_called_once()
-            user_id = mock_send.call_args[0][0]
-            assert user_id == ["user_id"]
 
     def test_awards(self):
         # Insert some Awards for some Teams
@@ -276,7 +270,7 @@ class TestTBANSHelper(unittest.TestCase):
             notification_types=[NotificationType.AWARDS],
         ).put()
 
-        TBANSHelper.awards(self.event)
+        TBANSHelper.awards(self.event.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 3
 
@@ -388,20 +382,16 @@ class TestTBANSHelper(unittest.TestCase):
             notification = mock_send_webhook.call_args[0][1]
             assert isinstance(notification, BroadcastNotification)
 
+    def test_event_level_match_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.event_level("2020nonexistent_qm99")
+            mock_send.assert_not_called()
+
     def test_event_level_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.event_level(self.match)
+            TBANSHelper.event_level(self.match.key_name)
             mock_send.assert_not_called()
-
-    def test_event_level_user_id(self):
-        # Test send called with user id
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.event_level(self.match, "user_id")
-            mock_send.assert_called()
-            assert len(mock_send.call_args_list) == 1
-            for call in mock_send.call_args_list:
-                assert call[0][0] == ["user_id"]
 
     def test_event_level(self):
         # Insert a Subscription for this Event
@@ -413,7 +403,7 @@ class TestTBANSHelper(unittest.TestCase):
             notification_types=[NotificationType.LEVEL_STARTING],
         ).put()
 
-        TBANSHelper.event_level(self.match)
+        TBANSHelper.event_level(self.match.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 1
 
@@ -430,20 +420,16 @@ class TestTBANSHelper(unittest.TestCase):
             assert notification.match == self.match
             assert notification.event == self.event
 
+    def test_event_schedule_event_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.event_schedule("2020nonexistent")
+            mock_send.assert_not_called()
+
     def test_event_schedule_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.event_schedule(self.event)
+            TBANSHelper.event_schedule(self.event.key_name)
             mock_send.assert_not_called()
-
-    def test_event_schedule_user_id(self):
-        # Test send called with user id
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.event_schedule(self.event, "user_id")
-            mock_send.assert_called()
-            assert len(mock_send.call_args_list) == 1
-            for call in mock_send.call_args_list:
-                assert call[0][0] == ["user_id"]
 
     def test_event_schedule(self):
         # Insert a Subscription for this Event
@@ -455,7 +441,7 @@ class TestTBANSHelper(unittest.TestCase):
             notification_types=[NotificationType.SCHEDULE_UPDATED],
         ).put()
 
-        TBANSHelper.event_schedule(self.event)
+        TBANSHelper.event_schedule(self.event.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 1
 
@@ -471,39 +457,16 @@ class TestTBANSHelper(unittest.TestCase):
             assert isinstance(notification, EventScheduleNotification)
             assert notification.event == self.event
 
+    def test_match_score_match_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.match_score("2020nonexistent_qm99")
+            mock_send.assert_not_called()
+
     def test_match_score_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
             TBANSHelper.match_score(self.match.key_name)
             mock_send.assert_not_called()
-
-    def test_match_score_user_id(self):
-        # Set some upcoming matches for the Event
-        match_creator = MatchTestCreator(self.event)
-        teams = [
-            Team(id="frc%s" % team_number, team_number=team_number)
-            for team_number in range(6)
-        ]
-        self.event._teams_future = ndb.Future()
-        self.event._teams_future.set_result(teams)
-        match_creator.createIncompleteQuals()
-
-        # Test send called with user id
-        with (
-            patch.object(TBANSHelper, "_send") as mock_send,
-            patch.object(
-                TBANSHelper, "schedule_upcoming_match"
-            ) as schedule_upcoming_match,
-        ):
-            TBANSHelper.match_score(self.match.key_name, "user_id")
-            mock_send.assert_called()
-            assert len(mock_send.call_args_list) == 3
-            for call in mock_send.call_args_list:
-                assert call[0][0] == ["user_id"]
-            # Make sure we called upcoming_match with the same user_id
-            schedule_upcoming_match.assert_called()
-            assert len(schedule_upcoming_match.call_args_list) == 1
-            assert schedule_upcoming_match.call_args[0][1] == "user_id"
 
     def test_match_score(self):
         # Insert a Subscription for this Event, Team, and Match so we call to send
@@ -575,27 +538,15 @@ class TestTBANSHelper(unittest.TestCase):
             TBANSHelper.match_score(self.match.key_name)
             schedule_upcoming_match.assert_called()
             assert len(schedule_upcoming_match.call_args_list) == 1
-            assert len(schedule_upcoming_match.call_args) == 2
-            assert schedule_upcoming_match.call_args[0][0] == next_matches.pop()
-            assert schedule_upcoming_match.call_args[0][1] is None
+            assert (
+                schedule_upcoming_match.call_args[0][0] == next_matches.pop().key_name
+            )
 
     def test_match_score_score_breakdown_update_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
             TBANSHelper.match_score(self.match.key_name, is_score_breakdown_update=True)
             mock_send.assert_not_called()
-
-    def test_match_score_score_breakdown_update_user_id(self):
-        # Test send called with user id - should use _send with WEBHOOK mode
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.match_score(
-                self.match.key_name, "user_id", is_score_breakdown_update=True
-            )
-            mock_send.assert_called()
-            assert len(mock_send.call_args_list) == 3
-            for call in mock_send.call_args_list:
-                assert call[0][0] == ["user_id"]
-                assert call[0][2] == _NotificationMode.WEBHOOK
 
     def test_match_score_score_breakdown_update(self):
         # Insert subscriptions for Event, Team, and Match
@@ -694,31 +645,16 @@ class TestTBANSHelper(unittest.TestCase):
         assert updated_match is not None
         assert not updated_match.push_sent
 
+    def test_match_upcoming_match_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.match_upcoming("2020nonexistent_qm99")
+            mock_send.assert_not_called()
+
     def test_match_upcoming_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.match_upcoming(self.match)
+            TBANSHelper.match_upcoming(self.match.key_name)
             mock_send.assert_not_called()
-
-    def test_match_upcoming_user_id(self):
-        # Set our match to be 1-1 so we can test event_level
-        self.match.set_number = 1
-        self.match.match_number = 1
-
-        # Test send called with user id
-        with (
-            patch.object(TBANSHelper, "_send") as mock_send,
-            patch.object(TBANSHelper, "event_level") as mock_event_level,
-        ):
-            TBANSHelper.match_upcoming(self.match, "user_id")
-            mock_send.assert_called()
-            assert len(mock_send.call_args_list) == 3
-            for call in mock_send.call_args_list:
-                assert call[0][0] == ["user_id"]
-            # Make sure we called event_level with the same user_id
-            mock_event_level.assert_called()
-            assert len(mock_event_level.call_args_list) == 1
-            assert mock_event_level.call_args[0][1] == "user_id"
 
     def test_match_upcoming(self):
         # Insert a Subscription for this Event, Team, and Match so we call to send
@@ -744,7 +680,7 @@ class TestTBANSHelper(unittest.TestCase):
             notification_types=[NotificationType.UPCOMING_MATCH],
         ).put()
 
-        TBANSHelper.match_upcoming(self.match)
+        TBANSHelper.match_upcoming(self.match.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 3
 
@@ -772,26 +708,21 @@ class TestTBANSHelper(unittest.TestCase):
         self.match.match_number = 1
 
         with patch.object(TBANSHelper, "event_level") as mock_event_level:
-            TBANSHelper.match_upcoming(self.match)
+            TBANSHelper.match_upcoming(self.match.key_name)
             mock_event_level.assert_called()
             assert len(mock_event_level.call_args_list) == 1
-            assert mock_event_level.call_args[0][0] == self.match
-            assert mock_event_level.call_args[0][1] is None
+            assert mock_event_level.call_args[0][0] == self.match.key_name
+
+    def test_match_video_match_not_found(self):
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
+            TBANSHelper.match_video("2020nonexistent_qm99")
+            mock_send.assert_not_called()
 
     def test_match_video_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.match_video(self.match)
+            TBANSHelper.match_video(self.match.key_name)
             mock_send.assert_not_called()
-
-    def test_match_video_user_id(self):
-        # Test send called with user id
-        with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.match_video(self.match, "user_id")
-            mock_send.assert_called()
-            assert len(mock_send.call_args_list) == 3
-            for call in mock_send.call_args_list:
-                assert call[0][0] == ["user_id"]
 
     def test_match_video(self):
         # Insert a Subscription for this Event, Team, and Match so we call to send
@@ -817,7 +748,7 @@ class TestTBANSHelper(unittest.TestCase):
             notification_types=[NotificationType.MATCH_VIDEO],
         ).put()
 
-        TBANSHelper.match_video(self.match)
+        TBANSHelper.match_video(self.match.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 3
 
@@ -1293,6 +1224,13 @@ class TestTBANSHelper(unittest.TestCase):
         )
         assert notification is None
 
+    def test_schedule_upcoming_matches_event_not_found(self):
+        with patch.object(
+            TBANSHelper, "schedule_upcoming_match"
+        ) as mock_schedule_upcoming_match:
+            TBANSHelper.schedule_upcoming_matches("2020nonexistent")
+            mock_schedule_upcoming_match.assert_not_called()
+
     def test_schedule_upcoming_matches_not_new_schedule(self):
         # Set some upcoming matches for the Event - not Match 1 though, so no notification gets sent
         # First, mark the setup match as "played" so it's not considered upcoming
@@ -1316,7 +1254,7 @@ class TestTBANSHelper(unittest.TestCase):
         with patch.object(
             TBANSHelper, "schedule_upcoming_match"
         ) as mock_schedule_upcoming_match:
-            TBANSHelper.schedule_upcoming_matches(self.event)
+            TBANSHelper.schedule_upcoming_matches(self.event.key_name)
             mock_schedule_upcoming_match.assert_not_called()
 
     def test_schedule_upcoming_matches(self):
@@ -1338,44 +1276,19 @@ class TestTBANSHelper(unittest.TestCase):
         with patch.object(
             TBANSHelper, "schedule_upcoming_match"
         ) as mock_schedule_upcoming_match:
-            TBANSHelper.schedule_upcoming_matches(self.event)
+            TBANSHelper.schedule_upcoming_matches(self.event.key_name)
             mock_schedule_upcoming_match.assert_called()
             assert len(mock_schedule_upcoming_match.call_args_list) == 2
 
-    def test_schedule_upcoming_matches_user_id(self):
-        # Set some upcoming matches for the Event
-        match_creator = MatchTestCreator(self.event)
-        teams = [
-            Team(id="frc%s" % team_number, team_number=team_number)
-            for team_number in range(6)
-        ]
-        self.event._teams_future = ndb.Future()
-        self.event._teams_future.set_result(teams)
-        matches = match_creator.createIncompleteQuals()
-
-        # Hack our first next upcoming match to be Match 1
-        first_match = matches[0]
-        first_match.match_number = 1
-        first_match.put()
-
-        with patch.object(
-            TBANSHelper, "schedule_upcoming_match"
-        ) as mock_schedule_upcoming_match:
-            TBANSHelper.schedule_upcoming_matches(self.event, "user_id")
-            mock_schedule_upcoming_match.assert_called()
-            assert ["user_id", "user_id"] == [
-                args[0][1] for args in mock_schedule_upcoming_match.call_args_list
-            ]
+    def test_schedule_upcoming_match_match_not_found(self):
+        with patch.object(TBANSHelper, "match_upcoming") as mock_match_upcoming:
+            TBANSHelper.schedule_upcoming_match("2020nonexistent_qm99")
+            mock_match_upcoming.assert_not_called()
 
     def test_schedule_upcoming_match_send(self):
         with patch.object(TBANSHelper, "match_upcoming") as mock_match_upcoming:
-            TBANSHelper.schedule_upcoming_match(self.match)
-            mock_match_upcoming.assert_called_once_with(self.match, None)
-
-    def test_schedule_upcoming_match_send_user_id(self):
-        with patch.object(TBANSHelper, "match_upcoming") as mock_match_upcoming:
-            TBANSHelper.schedule_upcoming_match(self.match, "user_id")
-            mock_match_upcoming.assert_called_once_with(self.match, "user_id")
+            TBANSHelper.schedule_upcoming_match(self.match.key_name)
+            mock_match_upcoming.assert_called_once_with(self.match.key_name)
 
     def test_schedule_upcoming_match_cancel(self):
         # Schedule a dummy task with the same name as the task we're about to schedule
@@ -1385,7 +1298,7 @@ class TestTBANSHelper(unittest.TestCase):
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 1
         # Make sure after calling our schedule_upcoming_match we delete the previously-scheduled task
-        TBANSHelper.schedule_upcoming_match(self.match)
+        TBANSHelper.schedule_upcoming_match(self.match.key_name)
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 0
 
@@ -1397,8 +1310,9 @@ class TestTBANSHelper(unittest.TestCase):
         self.match.time = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
             hours=1
         )
+        self.match.put()
         # Make sure after calling our schedule_upcoming_match we defer the task
-        TBANSHelper.schedule_upcoming_match(self.match)
+        TBANSHelper.schedule_upcoming_match(self.match.key_name)
 
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 1
@@ -1406,26 +1320,7 @@ class TestTBANSHelper(unittest.TestCase):
         # Make sure our taskqueue tasks execute what we expect
         with patch.object(TBANSHelper, "match_upcoming") as mockmatch_upcoming:
             run_from_task(tasks[0])
-            mockmatch_upcoming.assert_called_once_with(self.match, None)
-
-    def test_schedule_upcoming_match_defer_user_id(self):
-        # Sanity check - make sure there are no existing tasks in the queue
-        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
-        assert len(tasks) == 0
-
-        self.match.time = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
-            hours=1
-        )
-        # Make sure after calling our schedule_upcoming_match we defer the task
-        TBANSHelper.schedule_upcoming_match(self.match, "user_id")
-
-        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
-        assert len(tasks) == 1
-
-        # Make sure our taskqueue tasks execute what we expect
-        with patch.object(TBANSHelper, "match_upcoming") as mockmatch_upcoming:
-            run_from_task(tasks[0])
-            mockmatch_upcoming.assert_called_once_with(self.match, "user_id")
+            mockmatch_upcoming.assert_called_once_with(self.match.key_name)
 
     def test_verification(self):
         from backend.common.models.notifications.requests.webhook_request import (

--- a/src/backend/common/manipulators/award_manipulator.py
+++ b/src/backend/common/manipulators/award_manipulator.py
@@ -96,7 +96,7 @@ def award_post_update_hook(updated_models: List[TUpdatedModel[Award]]) -> None:
             try:
                 defer_safe(
                     TBANSHelper.awards,
-                    event,
+                    event.key_name,
                     _name=f"{event.key_name}_awards",
                     _target="py3-tasks-io",
                     _queue="push-notifications",

--- a/src/backend/common/manipulators/event_details_manipulator.py
+++ b/src/backend/common/manipulators/event_details_manipulator.py
@@ -77,7 +77,7 @@ def event_details_post_update_hook(
             try:
                 defer_safe(
                     TBANSHelper.alliance_selection,
-                    event,
+                    event.key_name,
                     _name=f"{event.key_name}_alliance_selection",
                     _target="py3-tasks-io",
                     _queue="push-notifications",

--- a/src/backend/common/manipulators/match_manipulator.py
+++ b/src/backend/common/manipulators/match_manipulator.py
@@ -173,7 +173,7 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
             try:
                 defer_safe(
                     TBANSHelper.match_video,
-                    match,
+                    match.key_name,
                     _name=f"{match.key_name}_match_video",
                     _target="py3-tasks-io",
                     _queue="push-notifications",
@@ -190,7 +190,7 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
         try:
             defer_safe(
                 TBANSHelper.event_schedule,
-                event,
+                event.key_name,
                 _name=f"{event.key_name}_event_schedule",
                 _target="py3-tasks-io",
                 _queue="push-notifications",
@@ -203,7 +203,7 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
         try:
             defer_safe(
                 TBANSHelper.schedule_upcoming_matches,
-                event,
+                event.key_name,
                 _name=f"{event.key_name}_schedule_upcoming_matches",
                 _target="py3-tasks-io",
                 _queue="push-notifications",


### PR DESCRIPTION
I'm sure it used to work this way - but with the change in https://github.com/the-blue-alliance/the-blue-alliance/pull/9312, I figured I'd make all these methods work the same.