### PR TITLE
Add endpoint to re-generate district points calculations for all events in a district for a singular district

### DIFF
--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -109,6 +109,37 @@ def enqueue_event_district_points_calc(year: Optional[Year]) -> Response:
     return make_response("")
 
 
+@blueprint.route("/tasks/math/enqueue/district_points_calc/district/<district_key>")
+def enqueue_district_points_calc_for_district(district_key: DistrictKey) -> Response:
+    """
+    Enqueues calculation of district points for all events in a single district.
+    Each per-event task auto-enqueues district_rankings_calc on completion.
+    """
+    district = District.get_by_id(district_key)
+    if not district:
+        return make_response(f"District {district_key} not found", 404)
+
+    events = DistrictEventsQuery(district_key).fetch()
+    event_keys = [
+        event.key_name
+        for event in events
+        if event.event_type_enum in SEASON_EVENT_TYPES
+    ]
+    for event_key in event_keys:
+        taskqueue.add(
+            url=url_for("math.event_district_points_calc", event_key=event_key),
+            method="GET",
+            target="py3-tasks-io",
+            queue_name="default",
+        )
+
+    if (
+        "X-Appengine-Taskname" not in request.headers
+    ):  # Only write out if not in taskqueue
+        return make_response(f"Enqueued for {district_key}: {event_keys}")
+    return make_response("")
+
+
 @blueprint.route("/tasks/math/do/district_points_calc/<event_key>")
 def event_district_points_calc(event_key: EventKey) -> Response:
     """

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from flask import abort, Blueprint, make_response, render_template, request, url_for
 from google.appengine.api import taskqueue
 from google.appengine.ext import ndb
+from markupsafe import escape
 from werkzeug.wrappers import Response
 
 from backend.common.consts.event_type import EventType, SEASON_EVENT_TYPES
@@ -115,9 +116,12 @@ def enqueue_district_points_calc_for_district(district_key: DistrictKey) -> Resp
     Enqueues calculation of district points for all events in a single district.
     Each per-event task auto-enqueues district_rankings_calc on completion.
     """
+    if not District.validate_key_name(district_key):
+        return make_response(f"{escape(district_key)} is not a valid district key", 400)
+
     district = District.get_by_id(district_key)
     if not district:
-        return make_response(f"District {district_key} not found", 404)
+        return make_response(f"District {escape(district_key)} not found", 404)
 
     events = DistrictEventsQuery(district_key).fetch()
     event_keys = [
@@ -136,7 +140,7 @@ def enqueue_district_points_calc_for_district(district_key: DistrictKey) -> Resp
     if (
         "X-Appengine-Taskname" not in request.headers
     ):  # Only write out if not in taskqueue
-        return make_response(f"Enqueued for {district_key}: {event_keys}")
+        return make_response(f"Enqueued for {escape(district_key)}: {event_keys}")
     return make_response("")
 
 

--- a/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
+++ b/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
@@ -145,6 +145,70 @@ def test_enqueue_skips_regionals_2025(
         assert task_resp.status_code == 200
 
 
+def test_enqueue_for_district_not_found(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    resp = tasks_client.get("/tasks/math/enqueue/district_points_calc/district/2025chs")
+    assert resp.status_code == 404
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 0
+
+
+def test_enqueue_for_district(
+    tasks_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+    ndb_stub,
+) -> None:
+    District(
+        id="2025chs",
+        year=2025,
+        abbreviation="chs",
+    ).put()
+    Event(
+        id="2025chsevent",
+        year=2025,
+        event_short="chsevent",
+        event_type_enum=EventType.DISTRICT,
+        district_key=ndb.Key(District, "2025chs"),
+    ).put()
+    Event(
+        id="2025chsoffseason",
+        year=2025,
+        event_short="chsoffseason",
+        event_type_enum=EventType.OFFSEASON,
+        district_key=ndb.Key(District, "2025chs"),
+    ).put()
+    resp = tasks_client.get("/tasks/math/enqueue/district_points_calc/district/2025chs")
+    assert resp.status_code == 200
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    task_urls = {t.url for t in tasks}
+    assert task_urls == {
+        "/tasks/math/do/district_points_calc/2025chsevent",
+    }
+
+
+def test_enqueue_for_district_no_output_in_taskqueue(
+    tasks_client: Client,
+    taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub,
+    ndb_stub,
+) -> None:
+    District(
+        id="2025chs",
+        year=2025,
+        abbreviation="chs",
+    ).put()
+    resp = tasks_client.get(
+        "/tasks/math/enqueue/district_points_calc/district/2025chs",
+        headers={
+            "X-Appengine-Taskname": "test",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.data == b""
+
+
 def test_calc_no_event(
     tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
 ) -> None:

--- a/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
+++ b/src/backend/tasks_io/handlers/tests/district_points_calc_test.py
@@ -145,6 +145,16 @@ def test_enqueue_skips_regionals_2025(
         assert task_resp.status_code == 200
 
 
+def test_enqueue_for_district_invalid_key(
+    tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
+) -> None:
+    resp = tasks_client.get("/tasks/math/enqueue/district_points_calc/district/asdf")
+    assert resp.status_code == 400
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="default")
+    assert len(tasks) == 0
+
+
 def test_enqueue_for_district_not_found(
     tasks_client: Client, taskqueue_stub: testbed.taskqueue_stub.TaskQueueServiceStub
 ) -> None:


### PR DESCRIPTION
In my effort to get our district rankings aligned with FIRST (see https://github.com/the-blue-alliance/the-blue-alliance/discussions/9678) I'm working through old seasons now. We need to consume the new changes in https://github.com/the-blue-alliance/the-blue-alliance/pull/9711 in order to generate the proper district points values for teams for previous seasons. However, the only mechanism we have to do this is to recompute all district event points for all events in a season.

This is scary, and I want to move slowly, so I've added an endpoint to do these one-district-at-a-time. This is mostly a lift code-wise from the "do it for all districts" - just scoped to a single district. No UI in the admin panel for now because I'm not sure if folks really need it, and we have an internal url to hit for it if folks do.