### PR TITLE
Switch v2 insights from district-event based to district-team based

### DIFF
--- a/src/backend/api/handlers/tests/insight_v2_test.py
+++ b/src/backend/api/handlers/tests/insight_v2_test.py
@@ -12,18 +12,25 @@ def _put_auth(key: str = "test_auth_key") -> None:
     ).put()
 
 
-def _put_insight(year: int, name: str = "blue_banners") -> InsightV2:
+def _put_insight(
+    year: int,
+    name: str = "blue_banners",
+    district_abbreviation: str | None = None,
+) -> InsightV2:
     data = {
         "key_type": "team",
         "rankings": [{"keys": ["frc1"], "value": 3}],
     }
     insight = InsightV2(
-        id=InsightV2.render_key_name(year, InsightCategory.LEADERBOARD, name),
+        id=InsightV2.render_key_name(
+            year, InsightCategory.LEADERBOARD, name, district_abbreviation
+        ),
         name=name,
         display_name="Total Blue Banners",
         year=year,
         category=InsightCategory.LEADERBOARD,
         data_json=data,
+        district_abbreviation=district_abbreviation,
     )
     insight.put()
     return insight
@@ -96,6 +103,30 @@ def test_insights_v2_year_category_empty(ndb_stub, api_client: Client) -> None:
     )
     assert resp.status_code == 200
     assert resp.json == []
+
+
+def test_insights_v2_year_no_district(ndb_stub, api_client: Client) -> None:
+    _put_auth()
+    _put_insight(2024)
+
+    resp = api_client.get(
+        "/api/v3/insights/v2/2024",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp.status_code == 200
+    assert resp.json[0]["district_abbreviation"] is None
+
+
+def test_insights_v2_year_with_district(ndb_stub, api_client: Client) -> None:
+    _put_auth()
+    _put_insight(2024, district_abbreviation="ne")
+
+    resp = api_client.get(
+        "/api/v3/insights/v2/2024",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp.status_code == 200
+    assert resp.json[0]["district_abbreviation"] == "ne"
 
 
 def test_insights_v2_requires_auth(api_client: Client) -> None:

--- a/src/backend/common/cache_clearing/get_affected_queries.py
+++ b/src/backend/common/cache_clearing/get_affected_queries.py
@@ -268,7 +268,7 @@ def districtteam_updated(affected_refs: TAffectedReferences) -> List[TCacheKeyAn
     district_keys = _filter(affected_refs["district_key"])
     team_keys = _filter(affected_refs["team"])
 
-    queries: List[CachedDatabaseQuery] = []
+    queries: List[CachedDatabaseQuery] = [district_query.AllDistrictTeamsQuery()]
     for district_key in district_keys:
         queries.append(team_query.DistrictTeamsQuery(district_key.id()))
 

--- a/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
+++ b/src/backend/common/cache_clearing/tests/database_cache_clearer_test.py
@@ -395,6 +395,7 @@ class TestDatabaseCacheClearer(unittest.TestCase):
         }
 
         assert cache_keys == {
+            district_query.AllDistrictTeamsQuery().cache_key,
             team_query.DistrictTeamsQuery("2015fim").cache_key,
             team_query.DistrictTeamsQuery("2015mar").cache_key,
             district_query.TeamDistrictsQuery("frc254").cache_key,

--- a/src/backend/common/helpers/insights_v2/blue_banners.py
+++ b/src/backend/common/helpers/insights_v2/blue_banners.py
@@ -18,8 +18,7 @@ class BlueBannersV2Calculator(LeaderboardV2Calculator):
         return "team"
 
     def on_event(self, event: Event) -> None:
-        district = event.event_district_abbrev
         for award in event.awards:
             if award.award_type_enum in BLUE_BANNER_AWARDS and award.count_banner:
                 for team_key in award.team_list:
-                    self._increment(str(team_key.id()), district=district)
+                    self._increment(str(team_key.id()))

--- a/src/backend/common/helpers/insights_v2/compute.py
+++ b/src/backend/common/helpers/insights_v2/compute.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Optional
+from typing import Any, DefaultDict, Dict, Iterable, List, Set
 
 from google.appengine.ext import ndb
 
@@ -16,6 +16,7 @@ from backend.common.models.insight_v2 import (
     LeaderboardRankingV2,
 )
 from backend.common.models.keys import Year
+from backend.common.queries.district_query import AllDistrictTeamsQuery
 from backend.common.queries.event_query import EventListQuery
 
 LEADERBOARD_TOP_N = 25
@@ -42,20 +43,47 @@ def build_leaderboard_rankings(
     ][:top_n]
 
 
+def _build_team_district_map(team_keys: Iterable[str]) -> Dict[str, str]:
+    """
+    Returns {team_key: district_abbrev} for the given team keys, using each
+    team's most recent district membership. Fetches all DistrictTeam records in
+    one query and filters in memory.
+    """
+    team_keys_set = set(team_keys)
+    all_district_teams = AllDistrictTeamsQuery().fetch()
+
+    team_district_teams: Dict[str, List[Any]] = defaultdict(list)
+    for dt in all_district_teams:
+        if dt.team and str(dt.team.id()) in team_keys_set:
+            team_district_teams[str(dt.team.id())].append(dt)
+
+    return {
+        team_key: str(max(dts, key=lambda dt: dt.year).district_key.id())[4:]
+        for team_key, dts in team_district_teams.items()
+    }
+
+
 class InsightV2Calculator(ABC):
+    @property
+    def team_keys(self) -> Set[str]:
+        return set()
+
     @abstractmethod
     def on_event(self, event: Event) -> None: ...
 
     @abstractmethod
-    def make_insights(self, year: Year) -> List[InsightV2]: ...
+    def make_insights(
+        self, year: Year, team_to_district: Dict[str, str]
+    ) -> List[InsightV2]: ...
 
 
 class LeaderboardV2Calculator(InsightV2Calculator, ABC):
     def __init__(self) -> None:
         self.counts: Dict[str, int] = defaultdict(int)
-        self.district_counts: DefaultDict[str, DefaultDict[str, int]] = defaultdict(
-            lambda: defaultdict(int)
-        )
+
+    @property
+    def team_keys(self) -> Set[str]:
+        return set(self.counts.keys())
 
     @property
     @abstractmethod
@@ -65,14 +93,19 @@ class LeaderboardV2Calculator(InsightV2Calculator, ABC):
     @abstractmethod
     def key_type(self) -> LeaderboardKeyType: ...
 
-    def _increment(
-        self, key: str, count: int = 1, district: Optional[str] = None
-    ) -> None:
+    def _increment(self, key: str, count: int = 1) -> None:
         self.counts[key] += count
-        if district:
-            self.district_counts[district][key] += count
 
-    def make_insights(self, year: Year) -> List[InsightV2]:
+    def make_insights(
+        self, year: Year, team_to_district: Dict[str, str]
+    ) -> List[InsightV2]:
+        district_counts: DefaultDict[str, DefaultDict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+        for team_key, count in self.counts.items():
+            if district := team_to_district.get(team_key):
+                district_counts[district][team_key] += count
+
         insights = []
 
         if self.counts:
@@ -95,7 +128,7 @@ class LeaderboardV2Calculator(InsightV2Calculator, ABC):
                 )
             )
 
-        for district_abbrev, counts in sorted(self.district_counts.items()):
+        for district_abbrev, counts in sorted(district_counts.items()):
             if not counts:
                 continue
             data = LeaderboardDataV2(
@@ -142,7 +175,12 @@ def compute_insights_for_year(
             event.clear_awards()
             ndb.get_context().clear_cache()
 
+    all_team_keys: Set[str] = set()
+    for calc in calculators:
+        all_team_keys.update(calc.team_keys)
+    team_to_district = _build_team_district_map(all_team_keys)
+
     insights = []
     for calc in calculators:
-        insights.extend(calc.make_insights(year))
+        insights.extend(calc.make_insights(year, team_to_district))
     return insights

--- a/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
@@ -1,6 +1,22 @@
+from google.appengine.ext import ndb
+
 from backend.common.helpers.insights_v2.blue_banners import BlueBannersV2Calculator
 from backend.common.helpers.insights_v2.compute import compute_insights_for_year
+from backend.common.models.district import District
+from backend.common.models.district_team import DistrictTeam
 from backend.common.models.insight_v2 import InsightCategory
+from backend.common.models.team import Team
+
+
+def make_district_team(team_key: str, year: int, district_abbrev: str) -> None:
+    district_key = f"{year}{district_abbrev}"
+    District(id=district_key, year=year, abbreviation=district_abbrev).put()
+    DistrictTeam(
+        id=f"{district_key}_{team_key}",
+        team=ndb.Key(Team, team_key),
+        year=year,
+        district_key=ndb.Key(District, district_key),
+    ).put()
 
 
 def test_no_events_returns_empty(ndb_stub) -> None:
@@ -88,6 +104,9 @@ def test_key_name(ndb_stub, test_data_importer) -> None:
 def test_district_insight_created(ndb_stub, test_data_importer) -> None:
     test_data_importer.import_event(__file__, "../data/2022on305.json")
     test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
+    # Winner teams are frc2200, frc610, frc4015 — register them in the ont district
+    for team_key in ("frc2200", "frc610", "frc4015"):
+        make_district_team(team_key, 2022, "ont")
 
     insights = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
 
@@ -100,36 +119,62 @@ def test_district_insight_created(ndb_stub, test_data_importer) -> None:
     assert district_insight.key_name == "2022_v2_leaderboard_blue_banners_ont"
     rankings = district_insight.data["rankings"]
     assert len(rankings) > 0
-    # all winner team keys should appear in the district rankings
     winner_keys = {"frc2200", "frc610", "frc4015"}
     ranked_keys = {k for r in rankings for k in r["keys"]}
     assert winner_keys <= ranked_keys
 
 
-def test_district_insight_excludes_non_district_event_teams(
+def test_district_insight_uses_team_membership_not_event_type(
     ndb_stub, test_data_importer
 ) -> None:
-    # 2024nytr is a regional (no district); 2022on305 is Ontario district
+    # 2024nytr is a regional, but frc1796 is registered as a ne district team.
+    # Their banner should appear in the ne district insight.
+    # frc1591, frc3181, frc9624 also win at 2024nytr but are not district members —
+    # they should not appear in any district insight.
     test_data_importer.import_event(__file__, "../data/2024nytr.json")
     test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
-    test_data_importer.import_event(__file__, "../data/2022on305.json")
-    test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
+    make_district_team("frc1796", 2024, "ne")
 
-    insights_2024 = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
-    # 2024nytr has no district — only the global insight
-    assert all(i.district_abbreviation is None for i in insights_2024)
+    insights = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
 
-    insights_2022 = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
-    district_insights = [
-        i for i in insights_2022 if i.district_abbreviation is not None
-    ]
+    district_insights = [i for i in insights if i.district_abbreviation is not None]
     assert len(district_insights) == 1
-    assert district_insights[0].district_abbreviation == "ont"
+    assert district_insights[0].district_abbreviation == "ne"
+
+    ranked_keys = {k for r in district_insights[0].data["rankings"] for k in r["keys"]}
+    assert "frc1796" in ranked_keys
+    assert "frc1591" not in ranked_keys
+    assert "frc3181" not in ranked_keys
+
+
+def test_district_uses_most_recent_district_team(ndb_stub, test_data_importer) -> None:
+    # frc1796 won in 2019 (ne district in 2019) and 2024 (ne district in 2024).
+    # They also have an older record in ont from 2018.
+    # Their most recent DistrictTeam is 2024 ne, so all their banners count toward ne.
+    test_data_importer.import_event(__file__, "../data/2019nyny.json")
+    test_data_importer.import_award_list(__file__, "../data/2019nyny_awards.json")
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
+    make_district_team("frc1796", 2018, "ont")
+    make_district_team("frc1796", 2024, "ne")
+
+    insights = compute_insights_for_year(0, [BlueBannersV2Calculator()])
+
+    district_insights = [i for i in insights if i.district_abbreviation is not None]
+    abbrevs = {i.district_abbreviation for i in district_insights}
+    assert "ne" in abbrevs
+    assert "ont" not in abbrevs
+
+    ne_insight = next(i for i in district_insights if i.district_abbreviation == "ne")
+    ranked_keys = {k for r in ne_insight.data["rankings"] for k in r["keys"]}
+    assert "frc1796" in ranked_keys
 
 
 def test_district_key_name(ndb_stub, test_data_importer) -> None:
     test_data_importer.import_event(__file__, "../data/2022on305.json")
     test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
+    for team_key in ("frc2200", "frc610", "frc4015"):
+        make_district_team(team_key, 2022, "ont")
 
     insights = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
     key_names = {i.key_name for i in insights}

--- a/src/backend/common/queries/dict_converters/insight_v2_converter.py
+++ b/src/backend/common/queries/dict_converters/insight_v2_converter.py
@@ -33,6 +33,7 @@ class InsightV2Converter(ConverterBase):
                 "display_name": insight.display_name,
                 "year": insight.year,
                 "category": insight.category,
+                "district_abbreviation": insight.district_abbreviation,
                 "data": insight.data_json,
             }
         )

--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -94,6 +94,21 @@ class TeamDistrictsQuery(CachedDatabaseQuery[List[District], List[DistrictDict]]
         return list(filter(lambda x: x is not None, districts))
 
 
+class AllDistrictTeamsQuery(CachedDatabaseQuery[List[DistrictTeam], None]):
+    CACHE_VERSION = 0
+    CACHE_KEY_FORMAT = "all_district_teams"
+    DICT_CONVERTER = None
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @typed_tasklet
+    def _query_async(self) -> Generator[Any, Any, List[DistrictTeam]]:
+        keys = yield DistrictTeam.query().fetch_async(keys_only=True)
+        district_teams = yield ndb.get_multi_async(keys)
+        return list(filter(lambda x: x is not None, district_teams))
+
+
 class DistrictAbbreviationQuery(
     CachedDatabaseQuery[List[District], List[DistrictDict]]
 ):


### PR DESCRIPTION
The v2 insights proto merged yesterday does district blue banners based on banners awarded at district events, not based on what team a district is in. this changes that. it adds a query to get all district teams and then it takes their most recent districtteam model. this should account for both district changes (eg PCH -> SC) and defunct teams (eg 1519).

also adds district abbreviation to the insight returned via api since that is missing