### PR TITLE
Fix faulty `DistrictTeam` deletion in `team_details` endpoint

### DIFF
--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -125,19 +125,24 @@ def enqueue_rolling_team_details() -> Response:
     return make_response("")
 
 
-@blueprint.route("/backend-tasks/get/team_details/<team_key>")
-def team_details(team_key: TeamKey) -> Response:
+@blueprint.route("/backend-tasks/get/team_details/<team_key>", defaults={"year": None})
+@blueprint.route("/backend-tasks/get/team_details/<team_key>/<int:year>")
+def team_details(team_key: TeamKey, year: Year | None) -> Response:
     if not Team.validate_key_name(team_key):
         return make_response(f"Bad team key: {Markup.escape(team_key)}", 400)
 
     fms_df = DatafeedFMSAPI(save_response=True)
-    year = datetime.date.today().year
+    if year is None:
+        year = SeasonHelper.get_max_year()
     fms_details = fms_df.get_team_details(year, team_key).get_result()
 
     team, district_team, robot = fms_details or (None, None, None)
     regional_pool_team: Optional[RegionalPoolTeam] = None
 
-    if team:
+    # Only write the Team row from the latest year's response — historical
+    # calls (e.g. backfilling 2025 DistrictTeams in 2026) should not clobber
+    # current Team metadata (name, city, website, etc.) with a stale snapshot.
+    if team and (year == SeasonHelper.get_max_year()):
         team = TeamManipulator.createOrUpdate(team, update_manual_attrs=False)
 
     if district_team:
@@ -166,34 +171,16 @@ def team_details(team_key: TeamKey) -> Response:
 
     # Clean up junk district teams
     # https://www.facebook.com/groups/moardata/permalink/1310068625680096/
+    # FIRST's response for this year is the authority — delete any other
+    # same-year DistrictTeam for this team. Other years are left alone;
+    # they are the responsibility of their own syncs, not this handler.
     keys_to_delete = set()
-    # Delete all DistrictTeams that are not valid in the current
-    # year, since each team can only be in one district per year
     dt_keys = DistrictTeam.query(
         DistrictTeam.team == ndb.Key(Team, team_key), DistrictTeam.year == year
     ).fetch(keys_only=True)
     for dt_key in dt_keys:
         if not district_team or dt_key.id() != district_team.key.id():
             keys_to_delete.add(dt_key)
-
-    # Delete all DistrictTeam that are for any year that the team
-    # does not have an event
-    dt_keys = DistrictTeam.query(DistrictTeam.team == ndb.Key(Team, team_key)).fetch()
-    et_keys = EventTeam.query(
-        EventTeam.team == ndb.Key(Team, team_key),
-        projection=[EventTeam.year],
-        group_by=[EventTeam.year],
-    ).fetch()
-    et_years = {et_key.year for et_key in et_keys}
-
-    # The API confirmed this team is in a district for this year, so
-    # treat it as a valid year even if EventTeams don't exist yet
-    if district_team:
-        et_years.add(district_team.year)
-
-    for dt_key in dt_keys:
-        if dt_key.year not in et_years:
-            keys_to_delete.add(dt_key.key)
     DistrictTeamManipulator.delete_keys(keys_to_delete)
 
     if robot:

--- a/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_teams_test.py
@@ -9,7 +9,6 @@ from backend.common.consts.media_type import MediaType
 from backend.common.futures import InstantFuture
 from backend.common.models.district import District
 from backend.common.models.district_team import DistrictTeam
-from backend.common.models.event_team import EventTeam
 from backend.common.models.media import Media
 from backend.common.models.robot import Robot
 from backend.common.models.team import Team
@@ -82,12 +81,6 @@ def test_fetch_team_details_bad_key(tasks_client: Client) -> None:
 
 @mock.patch.object(DatafeedFMSAPI, "get_team_details")
 def test_fetch_team_details(api_mock, tasks_client: Client) -> None:
-    EventTeam(
-        id="2019fim_frc254",
-        event=ndb.Key("Event", "2019fim"),
-        team=ndb.Key("Team", "frc254"),
-        year=2019,
-    ).put()
     api_mock.return_value = InstantFuture(
         (
             Team(id="frc254", team_number=254),
@@ -109,12 +102,6 @@ def test_fetch_team_details(api_mock, tasks_client: Client) -> None:
 def test_fetch_team_details_no_output_in_taskqueue(
     api_mock, tasks_client: Client
 ) -> None:
-    EventTeam(
-        id="2019fim_frc254",
-        event=ndb.Key("Event", "2019fim"),
-        team=ndb.Key("Team", "frc254"),
-        year=2019,
-    ).put()
     api_mock.return_value = InstantFuture(
         (
             Team(id="frc254", team_number=254),
@@ -204,13 +191,9 @@ def test_fetch_team_none_clears_districtteams(api_mock, tasks_client: Client) ->
 @freeze_time("2019-04-01")
 @mock.patch.object(DatafeedFMSAPI, "get_team_details")
 def test_fetch_team_fixes_district_teams(api_mock, tasks_client: Client) -> None:
+    # Team moved districts within the same year: the old same-year row
+    # should be replaced with the new one the API just confirmed.
     DistrictTeam(id="2019ne_frc254", team=ndb.Key(Team, "frc254"), year=2019).put()
-    EventTeam(
-        id="2019ne_frc254",
-        event=ndb.Key("Event", "2019ne"),
-        team=ndb.Key("Team", "frc254"),
-        year=2019,
-    ).put()
     api_mock.return_value = InstantFuture(
         (
             Team(id="frc254", team_number=254),
@@ -222,7 +205,6 @@ def test_fetch_team_fixes_district_teams(api_mock, tasks_client: Client) -> None
     assert resp.status_code == 200
     assert len(resp.data) > 0
 
-    # Make sure we wrote no models
     assert Team.get_by_id("frc254") is not None
     assert DistrictTeam.get_by_id("2019fim_frc254") is not None
     assert DistrictTeam.get_by_id("2019ne_frc254") is None
@@ -231,19 +213,16 @@ def test_fetch_team_fixes_district_teams(api_mock, tasks_client: Client) -> None
 
 @freeze_time("2019-04-01")
 @mock.patch.object(DatafeedFMSAPI, "get_team_details")
-def test_fetch_team_removes_bad_district_teams(api_mock, tasks_client: Client) -> None:
-    # Create a bad DistrictTeam, from a previous year, with no events for that team
+def test_fetch_team_preserves_past_year_district_teams(
+    api_mock, tasks_client: Client
+) -> None:
+    # Past-year DistrictTeams must not be touched by a current-year sync.
+    # FIRST's answer for 2019 says nothing about 2018, so leave 2018 alone.
     DistrictTeam(
         id="2018in_frc254",
         district_key=ndb.Key(District, "2018in"),
         team=ndb.Key(Team, "frc254"),
         year=2018,
-    ).put()
-    EventTeam(
-        id="2019fim_frc254",
-        event=ndb.Key("Event", "2019fim"),
-        team=ndb.Key("Team", "frc254"),
-        year=2019,
     ).put()
     api_mock.return_value = InstantFuture(
         (
@@ -254,14 +233,9 @@ def test_fetch_team_removes_bad_district_teams(api_mock, tasks_client: Client) -
     )
     resp = tasks_client.get("/backend-tasks/get/team_details/frc254")
     assert resp.status_code == 200
-    assert len(resp.data) > 0
 
-    # Make sure we wrote no models
-    assert Team.get_by_id("frc254") is not None
-    assert DistrictTeam.get_by_id("2018in_frc254") is None
+    assert DistrictTeam.get_by_id("2018in_frc254") is not None
     assert DistrictTeam.get_by_id("2019fim_frc254") is not None
-    assert DistrictTeam.get_by_id("2019ne_frc254") is None
-    assert Robot.query().fetch() == []
 
 
 @freeze_time("2026-04-01")
@@ -269,9 +243,9 @@ def test_fetch_team_removes_bad_district_teams(api_mock, tasks_client: Client) -
 def test_fetch_team_keeps_district_team_without_eventteams(
     api_mock, tasks_client: Client
 ) -> None:
-    # Simulate the race condition: a team is in a district but has no EventTeam
-    # records yet (e.g., their events haven't been synced). The rolling team
-    # details cron should NOT delete the DistrictTeam for the current year.
+    # A team with no EventTeam records yet (e.g., rookies, or early season
+    # before events are synced) must still have their DistrictTeam preserved.
+    # FIRST's API is the authority on district membership, not EventTeam presence.
     api_mock.return_value = InstantFuture(
         (
             Team(id="frc6921", team_number=6921),
@@ -287,9 +261,106 @@ def test_fetch_team_keeps_district_team_without_eventteams(
     resp = tasks_client.get("/backend-tasks/get/team_details/frc6921")
     assert resp.status_code == 200
 
-    # DistrictTeam should be preserved even without EventTeam records
     assert Team.get_by_id("frc6921") is not None
     assert DistrictTeam.get_by_id("2026fma_frc6921") is not None
+
+
+@freeze_time("2026-04-01")
+@mock.patch.object(DatafeedFMSAPI, "get_team_details")
+def test_fetch_team_details_with_year_override(api_mock, tasks_client: Client) -> None:
+    # Callers can target a specific year via the ?year= query param. Useful for
+    # one-off backfill when a prior year's DistrictTeams are missing.
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc6921", team_number=6921),
+            DistrictTeam(
+                id="2025fma_frc6921",
+                team=ndb.Key(Team, "frc6921"),
+                year=2025,
+                district_key=ndb.Key(District, "2025fma"),
+            ),
+            None,
+        )
+    )
+    resp = tasks_client.get("/backend-tasks/get/team_details/frc6921/2025")
+    assert resp.status_code == 200
+
+    api_mock.assert_called_once_with(2025, "frc6921")
+    assert DistrictTeam.get_by_id("2025fma_frc6921") is not None
+
+
+@freeze_time("2026-04-01")
+@mock.patch.object(DatafeedFMSAPI, "get_team_details")
+def test_fetch_team_details_year_override_scoped_to_that_year(
+    api_mock, tasks_client: Client
+) -> None:
+    # A year-overridden call must only reconcile DistrictTeams for that year.
+    # Other years' rows must be untouched.
+    DistrictTeam(
+        id="2026fim_frc6921",
+        team=ndb.Key(Team, "frc6921"),
+        year=2026,
+        district_key=ndb.Key(District, "2026fim"),
+    ).put()
+    DistrictTeam(
+        id="2025ne_frc6921",
+        team=ndb.Key(Team, "frc6921"),
+        year=2025,
+        district_key=ndb.Key(District, "2025ne"),
+    ).put()
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc6921", team_number=6921),
+            DistrictTeam(
+                id="2025fma_frc6921",
+                team=ndb.Key(Team, "frc6921"),
+                year=2025,
+                district_key=ndb.Key(District, "2025fma"),
+            ),
+            None,
+        )
+    )
+    resp = tasks_client.get("/backend-tasks/get/team_details/frc6921/2025")
+    assert resp.status_code == 200
+
+    # 2025 reconciled: new row created, stale same-year row deleted
+    assert DistrictTeam.get_by_id("2025fma_frc6921") is not None
+    assert DistrictTeam.get_by_id("2025ne_frc6921") is None
+    # 2026 untouched
+    assert DistrictTeam.get_by_id("2026fim_frc6921") is not None
+
+
+@freeze_time("2026-04-01")
+@mock.patch.object(DatafeedFMSAPI, "get_team_details")
+def test_fetch_team_details_historical_year_does_not_overwrite_team(
+    api_mock, tasks_client: Client
+) -> None:
+    # Backfilling a historical year must not clobber current Team metadata
+    # (name, nickname, city, etc.) with a stale snapshot. The handler should
+    # still reconcile year-scoped rows (DistrictTeam, Robot) but skip the
+    # global Team write when year < max_year.
+    Team(id="frc6921", team_number=6921, nickname="Current Name").put()
+    api_mock.return_value = InstantFuture(
+        (
+            Team(id="frc6921", team_number=6921, nickname="Stale 2025 Name"),
+            DistrictTeam(
+                id="2025fma_frc6921",
+                team=ndb.Key(Team, "frc6921"),
+                year=2025,
+                district_key=ndb.Key(District, "2025fma"),
+            ),
+            None,
+        )
+    )
+    resp = tasks_client.get("/backend-tasks/get/team_details/frc6921/2025")
+    assert resp.status_code == 200
+
+    # DistrictTeam for 2025 was created (year-scoped, safe)
+    assert DistrictTeam.get_by_id("2025fma_frc6921") is not None
+    # Team metadata was NOT overwritten with the stale 2025 snapshot
+    current_team = Team.get_by_id("frc6921")
+    assert current_team is not None
+    assert current_team.nickname == "Current Name"
 
 
 def test_fetch_team_avatar_bad_key(tasks_client: Client) -> None:


### PR DESCRIPTION
This one is a tricky one so I wanna be through in the explanation - because we've actually attempted to fix this one a few times before.

The issue reported in #5761 was about team listings on the District Teams list. The issue was originally reported I think by Alan on Feb 2nd 2024, re-iterated by Michael O'Connell on Feb 3rd 2024, and later Brandon Liatys on Feb 22nd 2024. Jordan's fix in that PR did fix the issue of teams that did not compete in any events for a season would now have their `DistrictTeam` model cleaned up. But it introduced an unintended side effect where it started cleaning up teams that did not play at any events but they were a part of the district that season. Sometimes that's 0 point teams - but this also includes rookie teams that did not attend an event but were awarded their team age points.

My PR in #7012 was a follow up fix when we realized some teams were not getting their `DistrictTeam` deleted during their `team_details` fetch if their `frc-api/{year}/teams?teamNumber={team_number}` returned an empty response. This bug was initially reported by Alan on May 19th of 2024 at the end of the thread but got no responses. Justin brought up the bug again on December 16th 2024 - just indicating the same thing Alan saw. I said I would look into a fix, didn't, and then started digging on January 13th 2025. Eventually I got this resolved for NE 2024 (specifically for frc1124) by fetching 1124 -> recalculating rankings around Feb 18th 2025.

So what happened here was a bit tricky to track down. My initial confusion was "How did we get into this state this state if before Jordan's fix we were cleaning up empty district teams" and it looks like the FRC API was returning us data that a team did play in the district for a given season even if they had not. This was likely just looking at what district they *had* played in and extrapolating forward. But after Covid a lot of teams churned, and this was no longer accurate. API request in the screenshot is from Feb 22nd 2024

<img width="1640" height="1024" alt="image" src="https://github.com/user-attachments/assets/de1b82c4-3c51-4f74-b07c-b1df5c6c73ca" />

The FRC API now rightly returns the empty team response we were not handling properly in #7012 - so this likely got fixed sometime between Feb 2024 and May 2024

```
$ curl 'https://frc-api.firstinspires.org/v3.0/2024/teams?teamNumber=225' | jq .
{
  "teamCountTotal": 0,
  "teamCountPage": 0,
  "pageCurrent": 0,
  "pageTotal": 0,
  "teams": []
}
```

Jordan's original code was gated by `if team:` - so we'd only run the cleanup if we got a non-empty `teams` array back. My fix removed that check + handled non-empty arrays, so that fix worked for a while, but still had the problem of cleaning up valid ranked teams.

The timeline here is only important to note that my fix landed in 2025 - so we had not cleaned up all the `DistrictTeam` models with the fix in #7012 because our rolling team update had moved on to fetching 2025 teams.

The one outstanding mystery for me here is how between Jordan's fix getting merged -> the FRC API response updating to reflect teams no longer existing teams were getting `DistrictTeam` models inserted that lead to the reports in May and December. Those are no longer there so I can't really track them down - and there's only so many places we insert `DistrictTeam` models like when we do our `EventTeam` insertion for event team lists, the `team_details` endpoint we're talking about here, and `district_set_home_dcmp_post` which didn't exist during 2024. I have no idea how to square that. Or - there's possible some dead code I haven't tracked down that used to insert these.

All this is to say - in my effort to track down district ranking inconsistencies in https://github.com/the-blue-alliance/the-blue-alliance/discussions/9678 I'm going to say **the code that was added in #5761 is no longer necessary**, given the FRC API change we we handeled in #7012. The code in #9604 is actually what has kept the 2026 rankings in-sync with FIRST's, while we're missing teams for 2025. But that hack will break once we roll over to the 2027 season, and our rankings will go out-of-sync again (after we've spent so much time getting them right!)

Yes - sometimes, teams who did not compete at any district event will show up in the District Teams list, and they will have a District Ranking associated with them. In the cases of teams awarded team age bonuses these affect rankings and we ought to keep them in. But some of these teams have 0 points/no events and we still have them as playing in the district. We have to trust FIRST as the source of truth for that data. This means ex: 3265 in 2025 who had not played an event since 2018 but was listed as registered in 2025 will have both a listing and a ranking associated with them. FIRST says they registered for 2025 - I think we need to align with that. Even if we don't show a year on their Team page

<img width="1387" height="846" alt="Screenshot 2026-04-23 at 10 37 36 PM" src="https://github.com/user-attachments/assets/f70c5412-fb60-4fbd-a98e-1ccbfdf0f538" />

<img width="906" height="675" alt="Screenshot 2026-04-23 at 10 37 40 PM" src="https://github.com/user-attachments/assets/489ba3f1-9282-4217-8af9-17788afe0fb9" />

```
$ curl 'https://frc-api.firstinspires.org/v3.0/2025/teams?teamNumber=3265' | jq .
{
  "teamCountTotal": 1,
  "teamCountPage": 1,
  "pageCurrent": 1,
  "pageTotal": 1,
  "teams": [
    {
      "teamNumber": 3265,
      "nameFull": "GE Volunteers / Lockheed Martin / Automated Logic-United Technologies / Kennesaw State University & Mceachern High School",
      "nameShort": "Arrowheads",
      "city": "Powder Springs",
      "stateProv": "Georgia",
      "country": "USA",
      "rookieYear": 2010,
      "robotName": "",
      "districtCode": "PCH",
      "schoolName": "Mceachern High School",
      "website": "",
      "homeCMP": null
    }
  ]
}
```

Edit: Justin confirmed in Slack from some historic Slack messages from a bot that watches for event registration changes - 3265 (and actually - all teams we dropped a `DistrictTeam` for in 2025 because they did not compete at any events) was registered for events in 2025, but later dropped their events. My guess is that FIRST reports them as being a part of 2025pch because they did indeed register, they paid their registration fee, they've might've even gotten their kit of parts, etc.

If FIRST ever updates that data - we should be able to handle it with the new `/backend-tasks/get/team_details/<team_key>/<year>` endpoint added in this PR - which will re-fetch team data for a given year. The `Team` model will NOT be updated using this data if `year != SeasonHelper.get_max_year()` - but it will do things like update `DistrictTeam`, update robot names, etc. This also updates the `team_details` to use `SeasonHelper.get_max_year()` so when our we bump the max season we start using the new endpoint to get team data as opposed to the current year. This is a small bug but it means if we flip that sitevar in Nov, we really aren't getting up-to-date Team data until January.

---

Remove code from #5761 for DistrictTeam deletion. Rely on code from #7012 for DistricTeam deletion. Remove bad fix in #9604 for DistrictTeam deletion. Add ability to fetch team details for different years to fix DistrictTeam/RegionalPoolTeam/Robot for previous years - without updating Team