### PR TITLE
Bump match converter cache version to clear old matches pre-tiebreaker logic for 2026

### DIFF
--- a/src/backend/common/queries/dict_converters/match_converter.py
+++ b/src/backend/common/queries/dict_converters/match_converter.py
@@ -16,7 +16,7 @@ MatchDict = NewType("MatchDict", Dict)
 
 class MatchConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        ApiMajorVersion.API_V3: 7,
+        ApiMajorVersion.API_V3: 8,
     }
 
     @classmethod


### PR DESCRIPTION
Tiebreaker logic for 2026 was added in https://github.com/the-blue-alliance/the-blue-alliance/pull/9610 but we did not bump the match converter cache version, so we have cached matches still without things like `winning_alliance` set. This PR just bumps the version to clear the cache there.