### PR TITLE
Fix district event win count in district insights

### DIFF
--- a/src/backend/common/helpers/insights_districts_helper.py
+++ b/src/backend/common/helpers/insights_districts_helper.py
@@ -148,7 +148,7 @@ class InsightsDistrictsHelper:
                     if award.award_type_enum == AwardType.WINNER:
                         if award.event_type_enum == EventType.DISTRICT_CMP:
                             dcmp_wins[recipient.string_id()] += 1
-                        else:
+                        elif award.event_type_enum == EventType.DISTRICT:
                             district_event_wins[recipient.string_id()] += 1
 
             for match in event.matches:


### PR DESCRIPTION
this was including division wins by accident. example: 195 has 14, but it was showing 15.