### PR TITLE
fix division button incorrectly disabling sync

### DIFF
--- a/src/backend/tasks_io/handlers/admin/tasks.py
+++ b/src/backend/tasks_io/handlers/admin/tasks.py
@@ -38,7 +38,7 @@ def admin_post_division_tasks(event_key: EventKey) -> str:
         EventSyncOverrides,
         dict(cast(Dict[str, Any], event.sync_overrides or {})),
     )
-    sync_overrides["event_sync_disable"] = True
+    sync_overrides["skip_eventteams"] = True
     sync_overrides["set_start_day_to_last"] = True
     event.sync_overrides = sync_overrides
     EventManipulator.createOrUpdate(event)

--- a/src/backend/tasks_io/handlers/admin/tests/admin_post_division_tasks_test.py
+++ b/src/backend/tasks_io/handlers/admin/tests/admin_post_division_tasks_test.py
@@ -64,8 +64,9 @@ def test_post_division_tasks(
     # Event cmp hacks should be updated
     updated_event = Event.get_by_id("2020cmptx")
     sync_overrides = none_throws(updated_event).sync_overrides or {}
-    assert sync_overrides["event_sync_disable"] is True
+    assert "event_sync_disable" not in sync_overrides
     assert sync_overrides["set_start_day_to_last"] is True
+    assert sync_overrides["skip_eventteams"] is True
 
     # event_details task should be enqueued
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
@@ -98,6 +99,7 @@ def test_post_division_tasks_idempotent_event_config(
     sync_overrides = none_throws(updated_event).sync_overrides or {}
     assert sync_overrides["event_sync_disable"] is True
     assert sync_overrides["set_start_day_to_last"] is True
+    assert sync_overrides["skip_eventteams"] is True
 
     # event_details task should be enqueued
     tasks = taskqueue_stub.get_filtered_tasks(queue_names="datafeed")
@@ -129,7 +131,7 @@ def test_post_division_tasks_preserves_other_config(
 
     updated_event = Event.get_by_id("2020cmptx")
     sync_overrides = none_throws(updated_event).sync_overrides or {}
-    assert sync_overrides["event_sync_disable"] is True
+    assert "event_sync_disable" not in sync_overrides
     assert sync_overrides["set_start_day_to_last"] is True
     assert sync_overrides["skip_eventteams"] is True
     assert sync_overrides["event_name_override"] == {


### PR DESCRIPTION
The initial version incorrectly set `disable_sync`, which should have instead been `skip_eventteams`.

Fix this, which will fix why we were seeing issues fetching singular events (that have sync skipped)