### PR TITLE
ra: Include rookie bonus in single-event bonus

### DIFF
--- a/src/backend/common/helpers/regional_champs_pool_helper.py
+++ b/src/backend/common/helpers/regional_champs_pool_helper.py
@@ -115,7 +115,6 @@ class RegionalChampsPoolHelper(DistrictHelper):
         # aggregate points from first two regional events
         events_by_key: Dict[EventKey, Event] = {}
         team_attendance: DefaultDict[TeamKey, List[EventKey]] = defaultdict(list)
-        single_event_teams: Set[TeamKey] = set()
         team_totals: Dict[TeamKey, DistrictRankingTeamTotal] = defaultdict(
             lambda: DistrictRankingTeamTotal(
                 event_points=[],
@@ -145,11 +144,6 @@ class RegionalChampsPoolHelper(DistrictHelper):
                 team_attendance[team_key].append(event.key_name)
 
                 num_events = len(team_attendance[team_key])
-                if num_events == 1:
-                    single_event_teams.add(team_key)
-                else:
-                    single_event_teams.discard(team_key)
-
                 if num_events > 2:
                     continue
 
@@ -193,23 +187,6 @@ class RegionalChampsPoolHelper(DistrictHelper):
                         ],
                     )
 
-        # Single-Event regional teams are award additional points
-        # based on event 1 performance
-        # E2 points = 0.6 * (E1 points) + 14
-        # See section 12.3.1 of the 2025 game manual
-        for team_key in single_event_teams:
-            team_total = team_totals[team_key]
-            if len(team_total["event_points"]) != 1:
-                logging.warning(
-                    f"Team {team_key} has regional cmp point event count mismatch"
-                )
-                continue
-
-            first_event_points = team_total["event_points"][0][1]
-            bonus = round(0.6 * first_event_points["total"]) + 14
-            team_totals[team_key]["single_event_bonus"] = bonus
-            team_totals[team_key]["point_total"] += bonus
-
         if isinstance(teams, ndb.tasklets.Future):
             teams = teams.get_result()
 
@@ -219,19 +196,32 @@ class RegionalChampsPoolHelper(DistrictHelper):
                 team = team_f.get_result()
             else:
                 team = team_f
-            bonus = cls._get_rookie_bonus(year, team.rookie_year)
+            team_total = team_totals[team.key_name]
+            rookie_bonus_per_event = cls._get_rookie_bonus(year, team.rookie_year)
 
             # Rookie bonus is applied per event attended (up to 2 events)
-            num_events_attended = len(team_totals[team.key_name]["event_points"])
-            total_rookie_bonus = bonus * num_events_attended
+            num_events_attended = len(team_total["event_points"])
+            total_rookie_bonus = rookie_bonus_per_event * num_events_attended
 
-            team_totals[team.key_name]["rookie_bonus"] = total_rookie_bonus
-            team_totals[team.key_name]["point_total"] += total_rookie_bonus
+            # Single-Event regional teams are award additional points
+            # based on event 1 performance.
+            # E2 points = 0.6 * (E1 points) + 14
+            # Team age points are part of E1 points for regional events.
+            # See section 12.3.1 of the 2025 game manual.
+            if num_events_attended == 1:
+                first_event_points = team_total["event_points"][0][1]
+                first_event_total = first_event_points["total"] + rookie_bonus_per_event
+                single_event_bonus = round(0.6 * first_event_total) + 14
+                team_total["single_event_bonus"] = single_event_bonus
+                team_total["point_total"] += single_event_bonus
+
+            team_total["rookie_bonus"] = total_rookie_bonus
+            team_total["point_total"] += total_rookie_bonus
 
             # For other adjustments made by HQ
             if adjustments and (team_adjustment := adjustments.get(team.key_name)):
-                team_totals[team.key_name]["adjustments"] = team_adjustment
-                team_totals[team.key_name]["point_total"] += team_adjustment
+                team_total["adjustments"] = team_adjustment
+                team_total["point_total"] += team_adjustment
 
             valid_team_keys.add(team.key_name)
 

--- a/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
+++ b/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
@@ -226,3 +226,39 @@ def test_rookie_bonus_per_event(setup_full_event) -> None:
     assert rankings["frc9001"]["rookie_bonus"] == 20
     # Total: 25 (event1) + 30 (event2) + 20 (rookie bonus) = 75
     assert rankings["frc9001"]["point_total"] == 75
+
+
+def test_single_event_bonus_includes_rookie_bonus(setup_full_event) -> None:
+    setup_full_event("2025mndu")
+
+    event_details = none_throws(EventDetails.get_by_id("2025mndu"))
+    regional_pool_points = none_throws(event_details.regional_champs_pool_points)
+    regional_pool_points["points"]["frc9002"] = TeamAtEventDistrictPoints(
+        alliance_points=10,
+        award_points=0,
+        elim_points=0,
+        qual_points=15,
+        total=25,
+    )
+    event_details.regional_champs_pool_points = regional_pool_points
+    event_details.put()
+
+    event = none_throws(Event.get_by_id("2025mndu"))
+    event.prep_details()
+
+    rookie_single_event = Team(
+        id="frc9002",
+        team_number=9002,
+        rookie_year=2025,
+    )
+    rookie_single_event.put()
+
+    rankings = RegionalChampsPoolHelper.calculate_rankings(
+        [event], [rookie_single_event], 2025, None
+    )
+
+    # E1 includes rookie bonus for regional events: 25 + 10
+    # E2 = round(0.6 * E1) + 14 = round(0.6 * 35) + 14 = 35
+    assert rankings["frc9002"]["rookie_bonus"] == 10
+    assert rankings["frc9002"]["single_event_bonus"] == 35
+    assert rankings["frc9002"]["point_total"] == 70


### PR DESCRIPTION
This is also towards https://github.com/the-blue-alliance/the-blue-alliance/issues/8158 as https://github.com/the-blue-alliance/the-blue-alliance/pull/9276 didn't fully handle everything.

The main difference is: frc-events shows the rookie bonus as a property of the _event_ points, rather than a bonus applied at the ranking phase (the latter is how districts work, and also how TBA's implementation works). 

This means there are still two discrepancy: 
 1. the single event bonus should take the rookie bonus into account (as those points are from the "event")
 2. we don't display the rookie bonus on the per-event pages, which means the points don't match frc-events

This isn't a _perfect_ solution here, as it only handles (1), but it'll at least fix the overall rankings.

This will probably require an additional diff to actually move the rookie bonus into the per-event data model, but I'm not sure I'll get to that today.