### PR TITLE
Tolerate legacy tiebreaker key in district rankings calc

### DIFF
--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -298,9 +298,9 @@ class DistrictHelper:
                             team_totals[team_key]["match_scores"] = heapq.nlargest(
                                 3,
                                 [
-                                    *event_district_points["tiebreakers"][team_key][
-                                        "highest_match_scores"
-                                    ],
+                                    *event_district_points["tiebreakers"][team_key].get(
+                                        "highest_match_scores", []
+                                    ),
                                     *team_totals[team_key]["match_scores"],
                                 ],
                             )

--- a/src/backend/common/helpers/regional_champs_pool_helper.py
+++ b/src/backend/common/helpers/regional_champs_pool_helper.py
@@ -193,9 +193,9 @@ class RegionalChampsPoolHelper(DistrictHelper):
                     team_totals[team_key]["match_scores"] = heapq.nlargest(
                         3,
                         [
-                            *event_regional_points["tiebreakers"][team_key][
-                                "highest_match_scores"
-                            ],
+                            *event_regional_points["tiebreakers"][team_key].get(
+                                "highest_match_scores", []
+                            ),
                             *team_totals[team_key]["match_scores"],
                         ],
                     )

--- a/src/backend/common/helpers/tests/district_helper_test.py
+++ b/src/backend/common/helpers/tests/district_helper_test.py
@@ -10,6 +10,7 @@ from backend.common.helpers.district_helper import (
     TeamAtEventDistrictPoints,
 )
 from backend.common.models.event import Event
+from backend.common.models.event_details import EventDetails
 from backend.common.models.keys import Year
 from backend.common.models.team import Team
 
@@ -249,6 +250,30 @@ def test_2022_back_to_back_single_day_bonus(setup_full_event) -> None:
 )
 def test_pandemic_rookie_edge_cases(year: Year, rookie_year: Year, bonus: int) -> None:
     assert DistrictHelper._get_rookie_bonus(year, rookie_year) == bonus
+
+
+def test_calc_rankings_tolerates_legacy_tiebreaker_key(setup_full_event) -> None:
+    # Pre-migration EventDetails.district_points entries store
+    # "highest_qual_scores" instead of the renamed "highest_match_scores".
+    # Rankings calc reads stored JSON directly and must not KeyError on those.
+    setup_full_event("2019nyny")
+
+    event_details = none_throws(EventDetails.get_by_id("2019nyny"))
+    district_points = none_throws(event_details.district_points)
+    for team_key, tiebreakers in district_points["tiebreakers"].items():
+        legacy_scores = tiebreakers.pop("highest_match_scores", [])
+        tiebreakers["highest_qual_scores"] = legacy_scores
+    event_details.district_points = district_points
+    event_details.put()
+
+    event = none_throws(Event.get_by_id("2019nyny"))
+    event.prep_details()
+
+    teams = [none_throws(Team.get_by_id("frc694"))]
+    rankings = DistrictHelper.calculate_rankings([event], teams, 2019, None)
+
+    # Tiebreak scores aren't recovered from the old key, but the calc completes.
+    assert rankings["frc694"]["match_scores"] == []
 
 
 def test_hq_adjustments(setup_full_event) -> None:

--- a/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
+++ b/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
@@ -258,6 +258,30 @@ def test_rookie_bonus_per_event(setup_full_event) -> None:
     assert rankings["frc9001"]["point_total"] == 75
 
 
+def test_calc_rankings_tolerates_legacy_tiebreaker_key(setup_full_event) -> None:
+    # Pre-migration EventDetails.regional_champs_pool_points entries store
+    # "highest_qual_scores" instead of the renamed "highest_match_scores".
+    # Rankings calc reads stored JSON directly and must not KeyError on those.
+    setup_full_event("2025mndu")
+
+    event_details = none_throws(EventDetails.get_by_id("2025mndu"))
+    regional_pool_points = none_throws(event_details.regional_champs_pool_points)
+    for team_key, tiebreakers in regional_pool_points["tiebreakers"].items():
+        legacy_scores = tiebreakers.pop("highest_match_scores", [])
+        tiebreakers["highest_qual_scores"] = legacy_scores
+    event_details.regional_champs_pool_points = regional_pool_points
+    event_details.put()
+
+    event = none_throws(Event.get_by_id("2025mndu"))
+    event.prep_details()
+
+    teams = [none_throws(Team.get_by_id("frc2847"))]
+    rankings = RegionalChampsPoolHelper.calculate_rankings([event], teams, 2025, None)
+
+    # Tiebreak scores aren't recovered from the old key, but the calc completes.
+    assert rankings["frc2847"]["match_scores"] == []
+
+
 def test_single_event_bonus_includes_rookie_bonus(setup_full_event) -> None:
     setup_full_event("2025mndu")
 


### PR DESCRIPTION
## Summary
- PR #9711 renamed the tiebreaker dict key `highest_qual_scores` → `highest_match_scores`, but that key is persisted inside `EventDetails.district_points` / `regional_champs_pool_points` JSON. Un-migrated entities still have the old key, so `district_rankings_calc` and `regional_champs_pool_rankings_calc` crash with `KeyError: 'highest_match_scores'` in production until each event's points calc overwrites the stored JSON.
- Switches both callsites to `.get("highest_match_scores", [])` so the rankings calc completes on legacy data (contributing nothing to the match-score tiebreak); once the per-event points calc runs, the new key is populated and tiebreaks work normally.
- Adds regression tests that seed `EventDetails` with the pre-migration shape and assert `calculate_rankings` doesn't raise. Verified they reproduce the production traceback before the fix.

## Test plan
- [x] `make test ARGS='src/backend/common/helpers/tests/district_helper_test.py src/backend/common/helpers/tests/regional_champs_pool_helper_test.py'` — 40 passed
- [x] Confirmed new tests fail with the exact production `KeyError` when the fix is reverted
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)