### PR TITLE
Fix team admin redeem page loop for expired access

### DIFF
--- a/src/backend/web/handlers/team_admin.py
+++ b/src/backend/web/handlers/team_admin.py
@@ -254,7 +254,10 @@ def get_media_and_team_ref(media_key_name, team_number):
 @require_login
 def team_admin_redeem():
     user = none_throws(current_user()).account_key
-    existing_access = TeamAdminAccess.query(TeamAdminAccess.account == user).fetch()
+    now = datetime.now()
+    existing_access = TeamAdminAccess.query(
+        TeamAdminAccess.account == user, TeamAdminAccess.expiration > now
+    ).fetch()
 
     team_keys = [
         ndb.Key(Team, f"frc{access.team_number}") for access in existing_access

--- a/src/backend/web/handlers/tests/team_admin_redeem_test.py
+++ b/src/backend/web/handlers/tests/team_admin_redeem_test.py
@@ -23,15 +23,19 @@ def store_team(ndb_stub):
     team.put()
 
 
-def add_team_admin_access(account, team_number=1124, year=None, access_code="abc123"):
+def add_team_admin_access(
+    account, team_number=1124, year=None, access_code="abc123", expiration=None
+):
     if not year:
         year = datetime.datetime.now().year
+    if expiration is None:
+        expiration = datetime.datetime.now() + datetime.timedelta(days=1)
     access = TeamAdminAccess(
         id="test_access_{}".format(year),
         access_code=access_code,
         team_number=team_number,
         year=year,
-        expiration=datetime.datetime.now() + datetime.timedelta(days=1),
+        expiration=expiration,
         account=account,
     )
     return access.put()
@@ -141,6 +145,41 @@ def test_redeem_used_code(login_user: User, web_client: Client, captured_templat
     )
 
     assert_template_status(captured_templates, "code_used")
+
+
+def test_redeem_page_hides_expired_access(
+    login_user: User, web_client: Client, captured_templates
+):
+    add_team_admin_access(
+        account=login_user.account_key,
+        year=datetime.datetime.now().year - 1,
+        access_code="abc123_old",
+        expiration=datetime.datetime.now() - datetime.timedelta(days=1),
+    )
+
+    resp = web_client.get("/mod/redeem")
+    assert resp.status_code == 200
+
+    context = captured_templates[0][1]
+    assert list(context["existing_access"]) == []
+
+
+def test_mod_dashboard_does_not_loop_with_only_expired_access(
+    login_user: User, web_client: Client
+):
+    add_team_admin_access(
+        account=login_user.account_key,
+        year=datetime.datetime.now().year - 1,
+        access_code="abc123_old",
+        expiration=datetime.datetime.now() - datetime.timedelta(days=1),
+    )
+
+    resp = web_client.get("/mod")
+    assert resp.status_code == 302
+    assert urlparse(resp.headers["Location"]).path == "/mod/redeem"
+
+    resp = web_client.get("/mod/redeem")
+    assert resp.status_code == 200
 
 
 def test_redeem_code_after_redeeming_last_year(

--- a/src/backend/web/templates/team_admin_redeem.html
+++ b/src/backend/web/templates/team_admin_redeem.html
@@ -23,17 +23,17 @@
 {% endif %}
 
 {% if existing_access %}
-  <p>This account has been linked to the following teams:</p>
+  <p>This account has active moderator access for the following team{% if existing_access|length > 1 %}s{% endif %}:</p>
   <ul>
     {% for team_link in existing_access %}
-      <li><a href="/team/{{team_link.team_number}}">Team {{team_link.team_number}} - {{teams[team_link.team_number].nickname}}</a></li>
+      <li><a href="/team/{{team_link.team_number}}/{{team_link.year}}">Team {{team_link.team_number}} - {{teams[team_link.team_number].nickname}}</a> ({{team_link.year}} season)</li>
     {% endfor %}
   </ul>
   <a class="btn btn-primary" href="/mod"><span class="glyphicon glyphicon-eye-open"></span> View Team Admin Dashboard</a>
 {% endif %}
 <p>Redeem an access code to administer your team's media on The Blue Alliance. Having administrative access allows you to manage media linked to your team's TBA profile as well as accept or reject suggestions for additional media links.</p>
 
-<p>Only one account can be linked per team for each year and the administration access will expire at the end of the competition season. For additional support, please <a href="/contact">contact us</a>.</p>
+<p>Admin codes are issued per season, so access expires at the end of each competition season and you'll need to redeem a fresh code from the current year's FIRST Digital Kit of Parts to regain access. Only one account can be linked per team per year. For additional support, please <a href="/contact">contact us</a>.</p>
 <form class="form-inline" acount="/mod/redeem" method="post" id="redeem">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   <legend>Redeem</legend>


### PR DESCRIPTION
## Summary
- `/mod/redeem` listed teams with expired access and offered a "View Team Admin Dashboard" button; clicking it hit `/mod`, which filters by `expiration > now`, found nothing, and redirected back — a loop. Reported via support email from a user who couldn't open the dashboard despite being "linked."
- Filtered the redeem query by `expiration > now` so both pages agree on what "linked" means. Users with only expired access now land on the redeem form directly.
- Surfaced the season year in the linked-teams list (the dashboard already shows it) and rewrote the expiration blurb so users understand upfront that codes are per-season and need to be re-redeemed from the current year's FIRST Digital Kit of Parts.

## Test plan
- [x] `make test ARGS='src/backend/web/handlers/tests/team_admin_redeem_test.py'` — 11 passed, including two new tests
- [x] `make typecheck` clean
- [x] `make lint` clean
- [ ] Manual: visit `/mod/redeem` while logged in with only an expired `TeamAdminAccess` and confirm no "linked teams" list appears
- [ ] Manual: visit `/mod/redeem` with active access and confirm year shows after the team name
- [ ] Manual: click "View Team Admin Dashboard" and confirm it no longer bounces back

🤖 Generated with [Claude Code](https://claude.com/claude-code)