### PR TITLE
fix bug with updating district webcast metadata

### DIFF
--- a/src/backend/common/manipulators/tests/district_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/district_manipulator_test.py
@@ -152,7 +152,7 @@ class TestDistrictManipulator(unittest.TestCase):
             District(id="2016ne", abbreviation="ne", year=2016)
         )
         # We didn't originally specify uses_official_webcast_unit
-        assert updated.uses_official_webcast_unit is False
+        assert updated.uses_official_webcast_unit is None
 
         # But the update hook should add it in from the prior year's
         tasks = none_throws(self.taskqueue_stub).get_filtered_tasks(
@@ -188,7 +188,7 @@ class TestDistrictManipulator(unittest.TestCase):
 
         district = District.get_by_id("2016ne")
         assert district is not None
-        assert district.uses_official_webcast_unit is False
+        assert district.uses_official_webcast_unit is None
 
     def test_update_webcast_channels_from_last_year_on_create(self) -> None:
         District(
@@ -270,3 +270,67 @@ class TestDistrictManipulator(unittest.TestCase):
         # Should still have the new channel, not the old one
         assert district.webcast_channels[0]["channel"] == "New Channel"
         assert district.webcast_channels[0]["channel_id"] == "UC_new"
+
+    def test_webcast_channels_not_wiped_by_empty_update(self) -> None:
+        """Regression test: FRC API updates produce a District with no webcast_channels
+        (empty list). The manipulator should NOT overwrite admin-set channels with [].
+        """
+        District(
+            id="2016ne",
+            abbreviation="ne",
+            year=2016,
+            display_name="New England",
+            webcast_channels=[
+                {
+                    "type": "youtube",
+                    "channel": "FIRST in Michigan",
+                    "channel_id": "UC1234567890",
+                }
+            ],
+        ).put()
+
+        # Simulate an FRC API update: new model has no webcast_channels set
+        DistrictManipulator.createOrUpdate(
+            District(
+                id="2016ne",
+                abbreviation="ne",
+                year=2016,
+                display_name="New England Updated",
+            )
+        )
+
+        district = District.get_by_id("2016ne")
+        assert district is not None
+        assert district.display_name == "New England Updated"
+        # webcast_channels must NOT have been wiped
+        assert district.webcast_channels is not None
+        assert len(district.webcast_channels) == 1
+        assert district.webcast_channels[0]["channel_id"] == "UC1234567890"
+
+    def test_uses_official_webcast_unit_not_wiped_by_empty_update(self) -> None:
+        """Regression test: FRC API updates create a District without uses_official_webcast_unit
+        (None). The manipulator should NOT overwrite an admin-set True value with None.
+        """
+        District(
+            id="2016ne",
+            abbreviation="ne",
+            year=2016,
+            display_name="New England",
+            uses_official_webcast_unit=True,
+        ).put()
+
+        # Simulate an FRC API update: new model has no uses_official_webcast_unit set
+        DistrictManipulator.createOrUpdate(
+            District(
+                id="2016ne",
+                abbreviation="ne",
+                year=2016,
+                display_name="New England Updated",
+            )
+        )
+
+        district = District.get_by_id("2016ne")
+        assert district is not None
+        assert district.display_name == "New England Updated"
+        # uses_official_webcast_unit must NOT have been wiped
+        assert district.uses_official_webcast_unit is True

--- a/src/backend/common/models/district.py
+++ b/src/backend/common/models/district.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from google.appengine.ext import ndb
 from pyre_extensions import safe_cast
@@ -65,7 +65,8 @@ class District(CachedModel):
     # Whether the district uses FIRST's official webcast unit (aka, webcasts
     # are managed by FIRST and published in advance). Districts that do not
     # use the official unit may need TBA to discover webcasts from YouTube.
-    uses_official_webcast_unit: bool = ndb.BooleanProperty(default=False)
+    # None means unset (FRC API updates won't overwrite an admin-configured value).
+    uses_official_webcast_unit: Optional[bool] = ndb.BooleanProperty()
 
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
     updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
@@ -77,6 +78,11 @@ class District(CachedModel):
         "elasticsearch_name",
         "rankings",
         "uses_official_webcast_unit",
+    }
+
+    # webcast_channels is TBA-admin-managed: only overwrite when incoming list is non-empty,
+    # so FRC API updates (which produce an empty list) don't wipe admin-set channels.
+    _list_attrs: Set[str] = {
         "webcast_channels",
     }
 

--- a/src/backend/common/models/tests/district_test.py
+++ b/src/backend/common/models/tests/district_test.py
@@ -42,13 +42,13 @@ def test_render_name_falls_back_to_code() -> None:
     assert d.render_name == "NE"
 
 
-def test_uses_official_webcast_unit_defaults_false() -> None:
+def test_uses_official_webcast_unit_defaults_none() -> None:
     d = District(
         id="2020ne",
         year=2020,
         abbreviation="ne",
     )
-    assert d.uses_official_webcast_unit is False
+    assert d.uses_official_webcast_unit is None
 
 
 def test_uses_official_webcast_unit_can_be_set() -> None:


### PR DESCRIPTION
I think this is why the channel info / "uses official" flag are getting dropped after the overnight runs, we need to make sure the manipulators don't clobber the fields