### PR TITLE
[pwa] fix wisconsin eventlist color

### DIFF
--- a/pwa/app/components/tba/eventListTable.tsx
+++ b/pwa/app/components/tba/eventListTable.tsx
@@ -47,7 +47,7 @@ const DISTRICT_COLORS: Record<string, string> = {
   fit: 'border-l-[#E36A2E]',
   tx: 'border-l-[#E36A2E]',
   // Wisconsin
-  wi: 'border-l-[#5FAF8C]',
+  win: 'border-l-[#E84393]',
 };
 
 function getDistrictColorClass(


### PR DESCRIPTION
<img width="675" height="643" alt="image" src="https://github.com/user-attachments/assets/42db193c-173c-4547-8027-74912fa0013b" />

previously, WIN events weren't getting color bars due to a typo.

a wisconsinite surveyed their week 1 event regarding what color they want and the gathered consensus was hot pink. i am a man of the people