### PR TITLE
Fix Event Wizard match results fetch crashing with TypeError

### DIFF
--- a/src/frontend/eventwizard/components/eventMatchResultsTab/EventMatchResultsTab.tsx
+++ b/src/frontend/eventwizard/components/eventMatchResultsTab/EventMatchResultsTab.tsx
@@ -8,9 +8,9 @@ export interface EventMatchResultsTabProps {
     path: string,
     body: string | FormData
   ) => Promise<Response>;
-  makeApiV3Request: <T = unknown>(
+  makeApiV3Request: (
     path: string
-  ) => Promise<T>;
+  ) => Promise<Response>;
 }
 
 const EventMatchResultsTab: React.FC<EventMatchResultsTabProps> = ({

--- a/src/frontend/eventwizard/components/eventMatchResultsTab/MatchResultsFromMatchPlay.tsx
+++ b/src/frontend/eventwizard/components/eventMatchResultsTab/MatchResultsFromMatchPlay.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useState } from "react";
+import ensureRequestSuccess from "../../net/EnsureRequestSuccess";
 
 const COMP_LEVELS_PLAY_ORDER: Record<string, number> = {
   qm: 1,
@@ -41,13 +42,11 @@ interface MatchResultsFromMatchPlayProps {
   selectedEvent: string;
   makeTrustedRequest: (
     path: string,
-    body: string,
-    successCallback: (response: any) => void,
-    errorCallback: (error: any) => void
-  ) => void;
-  makeApiV3Request: <T = unknown>(
+    body: string | FormData
+  ) => Promise<Response>;
+  makeApiV3Request: (
     path: string
-  ) => Promise<T>;
+  ) => Promise<Response>;
 }
 
 const MatchResultsFromMatchPlay: React.FC<MatchResultsFromMatchPlayProps> = ({
@@ -71,12 +70,19 @@ const MatchResultsFromMatchPlay: React.FC<MatchResultsFromMatchPlayProps> = ({
     setStatusMessage("Loading matches...");
 
     try {
-      const data = await makeApiV3Request<SimpleMatch[]>(
+      const response = await makeApiV3Request(
         `/api/v3/event/${selectedEvent}/matches/simple`
       );
+      ensureRequestSuccess(response);
+      const data = await response.json();
 
-      // Sort matches by comp_level and match_number
-      const sortedMatches = data.sort((a, b) => {
+      if (!Array.isArray(data)) {
+        throw new Error("Unexpected matches response format");
+      }
+
+      const matchesFromApi = data as SimpleMatch[];
+
+      const sortedMatches = [...matchesFromApi].sort((a, b) => {
         const compLevelDiff =
           COMP_LEVELS_PLAY_ORDER[a.comp_level] -
           COMP_LEVELS_PLAY_ORDER[b.comp_level];
@@ -127,7 +133,7 @@ const MatchResultsFromMatchPlay: React.FC<MatchResultsFromMatchPlayProps> = ({
     }));
   };
 
-  const updateMatch = (match: SimpleMatch): void => {
+  const updateMatch = async (match: SimpleMatch): Promise<void> => {
     const matchKey = match.key;
     const redScore = parseInt(scores[matchKey]?.red);
     const blueScore = parseInt(scores[matchKey]?.blue);
@@ -156,18 +162,17 @@ const MatchResultsFromMatchPlay: React.FC<MatchResultsFromMatchPlayProps> = ({
       },
     };
 
-    makeTrustedRequest(
-      `/api/trusted/v1/event/${selectedEvent}/matches/update`,
-      JSON.stringify([matchUpdate]),
-      () => {
-        setUpdatingMatches((prev) => ({ ...prev, [matchKey]: false }));
-        setStatusMessage(`Successfully updated ${formatMatchName(match)}!`);
-      },
-      (error) => {
-        setUpdatingMatches((prev) => ({ ...prev, [matchKey]: false }));
-        setStatusMessage(`Error updating match: ${error}`);
-      }
-    );
+    try {
+      await makeTrustedRequest(
+        `/api/trusted/v1/event/${selectedEvent}/matches/update`,
+        JSON.stringify([matchUpdate])
+      );
+      setStatusMessage(`Successfully updated ${formatMatchName(match)}!`);
+    } catch (error) {
+      setStatusMessage(`Error updating match: ${error}`);
+    } finally {
+      setUpdatingMatches((prev) => ({ ...prev, [matchKey]: false }));
+    }
   };
 
   const formatMatchName = (match: SimpleMatch): string => {

--- a/src/frontend/eventwizard/components/eventMatchResultsTab/__tests__/MatchResultsFromMatchPlay.test.tsx
+++ b/src/frontend/eventwizard/components/eventMatchResultsTab/__tests__/MatchResultsFromMatchPlay.test.tsx
@@ -1,0 +1,221 @@
+/* @jest-environment jsdom */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MatchResultsFromMatchPlay from "../MatchResultsFromMatchPlay";
+
+describe("MatchResultsFromMatchPlay", () => {
+  const mockMakeTrustedRequest = jest.fn<Promise<Response>, [string, string]>();
+  const mockMakeApiV3Request = jest.fn<Promise<Response>, [string]>();
+  const selectedEvent = "2024nytr";
+
+  const makeJsonResponse = (payload: unknown): Response =>
+    ({
+      ok: true,
+      statusText: "OK",
+      json: async () => payload,
+    } as Response);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Fetching Matches", () => {
+    it("requests the simple matches endpoint when Fetch Matches is clicked", async () => {
+      mockMakeApiV3Request.mockResolvedValue(makeJsonResponse([]));
+
+      render(
+        <MatchResultsFromMatchPlay
+          selectedEvent={selectedEvent}
+          makeTrustedRequest={mockMakeTrustedRequest}
+          makeApiV3Request={mockMakeApiV3Request}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Fetch Matches/i }));
+
+      await waitFor(() => {
+        expect(mockMakeApiV3Request).toHaveBeenCalledWith(
+          `/api/v3/event/${selectedEvent}/matches/simple`
+        );
+      });
+    });
+
+    it("parses the JSON body and renders matches after a successful fetch", async () => {
+      const mockMatches = [
+        {
+          key: "2024nytr_qm2",
+          comp_level: "qm",
+          set_number: 1,
+          match_number: 2,
+          alliances: {
+            red: { team_keys: ["frc254", "frc971", "frc1678"], score: 110 },
+            blue: { team_keys: ["frc1323", "frc2056", "frc5499"], score: 95 },
+          },
+        },
+        {
+          key: "2024nytr_qm1",
+          comp_level: "qm",
+          set_number: 1,
+          match_number: 1,
+          alliances: {
+            red: { team_keys: ["frc254", "frc971", "frc1678"], score: 100 },
+            blue: { team_keys: ["frc1323", "frc2056", "frc5499"], score: 90 },
+          },
+        },
+      ];
+
+      mockMakeApiV3Request.mockResolvedValue(makeJsonResponse(mockMatches));
+
+      render(
+        <MatchResultsFromMatchPlay
+          selectedEvent={selectedEvent}
+          makeTrustedRequest={mockMakeTrustedRequest}
+          makeApiV3Request={mockMakeApiV3Request}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Fetch Matches/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Qualification 1")).toBeInTheDocument();
+        expect(screen.getByText("Qualification 2")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Loaded 2 matches")).toBeInTheDocument();
+
+      // Matches render in sorted play order — Qualification 1 before Qualification 2.
+      const matchRows = screen.getAllByRole("row");
+      const headerAndRows = matchRows.map((row) => row.textContent || "");
+      const qm1Index = headerAndRows.findIndex((t) => t.includes("Qualification 1"));
+      const qm2Index = headerAndRows.findIndex((t) => t.includes("Qualification 2"));
+      expect(qm1Index).toBeLessThan(qm2Index);
+    });
+
+    it("shows an error when the matches response is not an array", async () => {
+      mockMakeApiV3Request.mockResolvedValue(makeJsonResponse({ matches: [] }));
+
+      render(
+        <MatchResultsFromMatchPlay
+          selectedEvent={selectedEvent}
+          makeTrustedRequest={mockMakeTrustedRequest}
+          makeApiV3Request={mockMakeApiV3Request}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Fetch Matches/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error loading matches:/)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Unexpected matches response format/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("surfaces a friendly error when the request fails with a non-2xx status", async () => {
+      mockMakeApiV3Request.mockResolvedValue({
+        ok: false,
+        statusText: "Not Found",
+        json: async () => ({}),
+      } as Response);
+
+      render(
+        <MatchResultsFromMatchPlay
+          selectedEvent={selectedEvent}
+          makeTrustedRequest={mockMakeTrustedRequest}
+          makeApiV3Request={mockMakeApiV3Request}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Fetch Matches/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error loading matches:/)).toBeInTheDocument();
+        expect(screen.getByText(/Not Found/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Updating Matches", () => {
+    const mockMatches = [
+      {
+        key: "2024nytr_qm1",
+        comp_level: "qm",
+        set_number: 1,
+        match_number: 1,
+        alliances: {
+          red: { team_keys: ["frc254"], score: 100 },
+          blue: { team_keys: ["frc1323"], score: 90 },
+        },
+      },
+    ];
+
+    const renderAndFetch = async () => {
+      mockMakeApiV3Request.mockResolvedValue(makeJsonResponse(mockMatches));
+
+      render(
+        <MatchResultsFromMatchPlay
+          selectedEvent={selectedEvent}
+          makeTrustedRequest={mockMakeTrustedRequest}
+          makeApiV3Request={mockMakeApiV3Request}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Fetch Matches/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Qualification 1")).toBeInTheDocument();
+      });
+    };
+
+    it("posts the match update and reports success", async () => {
+      await renderAndFetch();
+
+      mockMakeTrustedRequest.mockResolvedValueOnce(makeJsonResponse({}));
+
+      fireEvent.click(screen.getByRole("button", { name: /^Update$/i }));
+
+      await waitFor(() => {
+        expect(mockMakeTrustedRequest).toHaveBeenCalledWith(
+          `/api/trusted/v1/event/${selectedEvent}/matches/update`,
+          JSON.stringify([
+            {
+              comp_level: "qm",
+              set_number: 1,
+              match_number: 1,
+              alliances: {
+                red: { teams: ["frc254"], score: 100 },
+                blue: { teams: ["frc1323"], score: 90 },
+              },
+            },
+          ])
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Successfully updated Qualification 1/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("reports an error and re-enables the row when the update request fails", async () => {
+      await renderAndFetch();
+
+      mockMakeTrustedRequest.mockRejectedValueOnce(new Error("Unauthorized"));
+
+      fireEvent.click(screen.getByRole("button", { name: /^Update$/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Error updating match:.*Unauthorized/)
+        ).toBeInTheDocument();
+      });
+
+      // Button returns to its idle state so the user can retry.
+      expect(screen.getByRole("button", { name: /^Update$/i })).toBeEnabled();
+    });
+  });
+});

--- a/src/frontend/eventwizard/containers/EventMatchResultsTabContainer.tsx
+++ b/src/frontend/eventwizard/containers/EventMatchResultsTabContainer.tsx
@@ -17,10 +17,10 @@ const mapStateToProps = (state: RootState) => ({
       requestBody
     );
   },
-  makeApiV3Request: <T = unknown>(
+  makeApiV3Request: (
     requestPath: string
   ) => {
-    return makeApiV3Request<T>(state.auth.authId || "", requestPath);
+    return makeApiV3Request(state.auth.authId || "", requestPath);
   },
 });
 


### PR DESCRIPTION
## Summary
- The match-play tab of Event Wizard's match results page crashed with `Error loading matches: TypeError: r.sort is not a function` when users tried to fetch matches. `makeApiV3Request` actually returns `Promise<Response>`, but the component treated the awaited value as already-parsed JSON and called `.sort()` on the `Response` object. A bogus `<T>` generic on the prop type (and container) masked the mismatch from TypeScript.
- Parse the body via `response.json()`, run it through `ensureRequestSuccess`, and guard for non-array shapes (matching the pattern in `MatchVideosTab`).
- While in there, rewrote the never-firing `updateMatch` callbacks — the component passed success/error callbacks to `makeTrustedRequest`, but the underlying function returns a `Promise<Response>` and ignores extra args, so status would hang on "Updating..." forever. Replaced with proper `try`/`catch`/`finally`.
- Corrected prop signatures on `MatchResultsFromMatchPlay`, `EventMatchResultsTab`, and the Redux container to truthfully declare `Promise<Response>` so this class of bug can't be hidden again.

## Test plan
- [x] New `MatchResultsFromMatchPlay.test.tsx` covers fetch success, non-array payload, non-2xx response, update success, and update failure (5 of 6 tests target the bug paths)
- [x] All 43 tests in the affected suites pass
- [x] `tsc --noEmit` clean on touched files
- [ ] Manually exercise the Event Wizard match-play tab in a dev environment: load matches, edit scores, publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)