### PR TITLE
[datafeed] Add concept of always_manual_attrs

### DIFF
--- a/src/backend/common/manipulators/manipulator_base.py
+++ b/src/backend/common/manipulators/manipulator_base.py
@@ -401,9 +401,12 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
         the "old" that are null in the "new".
         """
         updated_attrs: Set[str] = set()
+        manual_attrs = (
+            set(old_model.manual_attrs or []) | old_model._always_manual_attrs
+        )
 
         for attr in old_model._mutable_attrs:
-            if not update_manual_attrs and attr in old_model.manual_attrs:
+            if not update_manual_attrs and attr in manual_attrs:
                 continue
 
             if (
@@ -421,7 +424,7 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
                     old_model._dirty = True
 
         for attr in old_model._json_attrs:
-            if not update_manual_attrs and attr in old_model.manual_attrs:
+            if not update_manual_attrs and attr in manual_attrs:
                 continue
 
             if getattr(new_model, attr) is not None:
@@ -439,7 +442,7 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
         if not auto_union:
             list_attrs = list_attrs.union(old_model._auto_union_attrs)
         for attr in list_attrs:
-            if not update_manual_attrs and attr in old_model.manual_attrs:
+            if not update_manual_attrs and attr in manual_attrs:
                 continue
 
             if len(getattr(new_model, attr)) > 0 or not auto_union:
@@ -449,7 +452,7 @@ class ManipulatorBase(abc.ABC, Generic[TModel]):
                     old_model._dirty = True
 
         for attr in old_model._auto_union_attrs if auto_union else {}:
-            if not update_manual_attrs and attr in old_model.manual_attrs:
+            if not update_manual_attrs and attr in manual_attrs:
                 continue
 
             old_set = set(getattr(old_model, attr))

--- a/src/backend/common/manipulators/tests/base_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/base_manipulator_test.py
@@ -621,3 +621,14 @@ def test_no_update_manual_attrs() -> None:
     merged = DummyManipulator.updateMerge(new, old, True, False)
     expected = ManipulatorDummyModel(id="test", int_prop=42, manual_attrs=["int_prop"])
     assert merged == expected
+
+
+def test_no_update_always_manual_attrs(monkeypatch) -> None:
+    monkeypatch.setattr(ManipulatorDummyModel, "_always_manual_attrs", {"int_prop"})
+
+    old = ManipulatorDummyModel(id="test", int_prop=42)
+    new = ManipulatorDummyModel(id="test", int_prop=604)
+
+    merged = DummyManipulator.updateMerge(new, old, True, False)
+    expected = ManipulatorDummyModel(id="test", int_prop=42)
+    assert merged == expected

--- a/src/backend/common/manipulators/tests/event_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/event_manipulator_test.py
@@ -135,6 +135,29 @@ def test_clear_first_code() -> None:
 
 
 @pytest.mark.usefixtures("ndb_context", "taskqueue_stub")
+@pytest.mark.parametrize(
+    ("attr", "manual_value", "datafeed_value"),
+    [("first_code", "manual-first", None), ("nexus_code", "manual-nexus", "api-nexus")],
+)
+def test_datafeed_does_not_overwrite_always_manual_attrs(
+    attr: str,
+    manual_value: str,
+    datafeed_value: str | None,
+    old_event: Event,
+    new_event: Event,
+) -> None:
+    setattr(old_event, attr, manual_value)
+    EventManipulator.createOrUpdate(old_event)
+
+    setattr(new_event, attr, datafeed_value)
+    EventManipulator.createOrUpdate(new_event, update_manual_attrs=False)
+
+    updated_event = none_throws(Event.get_by_id("2011ct"))
+    assert getattr(updated_event, attr) == manual_value
+    assert updated_event.facebook_eid == "7"
+
+
+@pytest.mark.usefixtures("ndb_context", "taskqueue_stub")
 @pytest.mark.parametrize("official", [True, False])
 @patch.object(LocationHelper, "get_timezone_id")
 @patch.object(LocationHelper, "get_event_location")

--- a/src/backend/common/models/cached_model.py
+++ b/src/backend/common/models/cached_model.py
@@ -38,6 +38,9 @@ class CachedModel(ndb.Model):
 
     _auto_union_attrs: Set[str] = set()
 
+    # Always treat these as manual attrs
+    _always_manual_attrs: Set[str] = set()
+
     # This will get updated with the attrs that actually change
     _updated_attrs: Optional[Set[str]] = None
 

--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -201,6 +201,11 @@ class Event(CachedModel):
         "divisions",
     }
 
+    _always_manual_attrs: Set[str] = {
+        "first_code",
+        "nexus_code",
+    }
+
     def __init__(self, *args, **kw):
         # store set of affected references referenced keys for cache clearing
         # keys must be model properties

--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -311,6 +311,13 @@ def event_list(year: Year) -> Response:
     # For all matched offseason events, make sure the FIRST code matches the TBA FIRST code
     for tba_event, first_event in matched_offseason_events:
         tba_event.first_code = first_event.event_short
+
+        # This is the ONE TIME we want to write this field from the datafeed
+        # Normally, we want to skip it, because it's something we intentionally set, so we
+        # want to avoid clobbering it. But here, we are specifically setting it to the known-right value,
+        # so we can allow the write to go throuhg, in this midly hacky way
+        tba_event._always_manual_attrs.discard("first_code")
+
         events_to_put.append(tba_event)  # Update TBA events - discard the FIRST event
 
     # For all new offseason events we can't automatically match, create suggestions


### PR DESCRIPTION
We ran into a bug where the datafeed could clobber a manually set FIRST API code (after d75e3c39d), because the parser won't seed or preserve the value. So the next update would set it to `None`, which would then take effect.

This diff will allow marking some fields as "always consider me a `manual_attr`", which means _do not_ overwrite via the datafeed.

This should preserve the human input value across multiple datafeed fetches.