### PR TITLE
Fix Nexus queue status parser for 4-alliance double elim events

### DIFF
--- a/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
@@ -4,8 +4,14 @@ from typing import Dict, Optional
 
 from pyre_extensions import JSON
 
+from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.nexus_match_status import NexusMatchStatus
-from backend.common.consts.playoff_type import PlayoffType
+from backend.common.consts.playoff_type import (
+    DOUBLE_ELIM_4_MAPPING,
+    DOUBLE_ELIM_MAPPING,
+    LEGACY_DOUBLE_ELIM_MAPPING,
+    PlayoffType,
+)
 from backend.common.datafeeds.parsers.parser_base import ParserBase
 from backend.common.helpers.playoff_type_helper import PlayoffTypeHelper
 from backend.common.models.event import Event
@@ -17,6 +23,18 @@ from backend.common.models.event_queue_status import (
 )
 from backend.common.models.keys import MatchKey
 from backend.common.models.match import Match
+
+# Nexus labels finals "Final 1/2/3" but TBA continues its match numbering
+# from the semifinal bracket. Offset = (first F key in the mapping) - 1.
+_FINALS_LABEL_OFFSET: dict[PlayoffType, int] = {
+    playoff_type: min(k for k, (level, _, _) in mapping.items() if level == CompLevel.F)
+    - 1
+    for playoff_type, mapping in (
+        (PlayoffType.DOUBLE_ELIM_8_TEAM, DOUBLE_ELIM_MAPPING),
+        (PlayoffType.DOUBLE_ELIM_4_TEAM, DOUBLE_ELIM_4_MAPPING),
+        (PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM, LEGACY_DOUBLE_ELIM_MAPPING),
+    )
+}
 
 
 class NexusAPIQueueStatusParser(ParserBase[JSON, Optional[EventQueueStatus]]):
@@ -31,10 +49,11 @@ class NexusAPIQueueStatusParser(ParserBase[JSON, Optional[EventQueueStatus]]):
         self.matches = event.matches
 
     def parse(self, response: JSON) -> Optional[EventQueueStatus]:
-        if self.event.playoff_type != PlayoffType.DOUBLE_ELIM_8_TEAM:
+        if self.event.playoff_type not in _FINALS_LABEL_OFFSET:
             logging.warning(
-                f"Unable to parse nexus status for {self.event.key_name}, playoff type is {self.event.playoff_type}"
+                f"Unable to parse nexus status for {self.event.key_name}, unsupported playoff type {self.event.playoff_type}"
             )
+            return None
 
         if not isinstance(response, dict):
             return None
@@ -96,18 +115,23 @@ class NexusAPIQueueStatusParser(ParserBase[JSON, Optional[EventQueueStatus]]):
             return None
 
         if level == "Final":
-            # Nexus will report "Final 1, 2, 3"
-            # While FMS match nubmering does not reset for finals
-            # This assumes a double elim format
-            level_number += 13
+            # Nexus reports "Final 1, 2, 3" while TBA's match numbering
+            # continues from the semifinal bracket — the offset depends on
+            # the playoff format.
+            level_number += _FINALS_LABEL_OFFSET[self.event.playoff_type]
 
-        comp_level = PlayoffTypeHelper.get_comp_level(
-            self.event.playoff_type, level, level_number
-        )
-
-        set_number, match_number = PlayoffTypeHelper.get_set_match_number(
-            self.event.playoff_type, comp_level, level_number
-        )
+        try:
+            comp_level = PlayoffTypeHelper.get_comp_level(
+                self.event.playoff_type, level, level_number
+            )
+            set_number, match_number = PlayoffTypeHelper.get_set_match_number(
+                self.event.playoff_type, comp_level, level_number
+            )
+        except KeyError:
+            logging.warning(
+                f"Unable to map nexus match label {description!r} for {self.event.key_name} (playoff_type={self.event.playoff_type})"
+            )
+            return None
         return Match.render_key_name(
             self.event.key_name, comp_level.value, set_number, match_number
         )

--- a/src/backend/tasks_io/datafeeds/parsers/nexus_api/tests/queue_status_parser_test.py
+++ b/src/backend/tasks_io/datafeeds/parsers/nexus_api/tests/queue_status_parser_test.py
@@ -60,7 +60,19 @@ def create_match(played: bool) -> Match:
 
 def test_wrong_playoff_type(ndb_stub) -> None:
     e = create_event(playoff_type=PlayoffType.BRACKET_8_TEAM)
-    data: JSON = []
+    data: JSON = {
+        "dataAsOfTime": 0,
+        "matches": [
+            {
+                "label": "Qualification 1",
+                "status": "Now queuing",
+                "times": {
+                    "estimatedQueueTime": 0,
+                    "estimatedStartTime": 0,
+                },
+            }
+        ],
+    }
     parsed = NexusAPIQueueStatusParser(e).parse(data)
     assert parsed is None
 
@@ -241,6 +253,27 @@ def test_parse_match_label(
     ndb_stub, match_label: str, match_key: Optional[MatchKey]
 ) -> None:
     e = create_event()
+    parsed_key = NexusAPIQueueStatusParser(e)._parse_match_description(match_label)
+    assert parsed_key == match_key
+
+
+@pytest.mark.parametrize(
+    "match_label,match_key",
+    [
+        ("Qualification 1", "2019casj_qm1"),
+        ("Playoff 1", "2019casj_sf1m1"),
+        ("Playoff 5", "2019casj_sf5m1"),
+        ("Final 1", "2019casj_f1m1"),
+        ("Final 2", "2019casj_f1m2"),
+        ("Final 3", "2019casj_f1m3"),
+        # Out-of-range finals (beyond overtime 3) should not crash.
+        ("Final 7", None),
+    ],
+)
+def test_parse_match_label_double_elim_4(
+    ndb_stub, match_label: str, match_key: Optional[MatchKey]
+) -> None:
+    e = create_event(playoff_type=PlayoffType.DOUBLE_ELIM_4_TEAM)
     parsed_key = NexusAPIQueueStatusParser(e)._parse_match_description(match_label)
     assert parsed_key == match_key
 


### PR DESCRIPTION
## Summary
- `NexusAPIQueueStatusParser` hardcoded `level_number += 13` when translating Nexus `"Final N"` labels, so on `DOUBLE_ELIM_4_TEAM` events (finals start at match 6, not 14) the task crashed with `KeyError: 14` — reproduced for `2026micmp`.
- Derive the finals offset per playoff type from the existing `DOUBLE_ELIM_MAPPING` / `DOUBLE_ELIM_4_MAPPING` / `LEGACY_DOUBLE_ELIM_MAPPING` tables, bail out early on unsupported playoff types, and catch `KeyError` on unmappable labels so a single bad entry no longer takes down the whole event.
- Added parametrized tests covering DE4 playoff/finals labels and an out-of-range overtime case; updated `test_wrong_playoff_type` to exercise the playoff-type guard with a real payload.

## Test plan
- [x] `make test ARGS='src/backend/tasks_io/datafeeds/parsers/nexus_api/tests/queue_status_parser_test.py'`
- [x] `make test ARGS='src/backend/common/helpers/tests/playoff_type_helper_test.py'`
- [x] `make test` (full suite — 3794 passed, 38 skipped)
- [x] `make lint`
- [x] `make typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)