### PR TITLE
Use @meta content for oEmbed test page

### DIFF
--- a/src/backend/web/handlers/embed.py
+++ b/src/backend/web/handlers/embed.py
@@ -70,8 +70,8 @@ def instagram_oembed(media_key: str):
 
 def oembed_test():
     access_token = InstagramApiSecret.get()["api_key"]
-    instagram_url = "https://www.instagram.com/p/CbAabcyNUda/"
-    facebook_url = "https://www.facebook.com/thebluealliance/posts/pfbid0yVvTAw61qYufQZ1Pg288ioN6P3JAfCFMvgs5Cij6d7Ld2xSwVomxKRgR2CHM6bwVl"
+    instagram_url = "https://www.instagram.com/p/DVjWluEFN-r/"
+    facebook_url = "https://www.facebook.com/reel/26102042736113678"
 
     instagram_html = None
     instagram_error = None
@@ -95,7 +95,7 @@ def oembed_test():
 
     try:
         fb_response = requests.get(
-            "https://graph.facebook.com/v25.0/oembed_post",
+            "https://graph.facebook.com/v25.0/oembed_video",
             params={
                 "url": facebook_url,
                 "access_token": access_token,

--- a/src/backend/web/templates/local/oembed_test.html
+++ b/src/backend/web/templates/local/oembed_test.html
@@ -16,7 +16,7 @@
     <h1>oEmbed API Test</h1>
     <p class="meta">Using access token from <code>instagram.secrets</code> sitevar</p>
 
-    <h2>Instagram (@thebluealliance)</h2>
+    <h2>Instagram (@meta)</h2>
     <div class="embed-container">
         {% if instagram_error %}
             <div class="error">{{ instagram_error }}</div>
@@ -25,7 +25,7 @@
         {% endif %}
     </div>
 
-    <h2>Facebook (/thebluealliance)</h2>
+    <h2>Facebook (@meta reel)</h2>
     <div class="embed-container">
         {% if facebook_error %}
             <div class="error">{{ facebook_error }}</div>


### PR DESCRIPTION
## Summary
- Update oEmbed test page to use content from @meta pages for app review
- Changed Instagram URL to a @meta post
- Changed Facebook URL to a @meta reel (and switched endpoint from `oembed_post` to `oembed_video`)
- Updated labels to indicate @meta content

## Context
For app review, supposed to use content from @meta pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)