### PR TITLE
Fix flaky Ops Fullstack Test timeout

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -412,6 +412,9 @@ jobs:
       - name: Test Docker Startup
         if: steps.changes.outputs.web == 'true'
         run: python ./ops/test_docker_startup.py
+      - name: Pre-pull companion import image
+        if: steps.changes.outputs.web == 'true'
+        run: docker pull gcr.io/tbatv-prod-hrd/tba-offseason-companion-import:latest
       - name: Test Ops Fullstack
         if: steps.changes.outputs.web == 'true'
         run: ./ops/test_ops.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -392,6 +392,9 @@ jobs:
       - name: Test Docker Startup
         if: contains(github.event.commits[0].message, '[clowntown]') == false
         run: python ./ops/test_docker_startup.py
+      - name: Pre-pull companion import image
+        if: contains(github.event.commits[0].message, '[clowntown]') == false
+        run: docker pull gcr.io/tbatv-prod-hrd/tba-offseason-companion-import:latest
       - name: Test Ops Fullstack
         if: contains(github.event.commits[0].message, '[clowntown]') == false
         run: ./ops/test_ops.sh

--- a/ops/tests/fms_companion_import.test.js
+++ b/ops/tests/fms_companion_import.test.js
@@ -132,7 +132,7 @@ describe("FMS Companion Import", () => {
       if (error.stderr) console.error("stderr:", error.stderr);
       throw error;
     }
-  });
+  }, 180000); // 3 min — container execution + data processing
 
   it("should have matches written", async () => {
     expect(eventKey).not.toBeNull();


### PR DESCRIPTION
## Summary
- Pre-pull the `gcr.io/tbatv-prod-hrd/tba-offseason-companion-import:latest` Docker image in a separate CI step before running Jest tests, so the pull time doesn't count against the test timeout
- Increase the per-test timeout for the Docker container test from 120s to 180s as a safety margin
- Applied to both `pull_request.yml` and `push.yml` workflows

## Test plan
- [x] Verify the "Ops Fullstack Test" CI job passes on this PR
- [ ] Confirm the pre-pull step completes before the test step runs
- [ ] Check that the test itself runs in a reasonable time (<30s with pre-pulled image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)