### PR TITLE
Add score breakdown to seeded test matches

### DIFF
--- a/src/backend/web/local/dev_tools.py
+++ b/src/backend/web/local/dev_tools.py
@@ -74,6 +74,18 @@ def seed_test_event() -> Response:
         match_time = total_completed_time + datetime.timedelta(
             minutes=(i - 1) * MATCH_SPACING_MINUTES
         )
+        red_bonus_rp = random.randint(0, 2)
+        blue_bonus_rp = random.randint(0, 2)
+        red_rp = (
+            2 if red_score > blue_score else (1 if red_score == blue_score else 0)
+        ) + red_bonus_rp
+        blue_rp = (
+            2 if blue_score > red_score else (1 if red_score == blue_score else 0)
+        ) + blue_bonus_rp
+        score_breakdown = {
+            "red": {"totalPoints": red_score, "rp": red_rp},
+            "blue": {"totalPoints": blue_score, "rp": blue_rp},
+        }
         match = Match(
             id=Match.render_key_name(event_key, CompLevel.QM, 1, i),
             event=ndb.Key(Event, event_key),
@@ -98,6 +110,7 @@ def seed_test_event() -> Response:
                     },
                 }
             ),
+            score_breakdown_json=json.dumps(score_breakdown),
             time=match_time,
             actual_time=match_time,
         )


### PR DESCRIPTION
## Summary

- Adds `score_breakdown_json` with random bonus RPs and total points to seeded test event matches
- Makes test data more realistic for local dev, allowing features that depend on score breakdowns to be exercised

## Test plan

- [ ] Run "Seed Test Event" from `/local/bootstrap` and verify matches have score breakdowns
- [ ] Verify match detail pages show score breakdown data

🤖 Generated with [Claude Code](https://claude.com/claude-code)