### PR TITLE
Fix myTBA sessions expiring on browser close

### DIFF
--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -9,6 +9,10 @@ from backend.common.models.user import User
 
 _SESSION_KEY = "session"
 
+# 14 days is Firebase Admin's max (MAX_SESSION_COOKIE_DURATION_SECONDS) and
+# drives both the Firebase session cookie TTL and the Flask cookie's Max-Age.
+SESSION_COOKIE_LIFETIME = datetime.timedelta(days=14)
+
 
 # Code from https://firebase.google.com/docs/auth/admin/manage-cookies
 
@@ -28,6 +32,7 @@ def create_session_cookie(id_token: str, expires_in: datetime.timedelta) -> None
     session_cookie = auth.create_session_cookie(
         id_token, expires_in=expires_in, app=app()
     )
+    session.permanent = True
     session[_SESSION_KEY] = session_cookie
 
 

--- a/src/backend/common/tests/auth_test.py
+++ b/src/backend/common/tests/auth_test.py
@@ -39,6 +39,7 @@ def test_create_session_cookie(secret_app: Flask) -> None:
 
     with secret_app.test_request_context("/"):
         assert session.get("session") is None
+        assert session.permanent is False
 
         with patch.object(auth, "create_session_cookie") as mock_create_session_cookie:
             create_session_cookie(id_token, expires_in)
@@ -47,6 +48,7 @@ def test_create_session_cookie(secret_app: Flask) -> None:
         )
 
         assert session["session"] is not None
+        assert session.permanent is True
 
 
 def test_revoke_session_cookie_no_claims(secret_app: Flask) -> None:

--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 from flask import (
@@ -20,6 +19,7 @@ from backend.common.auth import (
     current_user,
     delete_user,
     revoke_session_cookie,
+    SESSION_COOKIE_LIFETIME,
 )
 from backend.common.consts.auth_type import (
     WRITE_TYPE_NAMES as AUTH_TYPE_WRITE_TYPE_NAMES,
@@ -152,10 +152,8 @@ def login() -> Response:
         if not id_token:
             abort(400)
 
-        expires_in = datetime.timedelta(days=5)
-
         response = jsonify({"status": "success"})
-        create_session_cookie(id_token, expires_in)
+        create_session_cookie(id_token, SESSION_COOKIE_LIFETIME)
         return response
     else:
         if current_user():

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qsl, quote, urlparse
 
 import pytest
@@ -8,6 +8,7 @@ from flask.testing import FlaskClient
 
 import backend
 from backend.common import auth
+from backend.common.auth import SESSION_COOKIE_LIFETIME
 from backend.common.consts.client_type import ClientType
 from backend.common.consts.model_type import ModelType
 from backend.common.helpers.account_deletion import AccountDeletionHelper
@@ -424,7 +425,7 @@ def test_login_success(web_client: FlaskClient) -> None:
     ) as mock_create_session_cookie:
         response = web_client.post("/account/login", data={"id_token": "abc"})
 
-    mock_create_session_cookie.assert_called_with("abc", ANY)
+    mock_create_session_cookie.assert_called_with("abc", SESSION_COOKIE_LIFETIME)
 
     assert response.status_code == 200
     assert response.get_json() == {"status": "success"}

--- a/src/backend/web/main.py
+++ b/src/backend/web/main.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask_wtf.csrf import CSRFProtect
 from google.appengine.api import wrap_wsgi_app
 
-from backend.common.auth import _user_context_processor
+from backend.common.auth import _user_context_processor, SESSION_COOKIE_LIFETIME
 from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
 from backend.common.middleware import install_middleware
@@ -85,6 +85,7 @@ configure_logging()
 app = Flask(__name__)
 app.wsgi_app = wrap_wsgi_app(app.wsgi_app)
 install_middleware(app, configure_secret_key=True, include_appspot_redirect=True)
+app.config["PERMANENT_SESSION_LIFETIME"] = SESSION_COOKIE_LIFETIME
 install_url_converters(app)
 configure_flask_cache(app)
 

--- a/src/backend/web/tests/main_test.py
+++ b/src/backend/web/tests/main_test.py
@@ -1,6 +1,6 @@
 import importlib
 
-from backend.common.auth import _user_context_processor
+from backend.common.auth import _user_context_processor, SESSION_COOKIE_LIFETIME
 from backend.common.environment import Environment
 from backend.web.handlers.account import blueprint as account_blueprint
 
@@ -14,6 +14,12 @@ def test_app_secret_key(ndb_stub) -> None:
 
     # Make sure the secret key is set
     assert main.app.secret_key == Environment.DEFAULT_FLASK_SECRET_KEY
+
+
+def test_app_permanent_session_lifetime() -> None:
+    from backend.web.main import app
+
+    assert app.config["PERMANENT_SESSION_LIFETIME"] == SESSION_COOKIE_LIFETIME
 
 
 def test_app_url_map_strict_slashes() -> None:


### PR DESCRIPTION
## Summary
- Mark the Flask session permanent in `create_session_cookie()` and set `PERMANENT_SESSION_LIFETIME` on the web app so the Flask session cookie gets an explicit `Max-Age` instead of being a browser-session cookie.
- Introduce `SESSION_COOKIE_LIFETIME = timedelta(days=14)` in `backend/common/auth.py` and use it for both the Firebase session cookie TTL (in the login handler) and the Flask `PERMANENT_SESSION_LIFETIME` so they can't drift.
- 14 days matches Firebase Admin's `MAX_SESSION_COOKIE_DURATION_SECONDS` hard limit; revocation check on every request (`check_revoked=True`) is unchanged, so disabled/revoked users still get kicked immediately.

### Root cause
TBA mints a Firebase session cookie with a 5-day TTL and stores it inside Flask's `session["session"]`. Flask's session cookie is emitted without `Max-Age`/`Expires` unless `session.permanent = True` is set and `PERMANENT_SESSION_LIFETIME` is configured — neither was set anywhere in the codebase. So the Flask cookie carrying the Firebase cookie was a browser-session cookie that got dropped on browser close, signing users out long before the 5-day Firebase TTL would have expired.

### Deploy safety
No forced logouts. Existing users' session cookies keep working — Flask only re-emits the session cookie when the session is mutated, and `session.permanent` is stored inside the session data. The new 14-day permanent behavior kicks in on each user's next login.

## Test plan
- [x] `make typecheck` — clean
- [x] `make lint` — clean
- [x] `make test ARGS='src/backend/common/tests/auth_test.py src/backend/web/handlers/tests/account_test.py src/backend/web/tests/main_test.py'` — 76 pass
- [ ] Local manual check via `docker compose up --build`: sign in, inspect `Set-Cookie: session=...` in DevTools — confirm it now has `Expires` / `Max-Age` ~14 days out
- [ ] Close the browser, reopen, navigate to `/account` — confirm still logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)