### PR TITLE
Exclude DQ'd and surrogate teams from match-score tiebreaker

### DIFF
--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -738,17 +738,24 @@ class DistrictHelper:
                         district_points["tiebreakers"][team]["qual_wins"] += 1
 
                 for color in ALLIANCE_COLORS:
-                    for team in match.alliances[color]["teams"]:
-                        score = match.alliances[color]["score"]
-                        district_points["tiebreakers"][team]["highest_match_scores"] = (
-                            heapq.nlargest(
+                    alliance = match.alliances[color]
+                    score = alliance["score"]
+                    # DQ'd and surrogate teams don't get credit for the match
+                    # score in the tiebreaker (they didn't really "play" it).
+                    excluded = set(alliance.get("dqs", [])) | set(
+                        alliance.get("surrogates", [])
+                    )
+                    for team in alliance["teams"]:
+                        if team not in excluded:
+                            district_points["tiebreakers"][team][
+                                "highest_match_scores"
+                            ] = heapq.nlargest(
                                 3,
                                 district_points["tiebreakers"][team][
                                     "highest_match_scores"
                                 ]
                                 + [score],
                             )
-                        )
                         # Make sure that teams without wins don't get dropped from 'points'
                         district_points["points"][team]["qual_points"] += 0
             else:  # Elim match points
@@ -803,8 +810,16 @@ class DistrictHelper:
         # top individual MATCH scores, qual + playoff
         for match in matches:
             for color in ALLIANCE_COLORS:
-                for team in match.alliances[color]["teams"]:
-                    score = match.alliances[color]["score"]
+                alliance = match.alliances[color]
+                score = alliance["score"]
+                # DQ'd and surrogate teams don't get credit for the match
+                # score in the tiebreaker (they didn't really "play" it).
+                excluded = set(alliance.get("dqs", [])) | set(
+                    alliance.get("surrogates", [])
+                )
+                for team in alliance["teams"]:
+                    if team in excluded:
+                        continue
                     district_points["tiebreakers"][team]["highest_match_scores"] = (
                         heapq.nlargest(
                             3,

--- a/src/backend/common/helpers/tests/data/2015nyny_district_points.json
+++ b/src/backend/common/helpers/tests/data/2015nyny_district_points.json
@@ -922,12 +922,12 @@
     }, 
     "frc5558": {
       "highest_match_scores": [
-        21, 
-        18, 
-        17
-      ], 
+        18,
+        13,
+        10
+      ],
       "qual_wins": 0
-    }, 
+    },
     "frc5599": {
       "highest_match_scores": [
         67, 

--- a/src/backend/common/helpers/tests/data/2018necmp_district_points.json
+++ b/src/backend/common/helpers/tests/data/2018necmp_district_points.json
@@ -708,12 +708,12 @@
     }, 
     "frc3930": {
       "highest_match_scores": [
-        419, 
-        408, 
-        388
-      ], 
+        408,
+        388,
+        365
+      ],
       "qual_wins": 0
-    }, 
+    },
     "frc4041": {
       "highest_match_scores": [
         455, 

--- a/src/backend/common/helpers/tests/data/2023onlon_district_points.json
+++ b/src/backend/common/helpers/tests/data/2023onlon_district_points.json
@@ -403,9 +403,9 @@
     },
     "frc6162": {
       "highest_match_scores": [
-        128,
         119,
-        88
+        88,
+        84
       ],
       "qual_wins": 0
     },

--- a/src/backend/common/helpers/tests/data/2024test_district_points.json
+++ b/src/backend/common/helpers/tests/data/2024test_district_points.json
@@ -278,9 +278,9 @@
      "frc6162":{
         "qual_wins":0,
         "highest_match_scores":[
-           128,
            119,
-           88
+           88,
+           84
         ]
      },
      "frc1325":{

--- a/src/backend/common/helpers/tests/data/2025mndu2_regional_champs_pool_points.json
+++ b/src/backend/common/helpers/tests/data/2025mndu2_regional_champs_pool_points.json
@@ -528,9 +528,9 @@
     },
     "frc2513": {
       "highest_match_scores": [
-        101,
         88,
-        72
+        72,
+        66
       ],
       "qual_wins": 0
     },

--- a/src/backend/common/helpers/tests/district_helper_test.py
+++ b/src/backend/common/helpers/tests/district_helper_test.py
@@ -56,6 +56,18 @@ def test_calc_event_points(
     assert event_points == expected_event_points
 
 
+def test_calc_event_points_excludes_dq_from_match_score_tiebreaker(
+    setup_full_event,
+) -> None:
+    # 2023onlon_qm27 scored 128 with frc6162 on the alliance but frc6162 was
+    # DQ'd in that match; the score must not count toward frc6162's top-3
+    # match score tiebreaker.
+    setup_full_event("2023onlon")
+    event = none_throws(Event.get_by_id("2023onlon"))
+    event_points = DistrictHelper.calculate_event_points(event)
+    assert 128 not in event_points["tiebreakers"]["frc6162"]["highest_match_scores"]
+
+
 def test_calculate_multi_event_rankings_all_teams_filtered(setup_full_event) -> None:
     setup_full_event("2019nyny")
     setup_full_event("2019micmp3")


### PR DESCRIPTION
## Description

`DistrictHelper._calc_rank_based_match_points` (2015+) and its pre-2023 twin in `_calc_match_points_pre_2015` credit every team listed in an alliance with the alliance's score for the "Highest Individual MATCH Score" tiebreaker (criteria 6–8 from Table 11-2 of the 2026 Game Manual). They don't skip teams in `alliance["dqs"]` or `alliance["surrogates"]`, so a DQ'd or surrogate team gets their alliance's score folded into their top-3 match scores. That silently inflates the tiebreaker and misorders tied clusters.

The fix: in both loops, build a set of excluded teams from `dqs ∪ surrogates` and skip them when appending to `highest_match_scores`.

## Motivation and Context

Reported by comparing 2026 FIM district rankings from TBA vs FRC Events. Within several tie clusters, team order disagreed — most visibly in the 17-team cluster at 18 points where one team was 6 positions out of place (frc1528, TBA=472 vs FRC=478).

### Rules from the 2026 Game Manual

- **§6 DISQUALIFIED** — "the state of a team in which they receive 0 MATCH points and 0 Ranking Points in a Qualification MATCH…" → a DQ'd team's alliance score shouldn't feed their tiebreaker.
- **§10.5.2 SURROGATES** — "If a team plays a MATCH as a SURROGATE… the outcome of the MATCH has no effect on the team's ranking." → same principle, applied by analogy from event-level ranking to district-point tiebreakers.

## How Has This Been Tested?

### 1. Empirical validation against FRC Events for 7 2026 FIM teams

For each team I pulled every 2026 match, identified the single score TBA counted that FRC didn't, and confirmed that score's match has the team in `dq_team_keys`. Every dropped score traces to a DQ; every replacement is the team's actual next-highest played match. All 7 predictions then matched the tiebreaker values displayed on FRC's site exactly.

| Team | TBA stored (buggy) | Computed after fix | FRC site L6/L7/L8 | DQ'd match | Replacement match |
|---|---|---|---|---|---|
| frc1528 | [323, 199, 197] | [199, 197, 165] | 199 / 197 / 165 | 2026mibro_qm78 (323) | 2026mibro_qm28 (165) |
| frc9312 | [393, 377, 342] | [377, 342, 330] | 377 / 342 / 330 | 2026mibkn_qm48 (393) | 2026micmp4_qm7 (330) |
| frc1940 | [311, 311, 181] | [311, 181, 166] | 311 / 181 / 166 | 2026mimas_qm56 (311) | 2026miber_qm48 (166) |
| frc7808 | [316, 278, 177] | [316, 278, 145] | 316 / 278 / 145 | 2026mitvc_qm67 (177) | 2026miken_qm33 (145) |
| frc8623 | [314, 211, 166] | [314, 211, 143] | 314 / 211 / 143 | 2026mibel_qm43 (166) | 2026miliv_qm30 (143) |
| frc5560 | [295, 223, 186] | [295, 223, 118] | 295 / 223 / 118 | 2026milac_qm63 (186) | 2026mitvc_qm34 (118) |
| frc9568 | [224, 191, 159] | [224, 191, 157] | 224 / 191 / 157 | 2026milac_qm68 (159) | 2026milac_qm46 (157) |

Levels 1–5 (playoff totals, alliance selection points, qual totals) were also spot-checked on every team and already matched FRC with no code change needed.

### 2. Full-sort verification

Simulated the complete district-rank sort key (`point_total → total_playoff_points → best_playoff_points → total_alliance_points → best_alliance_points → total_qual_points → top-3 match scores → team number`) on every 2026 FIM tied cluster that contains a DQ-affected team. All 6 clusters come out identical to FRC's published order:

| Cluster | Size | Affected team | Result |
|---|---|---|---|
| 26 pts | 6 teams | frc5560 | matches FRC |
| 24 pts | 11 teams | frc9568 | matches FRC |
| 23 pts | 4 teams | frc7808 | matches FRC |
| 18 pts | 17 teams | frc1528 | matches FRC (was the -6 outlier) |
| 15 pts | 10 teams | frc1940 | matches FRC |
| 12 pts | 4 teams | frc8623 | matches FRC |

frc9312 isn't in a tied cluster (unique total), so tiebreaker doesn't visibly affect its rank.

### 3. Regression-test fixture updates

5 fixtures had a single team whose top-3 changed after the fix. Each update was verified against the raw match JSON in the same test-data directory to confirm:
- The old value equals `nlargest(3, all_scores_including_DQ_and_surrogate)` — confirming it captured the buggy output.
- The new value equals `nlargest(3, scores_where_team_was_not_DQ_or_surrogate)` — confirming the corrected output.
- Every dropped score traces to a match where the team appears in that alliance's `dq_team_keys`.
- Every added score is a real played match for the team at that event.

| Fixture | Team | Old top-3 → New top-3 | Dropped (match → status) | Added (match → status) |
|---|---|---|---|---|
| 2015nyny | frc5558 | [21, 18, 17] → [18, 13, 10] | 21 ← qm64 (DQ), 17 ← qm6 (DQ) | 13 ← qm21 (played), 10 ← qm28 (played) |
| 2018necmp | frc3930 | [419, 408, 388] → [408, 388, 365] | 419 ← qm69 (DQ) | 365 ← qm18 (played) |
| 2023onlon | frc6162 | [128, 119, 88] → [119, 88, 84] | 128 ← qm27 (DQ) | 84 ← qm30 (played) |
| 2024test | frc6162 | [128, 119, 88] → [119, 88, 84] | 128 ← qm27 (DQ) | 84 ← qm30 (played) |
| 2025mndu2 | frc2513 | [101, 88, 72] → [88, 72, 66] | 101 ← qm32 (DQ) | 66 ← qm59 (played) |

Note: 2015nyny/frc5558 has **two** DQ'd scores in the original top-3, and exercises the pre-2023 code path. 2024test is a synthetic test event; its fixture mirrors 2023onlon because the test data is derived from it.

### 4. New regression test

`test_calc_event_points_excludes_dq_from_match_score_tiebreaker` pins the 2023onlon frc6162 case (128 came from qm27 where frc6162 was DQ'd, and must not appear in their top-3).

### 5. Test suite + type check

- `make test ARGS='src/backend/common/helpers/tests/district_helper_test.py src/backend/common/helpers/tests/regional_champs_pool_helper_test.py'` → **41 passed**
- `make typecheck` → clean, no type errors

## Deployment

After merge, re-run `/tasks/math/enqueue/district_points_calc/2026` to rewrite every 2026 `EventDetails.district_points` with correctly-filtered `highest_match_scores`. Each per-event recompute auto-enqueues `district_rankings_calc`, so the final rankings will update automatically.

## What is NOT validated here

To be transparent about the limits of this verification:

- **Surrogate exclusion is not empirically confirmed.** None of the 7 2026 FIM teams in the validation set had a surrogate match that hit their top-3. The surrogate branch is included in the fix based on §10.5.2 of the Game Manual, by analogy with the DQ rule — but we don't have an end-to-end FRC-comparison data point that exercises it. If a FIRST ruling ever contradicts this, the surrogate branch can be pulled out cleanly.
- **Districts other than FIM in 2026 weren't cross-checked.** The code path is shared, and the rule is simple, so this shouldn't matter, but I haven't done the cluster-by-cluster comparison for other districts.
- **Historical-fixture updates weren't cross-checked against archived FRC tiebreaker data.** The 5 updated fixtures were verified against the raw match JSON in the repo (dropped score came from a DQ match, added score is a real played match). We trust the rule; we did not independently query FRC for 2015/2018/2023/2025 tiebreaker values.
- **The frc11387 phantom DCMP award points issue** (a 2026 FIM rookie credited with 24 DCMP award points for Rookie All Star despite not attending a division) is a separate bug in award-point attribution, not tiebreakers, and is not addressed here. It's the only remaining source of TBA-vs-FRC rank mismatch in FIM 2026 after this fix + a recompute.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)