### PR TITLE
Add match count v2 insights

### DIFF
--- a/src/backend/common/helpers/insights_v2/compute.py
+++ b/src/backend/common/helpers/insights_v2/compute.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, Iterable, List, Set
+from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Set, Tuple
 
 from google.appengine.ext import ndb
 
@@ -40,6 +40,30 @@ def build_leaderboard_rankings(
             value=value,
         )
         for value, keys in sorted(value_to_keys.items(), reverse=True)
+    ][:top_n]
+
+
+def build_leaderboard_pair_rankings(
+    counts: Dict[str, int], top_n: int = LEADERBOARD_TOP_N
+) -> List[LeaderboardRankingV2]:
+    """
+    Converts a {"frcA|frcB": count} dict into a sorted list of LeaderboardRankingV2.
+    Pairs with equal counts are grouped into one entry (mirroring build_leaderboard_rankings).
+    keys is List[List[str]]; each inner list is [team_a, team_b].
+    """
+    value_to_pairs: Dict[int, List[List[str]]] = defaultdict(list)
+    for key, count in counts.items():
+        value_to_pairs[count].append(key.split("|"))
+
+    def _pair_sort_key(pair: List[str]) -> Tuple[int, int]:
+        return (int(pair[0][3:]), int(pair[1][3:]))
+
+    return [
+        LeaderboardRankingV2(
+            keys=sorted(pairs, key=_pair_sort_key),
+            value=value,
+        )
+        for value, pairs in sorted(value_to_pairs.items(), reverse=True)
     ][:top_n]
 
 
@@ -93,6 +117,21 @@ class LeaderboardV2Calculator(InsightV2Calculator, ABC):
     @abstractmethod
     def key_type(self) -> LeaderboardKeyType: ...
 
+    @abstractmethod
+    def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRankingV2]:
+        # Each leaderboard type controls how its counts are turned into rankings
+        # (e.g. single-string keys vs. compound pair keys have different sort/grouping
+        # logic and produce different keys shapes in the output).
+        ...
+
+    def _get_district(
+        self, key: str, team_to_district: Dict[str, str]
+    ) -> Optional[str]:
+        # Default: the count key IS the team key, so district lookup is direct.
+        # Override when a key encodes multiple teams (e.g. a pair), where the
+        # district should only be assigned if all teams share the same district.
+        return team_to_district.get(key)
+
     def _increment(self, key: str, count: int = 1) -> None:
         self.counts[key] += count
 
@@ -102,15 +141,15 @@ class LeaderboardV2Calculator(InsightV2Calculator, ABC):
         district_counts: DefaultDict[str, DefaultDict[str, int]] = defaultdict(
             lambda: defaultdict(int)
         )
-        for team_key, count in self.counts.items():
-            if district := team_to_district.get(team_key):
-                district_counts[district][team_key] += count
+        for key, count in self.counts.items():
+            if district := self._get_district(key, team_to_district):
+                district_counts[district][key] += count
 
         insights = []
 
         if self.counts:
             data = LeaderboardDataV2(
-                rankings=build_leaderboard_rankings(self.counts),
+                rankings=self._build_rankings(self.counts),
                 key_type=self.key_type,
             )
             insights.append(
@@ -132,7 +171,7 @@ class LeaderboardV2Calculator(InsightV2Calculator, ABC):
             if not counts:
                 continue
             data = LeaderboardDataV2(
-                rankings=build_leaderboard_rankings(counts),
+                rankings=self._build_rankings(counts),
                 key_type=self.key_type,
             )
             insights.append(
@@ -170,9 +209,11 @@ def compute_insights_for_year(
                 continue
 
             event.prep_awards()
+            event.prep_matches()
             for calc in calculators:
                 calc.on_event(event)
             event.clear_awards()
+            event.clear_matches()
             ndb.get_context().clear_cache()
 
     all_team_keys: Set[str] = set()

--- a/src/backend/common/helpers/insights_v2/most_matches_played.py
+++ b/src/backend/common/helpers/insights_v2/most_matches_played.py
@@ -1,6 +1,5 @@
 from typing import Dict, List
 
-from backend.common.consts.award_type import BLUE_BANNER_AWARDS
 from backend.common.helpers.insights_v2.compute import (
     build_leaderboard_rankings,
     LeaderboardV2Calculator,
@@ -14,10 +13,10 @@ from backend.common.models.insight_v2 import (
 )
 
 
-class BlueBannersV2Calculator(LeaderboardV2Calculator):
+class MostMatchesPlayedV2Calculator(LeaderboardV2Calculator):
     @property
     def insight_name(self) -> InsightV2NameEntry:
-        return InsightV2Names.BLUE_BANNERS
+        return InsightV2Names.MOST_MATCHES_PLAYED
 
     @property
     def key_type(self) -> LeaderboardKeyType:
@@ -27,7 +26,7 @@ class BlueBannersV2Calculator(LeaderboardV2Calculator):
         return build_leaderboard_rankings(counts)
 
     def on_event(self, event: Event) -> None:
-        for award in event.awards:
-            if award.award_type_enum in BLUE_BANNER_AWARDS and award.count_banner:
-                for team_key in award.team_list:
-                    self._increment(str(team_key.id()))
+        for match in event.matches:
+            if match.has_been_played:
+                for team_key in match.team_key_names:
+                    self._increment(team_key)

--- a/src/backend/common/helpers/insights_v2/most_matches_played_together.py
+++ b/src/backend/common/helpers/insights_v2/most_matches_played_together.py
@@ -1,0 +1,54 @@
+import itertools
+from typing import Dict, List, Optional, Set
+
+from backend.common.helpers.insights_v2.compute import (
+    build_leaderboard_pair_rankings,
+    LeaderboardV2Calculator,
+)
+from backend.common.models.event import Event
+from backend.common.models.insight_v2 import (
+    InsightV2NameEntry,
+    InsightV2Names,
+    LeaderboardKeyType,
+    LeaderboardRankingV2,
+)
+
+
+class MostMatchesPlayedTogetherV2Calculator(LeaderboardV2Calculator):
+    @property
+    def insight_name(self) -> InsightV2NameEntry:
+        return InsightV2Names.MOST_MATCHES_PLAYED_TOGETHER
+
+    @property
+    def key_type(self) -> LeaderboardKeyType:
+        return "team_pair"
+
+    @property
+    def team_keys(self) -> Set[str]:
+        keys: Set[str] = set()
+        for pair_key in self.counts:
+            team_a, team_b = pair_key.split("|")
+            keys.add(team_a)
+            keys.add(team_b)
+        return keys
+
+    def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRankingV2]:
+        return build_leaderboard_pair_rankings(counts)
+
+    def _get_district(
+        self, key: str, team_to_district: Dict[str, str]
+    ) -> Optional[str]:
+        team_a, team_b = key.split("|")
+        district_a = team_to_district.get(team_a)
+        district_b = team_to_district.get(team_b)
+        return district_a if district_a and district_a == district_b else None
+
+    def on_event(self, event: Event) -> None:
+        for match in event.matches:
+            if not match.has_been_played:
+                continue
+            for alliance in match.alliances.values():
+                teams = alliance["teams"]
+                for team_a, team_b in itertools.combinations(teams, 2):
+                    pair = sorted([team_a, team_b], key=lambda k: int(k[3:]))
+                    self._increment(f"{pair[0]}|{pair[1]}")

--- a/src/backend/common/helpers/insights_v2/registry.py
+++ b/src/backend/common/helpers/insights_v2/registry.py
@@ -5,6 +5,12 @@ from backend.common.helpers.insights_v2.compute import (
     compute_insights_for_year,
     InsightV2Calculator,
 )
+from backend.common.helpers.insights_v2.most_matches_played import (
+    MostMatchesPlayedV2Calculator,
+)
+from backend.common.helpers.insights_v2.most_matches_played_together import (
+    MostMatchesPlayedTogetherV2Calculator,
+)
 from backend.common.models.insight_v2 import InsightV2
 from backend.common.models.keys import Year
 
@@ -12,6 +18,8 @@ from backend.common.models.keys import Year
 def _build_calculators() -> List[InsightV2Calculator]:
     return [
         BlueBannersV2Calculator(),
+        MostMatchesPlayedV2Calculator(),
+        MostMatchesPlayedTogetherV2Calculator(),
     ]
 
 

--- a/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
@@ -1,27 +1,5 @@
-from google.appengine.ext import ndb
-
 from backend.common.helpers.insights_v2.blue_banners import BlueBannersV2Calculator
 from backend.common.helpers.insights_v2.compute import compute_insights_for_year
-from backend.common.models.district import District
-from backend.common.models.district_team import DistrictTeam
-from backend.common.models.insight_v2 import InsightCategory
-from backend.common.models.team import Team
-
-
-def make_district_team(team_key: str, year: int, district_abbrev: str) -> None:
-    district_key = f"{year}{district_abbrev}"
-    District(id=district_key, year=year, abbreviation=district_abbrev).put()
-    DistrictTeam(
-        id=f"{district_key}_{team_key}",
-        team=ndb.Key(Team, team_key),
-        year=year,
-        district_key=ndb.Key(District, district_key),
-    ).put()
-
-
-def test_no_events_returns_empty(ndb_stub) -> None:
-    insights = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
-    assert insights == []
 
 
 def test_blue_banners_year(ndb_stub, test_data_importer) -> None:
@@ -34,63 +12,19 @@ def test_blue_banners_year(ndb_stub, test_data_importer) -> None:
     insight = insights[0]
     assert insight.name == "blue_banners"
     assert insight.display_name == "Total Blue Banners"
-    assert insight.year == 2024
-    assert insight.category == InsightCategory.LEADERBOARD
-    assert insight.data["key_type"] == "team"
-    rankings = insight.data["rankings"]
-    assert len(rankings) > 0
-    # All values should be positive integers
-    for r in rankings:
-        assert r["value"] > 0
-        assert len(r["keys"]) > 0
+    assert len(insight.data["rankings"]) > 0
 
 
 def test_blue_banners_overall(ndb_stub, test_data_importer) -> None:
     test_data_importer.import_event(__file__, "../data/2019nyny.json")
     test_data_importer.import_award_list(__file__, "../data/2019nyny_awards.json")
-
     test_data_importer.import_event(__file__, "../data/2024nytr.json")
     test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
 
     insights = compute_insights_for_year(0, [BlueBannersV2Calculator()])
 
-    assert len(insights) == 1
-    insight = insights[0]
-    assert insight.year == 0
     # frc1796 wins at both 2019nyny and 2024nytr so should have 2 banners overall
-    rankings = insight.data["rankings"]
-    top = rankings[0]
-    assert top["value"] == 2
-    assert "frc1796" in top["keys"]
-
-
-def test_blue_banners_rankings_sorted_descending(ndb_stub, test_data_importer) -> None:
-    test_data_importer.import_event(__file__, "../data/2019nyny.json")
-    test_data_importer.import_award_list(__file__, "../data/2019nyny_awards.json")
-
-    test_data_importer.import_event(__file__, "../data/2024nytr.json")
-    test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
-
-    insights = compute_insights_for_year(0, [BlueBannersV2Calculator()])
-    rankings = insights[0].data["rankings"]
-
-    values = [r["value"] for r in rankings]
-    assert values == sorted(values, reverse=True)
-
-
-def test_blue_banners_team_keys_sorted_numerically(
-    ndb_stub, test_data_importer
-) -> None:
-    test_data_importer.import_event(__file__, "../data/2024nytr.json")
-    test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
-
-    insights = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
-    rankings = insights[0].data["rankings"]
-
-    for ranking in rankings:
-        keys = ranking["keys"]
-        nums = [int(k[3:]) for k in keys]
-        assert nums == sorted(nums)
+    assert insights[0].data["rankings"][0] == {"value": 2, "keys": ["frc1796"]}
 
 
 def test_key_name(ndb_stub, test_data_importer) -> None:
@@ -99,84 +33,3 @@ def test_key_name(ndb_stub, test_data_importer) -> None:
 
     insights = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
     assert insights[0].key_name == "2024_v2_leaderboard_blue_banners"
-
-
-def test_district_insight_created(ndb_stub, test_data_importer) -> None:
-    test_data_importer.import_event(__file__, "../data/2022on305.json")
-    test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
-    # Winner teams are frc2200, frc610, frc4015 — register them in the ont district
-    for team_key in ("frc2200", "frc610", "frc4015"):
-        make_district_team(team_key, 2022, "ont")
-
-    insights = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
-
-    # global insight + one district insight
-    assert len(insights) == 2
-    district_insight = next(i for i in insights if i.district_abbreviation == "ont")
-    assert district_insight.year == 2022
-    assert district_insight.name == "blue_banners"
-    assert district_insight.category == InsightCategory.LEADERBOARD
-    assert district_insight.key_name == "2022_v2_leaderboard_blue_banners_ont"
-    rankings = district_insight.data["rankings"]
-    assert len(rankings) > 0
-    winner_keys = {"frc2200", "frc610", "frc4015"}
-    ranked_keys = {k for r in rankings for k in r["keys"]}
-    assert winner_keys <= ranked_keys
-
-
-def test_district_insight_uses_team_membership_not_event_type(
-    ndb_stub, test_data_importer
-) -> None:
-    # 2024nytr is a regional, but frc1796 is registered as a ne district team.
-    # Their banner should appear in the ne district insight.
-    # frc1591, frc3181, frc9624 also win at 2024nytr but are not district members —
-    # they should not appear in any district insight.
-    test_data_importer.import_event(__file__, "../data/2024nytr.json")
-    test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
-    make_district_team("frc1796", 2024, "ne")
-
-    insights = compute_insights_for_year(2024, [BlueBannersV2Calculator()])
-
-    district_insights = [i for i in insights if i.district_abbreviation is not None]
-    assert len(district_insights) == 1
-    assert district_insights[0].district_abbreviation == "ne"
-
-    ranked_keys = {k for r in district_insights[0].data["rankings"] for k in r["keys"]}
-    assert "frc1796" in ranked_keys
-    assert "frc1591" not in ranked_keys
-    assert "frc3181" not in ranked_keys
-
-
-def test_district_uses_most_recent_district_team(ndb_stub, test_data_importer) -> None:
-    # frc1796 won in 2019 (ne district in 2019) and 2024 (ne district in 2024).
-    # They also have an older record in ont from 2018.
-    # Their most recent DistrictTeam is 2024 ne, so all their banners count toward ne.
-    test_data_importer.import_event(__file__, "../data/2019nyny.json")
-    test_data_importer.import_award_list(__file__, "../data/2019nyny_awards.json")
-    test_data_importer.import_event(__file__, "../data/2024nytr.json")
-    test_data_importer.import_award_list(__file__, "../data/2024nytr_awards.json")
-    make_district_team("frc1796", 2018, "ont")
-    make_district_team("frc1796", 2024, "ne")
-
-    insights = compute_insights_for_year(0, [BlueBannersV2Calculator()])
-
-    district_insights = [i for i in insights if i.district_abbreviation is not None]
-    abbrevs = {i.district_abbreviation for i in district_insights}
-    assert "ne" in abbrevs
-    assert "ont" not in abbrevs
-
-    ne_insight = next(i for i in district_insights if i.district_abbreviation == "ne")
-    ranked_keys = {k for r in ne_insight.data["rankings"] for k in r["keys"]}
-    assert "frc1796" in ranked_keys
-
-
-def test_district_key_name(ndb_stub, test_data_importer) -> None:
-    test_data_importer.import_event(__file__, "../data/2022on305.json")
-    test_data_importer.import_award_list(__file__, "../data/2022on305_awards.json")
-    for team_key in ("frc2200", "frc610", "frc4015"):
-        make_district_team(team_key, 2022, "ont")
-
-    insights = compute_insights_for_year(2022, [BlueBannersV2Calculator()])
-    key_names = {i.key_name for i in insights}
-    assert "2022_v2_leaderboard_blue_banners" in key_names
-    assert "2022_v2_leaderboard_blue_banners_ont" in key_names

--- a/src/backend/common/helpers/tests/insights_v2/leaderboard_v2_calculator_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboard_v2_calculator_test.py
@@ -1,0 +1,128 @@
+from typing import Dict, List
+
+from google.appengine.ext import ndb
+
+from backend.common.helpers.insights_v2.compute import (
+    _build_team_district_map,
+    build_leaderboard_rankings,
+    LeaderboardV2Calculator,
+)
+from backend.common.models.district import District
+from backend.common.models.district_team import DistrictTeam
+from backend.common.models.event import Event
+from backend.common.models.insight_v2 import (
+    InsightCategory,
+    InsightV2NameEntry,
+    InsightV2Names,
+    LeaderboardKeyType,
+    LeaderboardRankingV2,
+)
+from backend.common.models.team import Team
+
+
+class _StubLeaderboard(LeaderboardV2Calculator):
+    """Minimal concrete subclass used to exercise base-class behaviour."""
+
+    @property
+    def insight_name(self) -> InsightV2NameEntry:
+        return InsightV2Names.MOST_MATCHES_PLAYED
+
+    @property
+    def key_type(self) -> LeaderboardKeyType:
+        return "team"
+
+    def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRankingV2]:
+        return build_leaderboard_rankings(counts)
+
+    def on_event(self, event: Event) -> None:
+        pass
+
+
+def test_no_data_returns_no_insights() -> None:
+    assert _StubLeaderboard().make_insights(2024, {}) == []
+
+
+def test_rankings_sorted_descending(ndb_stub) -> None:
+    calc = _StubLeaderboard()
+    calc._increment("frc1", 5)
+    calc._increment("frc2", 3)
+    calc._increment("frc3", 8)
+
+    assert calc.make_insights(2024, {})[0].data["rankings"] == [
+        {"value": 8, "keys": ["frc3"]},
+        {"value": 5, "keys": ["frc1"]},
+        {"value": 3, "keys": ["frc2"]},
+    ]
+
+
+def test_team_keys_sorted_numerically(ndb_stub) -> None:
+    calc = _StubLeaderboard()
+    # Same count so all three land in the same ranking group
+    calc._increment("frc100", 3)
+    calc._increment("frc5", 3)
+    calc._increment("frc50", 3)
+
+    assert calc.make_insights(2024, {})[0].data["rankings"] == [
+        {"value": 3, "keys": ["frc5", "frc50", "frc100"]},
+    ]
+
+
+def test_district_insight_created(ndb_stub) -> None:
+    calc = _StubLeaderboard()
+    calc._increment("frc1", 5)
+    calc._increment("frc2", 3)
+
+    insights = calc.make_insights(2024, {"frc1": "ne", "frc2": "ne"})
+
+    assert len(insights) == 2
+    district_insight = next(i for i in insights if i.district_abbreviation == "ne")
+    assert district_insight.year == 2024
+    assert district_insight.category == InsightCategory.LEADERBOARD
+    assert district_insight.data["rankings"] == [
+        {"value": 5, "keys": ["frc1"]},
+        {"value": 3, "keys": ["frc2"]},
+    ]
+
+
+def test_district_insight_excludes_non_members(ndb_stub) -> None:
+    calc = _StubLeaderboard()
+    calc._increment("frc1", 5)
+    calc._increment("frc2", 3)  # not in any district
+
+    district_insights = [
+        i
+        for i in calc.make_insights(2024, {"frc1": "ne"})
+        if i.district_abbreviation is not None
+    ]
+    assert district_insights[0].data["rankings"] == [{"value": 5, "keys": ["frc1"]}]
+
+
+def test_district_key_name(ndb_stub) -> None:
+    calc = _StubLeaderboard()
+    calc._increment("frc1", 5)
+
+    assert {i.key_name for i in calc.make_insights(2024, {"frc1": "ne"})} == {
+        "2024_v2_leaderboard_most_matches_played",
+        "2024_v2_leaderboard_most_matches_played_ne",
+    }
+
+
+def test_district_uses_most_recent_district_team(ndb_stub) -> None:
+    district_key_ont = "2018ont"
+    district_key_ne = "2024ne"
+    District(id=district_key_ont, year=2018, abbreviation="ont").put()
+    District(id=district_key_ne, year=2024, abbreviation="ne").put()
+    DistrictTeam(
+        id=f"{district_key_ont}_frc1",
+        team=ndb.Key(Team, "frc1"),
+        year=2018,
+        district_key=ndb.Key(District, district_key_ont),
+    ).put()
+    DistrictTeam(
+        id=f"{district_key_ne}_frc1",
+        team=ndb.Key(Team, "frc1"),
+        year=2024,
+        district_key=ndb.Key(District, district_key_ne),
+    ).put()
+
+    assert _build_team_district_map(["frc1"]) == {"frc1": "ne"}

--- a/src/backend/common/helpers/tests/insights_v2/most_matches_played_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/most_matches_played_test.py
@@ -1,0 +1,33 @@
+from backend.common.helpers.insights_v2.compute import compute_insights_for_year
+from backend.common.helpers.insights_v2.most_matches_played import (
+    MostMatchesPlayedV2Calculator,
+)
+
+
+def test_most_matches_played_year(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(2024, [MostMatchesPlayedV2Calculator()])
+
+    assert len(insights) == 1
+    insight = insights[0]
+    assert insight.name == "most_matches_played"
+    assert insight.display_name == "Most Matches Played"
+    assert len(insight.data["rankings"]) > 0
+
+
+def test_most_matches_played_top_team(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(2024, [MostMatchesPlayedV2Calculator()])
+    assert insights[0].data["rankings"][0] == {"value": 17, "keys": ["frc6911"]}
+
+
+def test_key_name(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(2024, [MostMatchesPlayedV2Calculator()])
+    assert insights[0].key_name == "2024_v2_leaderboard_most_matches_played"

--- a/src/backend/common/helpers/tests/insights_v2/most_matches_played_together_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/most_matches_played_together_test.py
@@ -1,0 +1,69 @@
+from backend.common.helpers.insights_v2.compute import compute_insights_for_year
+from backend.common.helpers.insights_v2.most_matches_played_together import (
+    MostMatchesPlayedTogetherV2Calculator,
+)
+
+
+def test_most_matches_played_together_year(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(
+        2024, [MostMatchesPlayedTogetherV2Calculator()]
+    )
+
+    assert len(insights) == 1
+    insight = insights[0]
+    assert insight.name == "most_matches_played_together"
+    assert insight.display_name == "Most Matches Played Together"
+    assert insight.data["key_type"] == "team_pair"
+    assert len(insight.data["rankings"]) > 0
+
+
+def test_most_matches_played_together_top_pair(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(
+        2024, [MostMatchesPlayedTogetherV2Calculator()]
+    )
+    assert insights[0].data["rankings"][0] == {
+        "value": 8,
+        "keys": [["frc3173", "frc3419"]],
+    }
+
+
+def test_key_format(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(
+        2024, [MostMatchesPlayedTogetherV2Calculator()]
+    )
+    for ranking in insights[0].data["rankings"]:
+        for pair in ranking["keys"]:
+            team_a, team_b = pair
+            assert team_a.startswith("frc")
+            assert team_b.startswith("frc")
+            assert int(team_a[3:]) < int(
+                team_b[3:]
+            ), "pair teams not in ascending order"
+
+
+def test_key_name(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+    test_data_importer.import_match_list(__file__, "../data/2024nytr_matches.json")
+
+    insights = compute_insights_for_year(
+        2024, [MostMatchesPlayedTogetherV2Calculator()]
+    )
+    assert insights[0].key_name == "2024_v2_leaderboard_most_matches_played_together"
+
+
+def test_no_unplayed_matches_counted(ndb_stub, test_data_importer) -> None:
+    test_data_importer.import_event(__file__, "../data/2024nytr.json")
+
+    insights = compute_insights_for_year(
+        2024, [MostMatchesPlayedTogetherV2Calculator()]
+    )
+    assert insights == []

--- a/src/backend/common/models/insight_v2.py
+++ b/src/backend/common/models/insight_v2.py
@@ -5,7 +5,7 @@ from google.appengine.ext import ndb
 from backend.common.models.cached_model import CachedModel
 from backend.common.models.keys import DistrictAbbreviation
 
-LeaderboardKeyType = Literal["team", "event", "match"]
+LeaderboardKeyType = Literal["team", "event", "match", "team_pair"]
 
 
 class InsightCategory:
@@ -20,6 +20,12 @@ class InsightV2NameEntry(NamedTuple):
 
 class InsightV2Names:
     BLUE_BANNERS = InsightV2NameEntry("blue_banners", "Total Blue Banners")
+    MOST_MATCHES_PLAYED = InsightV2NameEntry(
+        "most_matches_played", "Most Matches Played"
+    )
+    MOST_MATCHES_PLAYED_TOGETHER = InsightV2NameEntry(
+        "most_matches_played_together", "Most Matches Played Together"
+    )
 
 
 class InsightV2(CachedModel):
@@ -73,7 +79,7 @@ class InsightV2(CachedModel):
 
 
 class LeaderboardRankingV2(TypedDict):
-    keys: List[str]
+    keys: List[str] | List[List[str]]
     value: int | float
 
 


### PR DESCRIPTION
Adds two new leaderboard insights to the v2 insights system:

- Most Matches Played (MostMatchesPlayedV2Calculator): ranks teams by total matches played across all events in a year.
- Most Matches Played Together (MostMatchesPlayedTogetherV2Calculator): ranks team pairs by how many matches they've played on the same alliance, using itertools.combinations over each alliance's robot slots.

To support pair-keyed leaderboards, this also:
- Adds build_leaderboard_pair_rankings() in compute.py for grouping and sorting "frcA|frcB" style keys.
- Makes _build_rankings() abstract on LeaderboardV2Calculator so each subclass controls its ranking shape.
- Adds a _get_district() override point so pair calculators can attribute a pair to a district only when both teams share one.