### PR TITLE
[pwa] Minor css adjustments + warning fixes

### DIFF
--- a/pwa/app/lib/gameday/useFirebaseWebcasts.ts
+++ b/pwa/app/lib/gameday/useFirebaseWebcasts.ts
@@ -80,9 +80,13 @@ export function useFirebaseWebcasts(): UseFirebaseWebcastsResult {
   // Read from TQ cache — data is populated by the effect above via setQueryData.
   // enabled: false means TQ never fetches on its own; isPending is true until
   // setQueryData is called for the first time (i.e. Firebase hasn't responded yet).
+  // TanStack Query v5 requires a queryFn even when enabled: false. These queries
+  // are never fetched — data is written exclusively via setQueryData in the
+  // Firebase subscription above. The queryFn placeholder satisfies the requirement.
   const { data: liveEventsData, isPending: liveEventsPending } =
     useQuery<Record<string, FirebaseLiveEvent> | null>({
       queryKey: [...FIREBASE_LIVE_EVENTS_QUERY_KEY],
+      queryFn: () => null,
       enabled: false,
       staleTime: Infinity,
     });
@@ -90,6 +94,7 @@ export function useFirebaseWebcasts(): UseFirebaseWebcastsResult {
   const { data: specialWebcastsData, isPending: specialWebcastsPending } =
     useQuery<Record<string, FirebaseSpecialWebcast> | null>({
       queryKey: [...FIREBASE_SPECIAL_WEBCASTS_QUERY_KEY],
+      queryFn: () => null,
       enabled: false,
       staleTime: Infinity,
     });

--- a/pwa/app/lib/gameday/useOnlineEventWebcasts.ts
+++ b/pwa/app/lib/gameday/useOnlineEventWebcasts.ts
@@ -1,13 +1,12 @@
 import { useCallback, useMemo } from 'react';
 
 import type { Event } from '~/api/tba/read';
-import { isEventActive } from '~/lib/eventUtils';
 import { useFirebaseWebcasts } from '~/lib/gameday/useFirebaseWebcasts';
 
 /**
  * Returns a function that checks whether a given event has a live stream.
- * Uses Firebase webcast status when loaded, falling back to date-based logic
- * while Firebase is still loading.
+ * Returns false while Firebase is still loading so buttons show as 'offline'
+ * (but remain clickable) until real webcast status is available.
  */
 export function useOnlineEventWebcasts(): (event: Event) => boolean {
   const { webcasts, isLoading } = useFirebaseWebcasts();
@@ -24,8 +23,7 @@ export function useOnlineEventWebcasts(): (event: Event) => boolean {
   }, [webcasts]);
 
   return useCallback(
-    (event: Event) =>
-      isLoading ? isEventActive(event) : onlineEventKeys.has(event.key),
+    (event: Event) => !isLoading && onlineEventKeys.has(event.key),
     [isLoading, onlineEventKeys],
   );
 }

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -718,7 +718,7 @@ function AwardsTab({ awards }: { awards: Award[] }) {
               className="grid grid-cols-1 gap-1 py-2 sm:grid-cols-3 sm:gap-4
                 sm:px-4"
             >
-              <dt className=":col-span-2 font-medium">{award.name}</dt>
+              <dt className="font-medium sm:col-span-2">{award.name}</dt>
               <dd className="text-muted-foreground sm:text-right">
                 {award.recipient_list
                   .sort((a, b) =>


### PR DESCRIPTION
- Add `queryFn: () => null` to Firebase-backed `useQuery` calls to satisfy TanStack Query v5's requirement (these queries are never fetched — data comes from `setQueryData` via Firebase subscriptions)
- Change webcast buttons to default to "Offline" while Firebase data is loading, rather than optimistically showing "Watch Now" based on event dates