### PR TITLE
Support nested dicts in score breakdown

### DIFF
--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -47,14 +47,13 @@ class FMSAPIHybridScheduleParser(
         self.year = year
         self.event_short = event_short
 
-    @staticmethod
-    def _is_blank_breakdown_value(value: Any) -> bool:
+    @classmethod
+    def _is_blank_breakdown_value(cls, value: Any) -> bool:
         """Recursively check if a score breakdown value is blank (zero, falsy, or sentinel string)."""
         if isinstance(value, dict):
-            return all(
-                FMSAPIHybridScheduleParser._is_blank_breakdown_value(v)
-                for v in value.values()
-            )
+            return all(cls._is_blank_breakdown_value(v) for v in value.values())
+        if isinstance(value, list):
+            return all(cls._is_blank_breakdown_value(v) for v in value)
         return not value or value in {"Unknown", "None"}
 
     @classmethod

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_hybrid_schedule_parser_test.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_hybrid_schedule_parser_test.py
@@ -460,3 +460,23 @@ def test_is_blank_match_deeply_nested_nonzero() -> None:
     }
     match = _make_sf_match(json.dumps(alliances), json.dumps(breakdown))
     assert FMSAPIHybridScheduleParser.is_blank_match(match) is False
+
+
+def test_is_blank_match_nested_dict_with_nonempty_list() -> None:
+    """Nested dict containing a non-empty list is not blank and must not raise TypeError."""
+    alliances = {
+        "red": MatchAlliance(teams=["frc1", "frc2", "frc3"], score=0),
+        "blue": MatchAlliance(teams=["frc4", "frc5", "frc6"], score=0),
+    }
+    breakdown = {
+        "red": {
+            "totalPoints": 0,
+            "hubScore": {"autoCount": 0, "totalPoints": 0, "notes": ["detail"]},
+        },
+        "blue": {
+            "totalPoints": 0,
+            "hubScore": {"autoCount": 0, "totalPoints": 0, "notes": []},
+        },
+    }
+    match = _make_sf_match(json.dumps(alliances), json.dumps(breakdown))
+    assert FMSAPIHybridScheduleParser.is_blank_match(match) is False


### PR DESCRIPTION
We're seeing a lot of errors with `/tasks/get/fmsapi_matches/2026mefal`

This should fix the following stacktrace
```
 TypeError: unhashable type: 'dict'
at .is_blank_match ( /workspace/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py:61 )
at .<lambda> ( /workspace/backend/tasks_io/datafeeds/datafeed_fms_api.py:382 )
at .get_event_matches ( /workspace/backend/tasks_io/datafeeds/datafeed_fms_api.py:380 )
at ._help_tasklet_along ( /layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/ext/ndb/tasklets.py:444 )
at .reraise ( /layers/google.python.pip/pip/lib/python3.13/site-packages/six.py:724 )
at .check_success ( /layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/ext/ndb/tasklets.py:394 )
at .get_result ( /layers/google.python.pip/pip/lib/python3.13/site-packages/google/appengine/ext/ndb/tasklets.py:397 )
at .event_matches ( /workspace/backend/tasks_io/handlers/frc_api.py:744 ) 
```