### PR TITLE
Create EventTeams from match sync for champs events

### DIFF
--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -790,6 +790,40 @@ def event_matches(event_key: EventKey) -> Response:
         MatchManipulator.createOrUpdate(matches, update_manual_attrs=False)
     )
 
+    # Create EventTeams for teams that played a match at this event. The normal
+    # EventTeam sync only runs on the daily event_details fetch, so without this,
+    # teams can appear on matches (e.g. finals-field alliances at a DCMP) without
+    # having an EventTeam binding them to the event.
+    team_ids: Set[TeamKey] = set()
+    for match in new_matches:
+        for team_key_name in match.team_key_names:
+            # strip all suffixes (eg B teams)
+            team_ids.add("frc" + re.sub("[^0-9]", "", team_key_name))
+    team_ids.discard("frc")
+
+    if team_ids:
+        teams = listify(
+            TeamManipulator.createOrUpdate(
+                [
+                    Team(id=team_id, team_number=int(team_id[3:]))
+                    for team_id in team_ids
+                ],
+                update_manual_attrs=False,
+            )
+        )
+        EventTeamManipulator.createOrUpdate(
+            [
+                EventTeam(
+                    id=event_key + "_" + team.key_name,
+                    event=event.key,
+                    team=team.key,
+                    year=event.year,
+                )
+                for team in teams
+            ],
+            update_manual_attrs=False,
+        )
+
     template_values = {"matches": new_matches, "deleted_keys": keys_to_delete}
 
     if (

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_matches_test.py
@@ -13,7 +13,9 @@ from backend.common.consts.event_sync_type import EventSyncType
 from backend.common.consts.event_type import EventType
 from backend.common.futures import InstantFuture
 from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
 from backend.common.models.match import Match
+from backend.common.models.team import Team
 from backend.tasks_io.datafeeds.datafeed_fms_api import DatafeedFMSAPI
 
 
@@ -227,6 +229,106 @@ def test_get_remap_teams(
     m = Match.get_by_id("2020nyny_qm1")
     assert m is not None
     assert m.team_key_names == ["frc9000"]
+
+
+@mock.patch.object(DatafeedFMSAPI, "get_event_matches")
+def test_get_creates_event_teams(
+    fmsapi_matches_mock,
+    tasks_client: Client,
+) -> None:
+    create_event(official=True)
+    matches = [
+        Match(
+            id="2020nyny_sf1m1",
+            event=ndb.Key(Event, "2020nyny"),
+            comp_level=CompLevel.SF,
+            set_number=1,
+            match_number=1,
+            year=2020,
+            alliances_json=json.dumps(
+                {
+                    "red": {
+                        "score": 100,
+                        "teams": ["frc2337", "frc7166", "frc8280"],
+                    },
+                    "blue": {
+                        "score": 90,
+                        "teams": ["frc27", "frc3668", "frc7769"],
+                    },
+                }
+            ),
+            team_key_names=[
+                "frc2337",
+                "frc7166",
+                "frc8280",
+                "frc27",
+                "frc3668",
+                "frc7769",
+            ],
+        )
+    ]
+
+    fmsapi_matches_mock.return_value = InstantFuture(matches)
+
+    resp = tasks_client.get("/tasks/get/fmsapi_matches/2020nyny")
+    assert resp.status_code == 200
+
+    # Every team that played a match gets bound to the event, even without
+    # an award or pre-registered roster.
+    et_team_ids = {
+        et.team.id()
+        for et in EventTeam.query(EventTeam.event == ndb.Key(Event, "2020nyny")).fetch()
+    }
+    assert et_team_ids == {
+        "frc2337",
+        "frc7166",
+        "frc8280",
+        "frc27",
+        "frc3668",
+        "frc7769",
+    }
+
+    # Stub Teams are created for any we haven't seen before.
+    team = Team.get_by_id("frc2337")
+    assert team is not None
+    assert team.team_number == 2337
+
+
+@mock.patch.object(DatafeedFMSAPI, "get_event_matches")
+def test_get_strips_b_team_suffix_when_creating_event_teams(
+    fmsapi_matches_mock,
+    tasks_client: Client,
+) -> None:
+    create_event(official=True)
+    matches = [
+        Match(
+            id="2020nyny_qm1",
+            event=ndb.Key(Event, "2020nyny"),
+            comp_level=CompLevel.QM,
+            set_number=1,
+            match_number=1,
+            year=2020,
+            alliances_json=json.dumps(
+                {
+                    "red": {"score": 10, "teams": ["frc254B"]},
+                    "blue": {"score": 20, "teams": []},
+                }
+            ),
+            team_key_names=["frc254B"],
+        )
+    ]
+
+    fmsapi_matches_mock.return_value = InstantFuture(matches)
+
+    resp = tasks_client.get("/tasks/get/fmsapi_matches/2020nyny")
+    assert resp.status_code == 200
+
+    # B-team suffixes are collapsed to the parent team number.
+    et_team_ids = {
+        et.team.id()
+        for et in EventTeam.query(EventTeam.event == ndb.Key(Event, "2020nyny")).fetch()
+    }
+    assert et_team_ids == {"frc254"}
 
 
 @mock.patch.object(DatafeedFMSAPI, "get_event_matches")


### PR DESCRIPTION
## Summary

Teams that play a match at a DCMP or CMP main event (e.g. the finals-field alliances at Michigan State Championship) now get an `EventTeam` record as soon as the match is synced, rather than having to wait for the daily `event_details` sync to trigger `EventTeamUpdater`.

## The bug

At the 2026 Michigan State Championship (`2026micmp`), four division alliances played on the DCMP finals field. The top half of the bracket (alliance captain 27 etc.) showed up on their team pages as having attended `2026micmp`. The bottom half (2337, 7166, 8280, 6090, 2586, 2767, 5460, 3538, 7197, 4327) did **not** — the event was missing from their team pages entirely, and they had no matches displayed for it, despite having played on the main field.

The difference between the two groups: the top-bracket teams won awards at the main event (Finalist, Winner, etc.), the bottom-bracket teams did not.

## Root cause

The team page uses `TeamYearEventsQuery` (`src/backend/common/queries/event_query.py:156`), which queries `EventTeam` records. No `EventTeam` → the event does not appear on the team page.

For DCMP/CMP_FINALS events with divisions, once the event starts, `ChampsRegistrationHacks.should_skip_eventteams()` returns `True` (`src/backend/common/sitevars/cmp_registration_hacks.py:41`). This is intentional — the FRC API's registration list for the main championship contains the division rosters, and we don't want to write an `EventTeam` for every team that attended any division. Only teams who *actually play* on the main field (or win an award there) should be bound to the main event.

With registration-based creation disabled, `EventTeam`s at the main event get created from three paths:

| Path | Trigger | Frequency |
|---|---|---|
| `EventTeamUpdater` via `frc_api.event_details` | Daily `event_list/current` cron | **Once per day, 01:00 PT** |
| `awards_event` handler writes `EventTeam`s for award winners | `fmsapi_awards/*` cron | Every hour, or every 5 min on last day |
| (nothing) | Match sync | — |

The gap: there was no eager `EventTeam` creation for teams that play matches. So when 2337 played their semifinal on the MSC finals field today, nothing bound them to `2026micmp` until the 01:00 PT cron ran the next day. Teams 27 / 3668 / 7769 were fine because they won awards, and `awards_event` creates `EventTeam`s immediately.

## Why not just wait for the cron?

It would self-heal at the next 01:00 PT daily sync via `EventTeamUpdater`, which correctly collects teams from matches + awards + alliances + division winners. But during the event itself — which is exactly when TBA gets its highest traffic and when teams are checking their own pages — the data is visibly broken for half the bracket for hours. \"It fixes itself tomorrow morning\" isn't good enough when the event is happening live.

## The fix

Mirror the existing pattern in `awards_event` (`src/backend/tasks_io/handlers/frc_api.py:867+`) inside `event_matches`. After writing matches, iterate over their `team_key_names`, create stub `Team`s for any unknowns, and `createOrUpdate` an `EventTeam` for each. The B-team suffix stripping (`re.sub(\"[^0-9]\", \"\", ...)`) matches the awards path exactly.

Since matches sync every 1 minute (`cron.yaml:12-14`), affected teams now appear on their team pages ~1 minute after the match is posted.

### Why this is safe alongside `should_skip_eventteams`

`should_skip_eventteams` gates the *registration-based* `EventTeam` creation and the companion deletion logic in `event_details` (`frc_api.py:480-499`). That logic only deletes `EventTeam`s not present in FRC API's registration list (except award winners). When `skip_eventteams=True`, that delete path doesn't run, so `EventTeam`s we create from match sync won't get removed out from under us. `EventTeamUpdater`'s own delete path (on the next daily run) considers match teams valid (`event_team_updater.py:38-44`), so our writes survive that too.

### Why in `event_matches` vs. `event_alliances` or calling `EventTeamUpdater`

- **`event_alliances`** would also work (alliance selection happens before playoffs) but wouldn't cover backup teams swapped in during playoffs, and alliance sync runs less often.
- **Calling `EventTeamUpdater.update()` from match sync** is heavier than needed — it re-queries *all* matches/awards/alliances/division winners for the event, runs cache-clearing for deletes, and its entry point (`math.update_eventteams`) expects to be called as a task, not inline.
- **`event_matches`** is the most direct fix: the team played a match, the sync already writes the match, we just also write the `EventTeam`. Matches every minute → fastest recovery.

## Backfilling existing broken data

Once merged and deployed, the next `fmsapi_matches/now` cron (≤1 min) will create the missing `EventTeam`s for any current event. For events that have already ended (like `2026micmp`), an admin can hit `/tasks/math/do/eventteam_update/2026micmp?allow_deletes=true` to run the existing `EventTeamUpdater` against the finalized match data.

## Test plan

- [x] New test: `test_get_creates_event_teams` — verifies every team in a synced match gets an `EventTeam` and a stub `Team` record.
- [x] New test: `test_get_strips_b_team_suffix_when_creating_event_teams` — verifies B-team suffixes (e.g. `frc254B`) are collapsed to the parent team.
- [x] Existing match / awards / eventteam-updater regression suites pass (55 tests).
- [x] `make lint` clean.
- [x] `make typecheck` clean.
- [ ] After deploy: verify `2026micmp` backfill completes, team pages for 2337 / 6090 / etc. show the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)