### PR TITLE
Add 2026 score breakdown keys to trusted API allowlist

### DIFF
--- a/src/backend/api/api_trusted_parsers/tests/json_matches_parser_test.py
+++ b/src/backend/api/api_trusted_parsers/tests/json_matches_parser_test.py
@@ -461,6 +461,66 @@ def test_score_breakdown_2025_keys() -> None:
     assert parsed[0]["score_breakdown_json"] is not None
 
 
+def test_score_breakdown_2026_keys() -> None:
+    # Test with 2026-specific keys, including the nested hubScore object
+    data = [
+        make_match(
+            {
+                "score_breakdown": {
+                    "red": {
+                        "totalAutoPoints": 26,
+                        "totalTeleopPoints": 223,
+                        "totalTowerPoints": 0,
+                        "energizedAchieved": True,
+                        "superchargedAchieved": False,
+                        "traversalAchieved": False,
+                        "hubScore": {
+                            "autoCount": 26,
+                            "teleopCount": 223,
+                            "totalPoints": 249,
+                        },
+                        "rp": 4,
+                        "totalPoints": 249,
+                    },
+                    "blue": {
+                        "totalAutoPoints": 56,
+                        "totalTeleopPoints": 179,
+                        "totalTowerPoints": 15,
+                        "energizedAchieved": False,
+                        "superchargedAchieved": False,
+                        "traversalAchieved": False,
+                        "hubScore": {
+                            "autoCount": 41,
+                            "teleopCount": 179,
+                            "totalPoints": 220,
+                        },
+                        "rp": 0,
+                        "totalPoints": 235,
+                    },
+                }
+            }
+        )
+    ]
+    parsed = JSONMatchesParser.parse(json.dumps(data), 2026)
+    assert parsed[0]["score_breakdown_json"] is not None
+
+
+def test_score_breakdown_2025_key_rejected_in_2026() -> None:
+    # algaePoints is a 2025 key, not valid for 2026
+    data = [
+        make_match(
+            {
+                "score_breakdown": {
+                    "red": {"algaePoints": 10},
+                    "blue": {"algaePoints": 5},
+                }
+            }
+        )
+    ]
+    with pytest.raises(ParserInputException, match="Invalid score breakdown fields"):
+        JSONMatchesParser.parse(json.dumps(data), 2026)
+
+
 def test_score_breakdown_wrong_year_key_raises_exception() -> None:
     # algaePoints is a 2025 key, not valid for 2024
     data = [

--- a/src/backend/common/helpers/score_breakdown_keys.py
+++ b/src/backend/common/helpers/score_breakdown_keys.py
@@ -455,6 +455,32 @@ VALID_BREAKDOWNS: Dict[Year, Set[str]] = {
             "wallAlgaeCount",
         ]
     ),
+    2026: set(
+        [
+            "adjustPoints",
+            "autoTowerPoints",
+            "autoTowerRobot1",
+            "autoTowerRobot2",
+            "autoTowerRobot3",
+            "endGameTowerPoints",
+            "endGameTowerRobot1",
+            "endGameTowerRobot2",
+            "endGameTowerRobot3",
+            "energizedAchieved",
+            "foulPoints",
+            "g206Penalty",
+            "hubScore",
+            "majorFoulCount",
+            "minorFoulCount",
+            "rp",
+            "superchargedAchieved",
+            "totalAutoPoints",
+            "totalPoints",
+            "totalTeleopPoints",
+            "totalTowerPoints",
+            "traversalAchieved",
+        ]
+    ),
     # when adding new fields, please keep them sorted alphabetically
 }
 


### PR DESCRIPTION
## Summary
- `VALID_BREAKDOWNS` in `src/backend/common/helpers/score_breakdown_keys.py` had no 2026 entry, so `get_valid_score_breakdown_keys(2026)` returned an empty set and the trusted-API match parser (`src/backend/api/api_trusted_parsers/json_matches_parser.py:162`) rejected every 2026 `score_breakdown` upload with "Invalid score breakdown fields."
- FMS Sync writes breakdowns directly to Datastore and bypasses the parser, so official in-season 2026 matches were fine — the gap only hit users trying to post breakdowns via the trusted API (e.g. an offseason event wanting detailed scoring).
- Added a 2026 entry mirroring the `Match_Score_Breakdown_2026_Alliance` schema in `src/backend/web/static/swagger/api_v3.json:9323`: 22 alliance-level fields, including the nested `hubScore` object (which the parser only validates at the top level, so the inner object passes through as-is).

## Notes
- This interacts with (but does not conflict with) #9748, which moves per-year game logic into `game_specific/seasons/game_specifics_<year>.py` classes that derive their allowlist from `ScoreDetailModelAlliance<year>`. When that lands and replaces `VALID_BREAKDOWNS`, this dict entry will be superseded — but 2026 trusted-API breakdowns are broken *today* on `main`, so this unblocks users in the interim without waiting for the larger refactor.

## Test plan
- [x] `make test ARGS='src/backend/api/api_trusted_parsers/tests/json_matches_parser_test.py'` — 58 passed, including 2 new tests (`test_score_breakdown_2026_keys`, `test_score_breakdown_2025_key_rejected_in_2026`)
- [x] `make lint` clean
- [x] `make typecheck` clean
- [ ] Manual: POST a 2026 match with breakdown to `/api/trusted/v1/event/{2026_event}/matches/update` in dev and confirm it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)