### PR TITLE
Add Insights tab to district detail page (/events/<abbrev>/<year>)

### DIFF
--- a/src/backend/web/handlers/district.py
+++ b/src/backend/web/handlers/district.py
@@ -69,6 +69,14 @@ def district_detail(
     # needed for valid_districts
     districts_in_year_future = DistrictsInYearQuery(district.year).fetch_async()
 
+    # needed for insights tab
+    year_specific_insight_future = ndb.Key(
+        Insight,
+        Insight.render_key_name(
+            year, Insight.INSIGHT_NAMES[Insight.YEAR_SPECIFIC], district_abbrev
+        ),
+    ).get_async()
+
     # needed for active team statuses
     live_events = []
     live_eventteams_futures = []
@@ -193,6 +201,10 @@ def district_detail(
         "live_events_with_teams": live_events_with_teams,
         "dcmp_events": dcmp_events,
         "home_dcmp_per_team": home_dcmp_per_team,
+        "year_specific": year_specific_insight_future.get_result(),
+        "year_specific_insights_template": "event_partials/event_insights_{}.html".format(
+            year
+        ),
     }
 
     return make_cached_response(

--- a/src/backend/web/handlers/tests/district_detail_test.py
+++ b/src/backend/web/handlers/tests/district_detail_test.py
@@ -261,3 +261,49 @@ def test_district_insights_page(ndb_stub, web_client: Client) -> None:
     body = resp.get_data(as_text=True)
     assert "2024 Michigan District Insights" in body
     assert "Top Blue Banner Winners" in body
+
+
+def test_district_detail_insights_tab(ndb_stub, web_client: Client) -> None:
+    District(
+        id="2015fim",
+        year=2015,
+        abbreviation="fim",
+        display_name="Michigan",
+    ).put()
+
+    Insight(
+        id=Insight.render_key_name(
+            2015,
+            Insight.INSIGHT_NAMES[Insight.YEAR_SPECIFIC],
+            "fim",
+        ),
+        year=2015,
+        district_abbreviation="fim",
+        name=Insight.INSIGHT_NAMES[Insight.YEAR_SPECIFIC],
+        data_json=json.dumps({"qual": {"some_stat": [1, 2, 50.0]}, "playoff": {}}),
+    ).put()
+
+    resp = web_client.get("/events/fim/2015")
+    assert resp.status_code == 200
+
+    body = resp.get_data(as_text=True)
+    assert 'href="#insights"' in body
+    assert "All Insights" in body
+    assert "/district/fim/insights/2015" in body
+
+
+def test_district_detail_no_insights_tab_when_no_insight(
+    ndb_stub, web_client: Client
+) -> None:
+    District(
+        id="2015fim",
+        year=2015,
+        abbreviation="fim",
+        display_name="Michigan",
+    ).put()
+
+    resp = web_client.get("/events/fim/2015")
+    assert resp.status_code == 200
+
+    body = resp.get_data(as_text=True)
+    assert 'href="#insights"' not in body

--- a/src/backend/web/templates/district_details.html
+++ b/src/backend/web/templates/district_details.html
@@ -80,6 +80,9 @@
         {% if live_events_with_teams %}
         <li><a href="#active-teams" role="tab" data-toggle="tab">Active Teams</a></li>
         {% endif %}
+        {% if year_specific and (year_specific.data.qual or year_specific.data.playoff) %}
+        <li><a href="#insights" role="tab" data-toggle="tab">Insights</a></li>
+        {% endif %}
       </ul>
 
       <div class="tab-content">
@@ -324,6 +327,29 @@
         {% if live_events_with_teams %}
         <div class="tab-pane" id="active-teams">
           {% include "live_teams_partial.html" %}
+        </div>
+        {% endif %}
+
+        {% if year_specific and (year_specific.data.qual or year_specific.data.playoff) %}
+        <div class="tab-pane" id="insights">
+          <p class="pull-right"><a class="btn btn-primary" href="/district/{{district_abbrev}}/insights/{{year}}"><span class="glyphicon glyphicon-align-left"></span> All Insights</a></p>
+          <h3>Year Specific Statistics</h3>
+          <div class="row">
+            {% if year_specific.data.qual %}
+            <div class="col-sm-6">
+              <h4>Qualification</h4>
+              {% set event_insights = year_specific.data.qual %}
+              {% include year_specific_insights_template ignore missing %}
+            </div>
+            {% endif %}
+            {% if year_specific.data.playoff %}
+            <div class="col-sm-6">
+              <h4>Playoff</h4>
+              {% set event_insights = year_specific.data.playoff %}
+              {% include year_specific_insights_template ignore missing %}
+            </div>
+            {% endif %}
+          </div>
         </div>
         {% endif %}
       </div>


### PR DESCRIPTION
Add a way to show district-level insights.

This adds a tab to the main district overview page with the year-aggregate bonus stats, as well as a link to the full page.