### PR TITLE
Impl district-scoped v2 insight for blue banners

### DIFF
--- a/src/backend/common/helpers/insights_v2/blue_banners.py
+++ b/src/backend/common/helpers/insights_v2/blue_banners.py
@@ -1,48 +1,25 @@
-from collections import defaultdict
-from typing import Dict, Optional
-
 from backend.common.consts.award_type import BLUE_BANNER_AWARDS
-from backend.common.helpers.insights_v2.compute import (
-    build_leaderboard_rankings,
-    InsightV2Calculator,
-)
+from backend.common.helpers.insights_v2.compute import LeaderboardV2Calculator
 from backend.common.models.event import Event
 from backend.common.models.insight_v2 import (
-    InsightCategory,
-    InsightV2,
-    InsightV2Name,
-    LeaderboardDataV2,
+    InsightV2NameEntry,
+    InsightV2Names,
+    LeaderboardKeyType,
 )
-from backend.common.models.keys import Year
-
-BLUE_BANNERS_DISPLAY_NAME = "Total Blue Banners"
 
 
-class BlueBannersV2Calculator(InsightV2Calculator):
-    def __init__(self) -> None:
-        self.counts: Dict[str, int] = defaultdict(int)
+class BlueBannersV2Calculator(LeaderboardV2Calculator):
+    @property
+    def insight_name(self) -> InsightV2NameEntry:
+        return InsightV2Names.BLUE_BANNERS
+
+    @property
+    def key_type(self) -> LeaderboardKeyType:
+        return "team"
 
     def on_event(self, event: Event) -> None:
+        district = event.event_district_abbrev
         for award in event.awards:
             if award.award_type_enum in BLUE_BANNER_AWARDS and award.count_banner:
                 for team_key in award.team_list:
-                    self.counts[str(team_key.id())] += 1
-
-    def make_insight(self, year: Year) -> Optional[InsightV2]:
-        if not self.counts:
-            return None
-
-        data = LeaderboardDataV2(
-            rankings=build_leaderboard_rankings(self.counts),
-            key_type="team",
-        )
-        return InsightV2(
-            id=InsightV2.render_key_name(
-                year, InsightCategory.LEADERBOARD, InsightV2Name.BLUE_BANNERS
-            ),
-            name=InsightV2Name.BLUE_BANNERS,
-            display_name=BLUE_BANNERS_DISPLAY_NAME,
-            year=year,
-            category=InsightCategory.LEADERBOARD,
-            data_json=data,
-        )
+                    self._increment(str(team_key.id()), district=district)

--- a/src/backend/common/helpers/insights_v2/compute.py
+++ b/src/backend/common/helpers/insights_v2/compute.py
@@ -1,13 +1,20 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import DefaultDict, Dict, List, Optional
 
 from google.appengine.ext import ndb
 
 from backend.common.consts.event_type import SEASON_EVENT_TYPES
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.event import Event
-from backend.common.models.insight_v2 import InsightV2, LeaderboardRankingV2
+from backend.common.models.insight_v2 import (
+    InsightCategory,
+    InsightV2,
+    InsightV2NameEntry,
+    LeaderboardDataV2,
+    LeaderboardKeyType,
+    LeaderboardRankingV2,
+)
 from backend.common.models.keys import Year
 from backend.common.queries.event_query import EventListQuery
 
@@ -40,7 +47,79 @@ class InsightV2Calculator(ABC):
     def on_event(self, event: Event) -> None: ...
 
     @abstractmethod
-    def make_insight(self, year: Year) -> Optional[InsightV2]: ...
+    def make_insights(self, year: Year) -> List[InsightV2]: ...
+
+
+class LeaderboardV2Calculator(InsightV2Calculator, ABC):
+    def __init__(self) -> None:
+        self.counts: Dict[str, int] = defaultdict(int)
+        self.district_counts: DefaultDict[str, DefaultDict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+
+    @property
+    @abstractmethod
+    def insight_name(self) -> InsightV2NameEntry: ...
+
+    @property
+    @abstractmethod
+    def key_type(self) -> LeaderboardKeyType: ...
+
+    def _increment(
+        self, key: str, count: int = 1, district: Optional[str] = None
+    ) -> None:
+        self.counts[key] += count
+        if district:
+            self.district_counts[district][key] += count
+
+    def make_insights(self, year: Year) -> List[InsightV2]:
+        insights = []
+
+        if self.counts:
+            data = LeaderboardDataV2(
+                rankings=build_leaderboard_rankings(self.counts),
+                key_type=self.key_type,
+            )
+            insights.append(
+                InsightV2(
+                    id=InsightV2.render_key_name(
+                        year,
+                        InsightCategory.LEADERBOARD,
+                        self.insight_name.name,
+                    ),
+                    name=self.insight_name.name,
+                    display_name=self.insight_name.display_name,
+                    year=year,
+                    category=InsightCategory.LEADERBOARD,
+                    data_json=data,
+                )
+            )
+
+        for district_abbrev, counts in sorted(self.district_counts.items()):
+            if not counts:
+                continue
+            data = LeaderboardDataV2(
+                rankings=build_leaderboard_rankings(counts),
+                key_type=self.key_type,
+            )
+            insights.append(
+                InsightV2(
+                    id=InsightV2.render_key_name(
+                        year,
+                        InsightCategory.LEADERBOARD,
+                        self.insight_name.name,
+                        district_abbrev,
+                    ),
+                    name=self.insight_name.name,
+                    display_name=self.insight_name.display_name,
+                    year=year,
+                    category=InsightCategory.LEADERBOARD,
+                    district_abbreviation=district_abbrev,
+                    data_json=data,
+                )
+            )
+
+        return insights
 
 
 def compute_insights_for_year(
@@ -65,6 +144,5 @@ def compute_insights_for_year(
 
     insights = []
     for calc in calculators:
-        if insight := calc.make_insight(year):
-            insights.append(insight)
+        insights.extend(calc.make_insights(year))
     return insights

--- a/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
@@ -83,3 +83,55 @@ def test_key_name(ndb_stub, test_data_importer) -> None:
 
     insights = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
     assert insights[0].key_name == "2024_v2_leaderboard_blue_banners"
+
+
+def test_district_insight_created(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2022on305.json")
+    test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
+
+    insights = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
+
+    # global insight + one district insight
+    assert len(insights) == 2
+    district_insight = next(i for i in insights if i.district_abbreviation == "ont")
+    assert district_insight.year == 2022
+    assert district_insight.name == "blue_banners"
+    assert district_insight.category == InsightCategory.LEADERBOARD
+    assert district_insight.key_name == "2022_v2_leaderboard_blue_banners_ont"
+    rankings = district_insight.data["rankings"]
+    assert len(rankings) > 0
+    # all winner team keys should appear in the district rankings
+    winner_keys = {"frc2200", "frc610", "frc4015"}
+    ranked_keys = {k for r in rankings for k in r["keys"]}
+    assert winner_keys <= ranked_keys
+
+
+def test_district_insight_excludes_non_district_event_teams(
+    ndb_stub, test_data_importer
+) -> None:
+    # 2024nytr is a regional (no district); 2022on305 is Ontario district
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
+    test_data_importer.import_event(__file__, "../data/2022on305.json")
+    test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
+
+    insights_2024 = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
+    # 2024nytr has no district — only the global insight
+    assert all(i.district_abbreviation is None for i in insights_2024)
+
+    insights_2022 = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
+    district_insights = [
+        i for i in insights_2022 if i.district_abbreviation is not None
+    ]
+    assert len(district_insights) == 1
+    assert district_insights[0].district_abbreviation == "ont"
+
+
+def test_district_key_name(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2022on305.json")
+    test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
+
+    insights = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
+    key_names = {i.key_name for i in insights}
+    assert "2022_v2_leaderboard_blue_banners" in key_names
+    assert "2022_v2_leaderboard_blue_banners_ont" in key_names

--- a/src/backend/common/models/insight_v2.py
+++ b/src/backend/common/models/insight_v2.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Set, TypedDict
+from typing import List, Literal, NamedTuple, Optional, Set, TypedDict
 
 from google.appengine.ext import ndb
 
@@ -12,8 +12,14 @@ class InsightCategory:
     LEADERBOARD = "leaderboard"
 
 
-class InsightV2Name:
-    BLUE_BANNERS = "blue_banners"
+# Helper for organizing insight names and display names
+class InsightV2NameEntry(NamedTuple):
+    name: str
+    display_name: str
+
+
+class InsightV2Names:
+    BLUE_BANNERS = InsightV2NameEntry("blue_banners", "Total Blue Banners")
 
 
 class InsightV2(CachedModel):


### PR DESCRIPTION
Adds per-district scoped blue banners. Achieves this by adding a new common base class for leaderboards that handles creation for the accumulator impl.