### PR TITLE
Dispatch Award notifications multiple times for Event as awards get posted

### DIFF
--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -142,10 +142,32 @@ class TBANSHelper:
             )
 
     @classmethod
-    def awards(cls, event_key: str) -> None:
+    def awards(
+        cls,
+        event_key: str,
+        new_award_team_keys: set[str],
+    ) -> None:
+        """Dispatch award notifications.
+
+        Args:
+            event_key: The event key string.
+            new_award_team_keys: Team key strings from new Award entities in
+                this update.
+                - non-empty set: send FCM + webhooks for matching teams and
+                  at the event level; webhooks only for other teams.
+                - empty set: no new awards, only existing awards were updated
+                  — send webhooks only so consumers stay in sync.
+        """
         event = Event.get_by_id(event_key)
         if event is None:
             return
+
+        # Determine notification mode.
+        # non-empty -> new awards exist for those teams, FCM + webhooks
+        # empty     -> update-only, webhooks only
+        event_mode = (
+            _NotificationMode.ALL if new_award_team_keys else _NotificationMode.WEBHOOK
+        )
 
         # Send to Event subscribers
         event_subscriptions_future = None
@@ -173,7 +195,9 @@ class TBANSHelper:
 
         if event_subscriptions_future:
             cls._batch_send_subscriptions(
-                event_subscriptions_future.get_result(), AwardsNotification(event)
+                event_subscriptions_future.get_result(),
+                AwardsNotification(event),
+                event_mode,
             )
 
         for team_key, team_subscriptions_future in team_subscriptions_futures.items():
@@ -182,8 +206,17 @@ class TBANSHelper:
             except Exception:
                 continue
 
+            # FCM only for teams with new awards;
+            # webhooks always fire so consumers stay in sync.
+            if team_key in new_award_team_keys:
+                team_mode = _NotificationMode.ALL
+            else:
+                team_mode = _NotificationMode.WEBHOOK
+
             cls._batch_send_subscriptions(
-                team_subscriptions_future.get_result(), AwardsNotification(event, team)
+                team_subscriptions_future.get_result(),
+                AwardsNotification(event, team),
+                team_mode,
             )
 
     @classmethod

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -211,13 +211,13 @@ class TestTBANSHelper(unittest.TestCase):
 
     def test_awards_event_not_found(self):
         with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:
-            TBANSHelper.awards("2020nonexistent")
+            TBANSHelper.awards("2020nonexistent", new_award_team_keys=set())
             mock_send.assert_not_called()
 
     def test_awards_no_users(self):
         # Test send not called with no subscribed users
         with patch.object(TBANSHelper, "_send") as mock_send:
-            TBANSHelper.awards(self.event.key_name)
+            TBANSHelper.awards(self.event.key_name, new_award_team_keys=set())
             mock_send.assert_not_called()
 
     def test_awards(self):
@@ -268,7 +268,7 @@ class TestTBANSHelper(unittest.TestCase):
             notification_types=[NotificationType.AWARDS],
         ).put()
 
-        TBANSHelper.awards(self.event.key_name)
+        TBANSHelper.awards(self.event.key_name, new_award_team_keys={"frc7332", "frc1"})
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names="push-notifications")
         assert len(tasks) == 3
 
@@ -300,6 +300,124 @@ class TestTBANSHelper(unittest.TestCase):
             assert event_notification.event == self.event
             assert event_notification.team == frc_1
             assert len(event_notification.team_awards) == 1
+
+    def test_awards_new_awards_sends_all_mode(self):
+        """When new_award_team_keys has team keys, FCM + webhooks fire for
+        matching teams and event-level; webhooks only for other teams."""
+        award = Award(
+            id=Award.render_key_name(self.event.key_name, AwardType.INDUSTRIAL_DESIGN),
+            name_str="Industrial Design Award",
+            award_type_enum=AwardType.INDUSTRIAL_DESIGN,
+            event=self.event.key,
+            event_type_enum=EventType.REGIONAL,
+            team_list=[ndb.Key(Team, "frc7332")],
+            year=2020,
+        )
+        award.put()
+        winner_award = Award(
+            id=Award.render_key_name(self.event.key_name, AwardType.WINNER),
+            name_str="Regional Event Winner",
+            award_type_enum=AwardType.WINNER,
+            event=self.event.key,
+            event_type_enum=EventType.REGIONAL,
+            team_list=[ndb.Key(Team, "frc7332"), ndb.Key(Team, "frc1")],
+            year=2020,
+        )
+        winner_award.put()
+        frc_1 = Team(id="frc1", team_number=1)
+        frc_1.put()
+
+        Subscription(
+            parent=ndb.Key(Account, "user_id_1"),
+            user_id="user_id_1",
+            model_key="frc1",
+            model_type=ModelType.TEAM,
+            notification_types=[NotificationType.AWARDS],
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, "user_id_2"),
+            user_id="user_id_2",
+            model_key="frc7332",
+            model_type=ModelType.TEAM,
+            notification_types=[NotificationType.AWARDS],
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, "user_id_3"),
+            user_id="user_id_3",
+            model_key=self.event.key_name,
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.AWARDS],
+        ).put()
+
+        # Only frc7332 is in the new_award_team_keys set
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_batch_send:
+            TBANSHelper.awards(self.event.key_name, new_award_team_keys={"frc7332"})
+
+            assert mock_batch_send.call_count == 3
+
+            calls = mock_batch_send.call_args_list
+            for call in calls:
+                assert isinstance(call[0][1], AwardsNotification)
+
+            # Event-level call has no team and uses ALL mode (new awards exist)
+            event_calls = [c for c in calls if c[0][1].team is None]
+            assert len(event_calls) == 1
+            assert event_calls[0][0][2] == _NotificationMode.ALL
+
+            # Look up team calls by team key name rather than list position,
+            # since team_awards() dict order is not guaranteed.
+            team_modes = {
+                c[0][1].team.key_name: c[0][2]
+                for c in calls
+                if c[0][1].team is not None
+            }
+            assert (
+                team_modes["frc7332"] == _NotificationMode.ALL
+            )  # in new_award_team_keys
+            assert (
+                team_modes["frc1"] == _NotificationMode.WEBHOOK
+            )  # not in new_award_team_keys
+
+    def test_awards_no_new_awards_webhook_only(self):
+        """When new_award_team_keys is empty, only webhooks fire."""
+        award = Award(
+            id=Award.render_key_name(self.event.key_name, AwardType.INDUSTRIAL_DESIGN),
+            name_str="Industrial Design Award",
+            award_type_enum=AwardType.INDUSTRIAL_DESIGN,
+            event=self.event.key,
+            event_type_enum=EventType.REGIONAL,
+            team_list=[ndb.Key(Team, "frc7332")],
+            year=2020,
+        )
+        award.put()
+
+        Subscription(
+            parent=ndb.Key(Account, "user_id_2"),
+            user_id="user_id_2",
+            model_key="frc7332",
+            model_type=ModelType.TEAM,
+            notification_types=[NotificationType.AWARDS],
+        ).put()
+        Subscription(
+            parent=ndb.Key(Account, "user_id_3"),
+            user_id="user_id_3",
+            model_key=self.event.key_name,
+            model_type=ModelType.EVENT,
+            notification_types=[NotificationType.AWARDS],
+        ).put()
+
+        with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_batch_send:
+            TBANSHelper.awards(self.event.key_name, new_award_team_keys=set())
+
+            assert mock_batch_send.call_count == 2
+
+            # Event-level: WEBHOOK only
+            event_call = mock_batch_send.call_args_list[0]
+            assert event_call[0][2] == _NotificationMode.WEBHOOK
+
+            # frc7332: WEBHOOK only
+            team_call = mock_batch_send.call_args_list[1]
+            assert team_call[0][2] == _NotificationMode.WEBHOOK
 
     def test_event_level_match_not_found(self):
         with patch.object(TBANSHelper, "_batch_send_subscriptions") as mock_send:

--- a/src/backend/common/manipulators/award_manipulator.py
+++ b/src/backend/common/manipulators/award_manipulator.py
@@ -75,11 +75,19 @@ class AwardManipulator(ManipulatorBase[Award]):
 
 @AwardManipulator.register_post_update_hook
 def award_post_update_hook(updated_models: List[TUpdatedModel[Award]]) -> None:
-    event_keys: Set[ndb.Key] = set()
+    # Group awards by event and collect team keys from new awards.
+    event_new_team_keys: dict[ndb.Key, Set[str]] = {}
     for updated_award in updated_models:
-        event_keys.add(none_throws(updated_award.model.event))
+        ek = none_throws(updated_award.model.event)
+        if ek not in event_new_team_keys:
+            event_new_team_keys[ek] = set()
+        if updated_award.is_new:
+            for tk in updated_award.model.team_list:
+                team_id = tk.string_id()
+                if team_id:
+                    event_new_team_keys[ek].add(team_id)
 
-    for event_key in event_keys:
+    for event_key, new_team_keys in event_new_team_keys.items():
         # Enqueue task to calculate district points
         taskqueue.add(
             url=f"/tasks/math/do/district_points_calc/{event_key.string_id()}",
@@ -92,12 +100,11 @@ def award_post_update_hook(updated_models: List[TUpdatedModel[Award]]) -> None:
         # Send push notifications if the awards post was within +/- 1 day of the Event
         event = event_key.get()
         if event and event.within_a_day:
-            # Catch TaskAlreadyExistsError + TombstonedTaskError
             try:
                 defer_safe(
                     TBANSHelper.awards,
                     event.key_name,
-                    _name=f"{event.key_name}_awards",
+                    new_award_team_keys=new_team_keys,
                     _target="py3-tasks-io",
                     _queue="push-notifications",
                     _url="/_ah/queue/deferred_notification_send",

--- a/src/backend/common/manipulators/tests/award_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/award_manipulator_test.py
@@ -227,8 +227,133 @@ class TestAwardManipulator(unittest.TestCase):
             queue_names="push-notifications"
         )
         assert len(tasks) == 1
-        task = tasks[0]
-        assert task.name == "2013casj_awards"
+
+    def test_postUpdateHook_notifications_second_update(self):
+        """A second award update should still enqueue a notification task."""
+        import datetime
+
+        self.event.start_date = datetime.datetime.now()
+        self.event.end_date = self.event.start_date + datetime.timedelta(days=1)
+
+        # First award creation
+        AwardManipulator.createOrUpdate(self.new_award)
+        hook_tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        )
+        assert len(hook_tasks) == 1
+        run_from_task(hook_tasks[0])
+
+        first_push_count = len(
+            none_throws(self.taskqueue_stub).get_filtered_tasks(
+                queue_names="push-notifications"
+            )
+        )
+        assert first_push_count == 1
+
+        # Second award creation for the same event
+        second_award = Award(
+            id=Award.render_key_name(self.event.key_name, AwardType.FINALIST),
+            name_str="Regional Finalist",
+            award_type_enum=AwardType.FINALIST,
+            year=2013,
+            event=self.event.key,
+            event_type_enum=EventType.REGIONAL,
+            team_list=[ndb.Key(Team, "frc111")],
+            recipient_json_list=[json.dumps({"team_number": 111, "awardee": None})],
+        )
+        AwardManipulator.createOrUpdate(second_award)
+        hook_tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        )
+        # Run only the second hook task
+        run_from_task(hook_tasks[-1])
+
+        # Should now have TWO push-notification tasks (not blocked by tombstone)
+        push_tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="push-notifications"
+        )
+        assert len(push_tasks) == 2
+
+    def test_postUpdateHook_notifications_passes_new_team_keys(self):
+        """New award team keys are passed through to TBANSHelper.awards()."""
+        import datetime
+
+        self.event.start_date = datetime.datetime.now()
+        self.event.end_date = self.event.start_date + datetime.timedelta(days=1)
+
+        AwardManipulator.createOrUpdate(self.new_award)
+
+        tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        )
+        for task in tasks:
+            run_from_task(task)
+
+        # Run the push-notification task and verify args
+        push_tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="push-notifications"
+        )
+        assert len(push_tasks) == 1
+
+        with patch.object(TBANSHelper, "awards") as mock_awards:
+            for task in push_tasks:
+                run_from_task(task)
+
+            mock_awards.assert_called_once()
+            call_kwargs = mock_awards.call_args
+            # event_key is the first positional arg
+            assert call_kwargs[0][0] == "2013casj"
+            # new_award_team_keys should contain the team from the new award
+            assert call_kwargs[1]["new_award_team_keys"] == {"frc359"}
+
+    def test_postUpdateHook_notifications_updated_award_empty_new_team_keys(self):
+        """Updated (not new) awards pass empty new_award_team_keys."""
+        import datetime
+
+        self.event.start_date = datetime.datetime.now()
+        self.event.end_date = self.event.start_date + datetime.timedelta(days=1)
+
+        # First, create the award
+        AwardManipulator.createOrUpdate(self.new_award)
+        # Drain post-update-hooks and push-notifications
+        for task in none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        ):
+            run_from_task(task)
+
+        # Now update the same award (change name)
+        updated_award = Award(
+            id="2013casj_1",
+            name_str="Regional Winner",
+            award_type_enum=AwardType.WINNER,
+            year=2013,
+            event=self.event.key,
+            event_type_enum=EventType.REGIONAL,
+            team_list=[ndb.Key(Team, "frc359")],
+            recipient_json_list=[json.dumps({"team_number": 359, "awardee": None})],
+        )
+        AwardManipulator.createOrUpdate(updated_award)
+
+        # Run the second post-update-hook
+        all_tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="post-update-hooks"
+        )
+        # Run only the latest hook (second one)
+        run_from_task(all_tasks[-1])
+
+        # Get push-notification tasks (there should be 2 now)
+        push_tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
+            queue_names="push-notifications"
+        )
+        # Run the latest push task and verify args
+        with patch.object(TBANSHelper, "awards") as mock_awards:
+            run_from_task(push_tasks[-1])
+
+            mock_awards.assert_called_once()
+            call_kwargs = mock_awards.call_args
+            assert call_kwargs[0][0] == "2013casj"
+            # Not a new award, so new_award_team_keys should be empty
+            assert call_kwargs[1]["new_award_team_keys"] == set()
 
     def test_postUpdateHook_notifications_notWithinADay(self):
         AwardManipulator.createOrUpdate(self.new_award)


### PR DESCRIPTION
This is something I noticed today from my working trying to get better observability into our webhooks

I think I was attempting to de-duplicate Award notifications by using the named task. However, this presents two problems. The first is that we can't enqueue a task with the same name for ~an hour, so if awards get posted, and then updated, we won't dispatch a notification.

We don't want to spam our mobile clients with awards updates, so this code introduces a way to track the awards that got changed, look for just those teams, and then dispatch just those notifications accordingly. For Event subscribers, they're going to get a post every time awards get updated (I think this is like, 3x per event).

The flow here is a little wonky because we're splitting how we deliver for webhooks vs push - which I think is okay in this case. Webhook consumer will get messages every time - which is okay.