### PR TITLE
Split district advancements and district adjustments

### DIFF
--- a/src/backend/tasks_io/handlers/frc_api.py
+++ b/src/backend/tasks_io/handlers/frc_api.py
@@ -952,8 +952,33 @@ def district_list(year: Year) -> Response:
     return make_response("")
 
 
+@blueprint.route("/tasks/enqueue/district_advancement/<int:year>")
+@blueprint.route("/tasks/enqueue/district_advancement", defaults={"year": None})
+def enqueue_district_advancement(year: Optional[Year]) -> Response:
+    """Enqueue an advancement refresh for every district in the given season."""
+    if year is None:
+        year = SeasonHelper.get_current_season()
+
+    districts = District.query(District.year == int(year)).fetch()
+    district_keys = [district.key.id() for district in districts]
+    for district_key in district_keys:
+        taskqueue.add(
+            url=url_for("frc_api.district_rankings", district_key=district_key),
+            method="GET",
+            target="py3-tasks-io",
+            queue_name="default",
+        )
+
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return make_response(f"Enqueued for: {district_keys}")
+    return make_response("")
+
+
 @blueprint.route("/backend-tasks/get/district_rankings/<district_key>")
 def district_rankings(district_key: DistrictKey) -> Response:
+    """Fetch district advancement (DCMP/CMP qualification flags) from FIRST."""
     district = (
         District.get_by_id(district_key)
         if District.validate_key_name(district_key)
@@ -967,18 +992,45 @@ def district_rankings(district_key: DistrictKey) -> Response:
         district_key
     ).get_result()
     district.advancement = data.advancement
-    district.adjustments = data.adjustments
     district = DistrictManipulator.createOrUpdate(district, update_manual_attrs=False)
-
-    template_values = {
-        "districts": listify(district),
-    }
 
     if (
         "X-Appengine-Taskname" not in request.headers
     ):  # Only write out if not in taskqueue
         return make_response(
-            render_template("datafeeds/fms_district_list_get.html", **template_values)
+            render_template(
+                "datafeeds/fms_district_advancement_get.html", district=district
+            )
+        )
+
+    return make_response("")
+
+
+@blueprint.route("/backend-tasks/get/district_adjustments/<district_key>")
+def district_adjustments(district_key: DistrictKey) -> Response:
+    """Fetch district point adjustments from FIRST, then recompute rankings."""
+    district = (
+        District.get_by_id(district_key)
+        if District.validate_key_name(district_key)
+        else None
+    )
+    if district is None:
+        return make_response(f"No District for key: {Markup.escape(district_key)}", 404)
+
+    df = DatafeedFMSAPI()
+    data: TParsedDistrictAdvancement = df.get_district_rankings(
+        district_key
+    ).get_result()
+    district.adjustments = data.adjustments
+    district = DistrictManipulator.createOrUpdate(district, update_manual_attrs=False)
+
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return make_response(
+            render_template(
+                "datafeeds/fms_district_adjustments_get.html", district=district
+            )
         )
 
     taskqueue.add(

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -209,7 +209,7 @@ def enqueue_district_rankings_calc(year: Optional[Year]) -> Response:
         # This will hit the FRC API for adjustment points, and then
         # call back into district_rankings_calc below
         taskqueue.add(
-            url=url_for("frc_api.district_rankings", district_key=district_key),
+            url=url_for("frc_api.district_adjustments", district_key=district_key),
             method="GET",
             target="py3-tasks-io",
             queue_name="default",

--- a/src/backend/tasks_io/handlers/tests/frc_api_event_district_test.py
+++ b/src/backend/tasks_io/handlers/tests/frc_api_event_district_test.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from freezegun import freeze_time
+from google.appengine.ext import testbed
 from werkzeug.test import Client
 
 from backend.common.futures import InstantFuture
@@ -63,9 +65,9 @@ def test_district_rankings_no_district(tasks_client: Client) -> None:
 def test_district_rankings(api_mock, tasks_client: Client) -> None:
     District(id="2020ne", year=2020, abbreviation="ne").put()
     advancement = {"frc254": TeamDistrictAdvancement(dcmp=True, cmp=True)}
-    adjustemnts = {"frc254": 5}
+    adjustments = {"frc254": 5}
     api_mock.return_value = InstantFuture(
-        TParsedDistrictAdvancement(advancement=advancement, adjustments=adjustemnts)
+        TParsedDistrictAdvancement(advancement=advancement, adjustments=adjustments)
     )
 
     resp = tasks_client.get(
@@ -74,11 +76,11 @@ def test_district_rankings(api_mock, tasks_client: Client) -> None:
     assert resp.status_code == 200
     assert len(resp.data) > 0
 
-    # Ensure we created models
+    # Advancement was saved; adjustments were not touched by this endpoint
     d = District.get_by_id("2020ne")
     assert d is not None
     assert d.advancement == advancement
-    assert d.adjustments == adjustemnts
+    assert d.adjustments is None
 
 
 @mock.patch.object(DatafeedFMSAPI, "get_district_rankings")
@@ -87,9 +89,9 @@ def test_district_rankings_no_output_in_taskqueue(
 ) -> None:
     District(id="2020ne", year=2020, abbreviation="ne").put()
     advancement = {"frc254": TeamDistrictAdvancement(dcmp=True, cmp=True)}
-    adjustemnts = {"frc254": 5}
+    adjustments = {"frc254": 5}
     api_mock.return_value = InstantFuture(
-        TParsedDistrictAdvancement(advancement=advancement, adjustments=adjustemnts)
+        TParsedDistrictAdvancement(advancement=advancement, adjustments=adjustments)
     )
 
     resp = tasks_client.get(
@@ -99,8 +101,125 @@ def test_district_rankings_no_output_in_taskqueue(
     assert resp.status_code == 200
     assert len(resp.data) == 0
 
-    # Ensure we created models
     d = District.get_by_id("2020ne")
     assert d is not None
     assert d.advancement == advancement
-    assert d.adjustments == adjustemnts
+    assert d.adjustments is None
+
+
+def test_district_adjustments_bad_key(tasks_client: Client) -> None:
+    resp = tasks_client.get("/backend-tasks/get/district_adjustments/asdf")
+    assert resp.status_code == 404
+
+
+def test_district_adjustments_no_district(tasks_client: Client) -> None:
+    resp = tasks_client.get("/backend-tasks/get/district_adjustments/2020ne")
+    assert resp.status_code == 404
+
+
+@mock.patch.object(DatafeedFMSAPI, "get_district_rankings")
+def test_district_adjustments(api_mock, tasks_client: Client) -> None:
+    District(id="2020ne", year=2020, abbreviation="ne").put()
+    advancement = {"frc254": TeamDistrictAdvancement(dcmp=True, cmp=True)}
+    adjustments = {"frc254": 5}
+    api_mock.return_value = InstantFuture(
+        TParsedDistrictAdvancement(advancement=advancement, adjustments=adjustments)
+    )
+
+    resp = tasks_client.get(
+        "/backend-tasks/get/district_adjustments/2020ne",
+    )
+    assert resp.status_code == 200
+    assert len(resp.data) > 0
+
+    # Adjustments were saved; advancement was not touched by this endpoint
+    d = District.get_by_id("2020ne")
+    assert d is not None
+    assert d.adjustments == adjustments
+    assert d.advancement is None
+
+
+@mock.patch.object(DatafeedFMSAPI, "get_district_rankings")
+def test_district_adjustments_no_output_in_taskqueue(
+    api_mock, tasks_client: Client
+) -> None:
+    District(id="2020ne", year=2020, abbreviation="ne").put()
+    advancement = {"frc254": TeamDistrictAdvancement(dcmp=True, cmp=True)}
+    adjustments = {"frc254": 5}
+    api_mock.return_value = InstantFuture(
+        TParsedDistrictAdvancement(advancement=advancement, adjustments=adjustments)
+    )
+
+    resp = tasks_client.get(
+        "/backend-tasks/get/district_adjustments/2020ne",
+        headers={"X-Appengine-Taskname": "test"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.data) == 0
+
+    d = District.get_by_id("2020ne")
+    assert d is not None
+    assert d.adjustments == adjustments
+    assert d.advancement is None
+
+
+@freeze_time("2020-4-1")
+def test_enqueue_district_advancement_no_districts(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    resp = tasks_client.get("/tasks/enqueue/district_advancement/2020")
+    assert resp.status_code == 200
+    assert resp.data == b"Enqueued for: []"
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 0
+
+
+@freeze_time("2020-4-1")
+def test_enqueue_district_advancement_with_districts(
+    tasks_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+    ndb_stub,
+) -> None:
+    District(id="2020ne", year=2020, abbreviation="ne").put()
+    District(id="2020fim", year=2020, abbreviation="fim").put()
+
+    resp = tasks_client.get("/tasks/enqueue/district_advancement/2020")
+    assert resp.status_code == 200
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 2
+    urls = sorted(task.url for task in tasks)
+    assert urls == [
+        "/backend-tasks/get/district_rankings/2020fim",
+        "/backend-tasks/get/district_rankings/2020ne",
+    ]
+    taskqueue_stub.Clear()
+
+
+@freeze_time("2020-4-1")
+def test_enqueue_district_advancement_default_year(
+    tasks_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+    ndb_stub,
+) -> None:
+    District(id="2020ne", year=2020, abbreviation="ne").put()
+
+    resp = tasks_client.get("/tasks/enqueue/district_advancement")
+    assert resp.status_code == 200
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 1
+    taskqueue_stub.Clear()
+
+
+@freeze_time("2020-4-1")
+def test_enqueue_district_advancement_no_output_in_taskqueue(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    resp = tasks_client.get(
+        "/tasks/enqueue/district_advancement/2020",
+        headers={"X-Appengine-Taskname": "test"},
+    )
+    assert resp.status_code == 200
+    assert resp.data == b""

--- a/src/backend/tasks_io/templates/datafeeds/fms_district_adjustments_get.html
+++ b/src/backend/tasks_io/templates/datafeeds/fms_district_adjustments_get.html
@@ -1,0 +1,19 @@
+<div class="row">
+    <div class="alert alert-block alert-success">
+        <h4>Got adjustments for {{ district.key_name }} ({{ (district.adjustments or {})|length }} teams)</h4>
+    </div>
+    <table class="table table-condensed table-hover table-striped">
+        <thead>
+            <th>team</th>
+            <th>adjustment</th>
+        </thead>
+        {% for team_key, adjustment in (district.adjustments or {}).items() %}
+        <tr>
+            <td>{{ team_key }}</td>
+            <td>{{ adjustment }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="2">No adjustments returned.</td></tr>
+        {% endfor %}
+    </table>
+</div>

--- a/src/backend/tasks_io/templates/datafeeds/fms_district_advancement_get.html
+++ b/src/backend/tasks_io/templates/datafeeds/fms_district_advancement_get.html
@@ -1,0 +1,21 @@
+<div class="row">
+    <div class="alert alert-block alert-success">
+        <h4>Got advancement for {{ district.key_name }} ({{ (district.advancement or {})|length }} teams)</h4>
+    </div>
+    <table class="table table-condensed table-hover table-striped">
+        <thead>
+            <th>team</th>
+            <th>qualified for DCMP</th>
+            <th>qualified for CMP</th>
+        </thead>
+        {% for team_key, advancement in (district.advancement or {}).items() %}
+        <tr>
+            <td>{{ team_key }}</td>
+            <td>{% if advancement.dcmp %}&#10004;{% endif %}</td>
+            <td>{% if advancement.cmp %}&#10004;{% endif %}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">No advancement data returned.</td></tr>
+        {% endfor %}
+    </table>
+</div>

--- a/src/backend/web/templates/admin/district_details.html
+++ b/src/backend/web/templates/admin/district_details.html
@@ -76,7 +76,8 @@
 
         <h2>Tasks</h2>
         <div class="btn-group">
-          <a href="/backend-tasks/get/district_rankings/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Details from FIRST</a>
+          <a href="/backend-tasks/get/district_rankings/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Fetch Advancement from FIRST</a>
+          <a href="/backend-tasks/get/district_adjustments/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-refresh"></span> Fetch Adjustments from FIRST</a>
           <a href="/tasks/math/do/district_rankings_calc/{{district.key_name}}" class="btn btn-warning"><span class="glyphicon glyphicon-stats"></span> Recompute Rankings</a>
                     {% if district_has_youtube_channel | default(false) %}
                         <a href="/tasks/do/find_event_webcasts/{{district.key_name}}" class="btn btn-info"><span class="glyphicon glyphicon-facetime-video"></span> Fetch Upcoming Webcasts</a>

--- a/src/backend/web/templates/admin/district_list.html
+++ b/src/backend/web/templates/admin/district_list.html
@@ -40,7 +40,8 @@
         <td>{% if district.rankings %}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
         <td>{% if district.advancement%}<span class="glyphicon glyphicon-ok"><span>{% endif %}</td>
         <td>
-          <a href="/backend-tasks/get/district_rankings/{{district.key_name}}" class="btn btn-default"><span class="glyphicon glyphicon-refresh"></span> Refresh Advancement from FIRST</a>
+          <a href="/backend-tasks/get/district_rankings/{{district.key_name}}" class="btn btn-default"><span class="glyphicon glyphicon-refresh"></span> Fetch Advancement from FIRST</a>
+          <a href="/backend-tasks/get/district_adjustments/{{district.key_name}}" class="btn btn-default"><span class="glyphicon glyphicon-refresh"></span> Fetch Adjustments from FIRST</a>
           <a href="/tasks/math/do/district_rankings_calc/{{district.key_name}}" class="btn btn-default"><span class="glyphicon glyphicon-stats"></span> Recompute Rankings</a>
           {% if (district_has_youtube_channel | default({})).get(district.abbreviation) %}
             <a href="/tasks/do/find_event_webcasts/{{district.key_name}}" class="btn btn-info"><span class="glyphicon glyphicon-facetime-video"></span> Fetch Upcoming Webcasts</a>

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -99,6 +99,11 @@ cron:
     schedule: every day 01:05
     timezone: America/Los_Angeles
 
+  - description: District Advancement Refresh
+    url: /tasks/enqueue/district_advancement
+    schedule: every day 01:05
+    timezone: America/Los_Angeles
+
   # Leaderboard Insights
   - description: Team Leaderboard Insights Calculation
     url: /backend-tasks-b2/enqueue/math/insights/leaderboards/team


### PR DESCRIPTION
We were talking about "hey do we have an endpoint to update district adjustments" earlier this week in Slack and we were like "I'm not sure" and - turns out, they're tied to district advancements. This is not inherently a problem - but it does make the "Fetch District Advancements" button in the admin UI a little scary, since it also does a mutation that it does not tell you about for a thing we might actually not want to respect.

This PR splits the district advancements and district adjustments into two different buttons in the admin UI. That way we know which does which, and we can just click the one we need in the moment. And maybe we have to click two buttons sometimes and I think that's fine.

<img width="1854" height="808" alt="Screenshot 2026-04-24 at 3 46 53 PM" src="https://github.com/user-attachments/assets/f83b8db7-f34c-478e-b647-ddb02d7abe85" />

<img width="2380" height="1248" alt="Screenshot 2026-04-24 at 3 44 18 PM" src="https://github.com/user-attachments/assets/9c6d7381-6491-4d5b-8274-885e69c8e000" />

A side effect of this is that the `enqueue_district_rankings_calc` no longer updates advancements since it's not really necessary for calculation - just adjustments. So there's a new cron job just to get advancements.

Finally - the advancements/adjustments just used the simple district fetched template, which was not obvious what data had actually been returned or if we got a response for either of these endpoints. So this PR adds new templates for both endpoints that does surface that data

<img width="519" height="758" alt="Screenshot 2026-04-24 at 4 01 27 PM" src="https://github.com/user-attachments/assets/49d12d4e-0513-48d2-9a4b-ac286228fe76" />

<img width="424" height="255" alt="Screenshot 2026-04-24 at 4 01 31 PM" src="https://github.com/user-attachments/assets/a62f252e-ffed-41ce-829f-3a4634f27fdb" />
