### PR TITLE
Strip whitespace from event first_code at all entry points

### DIFF
--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -181,8 +181,11 @@ def update_event_info(event_key: EventKey) -> Response:
         defer_safe(EventRemapTeamsHelper.remap_teams, event_key, _queue="admin")
 
     if "first_event_code" in parsed_info:
-        event.official = parsed_info["first_event_code"] is not None
-        event.first_code = parsed_info["first_event_code"]
+        first_code = parsed_info["first_event_code"]
+        if isinstance(first_code, str):
+            first_code = first_code.strip() or None
+        event.official = first_code is not None
+        event.first_code = first_code
 
     if "playoff_type" in parsed_info:
         playoff_type = parsed_info["playoff_type"]

--- a/src/backend/web/handlers/admin/event.py
+++ b/src/backend/web/handlers/admin/event.py
@@ -281,6 +281,8 @@ def event_edit_post(event_key: Optional[EventKey] = None) -> Response:
         end_date = datetime.datetime.strptime(request.form.get("end_date"), "%Y-%m-%d")
 
     first_code = request.form.get("first_code", None)
+    if first_code:
+        first_code = first_code.strip()
     district_key = request.form.get("event_district_key", None)
     parent_key = request.form.get("parent_event", None)
 

--- a/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
@@ -69,7 +69,7 @@ class SuggestOffseasonEventReviewController(
 
         first_code = request.form.get("first_code")
         if first_code:
-            first_code = first_code.upper()
+            first_code = first_code.strip().upper()
         event_type_enum = int(request.form.get("event_type_enum", EventType.OFFSEASON))
         event = Event(
             id=event_key,

--- a/src/backend/web/handlers/suggestions/suggestion_submission.py
+++ b/src/backend/web/handlers/suggestions/suggestion_submission.py
@@ -441,7 +441,7 @@ def submit_offseason() -> Response:
         city=request.form.get("venue_city", ""),
         state=request.form.get("venue_state", ""),
         country=request.form.get("venue_country", ""),
-        first_code=request.form.get("first_code"),
+        first_code=(request.form.get("first_code") or "").strip() or None,
     )
     if status != "success":
         # Don't completely wipe form data if validation fails

--- a/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_review_controller_test.py
+++ b/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_review_controller_test.py
@@ -146,6 +146,35 @@ def test_accept_suggestion_normalize_event_short_and_first_code(
     assert event.first_code == "FRCTEST"
 
 
+def test_accept_suggestion_strips_first_code_whitespace(
+    login_user_with_permission,
+    web_client: Client,
+    ndb_stub,
+    taskqueue_stub,
+) -> None:
+    suggestion_id = createSuggestion(login_user_with_permission)
+    queue, form_fields = get_suggestion_queue_and_fields(
+        web_client, f"review_{suggestion_id}"
+    )
+    assert queue == [suggestion_id]
+    assert form_fields != {}
+
+    form_fields["event_short"] = "test"
+    form_fields["first_code"] = " frctest "
+    form_fields["verdict"] = "accept"
+    response = web_client.post(
+        "/suggest/offseason/review",
+        data=form_fields,
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    event = Event.get_by_id("2016test")
+    assert event is not None
+    assert event.first_code == "FRCTEST"
+    assert event.official is True
+
+
 def test_reject_suggestion(
     login_user_with_permission, web_client: Client, ndb_stub
 ) -> None:


### PR DESCRIPTION
## Summary
- Event `first_code` (sync code) values were not being stripped of whitespace at any entry point, which caused issues like `2025parr` getting a leading space in its sync code
- Added `.strip()` at all four entry points: suggestion submission, suggestion review (most likely source of the bug — only had `.upper()`), admin event edit, and trusted API
- Added test covering whitespace stripping in the suggestion review flow

## Test plan
- [x] Existing tests pass (49 passed)
- [x] New test `test_accept_suggestion_strips_first_code_whitespace` verifies leading/trailing spaces are stripped and value is uppercased

🤖 Generated with [Claude Code](https://claude.com/claude-code)