### PR TITLE
[PWA] Fix dark mode divider text background

### DIFF
--- a/pwa/app/components/ui/divider.tsx
+++ b/pwa/app/components/ui/divider.tsx
@@ -11,7 +11,7 @@ const Divider = forwardRef<HTMLSpanElement, ComponentPropsWithoutRef<'span'>>(
           to-transparent opacity-75"
       ></div>
 
-      <span className="relative z-10 bg-white px-6">{children}</span>
+      <span className="relative z-10 bg-background px-6">{children}</span>
     </span>
   ),
 );


### PR DESCRIPTION
## Summary
This pull request makes a small visual update to the `Divider` component, ensuring that the divider label uses the current background color rather than always being white. This improves theme consistency, especially when using custom or dark backgrounds.

- Changed the `Divider` component to use the `bg-background` class instead of `bg-white` for its label, allowing the divider to adapt to different background themes.

## Screenshots:
Before:
<img width="1184" height="928" alt="image" src="https://github.com/user-attachments/assets/81f9f7fb-96f1-460c-9162-5498f81eb23c" />

After:
<img width="1184" height="928" alt="image" src="https://github.com/user-attachments/assets/36c0b4cc-1143-4b87-b10b-32794db668e6" />
