### PR TITLE
Fix pyre errors in legacy tiebreaker test

### DIFF
--- a/src/backend/common/helpers/tests/district_helper_test.py
+++ b/src/backend/common/helpers/tests/district_helper_test.py
@@ -1,4 +1,5 @@
 import json
+from typing import cast, Dict
 
 import pytest
 from pyre_extensions import none_throws
@@ -260,9 +261,10 @@ def test_calc_rankings_tolerates_legacy_tiebreaker_key(setup_full_event) -> None
 
     event_details = none_throws(EventDetails.get_by_id("2019nyny"))
     district_points = none_throws(event_details.district_points)
-    for team_key, tiebreakers in district_points["tiebreakers"].items():
-        legacy_scores = tiebreakers.pop("highest_match_scores", [])
-        tiebreakers["highest_qual_scores"] = legacy_scores
+    for tiebreakers in district_points["tiebreakers"].values():
+        # Cast away the TypedDict to simulate legacy on-disk JSON shape.
+        legacy: Dict[str, object] = cast(Dict[str, object], tiebreakers)
+        legacy["highest_qual_scores"] = legacy.pop("highest_match_scores", [])
     event_details.district_points = district_points
     event_details.put()
 

--- a/src/backend/common/helpers/tests/district_helper_test.py
+++ b/src/backend/common/helpers/tests/district_helper_test.py
@@ -1,5 +1,5 @@
 import json
-from typing import cast, Dict
+from typing import cast
 
 import pytest
 from pyre_extensions import none_throws
@@ -263,7 +263,7 @@ def test_calc_rankings_tolerates_legacy_tiebreaker_key(setup_full_event) -> None
     district_points = none_throws(event_details.district_points)
     for tiebreakers in district_points["tiebreakers"].values():
         # Cast away the TypedDict to simulate legacy on-disk JSON shape.
-        legacy: Dict[str, object] = cast(Dict[str, object], tiebreakers)
+        legacy: dict[str, object] = cast(dict[str, object], tiebreakers)
         legacy["highest_qual_scores"] = legacy.pop("highest_match_scores", [])
     event_details.district_points = district_points
     event_details.put()

--- a/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
+++ b/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
@@ -1,5 +1,5 @@
 import json
-from typing import cast, Dict
+from typing import cast
 
 import pytest
 from pyre_extensions import none_throws
@@ -268,7 +268,7 @@ def test_calc_rankings_tolerates_legacy_tiebreaker_key(setup_full_event) -> None
     regional_pool_points = none_throws(event_details.regional_champs_pool_points)
     for tiebreakers in regional_pool_points["tiebreakers"].values():
         # Cast away the TypedDict to simulate legacy on-disk JSON shape.
-        legacy: Dict[str, object] = cast(Dict[str, object], tiebreakers)
+        legacy: dict[str, object] = cast(dict[str, object], tiebreakers)
         legacy["highest_qual_scores"] = legacy.pop("highest_match_scores", [])
     event_details.regional_champs_pool_points = regional_pool_points
     event_details.put()

--- a/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
+++ b/src/backend/common/helpers/tests/regional_champs_pool_helper_test.py
@@ -1,5 +1,5 @@
 import json
-from typing import cast
+from typing import cast, Dict
 
 import pytest
 from pyre_extensions import none_throws
@@ -266,9 +266,10 @@ def test_calc_rankings_tolerates_legacy_tiebreaker_key(setup_full_event) -> None
 
     event_details = none_throws(EventDetails.get_by_id("2025mndu"))
     regional_pool_points = none_throws(event_details.regional_champs_pool_points)
-    for team_key, tiebreakers in regional_pool_points["tiebreakers"].items():
-        legacy_scores = tiebreakers.pop("highest_match_scores", [])
-        tiebreakers["highest_qual_scores"] = legacy_scores
+    for tiebreakers in regional_pool_points["tiebreakers"].values():
+        # Cast away the TypedDict to simulate legacy on-disk JSON shape.
+        legacy: Dict[str, object] = cast(Dict[str, object], tiebreakers)
+        legacy["highest_qual_scores"] = legacy.pop("highest_match_scores", [])
     event_details.regional_champs_pool_points = regional_pool_points
     event_details.put()
 


### PR DESCRIPTION
## Summary
- Follow-up to #9712: pyre fails on `main` because the regression tests call `.pop()` and assign `"highest_qual_scores"` on a `TeamAtEventDistrictPointTiebreakers` TypedDict that doesn't declare either.
- Cast the tiebreakers dict to `Dict[str, object]` inside the test helpers — the tests intentionally simulate pre-migration on-disk JSON, so the mutations are valid at runtime but must be hidden from the TypedDict.
- Failing CI: https://github.com/the-blue-alliance/the-blue-alliance/actions/runs/24609004803/job/71960014777

## Test plan
- [x] `make typecheck` — no type errors
- [x] `make test ARGS='src/backend/common/helpers/tests/district_helper_test.py src/backend/common/helpers/tests/regional_champs_pool_helper_test.py'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)