### PR TITLE
Hide RP fields from match breakdown display for playoff matches

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2026.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2026.html
@@ -244,6 +244,7 @@
     {% endif %}
 
     <!-- Bonus RP -->
+     {% if match.comp_level == 'qm' %}
     {% if "energizedAchieved" in match.score_breakdown.red %}
     <tr>
         <td class="red" colspan="2">
@@ -279,7 +280,7 @@
         </td>
     </tr>
     {% endif %}
-
+    {% endif %}
     <!-- Fouls & Adjustments -->
     {% if "minorFoulCount" in match.score_breakdown.red %}
     <tr>
@@ -321,6 +322,7 @@
       <td class="blueScore" colspan="2"><b>{%if match.score_breakdown.blue.totalPoints%}{{match.score_breakdown.blue.totalPoints}}{%else%}0{%endif%}</b></td>
     </tr>
 
+    {% if match.comp_level == 'qm' %}
     <tr>
       <td class="red" colspan="2">
         {% if match.score_breakdown.red.energizedAchieved %}
@@ -360,5 +362,6 @@
         +{{match.score_breakdown.blue.rp}} RP
       </td>
     </tr>
+    {% endif %}
     </tbody>
 </table>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hide ranking point fields from score summary for non-qualification matches

## Motivation and Context
Somewhat unintuitive to show that teams earned no ranking points during elims, as it implies that it's possible to earn them
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local instance of TBA

## Screenshots (if appropriate):

<table>
<tr>
 <td>Old
 <td>New
<tr>
<td><img width="717" height="1281" alt="image" src="https://github.com/user-attachments/assets/f1916431-1725-4af3-b0dd-6637e4f45c1c" />
 <td><img width="717" height="1258" alt="image" src="https://github.com/user-attachments/assets/e395516a-6336-4415-a6f4-0e72e586b817" />

 
</table>



## Screenshot Pages
<!--- For PRs that touch pwa/ files, list additional pages to screenshot. -->
<!--- Each line: - /path Optional Display Name -->
<!--- Example: - /match/2024mil_f1m2 Match Page -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
