### PR TITLE
Fix header offset in Scalar apidocs

### DIFF
--- a/pwa/app/routes/apidocs_.v3.tsx
+++ b/pwa/app/routes/apidocs_.v3.tsx
@@ -91,6 +91,10 @@ function ApiDocsV3(): React.JSX.Element {
   return (
     <>
       <ApiReferenceReact
+        style={{
+          "--scalar-custom-header-height": "calc(var(--spacing) * 14)"
+          /* this sets the vertical offset to the height of our header so that their header doesn't overlap with our header */
+        }}
         configuration={{
           url: 'https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/refs/heads/main/src/backend/web/static/swagger/api_v3.json',
           hideClientButton: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously the header overlapped when you scrolled. Now it doesn't.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I think this was removed at some point during the apidocs PR.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, works.
## Screenshots (if appropriate):

## Screenshot Pages
<!--- For PRs that touch pwa/ files, list additional pages to screenshot. -->
<!--- Each line: - /path Optional Display Name -->
<!--- Example: - /match/2024mil_f1m2 Match Page -->
- /apidocs/v3
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
