### PR TITLE
[PWA] Add "Most Successful Teamups" district stat

### DIFF
--- a/pwa/app/components/tba/leaderboard.tsx
+++ b/pwa/app/components/tba/leaderboard.tsx
@@ -40,11 +40,13 @@ export function Leaderboard({
   leaderboard,
   contextTooltipMap,
   year,
+  renderKey,
 }: {
   subtitle?: string;
   leaderboard: LeaderboardInsight;
   contextTooltipMap?: Record<string, ReactNode>;
   year: number;
+  renderKey?: (key: string) => ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -143,6 +145,7 @@ export function Leaderboard({
                         keyVals={r.keys}
                         contextTooltipMap={contextTooltipMap}
                         year={year}
+                        renderKey={renderKey}
                       />
                     </TableCell>
                   </TableRow>
@@ -161,12 +164,14 @@ function LeaderboardKeyList({
   cutoffSize,
   contextTooltipMap,
   year,
+  renderKey,
 }: {
   keyType: LeaderboardInsight['data']['key_type'];
   keyVals: string[];
   cutoffSize: number;
   contextTooltipMap?: Record<string, ReactNode>;
   year: number;
+  renderKey?: (key: string) => ReactNode;
 }) {
   return (
     <>
@@ -176,7 +181,12 @@ function LeaderboardKeyList({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
-                <LeaderboardKeyLink keyType={keyType} keyVal={k} year={year} />
+                <LeaderboardKeyLink
+                  keyType={keyType}
+                  keyVal={k}
+                  year={year}
+                  renderKey={renderKey}
+                />
               </TooltipTrigger>
               {contextTooltipMap?.[k] ? (
                 <TooltipContent>
@@ -206,6 +216,7 @@ function LeaderboardKeyList({
                       keyType={keyType}
                       keyVal={k}
                       year={year}
+                      renderKey={renderKey}
                     />
                   </Fragment>
                 ))}
@@ -222,11 +233,16 @@ function LeaderboardKeyLink({
   keyVal,
   keyType,
   year,
+  renderKey,
 }: {
   keyType: LeaderboardInsight['data']['key_type'];
   keyVal: string;
   year: number;
+  renderKey?: (key: string) => ReactNode;
 }) {
+  if (renderKey) {
+    return <>{renderKey(keyVal)}</>;
+  }
   if (keyType === 'team') {
     return (
       <TeamLink teamOrKey={keyVal} year={year}>

--- a/pwa/app/routes/district.$districtAbbreviation.stats.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.stats.tsx
@@ -11,7 +11,7 @@ import {
   getDistrictInsights,
 } from '~/api/tba/read';
 import { Leaderboard } from '~/components/tba/leaderboard';
-import { EventLink } from '~/components/tba/links';
+import { EventLink, TeamLink } from '~/components/tba/links';
 import {
   Select,
   SelectContent,
@@ -660,6 +660,100 @@ function computePerAwardLeaderboards(
   return leaderboards;
 }
 
+function computeTeamupLeaderboard(
+  yearResults: Array<{
+    year: number;
+    events: Event[];
+    awards: Award[];
+  }>,
+): {
+  rankings: LeaderboardInsight['data']['rankings'];
+  tooltips: Record<string, ReactNode>;
+} {
+  const { nameLookup: eventNameLookup, dateLookup: eventDateLookup } =
+    buildEventLookups(yearResults);
+
+  // Map from event_key -> Set of winning team keys
+  const eventWinners = new Map<string, Set<string>>();
+
+  for (const { events, awards } of yearResults) {
+    const relevantEventKeys = new Set(
+      events
+        .filter(
+          (e) =>
+            e.event_type === EventType.DISTRICT ||
+            e.event_type === EventType.DISTRICT_CMP ||
+            e.event_type === EventType.DISTRICT_CMP_DIVISION,
+        )
+        .map((e) => e.key),
+    );
+
+    for (const award of awards) {
+      if (award.award_type !== AwardType.WINNER) continue;
+      if (!relevantEventKeys.has(award.event_key)) continue;
+
+      const winners = eventWinners.get(award.event_key) ?? new Set<string>();
+      for (const recipient of award.recipient_list) {
+        if (recipient.team_key) {
+          winners.add(recipient.team_key);
+        }
+      }
+      eventWinners.set(award.event_key, winners);
+    }
+  }
+
+  // Count pairs
+  const pairCounts = new Map<string, number>();
+  const pairEvents = new Map<string, string[]>();
+
+  for (const [eventKey, winners] of eventWinners.entries()) {
+    const teamList = Array.from(winners).sort(
+      (a, b) => parseInt(a.substring(3)) - parseInt(b.substring(3)),
+    );
+
+    for (let i = 0; i < teamList.length; i++) {
+      for (let j = i + 1; j < teamList.length; j++) {
+        const pairKey = `${teamList[i]}+${teamList[j]}`;
+        pairCounts.set(pairKey, (pairCounts.get(pairKey) ?? 0) + 1);
+        const evs = pairEvents.get(pairKey) ?? [];
+        evs.push(eventKey);
+        pairEvents.set(pairKey, evs);
+      }
+    }
+  }
+
+  const rankings = mapToRankings(pairCounts);
+
+  // Build tooltips
+  const tooltips: Record<string, ReactNode> = {};
+  for (const [pairKey, eventKeys] of pairEvents.entries()) {
+    const uniqueKeys = Array.from(new Set(eventKeys)).sort((a, b) => {
+      const dateA = eventDateLookup.get(a) ?? '';
+      const dateB = eventDateLookup.get(b) ?? '';
+      return dateA.localeCompare(dateB);
+    });
+    if (uniqueKeys.length === 0) continue;
+    tooltips[pairKey] = (
+      <div className="flex flex-col gap-0.5">
+        {uniqueKeys.map((eventKey) => {
+          const name = eventNameLookup.get(eventKey) ?? eventKey;
+          return (
+            <EventLink
+              key={eventKey}
+              eventOrKey={eventKey}
+              className="underline-offset-2 hover:underline"
+            >
+              {name}
+            </EventLink>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return { rankings, tooltips };
+}
+
 function DistrictStatsPage() {
   const { abbreviation, history, insights, yearResults } =
     Route.useLoaderData();
@@ -674,6 +768,11 @@ function DistrictStatsPage() {
 
   const perAwardLeaderboards = useMemo(
     () => computePerAwardLeaderboards(yearResults),
+    [yearResults],
+  );
+
+  const teamupLeaderboard = useMemo(
+    () => computeTeamupLeaderboard(yearResults),
     [yearResults],
   );
 
@@ -843,6 +942,36 @@ function DistrictStatsPage() {
               }}
               year={0}
             />
+            {teamupLeaderboard.rankings.length > 0 && (
+              <Leaderboard
+                leaderboard={{
+                  data: {
+                    rankings: teamupLeaderboard.rankings,
+                    key_type: 'team',
+                  },
+                  name: 'Most Successful Teamups',
+                  year: 0,
+                }}
+                year={0}
+                contextTooltipMap={teamupLeaderboard.tooltips}
+                renderKey={(key: string) => {
+                  const parts = key.split('+');
+                  const team1 = parts[0] ?? '';
+                  const team2 = parts[1] ?? '';
+                  return (
+                    <>
+                      <TeamLink teamOrKey={team1} year={0}>
+                        {team1.substring(3)}
+                      </TeamLink>
+                      {' / '}
+                      <TeamLink teamOrKey={team2} year={0}>
+                        {team2.substring(3)}
+                      </TeamLink>
+                    </>
+                  );
+                }}
+              />
+            )}
           </div>
         </TabsContent>
 


### PR DESCRIPTION
## Description
This pull request adds a new "Most Successful Teamups" leaderboard to the district statistics page, showing pairs of teams that have won district events together most frequently. The implementation includes a new utility function to compute these teamups and extends the existing leaderboard components to support custom rendering of key values, allowing pairs of teams to be displayed with links.

**Feature Addition: Teamup Leaderboard**

* Added `computeTeamupLeaderboard` function to aggregate and rank pairs of teams that have won district events together, including tooltip support showing which events they won as a pair.

* Integrated the new teamup leaderboard into the district stats page, rendering it conditionally if there are any teamups, and displaying each team pair as linked team numbers separated by a slash. [[1]](diffhunk://#diff-cac8b966310437f13fbae8c5d30a4919f4d3725f532897b9009b4f1575c1b157R945-R974) [[2]](diffhunk://#diff-cac8b966310437f13fbae8c5d30a4919f4d3725f532897b9009b4f1575c1b157R774-R778)

**Component Extensibility: Leaderboard Key Rendering**

* Extended the `Leaderboard`, `LeaderboardKeyList`, and `LeaderboardKeyLink` components in `leaderboard.tsx` to accept a new optional `renderKey` prop, allowing custom rendering logic for leaderboard keys (such as displaying team pairs with links). [[1]](diffhunk://#diff-1ac71ef2e64d16a8fad39190e6040cb22657653342693047b452452c8c036e13R43-R49) [[2]](diffhunk://#diff-1ac71ef2e64d16a8fad39190e6040cb22657653342693047b452452c8c036e13R148) [[3]](diffhunk://#diff-1ac71ef2e64d16a8fad39190e6040cb22657653342693047b452452c8c036e13R167-R174) [[4]](diffhunk://#diff-1ac71ef2e64d16a8fad39190e6040cb22657653342693047b452452c8c036e13L179-R189) [[5]](diffhunk://#diff-1ac71ef2e64d16a8fad39190e6040cb22657653342693047b452452c8c036e13R219) [[6]](diffhunk://#diff-1ac71ef2e64d16a8fad39190e6040cb22657653342693047b452452c8c036e13R236-R245)

**Imports and Dependencies**

* Updated imports in the district stats route file to include `TeamLink` for rendering team links in the new leaderboard.

## Screenshots (if appropriate):
<img width="616" height="407" alt="image" src="https://github.com/user-attachments/assets/ca5af8cf-5fea-4567-8a40-05ae0d259dda" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
