### PR TITLE
Remove artificial delay for match score notifications - do not wait for breakdown

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -314,8 +314,8 @@ class TBANSHelper:
 
         # Mark the match as having had its score notification sent.
         # We do this *after* sending (not at enqueue time) so that a
-        # score-breakdown update arriving during a countdown delay
-        # window won't trigger a duplicate webhook-only notification.
+        # score-breakdown update arriving before this task executes
+        # won't trigger a duplicate webhook-only notification.
         if not is_score_breakdown_update and not match.push_sent:
             from backend.common.manipulators.match_manipulator import (
                 MatchManipulator,

--- a/src/backend/common/manipulators/match_manipulator.py
+++ b/src/backend/common/manipulators/match_manipulator.py
@@ -5,8 +5,6 @@ from google.appengine.api import taskqueue
 from pyre_extensions import none_throws
 
 from backend.common.cache_clearing import get_affected_queries
-from backend.common.consts.comp_level import CompLevel
-from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType
 from backend.common.helpers.deferred import defer_safe
 from backend.common.helpers.firebase_pusher import FirebasePusher
@@ -19,12 +17,6 @@ from backend.common.models.match import Match
 
 if TYPE_CHECKING:
     from backend.common.models.event import Event
-
-# How many seconds to wait before dispatching the match_score notification.
-# This gives the FRC API time to return score_breakdown data so the
-# notification payload includes it.  Only applied for events where we are
-# actively syncing from the FRC API (official events with sync enabled).
-MATCH_SCORE_DELAY_SECONDS = 10
 
 
 class MatchManipulator(ManipulatorBase[Match]):
@@ -120,11 +112,6 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
                 and (is_new or alliances_changed)
             ):
                 # Match has scores and we haven't sent a notification yet.
-                # Enqueue a match_score notification (possibly delayed to
-                # wait for score_breakdown data from the FRC API).
-                countdown = MatchPostUpdateHooks.match_score_notification_countdown(
-                    match, event
-                )
                 # Catch TaskAlreadyExistsError + TombstonedTaskError
                 try:
                     defer_safe(
@@ -134,7 +121,6 @@ def match_post_update_hook(updated_models: List[TUpdatedModel[Match]]) -> None:
                         _target="py3-tasks-io",
                         _queue="push-notifications",
                         _url="/_ah/queue/deferred_notification_send",
-                        _countdown=countdown,
                     )
                     # Note: push_sent is set to True inside
                     # TBANSHelper.match_score *after* the notification is
@@ -218,28 +204,6 @@ class MatchPostUpdateHooks:
     Since there are so many match update hooks, we can port them individually here
     and do a better job of batching so we don't have to iterate the same list a bunch
     """
-
-    @staticmethod
-    def match_score_notification_countdown(match: Match, event: "Event") -> int:
-        """Return the number of seconds to delay the match_score notification.
-
-        If the match already has a score_breakdown we send immediately (0).
-        Otherwise, for official events actively syncing from the FRC API, we
-        delay by MATCH_SCORE_DELAY_SECONDS so the breakdown has time to land
-        before the notification task executes.
-        """
-        if match.score_breakdown:
-            return 0
-
-        sync_type = (
-            EventSyncType.EVENT_QUAL_MATCHES
-            if match.comp_level == CompLevel.QM
-            else EventSyncType.EVENT_PLAYOFF_MATCHES
-        )
-        if event.is_sync_enabled(sync_type):
-            return MATCH_SCORE_DELAY_SECONDS
-
-        return 0
 
     @staticmethod
     def firebase_update(model: TUpdatedModel[Match]) -> None:

--- a/src/backend/common/manipulators/tests/match_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/match_manipulator_test.py
@@ -9,15 +9,10 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.consts.alliance_color import AllianceColor
-from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType
 from backend.common.helpers.deferred import run_from_task
 from backend.common.helpers.firebase_pusher import FirebasePusher
-from backend.common.manipulators.match_manipulator import (
-    MATCH_SCORE_DELAY_SECONDS,
-    MatchManipulator,
-    MatchPostUpdateHooks,
-)
+from backend.common.manipulators.match_manipulator import MatchManipulator
 from backend.common.models.event import Event
 from backend.common.models.match import Match
 
@@ -812,131 +807,3 @@ def test_postUpdateHook_new_played_match_no_schedule_notification(
     assert "2012ct_qm1_match_score" in task_names
     assert "2012ct_event_schedule" not in task_names
     assert "2012ct_schedule_upcoming_matches" not in task_names
-
-
-class TestMatchScoreNotificationCountdown:
-    """Tests for MatchPostUpdateHooks.match_score_notification_countdown."""
-
-    @pytest.fixture
-    def official_event(self, ndb_context) -> Event:
-        event = Event(
-            id="2024ct",
-            event_short="ct",
-            year=2024,
-            event_type_enum=EventType.REGIONAL,
-            official=True,
-        )
-        event.put()
-        return event
-
-    @pytest.fixture
-    def offseason_event(self, ndb_context) -> Event:
-        event = Event(
-            id="2024osc",
-            event_short="osc",
-            year=2024,
-            event_type_enum=EventType.OFFSEASON,
-            official=False,
-        )
-        event.put()
-        return event
-
-    @pytest.fixture
-    def qual_match_no_breakdown(self, ndb_context) -> Match:
-        return Match(
-            id="2024ct_qm1",
-            comp_level="qm",
-            event=ndb.Key(Event, "2024ct"),
-            year=2024,
-            set_number=1,
-            match_number=1,
-            alliances_json="""{"blue": {"score": 50, "teams": ["frc1", "frc2", "frc3"]}, "red": {"score": 60, "teams": ["frc4", "frc5", "frc6"]}}""",
-        )
-
-    @pytest.fixture
-    def qual_match_with_breakdown(self, ndb_context) -> Match:
-        return Match(
-            id="2024ct_qm1",
-            comp_level="qm",
-            event=ndb.Key(Event, "2024ct"),
-            year=2024,
-            set_number=1,
-            match_number=1,
-            alliances_json="""{"blue": {"score": 50, "teams": ["frc1", "frc2", "frc3"]}, "red": {"score": 60, "teams": ["frc4", "frc5", "frc6"]}}""",
-            score_breakdown_json=json.dumps(
-                {"red": {"auto": 20}, "blue": {"auto": 30}}
-            ),
-        )
-
-    @pytest.fixture
-    def playoff_match_no_breakdown(self, ndb_context) -> Match:
-        return Match(
-            id="2024ct_sf1m1",
-            comp_level="sf",
-            event=ndb.Key(Event, "2024ct"),
-            year=2024,
-            set_number=1,
-            match_number=1,
-            alliances_json="""{"blue": {"score": 50, "teams": ["frc1", "frc2", "frc3"]}, "red": {"score": 60, "teams": ["frc4", "frc5", "frc6"]}}""",
-        )
-
-    def test_returns_zero_when_breakdown_present(
-        self, qual_match_with_breakdown: Match, official_event: Event
-    ) -> None:
-        countdown = MatchPostUpdateHooks.match_score_notification_countdown(
-            qual_match_with_breakdown, official_event
-        )
-        assert countdown == 0
-
-    def test_returns_delay_for_sync_enabled_qual(
-        self, qual_match_no_breakdown: Match, official_event: Event
-    ) -> None:
-        with patch.object(Event, "is_sync_enabled", return_value=True) as mock_sync:
-            countdown = MatchPostUpdateHooks.match_score_notification_countdown(
-                qual_match_no_breakdown, official_event
-            )
-            assert countdown == MATCH_SCORE_DELAY_SECONDS
-            mock_sync.assert_called_once_with(EventSyncType.EVENT_QUAL_MATCHES)
-
-    def test_returns_delay_for_sync_enabled_playoff(
-        self, playoff_match_no_breakdown: Match, official_event: Event
-    ) -> None:
-        with patch.object(Event, "is_sync_enabled", return_value=True) as mock_sync:
-            countdown = MatchPostUpdateHooks.match_score_notification_countdown(
-                playoff_match_no_breakdown, official_event
-            )
-            assert countdown == MATCH_SCORE_DELAY_SECONDS
-            mock_sync.assert_called_once_with(EventSyncType.EVENT_PLAYOFF_MATCHES)
-
-    def test_returns_zero_for_sync_disabled(
-        self, qual_match_no_breakdown: Match, official_event: Event
-    ) -> None:
-        with patch.object(Event, "is_sync_enabled", return_value=False):
-            countdown = MatchPostUpdateHooks.match_score_notification_countdown(
-                qual_match_no_breakdown, official_event
-            )
-            assert countdown == 0
-
-    def test_returns_zero_for_offseason_event(self, ndb_context) -> None:
-        offseason_event = Event(
-            id="2024osc",
-            event_short="osc",
-            year=2024,
-            event_type_enum=EventType.OFFSEASON,
-            official=False,
-        )
-        offseason_event.put()
-        match = Match(
-            id="2024osc_qm1",
-            comp_level="qm",
-            event=ndb.Key(Event, "2024osc"),
-            year=2024,
-            set_number=1,
-            match_number=1,
-            alliances_json="""{"blue": {"score": 50, "teams": ["frc1", "frc2", "frc3"]}, "red": {"score": 60, "teams": ["frc4", "frc5", "frc6"]}}""",
-        )
-        # is_sync_enabled returns False for non-official events
-        countdown = MatchPostUpdateHooks.match_score_notification_countdown(
-            match, offseason_event
-        )
-        assert countdown == 0


### PR DESCRIPTION
From Slack - it seems this isn't really helpful or necessary. Going to remove this to keep match score notifications timely. 