### PR TITLE
Fix crash in match predictions when score_breakdown is None

### DIFF
--- a/src/backend/common/helpers/prediction_helper.py
+++ b/src/backend/common/helpers/prediction_helper.py
@@ -967,7 +967,9 @@ class PredictionHelper:
                         brier_sums["score"] += pow(prediction["prob"] - 0, 2)
 
                     for color in ALLIANCE_COLORS:
-                        score_breakdown = none_throws(match.score_breakdown)
+                        if match.score_breakdown is None:
+                            continue
+                        score_breakdown = match.score_breakdown
                         color_prediction = prediction[str(color)]  # pyre-ignore[26]
                         if event.year == 2016:
                             if score_breakdown[color]["teleopDefensesBreached"]:

--- a/src/backend/common/helpers/tests/predictions_helper_test.py
+++ b/src/backend/common/helpers/tests/predictions_helper_test.py
@@ -69,6 +69,43 @@ def test_past_event_seeds_match_predictions(test_data_importer) -> None:
         "2016nyny",
     ],
 )
+def test_compute_match_predictions_with_none_score_breakdown(
+    event_key: EventKey, test_data_importer
+) -> None:
+    """Regression test: played matches with None score_breakdown should not crash."""
+    test_data_importer.import_event(__file__, f"data/{event_key}.json")
+    test_data_importer.import_match_list(__file__, f"data/{event_key}_matches.json")
+
+    matches = Match.query(Match.event == ndb.Key(Event, event_key)).fetch()
+
+    # Null out score_breakdown on all played matches
+    for match in matches:
+        if match.has_been_played:
+            match.score_breakdown_json = None
+            match._score_breakdown = None
+
+    sorted_matches = MatchHelper.play_order_sorted_matches(matches)
+    (
+        match_predictions,
+        match_prediction_stats,
+        stat_mean_vars,
+    ) = PredictionHelper.get_match_predictions(sorted_matches)
+
+    assert match_predictions is not None
+    assert match_prediction_stats is not None
+    assert stat_mean_vars is not None
+
+
+@pytest.mark.parametrize(
+    "event_key",
+    [
+        "2020scmb",
+        "2019nyny",
+        "2018nyny",
+        "2017nyny",
+        "2016nyny",
+    ],
+)
 def test_compute_rankings_predictions(event_key: EventKey, test_data_importer) -> None:
     test_data_importer.import_event(__file__, f"data/{event_key}.json")
     test_data_importer.import_match_list(__file__, f"data/{event_key}_matches.json")


### PR DESCRIPTION
## Summary

- **Fix 500s in prod** on `/tasks/math/do/event_matchstats/<event_key>` for active Week 1 events (2026ncwak, 2026pahat, 2026njwas, 2026mimtp, 2026brba, etc.)
- Root cause: `PredictionHelper.get_match_predictions()` calls `none_throws(match.score_breakdown)` inside the `if match.has_been_played` block, but played matches can have scores without detailed score breakdown data from the upstream API
- Fix: skip brier score computation for year-specific bonus objectives (2016 breach/capture, 2017 pressure/gears) when `score_breakdown` is `None`, instead of crashing
- For 2026 events, none of the year-specific branches execute anyway, so the loop body is a no-op — the crash was entirely unnecessary

## Prod errors (sample from last hour)

```
File "/workspace/backend/common/helpers/prediction_helper.py", line 970, in get_match_predictions
    score_breakdown = none_throws(match.score_breakdown)
AssertionError: Unexpected `None`
```

Affected events: `2026ncwak`, `2026pahat`, `2026njwas`, `2026mimtp`, `2026brba`, `2026vaale`, `2026nccab`

## Test plan

- [x] Added regression test `test_compute_match_predictions_with_none_score_breakdown` parametrized across 5 event years (2016-2020)
- [x] All 21 prediction helper tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)