### PR TITLE
Add google-services.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tba_dev_config.local.json
 
 # Ignore Firebase config modules
 .firebaserc
+**/google-services.json
 ui-debug.log
 firebase-debug.log
 


### PR DESCRIPTION
## Summary

- Add `**/google-services.json` to `.gitignore` to prevent Firebase config files from being accidentally committed

A `google-services.json` was previously committed to a now-deleted branch during early Android app development (before the Android app moved to its own repo). The leaked credentials were for the dev Firebase project only — production was not affected — and the API key has already been rotated. This change prevents future accidents.

Also enabled GitHub secret scanning + push protection on both `the-blue-alliance` and `the-blue-alliance-android` repos.

## Test plan

- [x] Verified no `google-services.json` is currently tracked in the repo
- [x] Pattern matches the standard Firebase config filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)