### PR TITLE
fix bug in caching webcast online status

### DIFF
--- a/src/backend/tasks_io/helpers/tests/webcast_online_helper_test.py
+++ b/src/backend/tasks_io/helpers/tests/webcast_online_helper_test.py
@@ -92,6 +92,33 @@ def test_add_online_status_in_cache() -> None:
     assert webcast == webcast_with_status
 
 
+def test_add_online_status_in_cache_does_not_refresh_cache_ttl() -> None:
+    webcast = Webcast(
+        type=WebcastType.HTML5,
+        channel="test_stream.m4v",
+    )
+    webcast_with_status = Webcast(
+        type=WebcastType.HTML5,
+        channel="test_stream.m4v",
+        status=WebcastStatus.OFFLINE,
+        stream_title="Old Stream",
+        viewer_count=12,
+    )
+
+    WebcastOnlineStatusMemcache(webcast).put(webcast_with_status)
+
+    with mock.patch.object(
+        WebcastOnlineStatusMemcache,
+        "put_async",
+        return_value=InstantFuture(True),
+    ) as put_async_mock:
+        WebcastOnlineHelper.add_online_status([webcast])
+
+    # Cached entries should not be rewritten; otherwise stale statuses can persist forever.
+    put_async_mock.assert_not_called()
+    assert webcast == webcast_with_status
+
+
 @mock.patch.object(YoutubeWebcastStatusBatch, "fetch_async")
 def test_add_online_status_youtube(youtube_mock: mock.Mock) -> None:
     webcast = Webcast(

--- a/src/backend/tasks_io/helpers/webcast_online_helper.py
+++ b/src/backend/tasks_io/helpers/webcast_online_helper.py
@@ -88,6 +88,7 @@ class WebcastOnlineHelper:
         # Separate by cache status and type
         youtube_webcasts: List[Webcast] = []
         other_webcasts: List[Webcast] = []
+        webcasts_to_cache: List[Webcast] = []
         webcast_status_futures: List[Any] = []
 
         # Check cache and separate webcasts
@@ -97,7 +98,7 @@ class WebcastOnlineHelper:
         cached_results: List[Optional[Webcast]] = yield cache_futures
 
         for webcast, cached_webcast in zip(webcasts, cached_results):
-            if cached_webcast:
+            if cached_webcast is not None:
                 # Apply cached status
                 if "status" in cached_webcast:
                     webcast["status"] = cached_webcast.get(
@@ -112,6 +113,7 @@ class WebcastOnlineHelper:
                 webcast["status"] = WebcastStatus.UNKNOWN
                 webcast["stream_title"] = None
                 webcast["viewer_count"] = None
+                webcasts_to_cache.append(webcast)
 
                 if webcast["type"] == WebcastType.YOUTUBE:
                     youtube_webcasts.append(webcast)
@@ -133,10 +135,11 @@ class WebcastOnlineHelper:
         if webcast_status_futures:
             yield webcast_status_futures
 
-        # Cache all results
+        # Cache only statuses we freshly computed (cache misses).
+        # Do not rewrite cache hits, or stale statuses can be refreshed indefinitely.
         cache_put_futures = [
             WebcastOnlineStatusMemcache(webcast).put_async(webcast)
-            for webcast in webcasts
+            for webcast in webcasts_to_cache
             if webcast.get("status") is not None
         ]
         if cache_put_futures:


### PR DESCRIPTION
I think we are being a bit aggressive in re-writing cached status back, so we would in effect never re-fetch for the webcast