### PR TITLE
Add pwa preview deployments (opt-in)

### DIFF
--- a/.github/workflows/pwa_preview.yml
+++ b/.github/workflows/pwa_preview.yml
@@ -1,0 +1,164 @@
+name: PWA Preview Deploy
+
+on:
+  # Triggered after a successful PWA Preview Build run — downloads the pre-built artifact
+  # and deploys it. Secrets are available here; no fork code is executed.
+  workflow_run:
+    workflows: ["PWA Preview Build"]
+    types: [completed]
+
+  # Cleanup runs on PR close. pull_request_target gives access to secrets for fork PRs,
+  # and no fork code is checked out or executed.
+  pull_request_target:
+    types: [closed, unlabeled]
+
+jobs:
+  deploy-preview:
+    name: Deploy PWA Preview
+    runs-on: ubuntu-24.04
+    if: "github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'"
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pwa-preview-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          echo "pr_number=$(cat pr-number.txt)" >> $GITHUB_OUTPUT
+          echo "sha=$(cat pr-sha.txt)" >> $GITHUB_OUTPUT
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pwa-preview-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: pwa/
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+
+      - name: Setup Google Cloud Platform
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          version: "latest"
+          project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+
+      - name: Deploy Preview
+        run: |
+          gcloud app deploy pwa/pwa-preview.yaml \
+            --version "pr-${{ steps.meta.outputs.pr_number }}" \
+            --no-promote \
+            --quiet
+
+      - name: Post Preview URL Comment
+        uses: actions/github-script@v7
+        env:
+          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_SHA: ${{ steps.meta.outputs.sha }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const version = `pr-${prNumber}`;
+            const projectId = process.env.PROJECT_ID;
+            const previewUrl = `https://${version}-dot-pwa-dot-${projectId}.appspot.com`;
+            const sha = process.env.PR_SHA.substring(0, 7);
+            const body = [
+              '## PWA Preview Deployed',
+              '',
+              `**Preview URL:** ${previewUrl}`,
+              '',
+              `> Deployed from commit ${sha}`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(
+              c => c.user.type === 'Bot' && c.body.includes('## PWA Preview Deployed')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    name: Cleanup PWA Preview
+    runs-on: ubuntu-24.04
+    if: "github.event_name == 'pull_request_target' && (github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'preview-pwa')) && (github.event.action == 'unlabeled' || contains(github.event.pull_request.labels.*.name, 'preview-pwa'))"
+    permissions:
+      pull-requests: write
+    concurrency:
+      group: pwa-preview-cleanup-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    env:
+      PR_VERSION: pr-${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+
+      - name: Setup Google Cloud Platform
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          version: "latest"
+          project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+
+      - name: Delete Preview Version
+        run: |
+          gcloud app versions delete "$PR_VERSION" \
+            --service pwa \
+            --quiet \
+          || echo "Version $PR_VERSION not found, skipping."
+
+      - name: Update PR Comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(
+              c => c.user.type === 'Bot' && c.body.includes('## PWA Preview Deployed')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: '## PWA Preview Deployed\n\n~~Preview URL~~ — Preview deleted (PR closed).',
+              });
+            }

--- a/.github/workflows/pwa_preview_build.yml
+++ b/.github/workflows/pwa_preview_build.yml
@@ -1,0 +1,70 @@
+name: PWA Preview Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: pwa-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  VITE_TBA_API_READ_KEY: ${{ vars.VITE_TBA_API_READ_KEY }}
+  VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+  VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
+  VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
+  VITE_FIREBASE_DATABASE_URL: ${{ vars.VITE_FIREBASE_DATABASE_URL }}
+
+jobs:
+  build:
+    name: Build PWA Preview
+    runs-on: ubuntu-24.04
+    if: "(github.event.action == 'labeled' && github.event.label.name == 'preview-pwa') || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview-pwa'))"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.24.0"
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pwa/pnpm-lock.yaml"
+
+      - name: Install Dependencies
+        run: pnpm --dir pwa install --frozen-lockfile
+
+      - name: Create dotenv
+        run: ./ops/pwa/create_dotenv.sh --env
+
+      - name: Build
+        run: pnpm --dir pwa run build
+
+      - name: Save PR metadata
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > pr-sha.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pwa-preview-metadata
+          path: |
+            pr-number.txt
+            pr-sha.txt
+          retention-days: 1
+
+      - name: Remove node_modules
+        run: rm -rf pwa/node_modules
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pwa-preview-build
+          path: pwa/
+          retention-days: 1

--- a/pwa/pwa-preview.yaml
+++ b/pwa/pwa-preview.yaml
@@ -1,0 +1,9 @@
+service: pwa
+runtime: nodejs24
+
+instance_class: F1
+automatic_scaling:
+  max_idle_instances: 0
+  target_cpu_utilization: 0.9
+  target_throughput_utilization: 0.9
+  max_concurrent_requests: 80


### PR DESCRIPTION
  Adds a two-workflow system for deploying preview PWA builds to GAE. A maintainer (or anyone) can apply the `preview-pwa` label to a PR to trigger a preview deployment, including PRs from forks.

  **How it works:**
  - `pwa_preview_build.yml`: triggered by `pull_request`, builds the PWA and uploads the artifact + PR metadata. No secrets available here, so fork code is safe to run.
  - `pwa_preview.yml`: triggered by `workflow_run` (deploy) and `pull_request_target` (cleanup). Downloads the pre-built artifact and deploys to GAE — no fork code runs here, so secrets are safe to use.

  Each PR gets its own GAE version (`pr-{number}`) with a dedicated preview URL. Previews are cleaned up when the PR is closed or the label is removed. A `pwa-preview.yaml` with `max_idle_instances: 0` is used instead of the production config to avoid keeping idle instances warm.