### PR TITLE
preserve district webcast channels across years

### DIFF
--- a/src/backend/common/manipulators/district_manipulator.py
+++ b/src/backend/common/manipulators/district_manipulator.py
@@ -55,6 +55,12 @@ def district_post_update_hook(updated_models: List[TUpdatedModel[District]]) -> 
                         last_year_district.uses_official_webcast_unit
                     )
                     update = True
+                if (
+                    not updated.model.webcast_channels
+                    and last_year_district.webcast_channels
+                ):
+                    updated.model.webcast_channels = last_year_district.webcast_channels
+                    update = True
                 if update:
                     DistrictManipulator.createOrUpdate(
                         updated.model, run_post_update_hook=False

--- a/src/backend/common/manipulators/tests/district_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/district_manipulator_test.py
@@ -189,3 +189,84 @@ class TestDistrictManipulator(unittest.TestCase):
         district = District.get_by_id("2016ne")
         assert district is not None
         assert district.uses_official_webcast_unit is False
+
+    def test_update_webcast_channels_from_last_year_on_create(self) -> None:
+        District(
+            id="2015ne",
+            abbreviation="ne",
+            year=2015,
+            display_name="New England",
+            webcast_channels=[
+                {
+                    "type": "youtube",
+                    "channel": "FIRST in Michigan",
+                    "channel_id": "UC1234567890",
+                }
+            ],
+        ).put()
+
+        updated = DistrictManipulator.createOrUpdate(
+            District(id="2016ne", abbreviation="ne", year=2016)
+        )
+        # We didn't originally specify webcast_channels
+        assert updated.webcast_channels == []
+
+        # But the update hook should add it in from the prior year's
+        tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        )
+        assert len(tasks) == 1
+        for task in tasks:
+            run_from_task(task)
+
+        district = District.get_by_id("2016ne")
+        assert district is not None
+        assert district.webcast_channels is not None
+        assert len(district.webcast_channels) == 1
+        assert district.webcast_channels[0]["channel"] == "FIRST in Michigan"
+        assert district.webcast_channels[0]["channel_id"] == "UC1234567890"
+
+    def test_no_webcast_channels_propagation_when_already_set(self) -> None:
+        District(
+            id="2015ne",
+            abbreviation="ne",
+            year=2015,
+            display_name="New England",
+            webcast_channels=[
+                {
+                    "type": "youtube",
+                    "channel": "Old Channel",
+                    "channel_id": "UC_old",
+                }
+            ],
+        ).put()
+
+        DistrictManipulator.createOrUpdate(
+            District(
+                id="2016ne",
+                abbreviation="ne",
+                year=2016,
+                webcast_channels=[
+                    {
+                        "type": "youtube",
+                        "channel": "New Channel",
+                        "channel_id": "UC_new",
+                    }
+                ],
+            )
+        )
+
+        tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        )
+        assert len(tasks) == 1
+        for task in tasks:
+            run_from_task(task)
+
+        district = District.get_by_id("2016ne")
+        assert district is not None
+        assert district.webcast_channels is not None
+        assert len(district.webcast_channels) == 1
+        # Should still have the new channel, not the old one
+        assert district.webcast_channels[0]["channel"] == "New Channel"
+        assert district.webcast_channels[0]["channel_id"] == "UC_new"

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -40,6 +40,7 @@ from backend.web.handlers.admin.districts import (
     district_edit,
     district_edit_post,
     district_list,
+    district_remove_webcast_channel_post,
 )
 from backend.web.handlers.admin.event import (
     event_add_webcast_post,
@@ -245,6 +246,11 @@ admin_routes.add_url_rule(
     "/district/<district_key>/webcasts/add",
     methods=["POST"],
     view_func=district_add_webcast_channel_post,
+)
+admin_routes.add_url_rule(
+    "/district/<district_key>/webcasts/remove",
+    methods=["POST"],
+    view_func=district_remove_webcast_channel_post,
 )
 
 admin_routes.add_url_rule("/event/create", view_func=event_create, methods=["GET"])

--- a/src/backend/web/handlers/admin/districts.py
+++ b/src/backend/web/handlers/admin/districts.py
@@ -108,6 +108,39 @@ def district_add_webcast_channel_post(district_key: DistrictKey) -> Response:
     )
 
 
+def district_remove_webcast_channel_post(district_key: DistrictKey) -> Response:
+    district = District.get_by_id(district_key)
+    if not district:
+        abort(404)
+
+    channel_id = (request.form.get("channel_id") or "").strip()
+    if not channel_id:
+        return redirect(
+            f"{url_for('admin.district_details', district_key=district_key, webcast_error='missing_channel_id')}#webcasts"
+        )
+
+    district_channels = list(district.webcast_channels or [])
+    original_count = len(district_channels)
+
+    district_channels = [
+        channel
+        for channel in district_channels
+        if channel.get("channel_id") != channel_id
+    ]
+
+    if len(district_channels) == original_count:
+        return redirect(
+            f"{url_for('admin.district_details', district_key=district_key, webcast_error='channel_not_found_to_remove')}#webcasts"
+        )
+
+    district.webcast_channels = district_channels
+    DistrictManipulator.createOrUpdate(district)
+
+    return redirect(
+        f"{url_for('admin.district_details', district_key=district_key, webcast_success='channel_removed')}#webcasts"
+    )
+
+
 def district_edit(district_key: DistrictKey) -> str:
     district = District.get_by_id(district_key)
     if district is None:

--- a/src/backend/web/handlers/admin/tests/district_test.py
+++ b/src/backend/web/handlers/admin/tests/district_test.py
@@ -194,6 +194,73 @@ def test_district_add_webcast_channel_post_channel_not_found(
     assert district.webcast_channels == []
 
 
+def test_district_remove_webcast_channel_post(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    helpers.preseed_district(
+        "2020ne",
+        webcast_channels=[
+            WebcastChannel(
+                type=WebcastType.YOUTUBE,
+                channel="FIRST in Michigan",
+                channel_id="UCjX4WSaAFPgM2PYr-6P",
+            ),
+            WebcastChannel(
+                type=WebcastType.YOUTUBE,
+                channel="Another Channel",
+                channel_id="UC_another",
+            ),
+        ],
+    )
+
+    resp = web_client.post(
+        "/admin/district/2020ne/webcasts/remove",
+        data={"channel_id": "UCjX4WSaAFPgM2PYr-6P"},
+    )
+
+    assert resp.status_code == 302
+    assert (
+        resp.headers["Location"]
+        == "/admin/district/2020ne?webcast_success=channel_removed#webcasts"
+    )
+
+    district = District.get_by_id("2020ne")
+    assert district is not None
+    assert len(district.webcast_channels) == 1
+    assert district.webcast_channels[0]["channel"] == "Another Channel"
+    assert district.webcast_channels[0]["channel_id"] == "UC_another"
+
+
+def test_district_remove_webcast_channel_post_channel_not_found(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    helpers.preseed_district(
+        "2020ne",
+        webcast_channels=[
+            WebcastChannel(
+                type=WebcastType.YOUTUBE,
+                channel="FIRST in Michigan",
+                channel_id="UCjX4WSaAFPgM2PYr-6P",
+            )
+        ],
+    )
+
+    resp = web_client.post(
+        "/admin/district/2020ne/webcasts/remove",
+        data={"channel_id": "UC_nonexistent"},
+    )
+
+    assert resp.status_code == 302
+    assert (
+        resp.headers["Location"]
+        == "/admin/district/2020ne?webcast_error=channel_not_found_to_remove#webcasts"
+    )
+
+    district = District.get_by_id("2020ne")
+    assert district is not None
+    assert len(district.webcast_channels) == 1
+
+
 def test_district_edit_bad_event(web_client: Client, login_gae_admin) -> None:
     resp = web_client.get("/admin/district/edit/2021asdf")
     assert resp.status_code == 404

--- a/src/backend/web/handlers/tests/helpers.py
+++ b/src/backend/web/handlers/tests/helpers.py
@@ -1,7 +1,7 @@
 import json
 import re
 from datetime import datetime, timedelta
-from typing import Generator, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, Generator, List, NamedTuple, Optional, Tuple
 
 import bs4
 from google.appengine.ext import ndb
@@ -14,6 +14,7 @@ from backend.common.models.event import Event
 from backend.common.models.event_team import EventTeam
 from backend.common.models.keys import DistrictKey, EventKey, TeamNumber
 from backend.common.models.team import Team
+from backend.common.models.webcast import WebcastChannel
 
 
 class TeamCurrentEvent(NamedTuple):
@@ -101,14 +102,19 @@ def preseed_event(event_key: EventKey) -> Generator:
 
 
 @ndb.synctasklet
-def preseed_district(district_key: DistrictKey) -> Generator:
+def preseed_district(
+    district_key: DistrictKey, webcast_channels: Optional[List[WebcastChannel]] = None
+) -> Generator:
     year = int(district_key[:4])
-    yield District(
-        id=district_key,
-        year=year,
-        abbreviation=district_key[4:],
-        display_name=district_key[4:].upper(),
-    ).put_async()
+    district_kwargs: Dict[str, Any] = {
+        "id": district_key,
+        "year": year,
+        "abbreviation": district_key[4:],
+        "display_name": district_key[4:].upper(),
+    }
+    if webcast_channels is not None:
+        district_kwargs["webcast_channels"] = webcast_channels
+    yield District(**district_kwargs).put_async()
 
     yield ndb.put_multi_async(
         [

--- a/src/backend/web/templates/admin/district_details.html
+++ b/src/backend/web/templates/admin/district_details.html
@@ -8,6 +8,10 @@
     <div class="alert alert-block alert-success">
         Added YouTube channel to district webcast configuration.
     </div>
+{% elif webcast_success == "channel_removed" %}
+    <div class="alert alert-block alert-success">
+        Removed YouTube channel from district webcast configuration.
+    </div>
 {% endif %}
 {% if webcast_error == "missing_channel_name" %}
     <div class="alert alert-block alert-danger">
@@ -20,6 +24,14 @@
 {% elif webcast_error == "channel_exists" %}
     <div class="alert alert-block alert-warning">
         That YouTube channel is already configured for this district.
+    </div>
+{% elif webcast_error == "channel_not_found_to_remove" %}
+    <div class="alert alert-block alert-danger">
+        Could not find that YouTube channel to remove.
+    </div>
+{% elif webcast_error == "missing_channel_id" %}
+    <div class="alert alert-block alert-danger">
+        Channel ID is required for removal.
     </div>
 {% endif %}
 <div class="btn-group">
@@ -138,15 +150,23 @@
                 <th>Type</th>
                 <th>Channel Name</th>
                 <th>Channel ID</th>
+                <th>Actions</th>
             </tr>
             {% for channel in configured_webcast_channels %}
                 <tr>
                     <td>{{ channel.type }}</td>
                     <td>{{ channel.channel }}</td>
                     <td>{{ channel.channel_id }}</td>
+                    <td>
+                        <form action="/admin/district/{{district.key_name}}/webcasts/remove" method="post" style="display: inline;">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                            <input type="hidden" name="channel_id" value="{{ channel.channel_id }}"/>
+                            <button type="submit" class="btn btn-danger btn-xs" onclick="return confirm('Remove this channel?');"><span class="glyphicon glyphicon-remove"></span> Remove</button>
+                        </form>
+                    </td>
                 </tr>
             {% else %}
-                <tr><td colspan="3">No configured webcast channels for this district.</td></tr>
+                <tr><td colspan="4">No configured webcast channels for this district.</td></tr>
             {% endfor %}
         </table>
 


### PR DESCRIPTION
I forgot that we do this thing about propagating district properties across years, so hook this up for blessed webcast streams. This also adds a button on the admin tab to remove them