### PR TITLE
Add short URL routes for teams, events, and districts

### DIFF
--- a/src/backend/web/handlers/short.py
+++ b/src/backend/web/handlers/short.py
@@ -1,0 +1,20 @@
+from flask import redirect
+from werkzeug.wrappers import Response
+
+from backend.common.consts.renamed_districts import ALL_KNOWN_DISTRICT_ABBREVIATIONS
+from backend.common.models.keys import DistrictAbbreviation, EventKey
+
+
+def short_team(team_number: str) -> Response:
+    return redirect(f"/team/{int(team_number)}", code=301)
+
+
+def short_event_or_district(short_key: str) -> Response:
+    year = int(short_key[:4])
+    suffix: DistrictAbbreviation = short_key[4:]
+
+    if suffix in ALL_KNOWN_DISTRICT_ABBREVIATIONS:
+        return redirect(f"/events/{suffix}/{year}", code=301)
+
+    event_key: EventKey = short_key
+    return redirect(f"/event/{event_key}", code=301)

--- a/src/backend/web/handlers/tests/short_test.py
+++ b/src/backend/web/handlers/tests/short_test.py
@@ -1,0 +1,60 @@
+from werkzeug.test import Client
+
+
+def test_short_team_number(web_client: Client) -> None:
+    resp = web_client.get("/254")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/team/254"
+
+
+def test_short_team_number_leading_zeros_not_matched(web_client: Client) -> None:
+    # The regex only matches plain digits; leading zeros are valid but unusual
+    resp = web_client.get("/00254")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/team/254"
+
+
+def test_short_team_five_digits(web_client: Client) -> None:
+    resp = web_client.get("/99999")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/team/99999"
+
+
+def test_short_event_key(web_client: Client) -> None:
+    resp = web_client.get("/2024miket")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/event/2024miket"
+
+
+def test_short_event_key_with_digits_in_suffix(web_client: Client) -> None:
+    resp = web_client.get("/2024cmp2")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/event/2024cmp2"
+
+
+def test_short_district_key_known_abbreviation(web_client: Client) -> None:
+    resp = web_client.get("/2024fim")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/events/fim/2024"
+
+
+def test_short_district_key_old_abbreviation(web_client: Client) -> None:
+    # "mar" is an old abbreviation for "fma" — still in ALL_KNOWN_DISTRICT_ABBREVIATIONS
+    resp = web_client.get("/2019mar")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/events/mar/2019"
+
+
+def test_short_district_key_ne(web_client: Client) -> None:
+    resp = web_client.get("/2023ne")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/events/ne/2023"
+
+
+def test_short_event_key_unknown_abbreviation_goes_to_event(
+    web_client: Client,
+) -> None:
+    # "xyz" is not a known district abbreviation → treat as event key
+    resp = web_client.get("/2024xyz")
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "/event/2024xyz"

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -47,6 +47,7 @@ from backend.web.handlers.match import match_detail
 from backend.web.handlers.match_suggestion import match_suggestion
 from backend.web.handlers.mytba import mytba_live
 from backend.web.handlers.search import search_handler
+from backend.web.handlers.short import short_event_or_district, short_team
 from backend.web.handlers.static import (
     add_data,
     bigquery,
@@ -212,6 +213,16 @@ app.add_url_rule("/_/remap_teams/<event_key>", view_func=event_remap_teams_handl
 app.add_url_rule("/_/playoff_types", view_func=playoff_types_handler)
 app.add_url_rule("/_/typeahead/<search_key>", view_func=typeahead_handler)
 app.add_url_rule("/avatar/<int:year>/<team_key>.png", view_func=avatar_png)
+
+# Short routes: /<team_number> and /<event_or_district_key>
+app.add_url_rule(
+    '/<regex("[0-9]{1,5}"):team_number>',
+    view_func=short_team,
+)
+app.add_url_rule(
+    '/<regex("[0-9]{4}[a-z][a-z0-9]*"):short_key>',
+    view_func=short_event_or_district,
+)
 
 app.register_blueprint(apidocs_blueprint)
 app.register_blueprint(admin_blueprint)


### PR DESCRIPTION
This brings back the old redirects that let you do /teamNumber of /eventKey and redirect to the right page.