### PR TITLE
Add logging to track down register 500s errors with no email

### DIFF
--- a/src/backend/api/client_api_auth_helper.py
+++ b/src/backend/api/client_api_auth_helper.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Optional
 
 from flask import request
 
 from backend.common.auth import verify_id_token
 from backend.common.models.user import User
+
+logger = logging.getLogger(__name__)
 
 
 class ClientApiAuthHelper:
@@ -16,4 +19,17 @@ class ClientApiAuthHelper:
 
         id_token = auth_header[len(bearer_token_prefix) :]
         decoded_token = verify_id_token(id_token)
-        return User(decoded_token) if decoded_token is not None else None
+        if decoded_token is None:
+            logger.warning("[CLIENT_API_AUTH] Token verification failed")
+            return None
+
+        uid = decoded_token.get("uid")
+        email = decoded_token.get("email")
+        provider = decoded_token.get("firebase", {}).get("sign_in_provider", "unknown")
+        if not email:
+            logger.warning(
+                f"[CLIENT_API_AUTH] Token missing email claim: uid={uid}, provider={provider}"
+            )
+            return None
+
+        return User(decoded_token)

--- a/src/backend/api/handlers/tests/client_api_registration_test.py
+++ b/src/backend/api/handlers/tests/client_api_registration_test.py
@@ -23,6 +23,20 @@ def test_register_no_auth(api_client: Client) -> None:
     assert resp["code"] == 401
 
 
+def test_register_no_account(
+    api_client: Client, mock_clientapi_auth_no_account: None
+) -> None:
+    """A user with a valid Firebase token but no email should be rejected."""
+    req = RegistrationRequest(
+        operating_system="web",
+        mobile_id="abc123",
+        device_uuid="asdf",
+        name="Test Device",
+    )
+    resp = make_clientapi_request(api_client, "/register", req)
+    assert resp["code"] == 401
+
+
 def test_register_new_client(api_client: Client, mock_clientapi_auth: User) -> None:
     req = RegistrationRequest(
         operating_system="web",

--- a/src/backend/api/handlers/tests/clientapi_auth_test.py
+++ b/src/backend/api/handlers/tests/clientapi_auth_test.py
@@ -27,10 +27,22 @@ def test_valid_header(api_client: Client) -> None:
         ),
         patch.object(auth, "_verify_id_token") as mock_verify_id_token,
     ):
-        mock_verify_id_token.return_value = {}
+        mock_verify_id_token.return_value = {"uid": "abc123", "email": "test@tba.com"}
         user = ClientApiAuthHelper.get_current_user()
         assert user is not None
-        assert user._session_claims == {}
+        assert user._session_claims == {"uid": "abc123", "email": "test@tba.com"}
+
+
+def test_valid_header_no_email(api_client: Client) -> None:
+    with (
+        api_client.application.test_request_context(  # pyre-ignore[16]
+            headers={"Authorization": "Bearer abc123"}
+        ),
+        patch.object(auth, "_verify_id_token") as mock_verify_id_token,
+    ):
+        mock_verify_id_token.return_value = {"uid": "abc123"}
+        user = ClientApiAuthHelper.get_current_user()
+        assert user is None
 
 
 def test_invalid_header(api_client: Client) -> None:

--- a/src/backend/api/handlers/tests/conftest.py
+++ b/src/backend/api/handlers/tests/conftest.py
@@ -38,3 +38,14 @@ def mock_clientapi_auth(ndb_stub, monkeypatch: pytest.MonkeyPatch) -> User:
 
     monkeypatch.setattr(ClientApiAuthHelper, "get_current_user", mock_current_user)
     return mock_user
+
+
+@pytest.fixture
+def mock_clientapi_auth_no_account(ndb_stub, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulates a valid Firebase token but no email claim.
+    get_current_user returns None (rejected at auth helper)."""
+
+    def mock_current_user():
+        return None
+
+    monkeypatch.setattr(ClientApiAuthHelper, "get_current_user", mock_current_user)

--- a/src/backend/common/models/tests/user_test.py
+++ b/src/backend/common/models/tests/user_test.py
@@ -20,8 +20,13 @@ from backend.common.models.user import User
 from backend.common.queries.account_query import AccountQuery
 
 
-def test_init_no_email() -> None:
+def test_init_no_email_no_uid() -> None:
     user = User(session_claims={"email": ""})
+    assert user._account is None
+
+
+def test_init_no_email() -> None:
+    user = User(session_claims={})
     assert user._account is None
 
 


### PR DESCRIPTION
We're getting 500s from the client API `/register` endpoint in production. They're coming from iOS apps that the claim is decoding without an email address. I do not understand this - so I'm going to add some logging to try to track this down.