### PR TITLE
[cached-query] Compress API dicts

### DIFF
--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -12,7 +12,7 @@ class CachedQueryResult(ndb.Model):
 
     # Only one of result or result_dict should ever be populated for one model
     result = ndb.PickleProperty(compressed=True)  # Raw models
-    result_dict = ndb.JsonProperty()  # Dict version of models
+    result_dict = ndb.JsonProperty(compressed=True)  # Dict version of models
 
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True)

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -73,7 +73,7 @@ class CachedDatabaseQuery(
     Generic[QueryReturn, DictQueryReturn],
     metaclass=abc.ABCMeta,
 ):
-    DATABASE_QUERY_VERSION = 5
+    DATABASE_QUERY_VERSION = 6
     BASE_CACHE_KEY_FORMAT: str = (
         "{}:{}:{}"  # (partial_cache_key, cache_version, database_query_version)
     )


### PR DESCRIPTION
A good catch in the linked issue, where this is the cause of some OOMs and datastore write failures due to hitting the max size limit. This is probably something we should have always set from the start...

Closes https://github.com/the-blue-alliance/the-blue-alliance/issues/9731

