### PR TITLE
Fix district championship count being wrong in district insights

### DIFF
--- a/src/backend/common/helpers/insights_districts_helper.py
+++ b/src/backend/common/helpers/insights_districts_helper.py
@@ -20,6 +20,7 @@ from backend.common.queries.district_query import DistrictHistoryQuery
 from backend.common.queries.event_query import (
     CmpDivisionsInYearQuery,
     DistrictChampsInYearQuery,
+    DistrictCmpDivisionsInYearQuery,
     DistrictEventsQuery,
 )
 from backend.common.queries.team_query import DistrictTeamsQuery
@@ -90,6 +91,17 @@ class InsightsDistrictsHelper:
             partial_event_list = future.get_result()
             dcmp_event_list += partial_event_list
 
+        dcmp_division_event_futures = []
+        for district in history:
+            dcmp_division_event_futures.append(
+                DistrictCmpDivisionsInYearQuery(year=district.year).fetch_async()
+            )
+
+        dcmp_division_event_list: List[Event] = []
+        for future in dcmp_division_event_futures:
+            partial_event_list = future.get_result()
+            dcmp_division_event_list += partial_event_list
+
         cmp_event_futures = []
         for district in history:
             cmp_event_futures.append(
@@ -111,7 +123,7 @@ class InsightsDistrictsHelper:
         elims_record = defaultdict(lambda: WLTRecord(wins=0, losses=0, ties=0))
         district_event_per_year_count = defaultdict(lambda: defaultdict(int))
         total_matches_played = defaultdict(int)
-        dcmp_appearances = defaultdict(int)
+        dcmp_appearances_by_year: Dict[str, Set[int]] = defaultdict(set)
         cmp_appearances = defaultdict(int)
 
         for event in district_event_list:
@@ -171,7 +183,11 @@ class InsightsDistrictsHelper:
 
         for dcmp_event in dcmp_event_list:
             for team in dcmp_event.teams:
-                dcmp_appearances[team.key_name] += 1
+                dcmp_appearances_by_year[team.key_name].add(dcmp_event.year)
+
+        for dcmp_div_event in dcmp_division_event_list:
+            for team in dcmp_div_event.teams:
+                dcmp_appearances_by_year[team.key_name].add(dcmp_div_event.year)
 
         for cmp_event in cmp_event_list:
             for team in cmp_event.teams:
@@ -196,7 +212,7 @@ class InsightsDistrictsHelper:
                     ]
                 ),
                 total_matches_played=total_matches_played[k],
-                dcmp_appearances=dcmp_appearances[k],
+                dcmp_appearances=len(dcmp_appearances_by_year[k]),
                 cmp_appearances=cmp_appearances[k],
             )
             for k in years_participated.keys()

--- a/src/backend/common/helpers/tests/insights_districts_helper_test.py
+++ b/src/backend/common/helpers/tests/insights_districts_helper_test.py
@@ -1,0 +1,123 @@
+from google.appengine.ext import ndb
+
+from backend.common.consts.event_type import EventType
+from backend.common.helpers.insights_districts_helper import InsightsDistrictsHelper
+from backend.common.models.district import District
+from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
+from backend.common.models.team import Team
+
+
+def setup_district_with_team(year: int, abbreviation: str, team_key: str) -> None:
+    District(
+        id=f"{year}{abbreviation}",
+        year=year,
+        abbreviation=abbreviation,
+        rankings=[
+            {
+                "team_key": team_key,
+                "event_points": [{"total": 100, "district_cmp": False}],
+            }
+        ],
+    ).put()
+    Team(id=team_key, team_number=int(team_key.replace("frc", ""))).put()
+
+
+def register_team_at_event(event_key: str, team_key: str, year: int) -> None:
+    EventTeam(
+        id=f"{event_key}_{team_key}",
+        event=ndb.Key(Event, event_key),
+        team=ndb.Key(Team, team_key),
+        year=year,
+    ).put()
+
+
+def test_dcmp_appearances_counts_only_district_cmp_pre_division_era(ndb_stub) -> None:
+    """Pre-2019: only DISTRICT_CMP events exist."""
+    setup_district_with_team(2018, "ne", "frc5254")
+
+    Event(
+        id="2018nedcmp",
+        year=2018,
+        event_short="nedcmp",
+        event_type_enum=EventType.DISTRICT_CMP,
+    ).put()
+    register_team_at_event("2018nedcmp", "frc5254", 2018)
+
+    result = InsightsDistrictsHelper.make_insight_team_data("ne")
+    assert result["frc5254"]["dcmp_appearances"] == 1
+
+
+def test_dcmp_appearances_counts_division_event_when_team_eliminated_in_division(
+    ndb_stub,
+) -> None:
+    """2019+: team attends a DISTRICT_CMP_DIVISION but is eliminated before the finals."""
+    setup_district_with_team(2019, "ne", "frc5254")
+
+    Event(
+        id="2019nedcmp1",
+        year=2019,
+        event_short="nedcmp1",
+        event_type_enum=EventType.DISTRICT_CMP_DIVISION,
+    ).put()
+    # Finals event exists but team 195 did not advance
+    Event(
+        id="2019nedcmp",
+        year=2019,
+        event_short="nedcmp",
+        event_type_enum=EventType.DISTRICT_CMP,
+    ).put()
+    register_team_at_event("2019nedcmp1", "frc5254", 2019)
+
+    result = InsightsDistrictsHelper.make_insight_team_data("ne")
+    assert result["frc5254"]["dcmp_appearances"] == 1
+
+
+def test_dcmp_appearances_no_double_count_when_advancing_to_finals(ndb_stub) -> None:
+    """Team appears in both a DISTRICT_CMP_DIVISION and the DISTRICT_CMP finals in the same year."""
+    setup_district_with_team(2019, "ne", "frc5254")
+
+    Event(
+        id="2019nedcmp1",
+        year=2019,
+        event_short="nedcmp1",
+        event_type_enum=EventType.DISTRICT_CMP_DIVISION,
+    ).put()
+    Event(
+        id="2019nedcmp",
+        year=2019,
+        event_short="nedcmp",
+        event_type_enum=EventType.DISTRICT_CMP,
+    ).put()
+    register_team_at_event("2019nedcmp1", "frc5254", 2019)
+    register_team_at_event("2019nedcmp", "frc5254", 2019)
+
+    result = InsightsDistrictsHelper.make_insight_team_data("ne")
+    assert result["frc5254"]["dcmp_appearances"] == 1
+
+
+def test_dcmp_appearances_accumulates_across_years(ndb_stub) -> None:
+    """Team attends DCMP across multiple years with mixed event types."""
+    setup_district_with_team(2018, "ne", "frc5254")
+    setup_district_with_team(2019, "ne", "frc5254")
+
+    # 2018: pre-division era, team in DISTRICT_CMP finals only
+    Event(
+        id="2018nedcmp",
+        year=2018,
+        event_short="nedcmp",
+        event_type_enum=EventType.DISTRICT_CMP,
+    ).put()
+    register_team_at_event("2018nedcmp", "frc5254", 2018)
+
+    # 2019: team in DISTRICT_CMP_DIVISION only (eliminated in division)
+    Event(
+        id="2019nedcmp1",
+        year=2019,
+        event_short="nedcmp1",
+        event_type_enum=EventType.DISTRICT_CMP_DIVISION,
+    ).put()
+    register_team_at_event("2019nedcmp1", "frc5254", 2019)
+
+    result = InsightsDistrictsHelper.make_insight_team_data("ne")
+    assert result["frc5254"]["dcmp_appearances"] == 2

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -99,6 +99,25 @@ class DistrictChampsInYearQuery(CachedDatabaseQuery[List[Event], List[EventDict]
         return list(events)
 
 
+class DistrictCmpDivisionsInYearQuery(
+    CachedDatabaseQuery[List[Event], List[EventDict]]
+):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "district_cmp_division_events_{year}"
+    DICT_CONVERTER = EventConverter
+
+    def __init__(self, year: Year) -> None:
+        super().__init__(year=year)
+
+    @typed_tasklet
+    def _query_async(self, year: Year) -> Generator[Any, Any, List[Event]]:
+        all_cmp_event_keys = yield Event.query(
+            Event.year == year, Event.event_type_enum == EventType.DISTRICT_CMP_DIVISION
+        ).fetch_async(keys_only=True)
+        events = yield ndb.get_multi_async(all_cmp_event_keys)
+        return list(events)
+
+
 class CmpDivisionsInYearQuery(CachedDatabaseQuery[List[Event], List[EventDict]]):
     CACHE_VERSION = 0
     CACHE_KEY_FORMAT = "cmp_division_events_{year}"

--- a/src/backend/common/queries/tests/district_cmp_divisions_in_year_query_test.py
+++ b/src/backend/common/queries/tests/district_cmp_divisions_in_year_query_test.py
@@ -1,0 +1,28 @@
+from backend.common.consts.event_type import EventType
+from backend.common.models.event import Event
+from backend.common.models.keys import Year
+from backend.common.queries.event_query import DistrictCmpDivisionsInYearQuery
+
+
+def preseed_event(year: Year, short: str, type: EventType) -> None:
+    Event(
+        id=f"{year}{short}",
+        event_short=short,
+        year=year,
+        event_type_enum=type,
+    ).put()
+
+
+def test_none_found() -> None:
+    divisions = DistrictCmpDivisionsInYearQuery(year=2019).fetch()
+    assert divisions == []
+
+
+def test_with_district_cmp_division() -> None:
+    preseed_event(2019, "test1", EventType.DISTRICT_CMP_DIVISION)
+    preseed_event(2019, "test2", EventType.REGIONAL)
+    preseed_event(2019, "test3", EventType.DISTRICT_CMP)
+    preseed_event(2018, "test4", EventType.DISTRICT_CMP_DIVISION)
+
+    divisions = DistrictCmpDivisionsInYearQuery(year=2019).fetch()
+    assert divisions == [Event.get_by_id("2019test1")]


### PR DESCRIPTION
It was not counting DCMP appearances for teams that were eliminated in a DCMP division and did not win a DCMP-level award. This fixes that