### PR TITLE
fix firebase liveevent with firebase emulator

### DIFF
--- a/src/backend/web/static/javascript/tba_js/tba_firebase.js
+++ b/src/backend/web/static/javascript/tba_js/tba_firebase.js
@@ -12,3 +12,12 @@ firebase.initializeApp(config);
 
 const auth = firebase.auth();
 auth.setPersistence(firebase.auth.Auth.Persistence.NONE);
+
+// Connect to database emulator if available
+// Set firebaseDatabaseEmulatorHost in tba_keys.js (e.g., "localhost:9000")
+if (firebaseDatabaseEmulatorHost) {
+  var parts = firebaseDatabaseEmulatorHost.split(':');
+  var host = parts[0];
+  var port = parseInt(parts[1], 10);
+  firebase.database().useEmulator(host, port);
+}

--- a/src/backend/web/static/javascript/tba_js/tba_keys_template.js
+++ b/src/backend/web/static/javascript/tba_js/tba_keys_template.js
@@ -6,3 +6,4 @@ var firebaseProjectId = "demo-test";
 var firebaseStorageBucket = "";
 var firebaseMessagingSenderId = "";
 var firebaseAppId = "";
+var firebaseDatabaseEmulatorHost = ""; // localhost:9000 for local dev

--- a/src/frontend/liveevent/firebaseapp.js
+++ b/src/frontend/liveevent/firebaseapp.js
@@ -2,10 +2,35 @@
 import firebase from "firebase/compat/app";
 import "firebase/compat/database";
 
-const FirebaseApp = firebase.initializeApp({
-  apiKey: "AIzaSyDBlFwtAgb2i7hMCQ5vBv44UEKVsA543hs",
-  authDomain: "tbatv-prod-hrd.firebaseapp.com",
-  databaseURL: "https://tbatv-prod-hrd.firebaseio.com",
-});
+// Access Firebase config from window (loaded by tba_keys.js script tag)
+const emulatorHost = window.firebaseDatabaseEmulatorHost || "";
+const projectId = window.firebaseProjectId || "demo-test";
+
+// When using the emulator, construct a valid databaseURL from the emulator host
+// since the emulator still needs a URL with namespace to identify the database
+let databaseURL = window.firebaseDatabaseURL || "";
+if (emulatorHost && !databaseURL) {
+  databaseURL = `http://${emulatorHost}?ns=${projectId}`;
+}
+
+const config = {
+  apiKey: window.firebaseApiKey || "",
+  authDomain: window.firebaseAuthDomain || "",
+  databaseURL: databaseURL,
+  projectId: projectId,
+  storageBucket: window.firebaseStorageBucket || "",
+  messagingSenderId: window.firebaseMessagingSenderId || "",
+  appId: window.firebaseAppId || "",
+};
+
+const FirebaseApp = firebase.initializeApp(config);
+
+// Use emulator for local development if configured
+if (emulatorHost) {
+  const parts = emulatorHost.split(":");
+  const host = parts[0];
+  const port = parseInt(parts[1], 10);
+  firebase.database().useEmulator(host, port);
+}
 
 export default FirebaseApp;


### PR DESCRIPTION
This supports overriding the firebase connection in the live event pane to use the local emulator. 

This supports using the fields from `tba_keys.js`, which are generated as part of the build, instead of hard-coded values. 