### PR TITLE
add new enums to api spec

### DIFF
--- a/pwa/app/api/tba/read/index.ts
+++ b/pwa/app/api/tba/read/index.ts
@@ -84,6 +84,7 @@ export {
   type Options,
 } from './sdk.gen';
 export {
+  AllianceColor,
   type ApiStatus,
   type ApiStatusAppVersion,
   AutoChargeStationRobot2023,
@@ -589,6 +590,7 @@ export {
   TowerFace2016,
   TowerRobot2026,
   type Webcast,
+  WebcastStatus,
   type WltRecord,
   type Year,
   type Zebra,

--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -40,6 +40,22 @@ export type ApiStatusAppVersion = {
   latest_app_version: number;
 };
 
+/**
+ * AllianceColor
+ *
+ * The color of an alliance. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/alliance_color.py for full definitions.
+ */
+export enum AllianceColor {
+  /**
+   * RED
+   */
+  RED = 'red',
+  /**
+   * BLUE
+   */
+  BLUE = 'blue',
+}
+
 export enum AutoChargeStationRobot2023 {
   DOCKED = 'Docked',
   NONE = 'None',
@@ -1664,7 +1680,7 @@ export type Match = {
   /**
    * The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.
    */
-  winning_alliance: 'red' | 'blue' | '';
+  winning_alliance: AllianceColor | '';
   /**
    * Event key of the event the match was played at.
    */
@@ -2323,7 +2339,7 @@ export type MatchSimple = {
   /**
    * The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.
    */
-  winning_alliance: 'red' | 'blue' | '';
+  winning_alliance: AllianceColor | '';
   /**
    * Event key of the event the match was played at.
    */
@@ -3033,6 +3049,26 @@ export type WltRecord = {
   ties: number;
 };
 
+/**
+ * WebcastStatus
+ *
+ * Online status of a webcast. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/webcast_status.py for full definitions.
+ */
+export enum WebcastStatus {
+  /**
+   * UNKNOWN
+   */
+  UNKNOWN = 'unknown',
+  /**
+   * ONLINE
+   */
+  ONLINE = 'online',
+  /**
+   * OFFLINE
+   */
+  OFFLINE = 'offline',
+}
+
 export type Webcast = {
   /**
    * Type of webcast, typically descriptive of the streaming provider.
@@ -3065,7 +3101,7 @@ export type Webcast = {
   /**
    * The online status of the webcast, fetched from the streaming provider's API. May be null if not available.
    */
-  status?: 'unknown' | 'online' | 'offline';
+  status?: WebcastStatus | null;
   /**
    * The title of the stream from the streaming provider. May be null.
    */

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -16,6 +16,13 @@ export const zApiStatus = z.object({
   max_team_page: z.int(),
 });
 
+/**
+ * AllianceColor
+ *
+ * The color of an alliance. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/alliance_color.py for full definitions.
+ */
+export const zAllianceColor = z.enum(['red', 'blue']);
+
 export const zAutoChargeStationRobot2023 = z.enum(['Docked', 'None']);
 
 export const zAutoLineRobot2024 = z.enum(['No', 'Yes']);
@@ -750,7 +757,7 @@ export const zMatchSimple = z.object({
     red: zMatchAlliance,
     blue: zMatchAlliance,
   }),
-  winning_alliance: z.enum(['red', 'blue', '']),
+  winning_alliance: z.union([zAllianceColor, z.literal('')]),
   event_key: z.string(),
   time: z.coerce
     .bigint()
@@ -1428,7 +1435,7 @@ export const zMatch = z.object({
     red: zMatchAlliance,
     blue: zMatchAlliance,
   }),
-  winning_alliance: z.enum(['red', 'blue', '']),
+  winning_alliance: z.union([zAllianceColor, z.literal('')]),
   event_key: z.string(),
   time: z.coerce
     .bigint()
@@ -1628,6 +1635,13 @@ export const zTeamEventStatus = z.object({
   pit_location: z.string().nullish(),
 });
 
+/**
+ * WebcastStatus
+ *
+ * Online status of a webcast. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/webcast_status.py for full definitions.
+ */
+export const zWebcastStatus = z.enum(['unknown', 'online', 'offline']);
+
 export const zWebcast = z.object({
   type: z.enum([
     'youtube',
@@ -1646,7 +1660,7 @@ export const zWebcast = z.object({
   channel: z.string(),
   date: z.string().nullish(),
   file: z.string().nullish(),
-  status: z.enum(['unknown', 'online', 'offline']).optional(),
+  status: zWebcastStatus.nullish(),
   stream_title: z.string().nullish(),
   viewer_count: z.int().nullish(),
 });

--- a/pwa/app/components/tba/doubleElim4TeamBracket.tsx
+++ b/pwa/app/components/tba/doubleElim4TeamBracket.tsx
@@ -12,6 +12,7 @@ import {
 import PlayCircleIcon from '~icons/mdi/play-circle-outline';
 
 import {
+  AllianceColor,
   CompLevel,
   EliminationAlliance,
   Event,
@@ -357,16 +358,16 @@ export default function DoubleElim4TeamBracket({
 
     const redResults = setMatches.map((match) => ({
       score: match.alliances.red.score,
-      won: match.winning_alliance === 'red',
+      won: match.winning_alliance === AllianceColor.RED,
     }));
     const blueResults = setMatches.map((match) => ({
       score: match.alliances.blue.score,
-      won: match.winning_alliance === 'blue',
+      won: match.winning_alliance === AllianceColor.BLUE,
     }));
 
     const lastMatch = setMatches[setMatches.length - 1];
-    const redWon = lastMatch.winning_alliance === 'red';
-    const blueWon = lastMatch.winning_alliance === 'blue';
+    const redWon = lastMatch.winning_alliance === AllianceColor.RED;
+    const blueWon = lastMatch.winning_alliance === AllianceColor.BLUE;
 
     return {
       redTeams,

--- a/pwa/app/components/tba/eliminationBracket.tsx
+++ b/pwa/app/components/tba/eliminationBracket.tsx
@@ -12,6 +12,7 @@ import {
 import PlayCircleIcon from '~icons/mdi/play-circle-outline';
 
 import {
+  AllianceColor,
   CompLevel,
   EliminationAlliance,
   Event,
@@ -397,17 +398,17 @@ export default function EliminationBracket({
 
     const redResults = setMatches.map((match) => ({
       score: match.alliances.red.score,
-      won: match.winning_alliance === 'red',
+      won: match.winning_alliance === AllianceColor.RED,
     }));
     const blueResults = setMatches.map((match) => ({
       score: match.alliances.blue.score,
-      won: match.winning_alliance === 'blue',
+      won: match.winning_alliance === AllianceColor.BLUE,
     }));
 
     // Determine overall winner from the series
     const lastMatch = setMatches[setMatches.length - 1];
-    const redWon = lastMatch.winning_alliance === 'red';
-    const blueWon = lastMatch.winning_alliance === 'blue';
+    const redWon = lastMatch.winning_alliance === AllianceColor.RED;
+    const blueWon = lastMatch.winning_alliance === AllianceColor.BLUE;
 
     return {
       redTeams,

--- a/pwa/app/components/tba/eliminationBracketPaths.tsx
+++ b/pwa/app/components/tba/eliminationBracketPaths.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from 'react';
 
-import { Match } from '~/api/tba/read';
+import { AllianceColor, Match } from '~/api/tba/read';
 
 type MatchResult = {
   score: number;
@@ -38,7 +38,7 @@ export type PlayoffMatchHandle = {
 
 export type AdvancementPath = {
   d: string;
-  winner: 'red' | 'blue';
+  winner: AllianceColor;
   allianceNumber: number | null;
   key: string;
 };
@@ -84,18 +84,19 @@ export function useAdvancementPaths({
 
         const seriesResult = getSeriesResult(matchLookup[link.from]);
         if (!seriesResult) return;
-        let winner: 'red' | 'blue' | null = null;
+        let winner: AllianceColor | null = null;
         let allianceNumber: number | null = null;
         if (seriesResult.redWon && seriesResult.redAllianceNumber) {
-          winner = 'red';
+          winner = AllianceColor.RED;
           allianceNumber = seriesResult.redAllianceNumber;
         } else if (seriesResult.blueWon && seriesResult.blueAllianceNumber) {
-          winner = 'blue';
+          winner = AllianceColor.BLUE;
           allianceNumber = seriesResult.blueAllianceNumber;
         }
         if (!winner) return;
 
-        const fromRow = winner === 'red' ? fromNode.redRow : fromNode.blueRow;
+        const fromRow =
+          winner === AllianceColor.RED ? fromNode.redRow : fromNode.blueRow;
         const fromRect = (fromRow ?? fromNode.card)?.getBoundingClientRect();
         if (!fromRect) return;
 

--- a/pwa/app/components/tba/gameday/WebcastSelectorDialog.tsx
+++ b/pwa/app/components/tba/gameday/WebcastSelectorDialog.tsx
@@ -2,6 +2,7 @@ import HelpCircleIcon from '~icons/lucide/help-circle';
 import VideoIcon from '~icons/lucide/video';
 import VideoOffIcon from '~icons/lucide/video-off';
 
+import { WebcastStatus } from '~/api/tba/read';
 import { WebcastTypeIcon } from '~/components/tba/gameday/WebcastTypeIcon';
 import {
   Dialog,
@@ -27,16 +28,16 @@ export function WebcastSelectorDialog({
 
   // Group webcasts by special vs regular, then by online/offline status
   const specialWebcasts = availableWebcasts.filter(
-    (w) => w.isSpecial && w.webcast.status !== 'offline',
+    (w) => w.isSpecial && w.webcast.status !== WebcastStatus.OFFLINE,
   );
   const offlineSpecialWebcasts = availableWebcasts.filter(
-    (w) => w.isSpecial && w.webcast.status === 'offline',
+    (w) => w.isSpecial && w.webcast.status === WebcastStatus.OFFLINE,
   );
   const regularWebcasts = availableWebcasts.filter(
-    (w) => !w.isSpecial && w.webcast.status !== 'offline',
+    (w) => !w.isSpecial && w.webcast.status !== WebcastStatus.OFFLINE,
   );
   const offlineRegularWebcasts = availableWebcasts.filter(
-    (w) => !w.isSpecial && w.webcast.status === 'offline',
+    (w) => !w.isSpecial && w.webcast.status === WebcastStatus.OFFLINE,
   );
 
   return (
@@ -164,10 +165,10 @@ function WebcastItem({
 
   // Determine the status icon
   const StatusIcon = () => {
-    if (status === 'online') {
+    if (status === WebcastStatus.ONLINE) {
       return <VideoIcon className="h-4 w-4 shrink-0 text-green-500" />;
     }
-    if (status === 'offline') {
+    if (status === WebcastStatus.OFFLINE) {
       return (
         <VideoOffIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
       );
@@ -180,7 +181,7 @@ function WebcastItem({
 
   // Secondary text: stream title for online streams
   const secondaryText =
-    status === 'online' && webcast.webcast.stream_title
+    status === WebcastStatus.ONLINE && webcast.webcast.stream_title
       ? webcast.webcast.stream_title
       : null;
 
@@ -204,12 +205,13 @@ function WebcastItem({
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {/* Viewer count for online streams */}
-        {status === 'online' && webcast.webcast.viewer_count != null && (
-          <div className="text-right text-xs text-muted-foreground">
-            <div>{webcast.webcast.viewer_count.toLocaleString()}</div>
-            <div>Viewers</div>
-          </div>
-        )}
+        {status === WebcastStatus.ONLINE &&
+          webcast.webcast.viewer_count != null && (
+            <div className="text-right text-xs text-muted-foreground">
+              <div>{webcast.webcast.viewer_count.toLocaleString()}</div>
+              <div>Viewers</div>
+            </div>
+          )}
         <StatusIcon />
       </div>
     </button>

--- a/pwa/app/components/tba/match/matchRows.tsx
+++ b/pwa/app/components/tba/match/matchRows.tsx
@@ -8,7 +8,7 @@ import ChevronDownIcon from '~icons/lucide/chevron-down';
 import PlayCircleIcon from '~icons/mdi/play-circle-outline';
 import YoutubeIcon from '~icons/mdi/youtube';
 
-import { Event, Match, PlayoffType } from '~/api/tba/read';
+import { AllianceColor, Event, Match, PlayoffType } from '~/api/tba/read';
 import { MatchLink } from '~/components/tba/links';
 import { ShouldInsertBreakCallback } from '~/components/tba/match/breakers';
 import ScoreCell from '~/components/tba/match/scoreCell';
@@ -185,9 +185,9 @@ export function MatchRow({
     match.alliances.red.score !== -1 && match.alliances.blue.score !== -1;
   const focusedAlliance = focusTeamKey
     ? match.alliances.red.team_keys.includes(focusTeamKey)
-      ? 'red'
+      ? AllianceColor.RED
       : match.alliances.blue.team_keys.includes(focusTeamKey)
-        ? 'blue'
+        ? AllianceColor.BLUE
         : null
     : null;
 
@@ -237,7 +237,7 @@ export function MatchRow({
         allianceColor="red"
         className="col-span-3 pt-0.5 xl:col-span-3 xl:pb-0.5"
         teamCellClassName="max-xl:first:rounded-tl-lg max-xl:last:rounded-tr-lg xl:first:rounded-l-lg"
-        winner={match.winning_alliance === 'red'}
+        winner={match.winning_alliance === AllianceColor.RED}
         dq={match.alliances.red.dq_team_keys}
         surrogate={match.alliances.red.surrogate_team_keys}
         year={year}
@@ -250,7 +250,7 @@ export function MatchRow({
         allianceColor="blue"
         className="col-span-3 pb-0.5 xl:col-span-3 xl:pt-0.5"
         teamCellClassName="max-xl:first:rounded-bl-lg max-xl:last:rounded-br-lg xl:last:rounded-r-lg"
-        winner={match.winning_alliance === 'blue'}
+        winner={match.winning_alliance === AllianceColor.BLUE}
         dq={match.alliances.blue.dq_team_keys}
         surrogate={match.alliances.blue.surrogate_team_keys}
         year={year}
@@ -286,11 +286,11 @@ export function MatchRow({
           className="col-start-6 row-start-1 mt-0.5 max-lg:rounded-t-lg
             xl:col-span-1 xl:col-start-auto xl:row-start-auto xl:mb-0.5
             xl:rounded-l-lg"
-          winner={match.winning_alliance === 'red'}
+          winner={match.winning_alliance === AllianceColor.RED}
           scoreBreakdown={match.score_breakdown?.red}
           year={year}
           compLevel={match.comp_level}
-          focused={focusedAlliance === 'red'}
+          focused={focusedAlliance === AllianceColor.RED}
         />
       )}
 
@@ -302,11 +302,11 @@ export function MatchRow({
           className="col-start-6 row-start-2 mb-0.5 max-lg:rounded-b-lg
             xl:col-span-1 xl:col-start-auto xl:row-start-auto xl:mt-0.5
             xl:rounded-r-lg"
-          winner={match.winning_alliance === 'blue'}
+          winner={match.winning_alliance === AllianceColor.BLUE}
           scoreBreakdown={match.score_breakdown?.blue}
           year={year}
           compLevel={match.comp_level}
-          focused={focusedAlliance === 'blue'}
+          focused={focusedAlliance === AllianceColor.BLUE}
         />
       )}
     </div>
@@ -353,7 +353,7 @@ export function SimpleMatchRow({
           allianceColor="red"
           className="col-span-3 col-start-1 row-start-2"
           teamCellClassName="first:rounded-tl-lg last:rounded-tr-lg"
-          winner={match.winning_alliance === 'red'}
+          winner={match.winning_alliance === AllianceColor.RED}
           dq={match.alliances.red.dq_team_keys}
           surrogate={match.alliances.red.surrogate_team_keys}
           year={year}
@@ -365,7 +365,7 @@ export function SimpleMatchRow({
           allianceColor="blue"
           className="col-span-3 col-start-1 row-start-3"
           teamCellClassName="first:rounded-bl-lg last:rounded-br-lg"
-          winner={match.winning_alliance === 'blue'}
+          winner={match.winning_alliance === AllianceColor.BLUE}
           dq={match.alliances.blue.dq_team_keys}
           surrogate={match.alliances.blue.surrogate_team_keys}
           year={year}
@@ -397,7 +397,7 @@ export function SimpleMatchRow({
             score={match.alliances.red.score}
             allianceColor="red"
             className="col-start-4 row-start-2 rounded-tl-lg rounded-tr-lg"
-            winner={match.winning_alliance === 'red'}
+            winner={match.winning_alliance === AllianceColor.RED}
             scoreBreakdown={match.score_breakdown?.red}
             year={year}
             compLevel={match.comp_level}
@@ -410,7 +410,7 @@ export function SimpleMatchRow({
             score={match.alliances.blue.score}
             allianceColor="blue"
             className="col-start-4 row-start-3 rounded-br-lg rounded-bl-lg"
-            winner={match.winning_alliance === 'blue'}
+            winner={match.winning_alliance === AllianceColor.BLUE}
             scoreBreakdown={match.score_breakdown?.blue}
             year={year}
             compLevel={match.comp_level}

--- a/pwa/app/components/tba/match/scoreByShift2026.tsx
+++ b/pwa/app/components/tba/match/scoreByShift2026.tsx
@@ -8,7 +8,7 @@ import {
   YAxis,
 } from 'recharts';
 
-import { Match, MatchScoreBreakdown2026 } from '~/api/tba/read';
+import { AllianceColor, Match, MatchScoreBreakdown2026 } from '~/api/tba/read';
 import {
   type ChartConfig,
   ChartContainer,
@@ -43,8 +43,8 @@ function makeChartConfig(match: Match): ChartConfig {
 
 // Red is above when red >= blue; blue is above when blue > red.
 // This guarantees the two labels always end up on opposite sides.
-function makeLabel(alliance: 'red' | 'blue', data: ShiftScore[]) {
-  const fill = alliance === 'red' ? RED_COLOR : BLUE_COLOR;
+function makeLabel(alliance: AllianceColor, data: ShiftScore[]) {
+  const fill = alliance === AllianceColor.RED ? RED_COLOR : BLUE_COLOR;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function ShiftLabel(props: any) {
     const { x, y, value, index } = props as {
@@ -63,7 +63,9 @@ function makeLabel(alliance: 'red' | 'blue', data: ShiftScore[]) {
       return null;
     const point = data[index];
     const isAbove =
-      alliance === 'red' ? point.red >= point.blue : point.blue > point.red;
+      alliance === AllianceColor.RED
+        ? point.red >= point.blue
+        : point.blue > point.red;
     const dy = isAbove ? -10 : 18;
     return (
       <text
@@ -130,8 +132,8 @@ export default function ScoreByShift2026({
   const [activeOnly, setActiveOnly] = useState(false);
   const data = buildShiftData(scoreBreakdown, activeOnly);
   const chartConfig = makeChartConfig(match);
-  const RedLabel = makeLabel('red', data);
-  const BlueLabel = makeLabel('blue', data);
+  const RedLabel = makeLabel(AllianceColor.RED, data);
+  const BlueLabel = makeLabel(AllianceColor.BLUE, data);
 
   return (
     <div className="rounded-lg border bg-card p-3">

--- a/pwa/app/components/tba/teamMatchStats.tsx
+++ b/pwa/app/components/tba/teamMatchStats.tsx
@@ -9,7 +9,13 @@ import {
   YAxis,
 } from 'recharts';
 
-import { CompLevel, Event, Match, WltRecord } from '~/api/tba/read';
+import {
+  AllianceColor,
+  CompLevel,
+  Event,
+  Match,
+  WltRecord,
+} from '~/api/tba/read';
 import { TitledCard } from '~/components/tba/cards';
 import { TeamLink } from '~/components/tba/links';
 import {
@@ -136,7 +142,7 @@ function calculateStreaks(teamKey: string, matches: Match[]): Streak[] {
 
     const result = getAllianceMatchResult(
       matches[i],
-      isRed ? 'red' : 'blue',
+      isRed ? AllianceColor.RED : AllianceColor.BLUE,
       'score-based',
     );
 
@@ -336,11 +342,17 @@ function MatchWinOverTimeChart({
 
       const isRed = match.alliances.red.team_keys.includes(teamKey);
       const didWin =
-        getAllianceMatchResult(match, isRed ? 'red' : 'blue', 'score-based') ===
-        'win';
+        getAllianceMatchResult(
+          match,
+          isRed ? AllianceColor.RED : AllianceColor.BLUE,
+          'score-based',
+        ) === 'win';
       const didLose =
-        getAllianceMatchResult(match, isRed ? 'red' : 'blue', 'score-based') ===
-        'loss';
+        getAllianceMatchResult(
+          match,
+          isRed ? AllianceColor.RED : AllianceColor.BLUE,
+          'score-based',
+        ) === 'loss';
 
       const newNet =
         data[data.length - 1].netWins + (didWin ? 1 : didLose ? -1 : 0);
@@ -413,7 +425,7 @@ export default function TeamMatchStats({
       const alliance = isRed ? match.alliances.red : match.alliances.blue;
       const result = getAllianceMatchResult(
         match,
-        isRed ? 'red' : 'blue',
+        isRed ? AllianceColor.RED : AllianceColor.BLUE,
         'score-based',
       );
 
@@ -443,7 +455,7 @@ export default function TeamMatchStats({
         : match.alliances.red;
       const result = getAllianceMatchResult(
         match,
-        isRed ? 'red' : 'blue',
+        isRed ? AllianceColor.RED : AllianceColor.BLUE,
         'score-based',
       );
 

--- a/pwa/app/components/tba/traditionalBracket.tsx
+++ b/pwa/app/components/tba/traditionalBracket.tsx
@@ -12,6 +12,7 @@ import {
 import PlayCircleIcon from '~icons/mdi/play-circle-outline';
 
 import {
+  AllianceColor,
   CompLevel,
   EliminationAlliance,
   Event,
@@ -381,16 +382,16 @@ export default function TraditionalBracket({
 
     const redResults = setMatches.map((match) => ({
       score: match.alliances.red.score,
-      won: match.winning_alliance === 'red',
+      won: match.winning_alliance === AllianceColor.RED,
     }));
     const blueResults = setMatches.map((match) => ({
       score: match.alliances.blue.score,
-      won: match.winning_alliance === 'blue',
+      won: match.winning_alliance === AllianceColor.BLUE,
     }));
 
     const lastMatch = setMatches[setMatches.length - 1];
-    const redWon = lastMatch.winning_alliance === 'red';
-    const blueWon = lastMatch.winning_alliance === 'blue';
+    const redWon = lastMatch.winning_alliance === AllianceColor.RED;
+    const blueWon = lastMatch.winning_alliance === AllianceColor.BLUE;
 
     return {
       redTeams,

--- a/pwa/app/lib/gameday/types.ts
+++ b/pwa/app/lib/gameday/types.ts
@@ -1,4 +1,4 @@
-import type { Webcast } from '~/api/tba/read';
+import type { Webcast, WebcastStatus } from '~/api/tba/read';
 
 /**
  * Supported webcast types
@@ -15,7 +15,7 @@ export interface FirebaseWebcast {
   file?: string;
   date?: string;
   // Live status fields populated by WebcastOnlineHelper
-  status?: 'unknown' | 'online' | 'offline';
+  status?: WebcastStatus;
   stream_title?: string | null;
   viewer_count?: number | null;
 }

--- a/pwa/app/lib/gameday/useOnlineEventWebcasts.ts
+++ b/pwa/app/lib/gameday/useOnlineEventWebcasts.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
 import type { Event } from '~/api/tba/read';
+import { WebcastStatus } from '~/api/tba/read';
 import { useFirebaseWebcasts } from '~/lib/gameday/useFirebaseWebcasts';
 
 /**
@@ -14,7 +15,7 @@ export function useOnlineEventWebcasts(): (event: Event) => boolean {
   const onlineEventKeys = useMemo(() => {
     const online = new Set<string>();
     Object.entries(webcasts).forEach(([id, { webcast, isSpecial }]) => {
-      if (!isSpecial && webcast.status === 'online') {
+      if (!isSpecial && webcast.status === WebcastStatus.ONLINE) {
         // id format is `${eventKey}-${index}`
         online.add(id.substring(0, id.lastIndexOf('-')));
       }

--- a/pwa/app/lib/matchUtils.test.ts
+++ b/pwa/app/lib/matchUtils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import type { Match } from '~/api/tba/read';
-import { CompLevel } from '~/api/tba/read';
+import { AllianceColor, CompLevel } from '~/api/tba/read';
 import { getAllianceMatchResult, isValidMatchKey } from '~/lib/matchUtils';
 
 describe.concurrent('isValidMatchKey', () => {
@@ -37,7 +37,7 @@ describe.concurrent('getAllianceMatchResult', () => {
     key: string,
     redScore: number,
     blueScore: number,
-    winningAlliance: '' | 'red' | 'blue',
+    winningAlliance: '' | AllianceColor,
   ): Match {
     return {
       key,
@@ -71,70 +71,120 @@ describe.concurrent('getAllianceMatchResult', () => {
 
   test('returns undefined when match has not been played', () => {
     const match = createMockMatch('2024test_qm1', -1, -1, '');
-    expect(getAllianceMatchResult(match, 'red', 'official')).toBeUndefined();
-    expect(getAllianceMatchResult(match, 'blue', 'official')).toBeUndefined();
+    expect(
+      getAllianceMatchResult(match, AllianceColor.RED, 'official'),
+    ).toBeUndefined();
+    expect(
+      getAllianceMatchResult(match, AllianceColor.BLUE, 'official'),
+    ).toBeUndefined();
   });
 
   test('returns win when alliance won', () => {
-    const match = createMockMatch('2024test_qm1', 100, 80, 'red');
-    expect(getAllianceMatchResult(match, 'red', 'official')).toBe('win');
+    const match = createMockMatch('2024test_qm1', 100, 80, AllianceColor.RED);
+    expect(getAllianceMatchResult(match, AllianceColor.RED, 'official')).toBe(
+      'win',
+    );
   });
 
   test('returns loss when alliance lost', () => {
-    const match = createMockMatch('2024test_qm1', 100, 80, 'red');
-    expect(getAllianceMatchResult(match, 'blue', 'official')).toBe('loss');
+    const match = createMockMatch('2024test_qm1', 100, 80, AllianceColor.RED);
+    expect(getAllianceMatchResult(match, AllianceColor.BLUE, 'official')).toBe(
+      'loss',
+    );
   });
 
   test('returns tie when match is tied (non-2015)', () => {
     const match = createMockMatch('2024test_qm1', 100, 100, '');
-    expect(getAllianceMatchResult(match, 'red', 'official')).toBe('tie');
-    expect(getAllianceMatchResult(match, 'blue', 'official')).toBe('tie');
+    expect(getAllianceMatchResult(match, AllianceColor.RED, 'official')).toBe(
+      'tie',
+    );
+    expect(getAllianceMatchResult(match, AllianceColor.BLUE, 'official')).toBe(
+      'tie',
+    );
   });
 
   test('returns tie for 2015 match with official strategy', () => {
     const match = createMockMatch('2015test_qm1', 100, 80, '');
-    expect(getAllianceMatchResult(match, 'red', 'official')).toBe('tie');
-    expect(getAllianceMatchResult(match, 'blue', 'official')).toBe('tie');
+    expect(getAllianceMatchResult(match, AllianceColor.RED, 'official')).toBe(
+      'tie',
+    );
+    expect(getAllianceMatchResult(match, AllianceColor.BLUE, 'official')).toBe(
+      'tie',
+    );
   });
 
   test('returns win/loss for 2015 match with score-based strategy when red scores higher', () => {
     const match = createMockMatch('2015test_qm1', 100, 80, '');
-    expect(getAllianceMatchResult(match, 'red', 'score-based')).toBe('win');
-    expect(getAllianceMatchResult(match, 'blue', 'score-based')).toBe('loss');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.RED, 'score-based'),
+    ).toBe('win');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.BLUE, 'score-based'),
+    ).toBe('loss');
   });
 
   test('returns win/loss for 2015 match with score-based strategy when blue scores higher', () => {
     const match = createMockMatch('2015test_qm1', 80, 100, '');
-    expect(getAllianceMatchResult(match, 'red', 'score-based')).toBe('loss');
-    expect(getAllianceMatchResult(match, 'blue', 'score-based')).toBe('win');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.RED, 'score-based'),
+    ).toBe('loss');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.BLUE, 'score-based'),
+    ).toBe('win');
   });
 
   test('returns tie for 2015 match with score-based strategy when scores are equal', () => {
     const match = createMockMatch('2015test_qm1', 100, 100, '');
-    expect(getAllianceMatchResult(match, 'red', 'score-based')).toBe('tie');
-    expect(getAllianceMatchResult(match, 'blue', 'score-based')).toBe('tie');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.RED, 'score-based'),
+    ).toBe('tie');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.BLUE, 'score-based'),
+    ).toBe('tie');
   });
 
   test('handles blue alliance winning', () => {
-    const match = createMockMatch('2024test_qm1', 80, 100, 'blue');
-    expect(getAllianceMatchResult(match, 'blue', 'official')).toBe('win');
-    expect(getAllianceMatchResult(match, 'red', 'official')).toBe('loss');
+    const match = createMockMatch('2024test_qm1', 80, 100, AllianceColor.BLUE);
+    expect(getAllianceMatchResult(match, AllianceColor.BLUE, 'official')).toBe(
+      'win',
+    );
+    expect(getAllianceMatchResult(match, AllianceColor.RED, 'official')).toBe(
+      'loss',
+    );
   });
 
   test('handles different comp levels', () => {
-    const qualsMatch = createMockMatch('2024test_qm1', 100, 80, 'red');
+    const qualsMatch = createMockMatch(
+      '2024test_qm1',
+      100,
+      80,
+      AllianceColor.RED,
+    );
     qualsMatch.comp_level = CompLevel.QM;
-    expect(getAllianceMatchResult(qualsMatch, 'red', 'official')).toBe('win');
+    expect(
+      getAllianceMatchResult(qualsMatch, AllianceColor.RED, 'official'),
+    ).toBe('win');
 
-    const finalsMatch = createMockMatch('2024test_f1m1', 100, 80, 'red');
+    const finalsMatch = createMockMatch(
+      '2024test_f1m1',
+      100,
+      80,
+      AllianceColor.RED,
+    );
     finalsMatch.comp_level = CompLevel.F;
-    expect(getAllianceMatchResult(finalsMatch, 'red', 'official')).toBe('win');
+    expect(
+      getAllianceMatchResult(finalsMatch, AllianceColor.RED, 'official'),
+    ).toBe('win');
   });
 
   test('handles 2015 playoff matches with score-based strategy', () => {
     const match = createMockMatch('2015test_sf1m1', 100, 80, '');
     match.comp_level = CompLevel.SF;
-    expect(getAllianceMatchResult(match, 'red', 'score-based')).toBe('win');
-    expect(getAllianceMatchResult(match, 'blue', 'score-based')).toBe('loss');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.RED, 'score-based'),
+    ).toBe('win');
+    expect(
+      getAllianceMatchResult(match, AllianceColor.BLUE, 'score-based'),
+    ).toBe('loss');
   });
 });

--- a/pwa/app/lib/matchUtils.ts
+++ b/pwa/app/lib/matchUtils.ts
@@ -1,4 +1,5 @@
 import {
+  AllianceColor,
   CompLevel,
   Event,
   Match,
@@ -8,23 +9,21 @@ import {
 } from '~/api/tba/read';
 import { median } from '~/lib/utils';
 
-const COMP_LEVEL_SORT_ORDER = {
-  f: 5,
-  sf: 4,
-  qf: 3,
-  ef: 2,
-  qm: 1,
+const COMP_LEVEL_SORT_ORDER: Record<CompLevel, number> = {
+  [CompLevel.F]: 5,
+  [CompLevel.SF]: 4,
+  [CompLevel.QF]: 3,
+  [CompLevel.EF]: 2,
+  [CompLevel.QM]: 1,
 };
 
-export const COMP_LEVEL_SHORT_STRINGS = {
-  f: 'Finals',
-  sf: 'Semis',
-  qf: 'Quarters',
-  ef: 'Eighths',
-  qm: 'Quals',
+export const COMP_LEVEL_SHORT_STRINGS: Record<CompLevel, string> = {
+  [CompLevel.F]: 'Finals',
+  [CompLevel.SF]: 'Semis',
+  [CompLevel.QF]: 'Quarters',
+  [CompLevel.EF]: 'Eighths',
+  [CompLevel.QM]: 'Quals',
 };
-
-export type AllianceColor = 'red' | 'blue';
 
 type RecycleRushWLTStrategy = 'official' | 'score-based';
 
@@ -148,17 +147,17 @@ export function getAllianceMatchResult(
     if (recycleRushStrategy === 'score-based') {
       if (
         (match.alliances.red.score > match.alliances.blue.score &&
-          alliance === 'red') ||
+          alliance === AllianceColor.RED) ||
         (match.alliances.blue.score > match.alliances.red.score &&
-          alliance === 'blue')
+          alliance === AllianceColor.BLUE)
       ) {
         return 'win';
       }
       if (
         (match.alliances.red.score < match.alliances.blue.score &&
-          alliance === 'red') ||
+          alliance === AllianceColor.RED) ||
         (match.alliances.blue.score < match.alliances.red.score &&
-          alliance === 'blue')
+          alliance === AllianceColor.BLUE)
       ) {
         return 'loss';
       }
@@ -180,23 +179,29 @@ export function getTeamMatchResults(
 } {
   const allWins = matches.filter(
     (m) =>
-      (getAllianceMatchResult(m, 'red', recycleRushStrategy) === 'win' &&
+      (getAllianceMatchResult(m, AllianceColor.RED, recycleRushStrategy) ===
+        'win' &&
         m.alliances.red.team_keys.includes(teamKey)) ||
-      (getAllianceMatchResult(m, 'blue', recycleRushStrategy) === 'win' &&
+      (getAllianceMatchResult(m, AllianceColor.BLUE, recycleRushStrategy) ===
+        'win' &&
         m.alliances.blue.team_keys.includes(teamKey)),
   );
   const allLosses = matches.filter(
     (m) =>
-      (getAllianceMatchResult(m, 'red', recycleRushStrategy) === 'loss' &&
+      (getAllianceMatchResult(m, AllianceColor.RED, recycleRushStrategy) ===
+        'loss' &&
         m.alliances.red.team_keys.includes(teamKey)) ||
-      (getAllianceMatchResult(m, 'blue', recycleRushStrategy) === 'loss' &&
+      (getAllianceMatchResult(m, AllianceColor.BLUE, recycleRushStrategy) ===
+        'loss' &&
         m.alliances.blue.team_keys.includes(teamKey)),
   );
   const allTies = matches.filter(
     (m) =>
-      (getAllianceMatchResult(m, 'red', recycleRushStrategy) === 'tie' &&
+      (getAllianceMatchResult(m, AllianceColor.RED, recycleRushStrategy) ===
+        'tie' &&
         m.alliances.red.team_keys.includes(teamKey)) ||
-      (getAllianceMatchResult(m, 'blue', recycleRushStrategy) === 'tie' &&
+      (getAllianceMatchResult(m, AllianceColor.BLUE, recycleRushStrategy) ===
+        'tie' &&
         m.alliances.blue.team_keys.includes(teamKey)),
   );
   const quals = {

--- a/src/backend/common/consts/tests/api_spec_enum_test.py
+++ b/src/backend/common/consts/tests/api_spec_enum_test.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.award_type import AwardType
 from backend.common.consts.event_type import EventType
 from backend.common.consts.playoff_type import PlayoffType
+from backend.common.consts.webcast_status import WebcastStatus
 
 SPEC_PATH = (
     Path(__file__).resolve().parents[4]
@@ -41,6 +43,32 @@ def test_spec_integer_enum_matches_python(
     expected_names = [member.name for member in enum_class]
 
     assert schema["type"] == "integer"
+    assert schema["enum"] == expected_values, (
+        f"{schema_name}.enum in api_v3.json does not match "
+        f"{enum_class.__name__} value order from Python"
+    )
+    assert schema["x-enum-varnames"] == expected_names, (
+        f"{schema_name}.x-enum-varnames in api_v3.json does not match "
+        f"{enum_class.__name__} member names from Python"
+    )
+    assert len(schema["enum"]) == len(schema["x-enum-varnames"])
+
+
+@pytest.mark.parametrize(
+    "schema_name,enum_class",
+    [
+        ("AllianceColor", AllianceColor),
+        ("WebcastStatus", WebcastStatus),
+    ],
+)
+def test_spec_string_enum_matches_python(
+    spec_schemas: dict, schema_name: str, enum_class: type[enum.StrEnum]
+) -> None:
+    schema = spec_schemas[schema_name]
+    expected_values = [member.value for member in enum_class]
+    expected_names = [member.name for member in enum_class]
+
+    assert schema["type"] == "string"
     assert schema["enum"] == expected_values, (
         f"{schema_name}.enum in api_v3.json does not match "
         f"{enum_class.__name__} value order from Python"

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.13.0",
+    "version": "3.14.0",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.14.0: Introduce named string enum schemas (AllianceColor, WebcastStatus). Webcast.status now references the WebcastStatus schema. Match.winning_alliance now typed as AllianceColor | empty-string. Wire values are unchanged; clients regenerated against the spec get correctly-named enum members. 3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -5059,6 +5059,19 @@
           }
         }
       },
+      "AllianceColor": {
+        "title": "AllianceColor",
+        "description": "The color of an alliance. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/alliance_color.py for full definitions.",
+        "type": "string",
+        "enum": [
+          "red",
+          "blue"
+        ],
+        "x-enum-varnames": [
+          "RED",
+          "BLUE"
+        ]
+      },
       "AutoChargeStationRobot_2023": {
         "type": "string",
         "enum": [
@@ -7410,13 +7423,16 @@
             "description": "A list of alliances, the teams on the alliances, and their score."
           },
           "winning_alliance": {
-            "type": "string",
-            "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
-            "enum": [
-              "red",
-              "blue",
-              ""
-            ]
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AllianceColor"
+              },
+              {
+                "type": "string",
+                "const": ""
+              }
+            ],
+            "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie."
           },
           "event_key": {
             "type": "string",
@@ -9462,13 +9478,16 @@
             "description": "A list of alliances, the teams on the alliances, and their score."
           },
           "winning_alliance": {
-            "type": "string",
-            "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
-            "enum": [
-              "red",
-              "blue",
-              ""
-            ]
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AllianceColor"
+              },
+              {
+                "type": "string",
+                "const": ""
+              }
+            ],
+            "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie."
           },
           "event_key": {
             "type": "string",
@@ -10715,6 +10734,21 @@
         },
         "description": "A Win-Loss-Tie record for a team, or an alliance."
       },
+      "WebcastStatus": {
+        "title": "WebcastStatus",
+        "description": "Online status of a webcast. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/webcast_status.py for full definitions.",
+        "type": "string",
+        "enum": [
+          "unknown",
+          "online",
+          "offline"
+        ],
+        "x-enum-varnames": [
+          "UNKNOWN",
+          "ONLINE",
+          "OFFLINE"
+        ]
+      },
       "Webcast": {
         "required": [
           "channel",
@@ -10759,16 +10793,15 @@
             "description": "File identification as may be required for some types. May be null."
           },
           "status": {
-            "type": [
-              "string",
-              "null"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WebcastStatus"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "description": "The online status of the webcast, fetched from the streaming provider's API. May be null if not available.",
-            "enum": [
-              "unknown",
-              "online",
-              "offline"
-            ]
+            "description": "The online status of the webcast, fetched from the streaming provider's API. May be null if not available."
           },
           "stream_title": {
             "type": [


### PR DESCRIPTION
Adds AllianceColor and WebcastStatus as named string enum schemas in api_v3.json (with x-enum-varnames), following the same pattern as the existing integer enum schemas (AwardType, EventType, PlayoffType).

- Webcast.status now references WebcastStatus instead of an inline enum
- Match.winning_alliance is now typed as AllianceColor | '' via oneOf, enabling type-safe enum comparisons in clients
- PWA migrated from raw 'red'/'blue' string literals to AllianceColor.RED/AllianceColor.BLUE throughout
- Backend test updated to verify AllianceColor and WebcastStatus schemas stay in sync with the Python StrEnum definitions

Wire values are unchanged