### PR TITLE
[pwa] Fix 'this weeks events' being wonky with utc ssr

### DIFF
--- a/pwa/app/lib/eventUtils.test.ts
+++ b/pwa/app/lib/eventUtils.test.ts
@@ -559,6 +559,28 @@ describe('getCurrentWeekEvents 8am-6pm window', () => {
     vi.useRealTimers();
   });
 
+  // Regression: a Pacific event ending Sunday 6pm PDT = Monday 1am UTC only overlaps
+  // the UTC week by 1 hour, which is under the 6-hour minimum. A UTC server must not
+  // include it, or the SSR would flash those events after the week has ended.
+  test('excludes Sunday Pacific event that bleeds only 1 hour into UTC Monday', () => {
+    vi.useFakeTimers();
+    // Wednesday April 17 2026, noon UTC — server timezone is UTC
+    vi.setSystemTime(new Date('2026-04-15T12:00:00Z'));
+    vi.spyOn(Temporal.Now, 'timeZoneId').mockReturnValue('UTC');
+
+    // CA state champs: ended Sunday April 12 at 6pm PDT = April 13 01:00 UTC.
+    // Week starts Monday April 13 00:00 UTC — only 1 hour of overlap.
+    const caStateChamps = {
+      start_date: '2026-04-09',
+      end_date: '2026-04-12',
+      timezone: 'America/Los_Angeles',
+    } as Event;
+
+    expect(getCurrentWeekEvents([caStateChamps])).not.toContain(caStateChamps);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
   // Events without a timezone should use the Eastern fallback.
   test('uses Eastern fallback timezone when event has no timezone', () => {
     vi.useFakeTimers();

--- a/pwa/app/lib/eventUtils.ts
+++ b/pwa/app/lib/eventUtils.ts
@@ -155,6 +155,13 @@ export function getEventWeekString(event: Event) {
   }
 }
 
+// Minimum overlap (in seconds) between an event's active window and the
+// user's week before the event is considered "this week". 6 hours ensures that
+// an event ending Sunday evening in a western timezone doesn't bleed into the
+// next week on a UTC server, while still catching events that start or end
+// partway through the week.
+const MIN_WEEK_OVERLAP_SECONDS = 6 * 60 * 60;
+
 export function getCurrentWeekEvents(events: Event[]) {
   // Build the user's week window as Instants so we can compare against the
   // event's active window (8am–6pm in the event's timezone) correctly even
@@ -170,11 +177,15 @@ export function getCurrentWeekEvents(events: Event[]) {
   const filteredEvents = [];
   for (const event of events) {
     const { start: eventStart, end: eventEnd } = getEventActiveWindow(event);
-    // Include if the event's active window overlaps with the user's week at all.
-    if (
-      Temporal.Instant.compare(eventStart, weekEnd) < 0 &&
-      Temporal.Instant.compare(eventEnd, weekStart) > 0
-    ) {
+    // Compute how much of the event's active window falls inside this week.
+    const overlapStart =
+      Temporal.Instant.compare(eventStart, weekStart) > 0
+        ? eventStart
+        : weekStart;
+    const overlapEnd =
+      Temporal.Instant.compare(eventEnd, weekEnd) < 0 ? eventEnd : weekEnd;
+    const overlapSeconds = overlapEnd.since(overlapStart).total('seconds');
+    if (overlapSeconds >= MIN_WEEK_OVERLAP_SECONDS) {
       filteredEvents.push(event);
     }
   }


### PR DESCRIPTION
I believe that the pwa server is running in utc time. NorCal champs ended at 1am UTC time this week, so the SSR renders NorCal (and SoCal as well) as part of 'this weeks events' on the homepage. The client then rerenders it (for some reason?) and realizes that norcal/socal were not in the browser's "week", so it removes it from the homepage list. This causes a brief flash of norcal/socal on the homepage before they quickly vanish.

This makes it so in order for an event to be considered in "this week," it must take place for at least 6 hours during the week, rather than just ending 1 hour into the server's week and it showing up for the rest of the week.