### PR TITLE
[pwa] Add text-balance to banners

### DIFF
--- a/pwa/app/components/tba/banner.tsx
+++ b/pwa/app/components/tba/banner.tsx
@@ -206,7 +206,7 @@ export function Banner({
         />
       </svg>
       <span
-        className={cn('text-lg/5 font-bold', {
+        className={cn('text-lg/5 font-bold text-balance', {
           'text-sm/4': title && title.length > 25,
           'text-base/4': title && 20 <= title.length && title.length <= 25,
           'text-lg/5': title && title.length < 20,
@@ -214,7 +214,7 @@ export function Banner({
       >
         {formattedTitle}
       </span>
-      <span className="text-xs/4 font-bold">
+      <span className="text-xs/4 font-bold text-balance">
         <span className="mb-1 block text-xs">{year}</span>
         {description?.toUpperCase()}
       </span>


### PR DESCRIPTION
before:

<img width="1918" height="2159" alt="image" src="https://github.com/user-attachments/assets/d03fe75f-c4b6-4870-8a8e-69b7f48ba849" />

after:

<img width="1918" height="2159" alt="image" src="https://github.com/user-attachments/assets/db6442c5-3bc5-421a-8e47-c3401dfe3a7b" />
