### PR TITLE
update youtube channel resolution to not use search

### DIFF
--- a/src/backend/common/datafeeds/datafeed_youtube.py
+++ b/src/backend/common/datafeeds/datafeed_youtube.py
@@ -7,6 +7,10 @@ from google.appengine.ext import ndb
 
 from backend.common.consts.webcast_type import WebcastType
 from backend.common.datafeeds.datafeed_base import DatafeedBase
+from backend.common.datafeeds.parsers.youtube.youtube_channel_list_parser import (
+    ParsedChannelListResult,
+    YoutubeChannelListParser,
+)
 from backend.common.datafeeds.parsers.youtube.youtube_playlist_items_parser import (
     ParsedPlaylistItem,
     YoutubePlaylistItemsParser,
@@ -101,25 +105,39 @@ class YoutubeVideoDetailsDatafeed(YoutubeApiBase[Optional[ParsedVideoDetails]]):
         return YoutubeVideoDetailsParser()
 
 
-class YoutubeSearchDatafeed(YoutubeApiBase[List[ParsedSearchResult]]):
+class YoutubeChannelListForHandleDatafeed(
+    YoutubeApiBase[List[ParsedChannelListResult]]
+):
+    def __init__(self, handle: str) -> None:
+        super().__init__()
+        self.handle = handle.lstrip("@")
+
+    def endpoint(self) -> str:
+        return "channels"
+
+    def url_params(self) -> Dict[str, str]:
+        return {
+            "part": "id,snippet",
+            "forHandle": self.handle,
+        }
+
+    def parser(self) -> YoutubeChannelListParser:
+        return YoutubeChannelListParser()
+
+
+class YoutubeUpcomingStreamsDatafeed(YoutubeApiBase[List[ParsedSearchResult]]):
     def __init__(
         self,
-        query: Optional[str] = None,
-        search_type: str = "channel",
-        max_results: int = 1,
-        order: str = "relevance",
+        channel_id: str,
+        max_results: int = 50,
+        order: str = "date",
         page_token: str = "",
-        channel_id: Optional[str] = None,
-        event_type: Optional[str] = None,
     ) -> None:
         super().__init__()
-        self.query = query
-        self.search_type = search_type
+        self.channel_id = channel_id
         self.max_results = max_results
         self.order = order
         self.page_token = page_token
-        self.channel_id = channel_id
-        self.event_type = event_type
 
     def endpoint(self) -> str:
         return "search"
@@ -127,16 +145,12 @@ class YoutubeSearchDatafeed(YoutubeApiBase[List[ParsedSearchResult]]):
     def url_params(self) -> Dict[str, str]:
         params = {
             "part": "snippet",
-            "type": self.search_type,
+            "type": "video",
             "maxResults": str(self.max_results),
             "order": self.order,
+            "channelId": self.channel_id,
+            "eventType": "upcoming",
         }
-        if self.query is not None:
-            params["q"] = self.query
-        if self.channel_id is not None:
-            params["channelId"] = self.channel_id
-        if self.event_type is not None:
-            params["eventType"] = self.event_type
         if self.page_token:
             params["pageToken"] = self.page_token
         return params
@@ -149,7 +163,7 @@ class YoutubeSearchDatafeed(YoutubeApiBase[List[ParsedSearchResult]]):
         self,
         max_pages: int = 10,
     ) -> Generator[Any, Any, List[ParsedSearchResult]]:
-        """Fetch and parse all pages for this search request.
+        """Fetch and parse all pages for this request.
 
         Follows YouTube's `nextPageToken` chain up to `max_pages` pages.
         """
@@ -158,14 +172,11 @@ class YoutubeSearchDatafeed(YoutubeApiBase[List[ParsedSearchResult]]):
         page_count = 0
 
         while page_count < max_pages:
-            page_datafeed = YoutubeSearchDatafeed(
-                query=self.query,
-                search_type=self.search_type,
+            page_datafeed = YoutubeUpcomingStreamsDatafeed(
+                channel_id=self.channel_id,
                 max_results=self.max_results,
                 order=self.order,
                 page_token=next_page_token,
-                channel_id=self.channel_id,
-                event_type=self.event_type,
             )
             response = yield page_datafeed._fetch()
 

--- a/src/backend/common/datafeeds/parsers/youtube/youtube_channel_list_parser.py
+++ b/src/backend/common/datafeeds/parsers/youtube/youtube_channel_list_parser.py
@@ -1,0 +1,46 @@
+"""Parser for YouTube channels.list API responses."""
+
+from typing import Any, cast, List, NotRequired, TypedDict
+
+from backend.common.datafeeds.parsers.parser_base import ParserBase
+
+
+class _ChannelListSnippet(TypedDict):
+    title: str
+
+
+class _ChannelListItem(TypedDict):
+    id: str
+    snippet: NotRequired[_ChannelListSnippet]
+
+
+class _ChannelListResponse(TypedDict):
+    items: List[_ChannelListItem]
+
+
+class ParsedChannelListResult(TypedDict):
+    channel_id: str
+    channel_name: str
+
+
+class YoutubeChannelListParser(ParserBase[Any, List[ParsedChannelListResult]]):
+    def parse(self, response: Any) -> List[ParsedChannelListResult]:
+        response_data = cast(_ChannelListResponse, response)
+        results: List[ParsedChannelListResult] = []
+
+        for item in response_data.get("items", []):
+            channel_id = item.get("id")
+            snippet = item.get("snippet", {})
+            channel_name = snippet.get("title")
+
+            if not channel_id or not channel_name:
+                continue
+
+            results.append(
+                ParsedChannelListResult(
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                )
+            )
+
+        return results

--- a/src/backend/common/helpers/tests/youtube_video_helper_test.py
+++ b/src/backend/common/helpers/tests/youtube_video_helper_test.py
@@ -314,62 +314,80 @@ def test_get_scheduled_start_time_success(ndb_context, mock_google_api_secret) -
     assert result == "2023-03-15"
 
 
-def test_resolve_channel_name_no_secret(ndb_context) -> None:
-    result = YouTubeVideoHelper.resolve_channel_name("FIRST in Michigan").get_result()
+def test_resolve_channel_id_no_secret(ndb_context) -> None:
+    result = YouTubeVideoHelper.resolve_channel_id("FIRSTinMichigan").get_result()
     assert result is None
 
 
-def test_resolve_channel_name_api_error(ndb_context, mock_google_api_secret) -> None:
+def test_resolve_channel_id_api_error(ndb_context, mock_google_api_secret) -> None:
     mock_urlfetch_result = URLFetchResult.mock_for_content(
-        "https://www.googleapis.com/youtube/v3/search",
+        "https://www.googleapis.com/youtube/v3/channels",
         403,
         "{}",
     )
     mock_future = InstantFuture(mock_urlfetch_result)
 
     with patch("google.appengine.ext.ndb.Context.urlfetch", return_value=mock_future):
-        result = YouTubeVideoHelper.resolve_channel_name(
-            "FIRST in Michigan"
-        ).get_result()
+        result = YouTubeVideoHelper.resolve_channel_id("FIRSTinMichigan").get_result()
     assert result is None
 
 
-def test_resolve_channel_name_not_found(ndb_context, mock_google_api_secret) -> None:
+def test_resolve_channel_id_not_found(ndb_context, mock_google_api_secret) -> None:
     mock_urlfetch_result = URLFetchResult.mock_for_content(
-        "https://www.googleapis.com/youtube/v3/search",
+        "https://www.googleapis.com/youtube/v3/channels",
         200,
         '{"items": []}',
     )
     mock_future = InstantFuture(mock_urlfetch_result)
 
     with patch("google.appengine.ext.ndb.Context.urlfetch", return_value=mock_future):
-        result = YouTubeVideoHelper.resolve_channel_name("does-not-exist").get_result()
+        result = YouTubeVideoHelper.resolve_channel_id("does-not-exist").get_result()
     assert result is None
 
 
-def test_resolve_channel_name_success(ndb_context, mock_google_api_secret) -> None:
+def test_resolve_channel_id_success(ndb_context, mock_google_api_secret) -> None:
     api_resp = {
         "items": [
             {
-                "id": {
-                    "kind": "youtube#channel",
-                    "channelId": "UCjX4WSaAFPgM2PYr-6P",
-                },
+                "id": "UCjX4WSaAFPgM2PYr-6P",
                 "snippet": {"title": "FIRST in Michigan"},
             }
         ]
     }
     mock_urlfetch_result = URLFetchResult.mock_for_content(
-        "https://www.googleapis.com/youtube/v3/search",
+        "https://www.googleapis.com/youtube/v3/channels",
         200,
         json.dumps(api_resp),
     )
     mock_future = InstantFuture(mock_urlfetch_result)
 
     with patch("google.appengine.ext.ndb.Context.urlfetch", return_value=mock_future):
-        result = YouTubeVideoHelper.resolve_channel_name(
-            "FIRST in Michigan"
-        ).get_result()
+        result = YouTubeVideoHelper.resolve_channel_id("@FIRSTinMichigan").get_result()
+    assert result == YouTubeChannel(
+        channel_id="UCjX4WSaAFPgM2PYr-6P",
+        channel_name="FIRST in Michigan",
+    )
+
+
+def test_resolve_channel_name_wrapper(ndb_context, mock_google_api_secret) -> None:
+    api_resp = {
+        "items": [
+            {
+                "id": "UCjX4WSaAFPgM2PYr-6P",
+                "snippet": {"title": "FIRST in Michigan"},
+            }
+        ]
+    }
+    mock_urlfetch_result = URLFetchResult.mock_for_content(
+        "https://www.googleapis.com/youtube/v3/channels",
+        200,
+        json.dumps(api_resp),
+    )
+    mock_future = InstantFuture(mock_urlfetch_result)
+
+    with patch("google.appengine.ext.ndb.Context.urlfetch", return_value=mock_future):
+        result = YouTubeVideoHelper.resolve_channel_name("FIRSTinMichigan").get_result()
+
     assert result == YouTubeChannel(
         channel_id="UCjX4WSaAFPgM2PYr-6P",
         channel_name="FIRST in Michigan",

--- a/src/backend/common/helpers/youtube_video_helper.py
+++ b/src/backend/common/helpers/youtube_video_helper.py
@@ -7,8 +7,9 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.datafeeds.datafeed_youtube import (
+    YoutubeChannelListForHandleDatafeed,
     YoutubePlaylistItemsDatafeed,
-    YoutubeSearchDatafeed,
+    YoutubeUpcomingStreamsDatafeed,
     YoutubeVideoDetailsDatafeed,
     YoutubeVideoLiveDetailsBatchDatafeed,
 )
@@ -151,19 +152,19 @@ class YouTubeVideoHelper(object):
 
     @classmethod
     @typed_tasklet
-    def resolve_channel_name(
-        cls, channel_name: str
+    def resolve_channel_id(
+        cls, channel_username: str
     ) -> Generator[Any, Any, Optional[YouTubeChannel]]:
         """
-        Resolves a YouTube channel name to a channel ID.
+        Resolves a YouTube channel username/handle to a channel ID.
         Returns channel metadata if found, else None.
         """
+        normalized_handle = channel_username.strip().lstrip("@")
+        if not normalized_handle:
+            raise ndb.Return(None)
+
         try:
-            datafeed = YoutubeSearchDatafeed(
-                query=channel_name,
-                search_type="channel",
-                max_results=1,
-            )
+            datafeed = YoutubeChannelListForHandleDatafeed(normalized_handle)
             response = yield datafeed._fetch()
 
             if response.status_code != 200:
@@ -174,21 +175,19 @@ class YouTubeVideoHelper(object):
                 raise ndb.Return(None)
 
             parsed_data = datafeed.parser().parse(raw_data)
-            if parsed_data:
-                first_item = parsed_data[0]
-                resolved_channel_id = first_item.get("channel_id")
-                resolved_channel_name = first_item.get("title")
-            else:
-                resolved_channel_id = None
-                resolved_channel_name = None
+            if not parsed_data:
+                raise ndb.Return(None)
 
+            first_item = parsed_data[0]
+            resolved_channel_id = first_item.get("channel_id")
+            resolved_channel_name = first_item.get("channel_name")
             if not resolved_channel_id:
                 raise ndb.Return(None)
 
             raise ndb.Return(
                 YouTubeChannel(
                     channel_id=resolved_channel_id,
-                    channel_name=resolved_channel_name or channel_name,
+                    channel_name=resolved_channel_name or channel_username,
                 )
             )
         except ValueError:
@@ -198,10 +197,19 @@ class YouTubeVideoHelper(object):
             raise
         except Exception:
             logging.exception(
-                "Failed to resolve YouTube channel name '%s'",
-                channel_name,
+                "Failed to resolve YouTube channel handle '%s'",
+                channel_username,
             )
             raise ndb.Return(None)
+
+    @classmethod
+    @typed_tasklet
+    def resolve_channel_name(
+        cls, channel_name: str
+    ) -> Generator[Any, Any, Optional[YouTubeChannel]]:
+        """Backward-compatible wrapper around handle-based channel resolution."""
+        resolved_channel = yield cls.resolve_channel_id(channel_name)
+        raise ndb.Return(resolved_channel)
 
     @classmethod
     @typed_tasklet
@@ -278,12 +286,10 @@ class YouTubeVideoHelper(object):
         """
         stream_basics: List[Dict[str, str]] = []
         try:
-            search_datafeed = YoutubeSearchDatafeed(
-                search_type="video",
+            search_datafeed = YoutubeUpcomingStreamsDatafeed(
+                channel_id=channel_id,
                 max_results=50,
                 order="date",
-                channel_id=channel_id,
-                event_type="upcoming",
             )
             parsed_search_results = yield search_datafeed.fetch_all_pages_async()
         except ValueError:

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_youtube_search_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_youtube_search_test.py
@@ -1,11 +1,17 @@
-"""Tests for YouTube search API datafeeds and parser."""
+"""Tests for YouTube channel and search datafeeds/parsers."""
 
 import json
 from unittest import mock
 
 import pytest
 
-from backend.common.datafeeds.datafeed_youtube import YoutubeSearchDatafeed
+from backend.common.datafeeds.datafeed_youtube import (
+    YoutubeChannelListForHandleDatafeed,
+    YoutubeUpcomingStreamsDatafeed,
+)
+from backend.common.datafeeds.parsers.youtube.youtube_channel_list_parser import (
+    YoutubeChannelListParser,
+)
 from backend.common.datafeeds.parsers.youtube.youtube_search_parser import (
     YoutubeSearchParser,
 )
@@ -18,7 +24,6 @@ class TestYoutubeSearchParser:
     """Tests for YoutubeSearchParser."""
 
     def test_parse_channel_search_results(self) -> None:
-        """Test parsing search results for channels."""
         response = {
             "items": [
                 {
@@ -46,56 +51,7 @@ class TestYoutubeSearchParser:
         assert result["title"] == "Example Channel"
         assert result["channel_id"] == "UCabc123"
 
-    def test_parse_channel_id_not_overwritten_by_snippet_channel_id(self) -> None:
-        """Test parser prefers ID block channelId over snippet channelId."""
-        response = {
-            "items": [
-                {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#channel",
-                        "channelId": "UCidBlock",
-                    },
-                    "snippet": {
-                        "title": "Example Channel",
-                        "channelId": "UCsnippetBlock",
-                        "channelTitle": "Example Channel",
-                    },
-                }
-            ]
-        }
-
-        parser = YoutubeSearchParser()
-        results = parser.parse(response)
-
-        assert len(results) == 1
-        assert results[0]["channel_id"] == "UCidBlock"
-
-    def test_parse_channel_title_not_used_as_channel_id(self) -> None:
-        """Test parser does not use channelTitle as channel_id fallback."""
-        response = {
-            "items": [
-                {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#channel",
-                    },
-                    "snippet": {
-                        "title": "Example Channel",
-                        "channelTitle": "Example Channel",
-                    },
-                }
-            ]
-        }
-
-        parser = YoutubeSearchParser()
-        results = parser.parse(response)
-
-        assert len(results) == 1
-        assert "channel_id" not in results[0]
-
     def test_parse_video_search_results(self) -> None:
-        """Test parsing search results for videos."""
         response = {
             "items": [
                 {
@@ -107,7 +63,6 @@ class TestYoutubeSearchParser:
                     "snippet": {
                         "title": "Example Video",
                         "description": "A test video",
-                        "liveBroadcastContent": "none",
                     },
                 },
                 {
@@ -129,229 +84,94 @@ class TestYoutubeSearchParser:
 
         assert len(results) == 2
         assert results[0]["video_id"] == "video_xyz"
-        assert results[0]["title"] == "Example Video"
         assert results[1]["video_id"] == "video_abc"
-        assert results[1]["title"] == "Upcoming Stream"
 
-    def test_parse_multiple_result_types(self) -> None:
-        """Test parsing mixed result types (channel, video, playlist)."""
+
+class TestYoutubeChannelListParser:
+    def test_parse_channel_list(self) -> None:
+        parser = YoutubeChannelListParser()
         response = {
             "items": [
                 {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#channel",
-                        "channelId": "channel_123",
-                    },
-                    "snippet": {
-                        "title": "Test Channel",
-                    },
-                },
-                {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#video",
-                        "videoId": "video_456",
-                    },
-                    "snippet": {
-                        "title": "Test Video",
-                    },
-                },
-                {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#playlist",
-                        "playlistId": "playlist_789",
-                    },
-                    "snippet": {
-                        "title": "Test Playlist",
-                    },
-                },
-            ]
-        }
-
-        parser = YoutubeSearchParser()
-        results = parser.parse(response)
-
-        assert len(results) == 3
-        assert results[0]["channel_id"] == "channel_123"
-        assert results[1]["video_id"] == "video_456"
-        assert results[2]["playlist_id"] == "playlist_789"
-
-    def test_parse_empty_response(self) -> None:
-        """Test parsing empty response returns empty list."""
-        response = {"items": []}
-
-        parser = YoutubeSearchParser()
-        results = parser.parse(response)
-
-        assert results == []
-
-    def test_parse_missing_snippet_skipped(self) -> None:
-        """Test that items without snippets are skipped."""
-        response = {
-            "items": [
-                {
-                    "id": {
-                        "kind": "youtube#channel",
-                        "channelId": "channel_123",
-                    },
-                    # Missing snippet
-                },
-                {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#channel",
-                        "channelId": "channel_456",
-                    },
-                    "snippet": {
-                        "title": "Valid Channel",
-                    },
-                },
-            ]
-        }
-
-        parser = YoutubeSearchParser()
-        results = parser.parse(response)
-
-        assert len(results) == 1
-        assert results[0]["channel_id"] == "channel_456"
-
-    def test_parse_page_tokens(self) -> None:
-        """Test that page tokens are preserved in response."""
-        response = {
-            "items": [
-                {
-                    "kind": "youtube#searchResult",
-                    "id": {
-                        "kind": "youtube#video",
-                        "videoId": "video_1",
-                    },
-                    "snippet": {
-                        "title": "Video 1",
-                    },
+                    "id": "UCjX4WSaAFPgM2PYr-6P",
+                    "snippet": {"title": "FIRST in Michigan"},
                 }
-            ],
-            "nextPageToken": "NEXT_TOKEN_123",
-            "prevPageToken": "PREV_TOKEN_456",
+            ]
         }
 
-        parser = YoutubeSearchParser()
         results = parser.parse(response)
 
-        assert len(results) == 1
-        # Note: Parser returns just the items, not the tokens
-        # Tokens would need to be handled separately by the caller
+        assert results == [
+            {
+                "channel_id": "UCjX4WSaAFPgM2PYr-6P",
+                "channel_name": "FIRST in Michigan",
+            }
+        ]
+
+    def test_parse_channel_list_missing_fields(self) -> None:
+        parser = YoutubeChannelListParser()
+        response = {"items": [{"snippet": {"title": "No id"}}, {"id": "UC123"}]}
+
+        assert parser.parse(response) == []
 
 
-class TestYoutubeSearchDatafeed:
-    """Tests for YoutubeSearchDatafeed."""
-
-    def test_datafeed_initialization(self) -> None:
-        """Test datafeed initializes with search query."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("test channel")
-            assert datafeed.query == "test channel"
-
+class TestYoutubeChannelListForHandleDatafeed:
     def test_datafeed_endpoint(self) -> None:
-        """Test datafeed returns correct endpoint."""
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("query")
+            datafeed = YoutubeChannelListForHandleDatafeed("@FIRSTinMichigan")
+            assert datafeed.endpoint() == "channels"
+
+    def test_datafeed_url_params(self) -> None:
+        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
+            datafeed = YoutubeChannelListForHandleDatafeed("@FIRSTinMichigan")
+            params = datafeed.url_params()
+
+            assert params["part"] == "id,snippet"
+            assert params["forHandle"] == "FIRSTinMichigan"
+
+    def test_datafeed_parser(self) -> None:
+        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
+            datafeed = YoutubeChannelListForHandleDatafeed("FIRSTinMichigan")
+            assert isinstance(datafeed.parser(), YoutubeChannelListParser)
+
+
+class TestYoutubeUpcomingStreamsDatafeed:
+    def test_datafeed_endpoint(self) -> None:
+        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
             assert datafeed.endpoint() == "search"
 
     def test_datafeed_default_params(self) -> None:
-        """Test datafeed constructs default URL parameters."""
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("test")
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
             params = datafeed.url_params()
 
             assert params["part"] == "snippet"
-            assert params["type"] == "channel"
-            assert params["q"] == "test"
-            assert params["maxResults"] == "1"
-            assert params["order"] == "relevance"
+            assert params["type"] == "video"
+            assert params["channelId"] == "UC_channel_id"
+            assert params["eventType"] == "upcoming"
+            assert params["maxResults"] == "50"
+            assert params["order"] == "date"
             assert "pageToken" not in params
 
-    def test_datafeed_custom_search_type(self) -> None:
-        """Test datafeed with custom search type."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("query", search_type="video")
-            params = datafeed.url_params()
-
-            assert params["type"] == "video"
-
-    def test_datafeed_with_max_results(self) -> None:
-        """Test datafeed with custom max results."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("query", max_results=50)
-            params = datafeed.url_params()
-
-            assert params["maxResults"] == "50"
-
     def test_datafeed_with_page_token(self) -> None:
-        """Test datafeed with pagination token."""
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("query", page_token="TOKEN_123")
+            datafeed = YoutubeUpcomingStreamsDatafeed(
+                channel_id="UC_channel_id",
+                page_token="TOKEN_123",
+            )
             params = datafeed.url_params()
 
             assert params["pageToken"] == "TOKEN_123"
 
-    def test_datafeed_with_custom_order(self) -> None:
-        """Test datafeed with custom sort order."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("query", order="date")
-            params = datafeed.url_params()
-
-            assert params["order"] == "date"
-
-    def test_datafeed_without_query(self) -> None:
-        """Test datafeed can omit free-text query."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed(query=None, search_type="video")
-            params = datafeed.url_params()
-
-            assert "q" not in params
-
-    def test_datafeed_with_channel_and_event_type(self) -> None:
-        """Test datafeed supports channel/event constrained searches."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed(
-                query=None,
-                search_type="video",
-                order="date",
-                max_results=50,
-                channel_id="UC_channel_id",
-                event_type="upcoming",
-            )
-            params = datafeed.url_params()
-
-            assert params["channelId"] == "UC_channel_id"
-            assert params["eventType"] == "upcoming"
-            assert params["type"] == "video"
-            assert params["order"] == "date"
-            assert params["maxResults"] == "50"
-
-    def test_datafeed_url_construction(self) -> None:
-        """Test complete URL construction."""
-        with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("python tutorial", search_type="video")
-            url = datafeed.url()
-
-            assert "search" in url
-            assert "python%20tutorial" in url or "python+tutorial" in url
-            assert "video" in url
-
     def test_datafeed_parser(self) -> None:
-        """Test datafeed returns correct parser instance."""
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed("query")
-            parser = datafeed.parser()
-
-            assert isinstance(parser, YoutubeSearchParser)
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
+            assert isinstance(datafeed.parser(), YoutubeSearchParser)
 
     def test_fetch_all_pages_async_single_page(self, ndb_context) -> None:
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed(query=None, search_type="video")
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
 
             response = {
                 "items": [
@@ -367,7 +187,9 @@ class TestYoutubeSearchDatafeed:
                 json.dumps(response),
             )
 
-            with mock.patch.object(YoutubeSearchDatafeed, "_fetch") as mock_fetch:
+            with mock.patch.object(
+                YoutubeUpcomingStreamsDatafeed, "_fetch"
+            ) as mock_fetch:
                 mock_fetch.return_value = InstantFuture(mock_result)
                 results = datafeed.fetch_all_pages_async().get_result()
 
@@ -378,7 +200,7 @@ class TestYoutubeSearchDatafeed:
 
     def test_fetch_all_pages_async_pagination(self, ndb_context) -> None:
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed(query=None, search_type="video")
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
 
             response_1 = {
                 "items": [
@@ -409,7 +231,9 @@ class TestYoutubeSearchDatafeed:
                 json.dumps(response_2),
             )
 
-            with mock.patch.object(YoutubeSearchDatafeed, "_fetch") as mock_fetch:
+            with mock.patch.object(
+                YoutubeUpcomingStreamsDatafeed, "_fetch"
+            ) as mock_fetch:
                 mock_fetch.side_effect = [
                     InstantFuture(mock_result_1),
                     InstantFuture(mock_result_2),
@@ -423,9 +247,8 @@ class TestYoutubeSearchDatafeed:
 
     def test_fetch_all_pages_async_fallback_parser(self, ndb_context) -> None:
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed(query=None, search_type="video")
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
 
-            # Missing id.kind, so parser returns empty and fallback parser is used.
             response = {
                 "items": [
                     {
@@ -440,7 +263,9 @@ class TestYoutubeSearchDatafeed:
                 json.dumps(response),
             )
 
-            with mock.patch.object(YoutubeSearchDatafeed, "_fetch") as mock_fetch:
+            with mock.patch.object(
+                YoutubeUpcomingStreamsDatafeed, "_fetch"
+            ) as mock_fetch:
                 mock_fetch.return_value = InstantFuture(mock_result)
                 results = datafeed.fetch_all_pages_async().get_result()
 
@@ -450,7 +275,7 @@ class TestYoutubeSearchDatafeed:
 
     def test_fetch_all_pages_async_non_200_raises(self, ndb_context) -> None:
         with mock.patch.object(GoogleApiSecret, "secret_key", return_value="test_key"):
-            datafeed = YoutubeSearchDatafeed(query=None, search_type="video")
+            datafeed = YoutubeUpcomingStreamsDatafeed(channel_id="UC_channel_id")
 
             mock_result = URLFetchResult.mock_for_content(
                 "https://www.googleapis.com/youtube/v3/search",
@@ -458,7 +283,9 @@ class TestYoutubeSearchDatafeed:
                 "{}",
             )
 
-            with mock.patch.object(YoutubeSearchDatafeed, "_fetch") as mock_fetch:
+            with mock.patch.object(
+                YoutubeUpcomingStreamsDatafeed, "_fetch"
+            ) as mock_fetch:
                 mock_fetch.return_value = InstantFuture(mock_result)
                 with pytest.raises(
                     Exception,

--- a/src/backend/web/handlers/admin/districts.py
+++ b/src/backend/web/handlers/admin/districts.py
@@ -75,9 +75,7 @@ def district_add_webcast_channel_post(district_key: DistrictKey) -> Response:
             f"{url_for('admin.district_details', district_key=district_key, webcast_error='missing_channel_name')}#webcasts"
         )
 
-    resolved_channel = YouTubeVideoHelper.resolve_channel_name(
-        channel_name
-    ).get_result()
+    resolved_channel = YouTubeVideoHelper.resolve_channel_id(channel_name).get_result()
     if not resolved_channel:
         return redirect(
             f"{url_for('admin.district_details', district_key=district_key, webcast_error='channel_not_found')}#webcasts"

--- a/src/backend/web/handlers/admin/tests/district_test.py
+++ b/src/backend/web/handlers/admin/tests/district_test.py
@@ -138,7 +138,7 @@ def test_district_add_webcast_channel_post(
 
     with patch.object(
         YouTubeVideoHelper,
-        "resolve_channel_name",
+        "resolve_channel_id",
         return_value=InstantFuture(
             YouTubeChannel(
                 channel_id="UCjX4WSaAFPgM2PYr-6P",
@@ -175,7 +175,7 @@ def test_district_add_webcast_channel_post_channel_not_found(
 
     with patch.object(
         YouTubeVideoHelper,
-        "resolve_channel_name",
+        "resolve_channel_id",
         return_value=InstantFuture(None),
     ):
         resp = web_client.post(


### PR DESCRIPTION
This helps the admin handler resolve channel names without needing search (we can actually do this more deterministically here)