### PR TITLE
pwa: Fix dark mode for score breakdown label cells

### DIFF
--- a/pwa/app/components/tba/match/scoreBreakdown.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown.tsx
@@ -118,12 +118,12 @@ const cellVariants = cva('', {
     {
       color: 'neutral',
       shade: 'light',
-      class: 'bg-neutral-50',
+      class: 'bg-neutral-50 dark:bg-neutral-900',
     },
     {
       color: 'neutral',
       shade: 'dark',
-      class: 'bg-neutral-200',
+      class: 'bg-neutral-200 dark:bg-neutral-800',
     },
   ],
   defaultVariants: {


### PR DESCRIPTION
## Summary

- Fix dark mode rendering of the center label column in score breakdown tables
- The neutral cells used hardcoded light-mode colors (`bg-neutral-50`, `bg-neutral-200`) that render as white/light gray on dark backgrounds
- Added `dark:bg-neutral-900` and `dark:bg-neutral-800` variants to match the dark theme

## Screenshot Pages

- /match/2026mabil_qm1

🤖 Generated with [Claude Code](https://claude.com/claude-code)