### PR TITLE
Add interface to manually clean up old CachedQueryResult versions

### DIFF
--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -111,6 +111,21 @@ class CachedQueryResult(ndb.Model):
         if delete_batch_size <= 0:
             raise ValueError("delete_batch_size must be > 0")
 
+        # Validate db_version for safe deletion
+        if db_version <= 0:
+            raise ValueError(
+                f"Cannot delete version {db_version}: must be a positive integer"
+            )
+
+        current_version = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+        min_safe_current = current_version - 1
+        if db_version >= min_safe_current:
+            raise ValueError(
+                f"Cannot delete version {db_version}: must be less than "
+                f"{min_safe_current} (current version {current_version} must "
+                "have at least one prior version as a buffer)"
+            )
+
         cache_key_prefix = cls.cache_key_prefix_from_format(
             query_class.CACHE_KEY_FORMAT
         )

--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -1,6 +1,6 @@
 import logging
 import traceback
-from typing import Any
+from typing import Any, Generator, Iterable, Optional
 
 from google.appengine.ext import ndb
 
@@ -16,6 +16,126 @@ class CachedQueryResult(ndb.Model):
 
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True)
+
+    @staticmethod
+    def cache_key_prefix_from_format(cache_key_format: str) -> str:
+        cache_key_splits = cache_key_format.split("_")
+        cache_key_prefix_parts = []
+        for part in cache_key_splits:
+            if "{" not in part and "}" not in part:
+                cache_key_prefix_parts.append(part)
+        return "_".join(cache_key_prefix_parts)
+
+    @classmethod
+    def all_cache_key_prefixes_from_query_classes(
+        cls, query_classes: Iterable[Any]
+    ) -> set[str]:
+        return {
+            cls.cache_key_prefix_from_format(query_class.CACHE_KEY_FORMAT)
+            for query_class in query_classes
+        }
+
+    @staticmethod
+    def cache_key_bounds_from_prefix(cache_key_prefix: str) -> tuple[str, str]:
+        # Query keys in the lexical range ["{prefix}_*"].
+        #
+        # Lower bound: > "{prefix}_" to skip the synthetic anchor key itself.
+        # Upper bound: < "{prefix}`" where '`' (ASCII 96) is the next character
+        # after '_' (ASCII 95), so all strings beginning with "{prefix}_" match.
+        lower_bound = cache_key_prefix + "_"
+        upper_bound = cache_key_prefix + "`"
+        return lower_bound, upper_bound
+
+    @classmethod
+    def query_by_cache_key_prefix(cls, cache_key_prefix: str) -> ndb.Query:
+        lower_bound, upper_bound = cls.cache_key_bounds_from_prefix(cache_key_prefix)
+        return (
+            cls.query()
+            .filter(cls.key > ndb.Key(cls, lower_bound))  # pyre-ignore[58]
+            .filter(cls.key < ndb.Key(cls, upper_bound))  # pyre-ignore[58]
+        )
+
+    @classmethod
+    def iter_keys_by_cache_key_prefix(
+        cls, cache_key_prefix: str, page_size: int
+    ) -> Generator[ndb.Key, None, None]:
+        query = cls.query_by_cache_key_prefix(cache_key_prefix)
+
+        cursor = None
+        more = True
+        while more:
+            keys, cursor, more = query.fetch_page(
+                page_size, start_cursor=cursor, keys_only=True
+            )
+            for key in keys:
+                yield key
+
+    @staticmethod
+    def db_version_from_key_string(key_string: str) -> Optional[int]:
+        parts = key_string.split(":")
+        if len(parts) < 3:
+            return None
+        db_version_str = parts[2].split("~")[0]
+        try:
+            return int(db_version_str)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def query_version_from_key_string(key_string: str) -> Optional[int]:
+        parts = key_string.split(":")
+        if len(parts) < 2:
+            return None
+        try:
+            return int(parts[1])
+        except ValueError:
+            return None
+
+    @classmethod
+    def purge_query_class_global_version(
+        cls,
+        query_class: Any,
+        db_version: int,
+        page_size: int,
+        delete_batch_size: int,
+    ) -> int:
+        from backend.common.queries.database_query import CachedDatabaseQuery
+
+        if not isinstance(query_class, type) or not issubclass(
+            query_class, CachedDatabaseQuery
+        ):
+            raise TypeError("query_class must be a CachedDatabaseQuery subclass")
+
+        if page_size <= 0:
+            raise ValueError("page_size must be > 0")
+        if delete_batch_size <= 0:
+            raise ValueError("delete_batch_size must be > 0")
+
+        cache_key_prefix = cls.cache_key_prefix_from_format(
+            query_class.CACHE_KEY_FORMAT
+        )
+
+        deleted = 0
+        keys_to_delete = []
+        for key in cls.iter_keys_by_cache_key_prefix(cache_key_prefix, page_size):
+            key_string = key.string_id()
+            if key_string is None:
+                continue
+            key_db_version = cls.db_version_from_key_string(key_string)
+            if key_db_version is None or key_db_version != db_version:
+                continue
+
+            keys_to_delete.append(key)
+            if len(keys_to_delete) >= delete_batch_size:
+                deleted += len(keys_to_delete)
+                ndb.delete_multi(keys_to_delete)
+                keys_to_delete = []
+
+        if keys_to_delete:
+            deleted += len(keys_to_delete)
+            ndb.delete_multi(keys_to_delete)
+
+        return deleted
 
     def _validate_result_properties(self) -> bool:
         """

--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -111,20 +111,7 @@ class CachedQueryResult(ndb.Model):
         if delete_batch_size <= 0:
             raise ValueError("delete_batch_size must be > 0")
 
-        # Validate db_version for safe deletion
-        if db_version <= 0:
-            raise ValueError(
-                f"Cannot delete version {db_version}: must be a positive integer"
-            )
-
-        current_version = CachedDatabaseQuery.DATABASE_QUERY_VERSION
-        min_safe_current = current_version - 1
-        if db_version >= min_safe_current:
-            raise ValueError(
-                f"Cannot delete version {db_version}: must be less than "
-                f"{min_safe_current} (current version {current_version} must "
-                "have at least one prior version as a buffer)"
-            )
+        CachedDatabaseQuery.validate_db_version_for_deletion(db_version)
 
         cache_key_prefix = cls.cache_key_prefix_from_format(
             query_class.CACHE_KEY_FORMAT

--- a/src/backend/common/models/tests/cached_query_result_test.py
+++ b/src/backend/common/models/tests/cached_query_result_test.py
@@ -349,9 +349,12 @@ def test_purge_query_class_global_version_rejects_bad_batch_sizes(ndb_stub) -> N
 def test_purge_query_class_global_version_deletes_only_matching_version(
     ndb_stub,
 ) -> None:
-    old_key = "dummy_purge_query_a:1:4"
-    old_dict_key = "dummy_purge_query_b:1:4~dictv3.0"
-    new_key = "dummy_purge_query_c:1:5"
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    db_version = current_v - 2  # Must be < current_v - 1 to pass validation
+
+    old_key = f"dummy_purge_query_a:1:{db_version}"
+    old_dict_key = f"dummy_purge_query_b:1:{db_version}~dictv3.0"
+    new_key = f"dummy_purge_query_c:1:{current_v}"
     other_prefix_key = "dummy_other_query_z:1:4"
 
     CachedQueryResult(id=old_key, result=None).put()
@@ -361,7 +364,7 @@ def test_purge_query_class_global_version_deletes_only_matching_version(
 
     deleted = CachedQueryResult.purge_query_class_global_version(
         _DummyCachedQueryForPurge,
-        db_version=4,
+        db_version=db_version,
         page_size=10,
         delete_batch_size=2,
     )
@@ -371,3 +374,65 @@ def test_purge_query_class_global_version_deletes_only_matching_version(
     assert CachedQueryResult.get_by_id(old_dict_key) is None
     assert CachedQueryResult.get_by_id(new_key) is not None
     assert CachedQueryResult.get_by_id(other_prefix_key) is not None
+
+
+def test_purge_query_class_global_version_rejects_non_positive_version(
+    ndb_stub,
+) -> None:
+    """Test that version 0 and negative versions are rejected."""
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        CachedQueryResult.purge_query_class_global_version(
+            _DummyCachedQueryForPurge,
+            db_version=0,
+            page_size=100,
+            delete_batch_size=50,
+        )
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        CachedQueryResult.purge_query_class_global_version(
+            _DummyCachedQueryForPurge,
+            db_version=-1,
+            page_size=100,
+            delete_batch_size=50,
+        )
+
+
+def test_purge_query_class_global_version_rejects_recent_version(
+    ndb_stub,
+) -> None:
+    """Test that versions >= (CURRENT_VERSION - 1) are rejected."""
+    current_version = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    min_safe_current = current_version - 1
+
+    # Try to delete the current version (should fail)
+    with pytest.raises(
+        ValueError,
+        match=f"must be less than {min_safe_current}",
+    ):
+        CachedQueryResult.purge_query_class_global_version(
+            _DummyCachedQueryForPurge,
+            db_version=current_version,
+            page_size=100,
+            delete_batch_size=50,
+        )
+
+    # Try to delete the prior version (should fail)
+    with pytest.raises(
+        ValueError,
+        match=f"must be less than {min_safe_current}",
+    ):
+        CachedQueryResult.purge_query_class_global_version(
+            _DummyCachedQueryForPurge,
+            db_version=min_safe_current,
+            page_size=100,
+            delete_batch_size=50,
+        )
+
+    # Older version should succeed (db_version = current - 2)
+    deleted = CachedQueryResult.purge_query_class_global_version(
+        _DummyCachedQueryForPurge,
+        db_version=current_version - 2,
+        page_size=100,
+        delete_batch_size=50,
+    )
+    assert deleted == 0  # No entries created, but validation passed

--- a/src/backend/common/models/tests/cached_query_result_test.py
+++ b/src/backend/common/models/tests/cached_query_result_test.py
@@ -1,10 +1,12 @@
 import logging
+from typing import Any, Generator, List
 
 import pytest
 from google.appengine.ext import ndb
 
 from backend.common.models.cached_model import CachedModel
 from backend.common.models.cached_query_result import CachedQueryResult
+from backend.common.queries.database_query import CachedDatabaseQuery
 
 
 class DummyModelWithRequiredProps(CachedModel):
@@ -13,6 +15,31 @@ class DummyModelWithRequiredProps(CachedModel):
     required_prop = ndb.StringProperty(required=True)
     optional_prop = ndb.StringProperty()
     required_int = ndb.IntegerProperty(required=True)
+
+
+class _DummyQueryClassA:
+    CACHE_KEY_FORMAT = "dummy_query_a_{key}"
+
+
+class _DummyQueryClassB:
+    CACHE_KEY_FORMAT = "dummy_query_b_{x}_{y}"
+
+
+class _DummyQueryClassDuplicatePrefix:
+    CACHE_KEY_FORMAT = "dummy_query_a_{other}"
+
+
+class _DummyCachedQueryForPurge(CachedDatabaseQuery[List[ndb.Model], None]):
+    CACHE_KEY_FORMAT = "dummy_purge_query_{key}"
+    CACHE_VERSION = 1
+    DICT_CONVERTER = None
+
+    @ndb.tasklet
+    def _query_async(self, key: str) -> Generator[Any, Any, List[ndb.Model]]:  # type: ignore[override]
+        future = ndb.Future()
+        future.set_result([])
+        models = yield future
+        return models
 
 
 def test_validate_result_properties_all_set(ndb_stub, caplog) -> None:
@@ -190,3 +217,157 @@ def test_validate_result_properties_mixed_types(ndb_stub, caplog) -> None:
     # No errors should be logged (only valid models are checked)
     assert has_missing_required_properties is False
     assert len(caplog.records) == 0
+
+
+def test_cache_key_prefix_from_format() -> None:
+    cache_key_format = "event_teams_query_{event_key}_{year}"
+    prefix = CachedQueryResult.cache_key_prefix_from_format(cache_key_format)
+    assert prefix == "event_teams_query"
+
+
+def test_cache_key_bounds_from_prefix() -> None:
+    lower, upper = CachedQueryResult.cache_key_bounds_from_prefix("test_prefix")
+    assert lower == "test_prefix_"
+    assert upper == "test_prefix`"
+
+
+def test_all_cache_key_prefixes_from_query_classes() -> None:
+    prefixes = CachedQueryResult.all_cache_key_prefixes_from_query_classes(
+        [_DummyQueryClassA, _DummyQueryClassB, _DummyQueryClassDuplicatePrefix]
+    )
+    assert prefixes == {"dummy_query_a", "dummy_query_b"}
+
+
+def test_iter_keys_by_cache_key_prefix_filters(ndb_stub) -> None:
+    # Matching prefix
+    CachedQueryResult(id="test_prefix_a:1:5", result=None).put()
+    CachedQueryResult(id="test_prefix_b:2:5", result=None).put()
+    CachedQueryResult(id="test_prefix_b:2:5~dictv3.0", result=None).put()
+
+    # Non-matching prefix and malformed keys
+    CachedQueryResult(id="other_prefix_a:1:5", result=None).put()
+    CachedQueryResult(id="testprefix_no_underscore:1:5", result=None).put()
+
+    keys = {
+        key.string_id()
+        for key in CachedQueryResult.iter_keys_by_cache_key_prefix(
+            "test_prefix", page_size=2
+        )
+    }
+
+    assert "test_prefix_a:1:5" in keys
+    assert "test_prefix_b:2:5" in keys
+    assert "test_prefix_b:2:5~dictv3.0" in keys
+    assert "other_prefix_a:1:5" not in keys
+    assert "testprefix_no_underscore:1:5" not in keys
+
+
+def test_iter_keys_by_cache_key_prefix_lexical_bounds(ndb_stub) -> None:
+    # Inside the range
+    CachedQueryResult(id="test_prefix_a:1:5", result=None).put()
+
+    # Outside lower bound (no underscore after prefix)
+    CachedQueryResult(id="test_prefix:1:5", result=None).put()
+
+    # Outside upper bound (starts with prefix followed by backtick)
+    CachedQueryResult(id="test_prefix`a:1:5", result=None).put()
+
+    # Exact lower-bound anchor should be excluded by strict '>'
+    CachedQueryResult(id="test_prefix_", result=None).put()
+
+    keys = {
+        key.string_id()
+        for key in CachedQueryResult.iter_keys_by_cache_key_prefix(
+            "test_prefix", page_size=10
+        )
+    }
+
+    assert "test_prefix_a:1:5" in keys
+    assert "test_prefix:1:5" not in keys
+    assert "test_prefix`a:1:5" not in keys
+    assert "test_prefix_" not in keys
+
+
+def test_iter_keys_by_cache_key_prefix_paginates(ndb_stub) -> None:
+    for i in range(0, 7):
+        CachedQueryResult(id=f"test_page_{i}:1:5", result=None).put()
+
+    keys = {
+        key.string_id()
+        for key in CachedQueryResult.iter_keys_by_cache_key_prefix(
+            "test_page", page_size=3
+        )
+    }
+
+    assert len(keys) == 7
+    for i in range(0, 7):
+        assert f"test_page_{i}:1:5" in keys
+
+
+def test_db_version_from_key_string() -> None:
+    assert CachedQueryResult.db_version_from_key_string("abc:2:5") == 5
+    assert CachedQueryResult.db_version_from_key_string("abc:2:5~dictv3.0") == 5
+    assert CachedQueryResult.db_version_from_key_string("abc:2:not_an_int") is None
+    assert CachedQueryResult.db_version_from_key_string("abc:2") is None
+
+
+def test_query_version_from_key_string() -> None:
+    assert CachedQueryResult.query_version_from_key_string("abc:2:5") == 2
+    assert CachedQueryResult.query_version_from_key_string("abc:2:5~dictv3.0") == 2
+    assert CachedQueryResult.query_version_from_key_string("abc:not_an_int:5") is None
+    assert CachedQueryResult.query_version_from_key_string("abc") is None
+
+
+def test_purge_query_class_global_version_rejects_non_subclass(ndb_stub) -> None:
+    with pytest.raises(TypeError):
+        CachedQueryResult.purge_query_class_global_version(
+            CachedQueryResult,
+            db_version=5,
+            page_size=100,
+            delete_batch_size=50,
+        )
+
+
+def test_purge_query_class_global_version_rejects_bad_batch_sizes(ndb_stub) -> None:
+    with pytest.raises(ValueError):
+        CachedQueryResult.purge_query_class_global_version(
+            _DummyCachedQueryForPurge,
+            db_version=5,
+            page_size=0,
+            delete_batch_size=50,
+        )
+
+    with pytest.raises(ValueError):
+        CachedQueryResult.purge_query_class_global_version(
+            _DummyCachedQueryForPurge,
+            db_version=5,
+            page_size=100,
+            delete_batch_size=0,
+        )
+
+
+def test_purge_query_class_global_version_deletes_only_matching_version(
+    ndb_stub,
+) -> None:
+    old_key = "dummy_purge_query_a:1:4"
+    old_dict_key = "dummy_purge_query_b:1:4~dictv3.0"
+    new_key = "dummy_purge_query_c:1:5"
+    other_prefix_key = "dummy_other_query_z:1:4"
+
+    CachedQueryResult(id=old_key, result=None).put()
+    CachedQueryResult(id=old_dict_key, result=None).put()
+    CachedQueryResult(id=new_key, result=None).put()
+    CachedQueryResult(id=other_prefix_key, result=None).put()
+
+    deleted = CachedQueryResult.purge_query_class_global_version(
+        _DummyCachedQueryForPurge,
+        db_version=4,
+        page_size=10,
+        delete_batch_size=2,
+    )
+
+    assert deleted == 2
+    assert CachedQueryResult.get_by_id(old_key) is None
+    assert CachedQueryResult.get_by_id(old_dict_key) is None
+    assert CachedQueryResult.get_by_id(new_key) is not None
+    assert CachedQueryResult.get_by_id(other_prefix_key) is not None

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -120,6 +120,52 @@ class CachedDatabaseQuery(
             [ndb.Key(CachedQueryResult, cache_key) for cache_key in all_cache_keys]
         )
 
+    @classmethod
+    def get_query_class_by_name(
+        cls, query_class_name: str
+    ) -> Optional[Type[CachedDatabaseQuery]]:
+        """Find a CachedDatabaseQuery subclass by name.
+
+        Args:
+            query_class_name: The name of the query class to find
+
+        Returns:
+            The query class if found, None otherwise
+        """
+        return next(
+            (c for c in cls.__subclasses__() if c.__name__ == query_class_name),
+            None,
+        )
+
+    @classmethod
+    def validate_db_version_for_deletion(cls, db_version: int) -> None:
+        """Validate that db_version is safe to delete.
+
+        Rules:
+        - Must be a positive integer
+        - Must be less than (CURRENT_VERSION - 1), ensuring the prior version
+          is kept as a buffer.
+
+        Args:
+            db_version: The database version to validate
+
+        Raises:
+            ValueError: If db_version is invalid or too recent
+        """
+        if db_version <= 0:
+            raise ValueError(
+                f"Cannot delete version {db_version}: must be a positive integer"
+            )
+
+        current_version = cls.DATABASE_QUERY_VERSION
+        min_safe_current = current_version - 1
+        if db_version >= min_safe_current:
+            raise ValueError(
+                f"Cannot delete version {db_version}: must be less than "
+                f"{min_safe_current} (current version {current_version} must "
+                "have at least one prior version as a buffer)"
+            )
+
     @ndb.tasklet
     def _do_query(self, *args, **kwargs) -> Generator[Any, Any, QueryReturn]:
         if not self.MODEL_CACHING_ENABLED:

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -31,6 +31,8 @@ from backend.web.handlers.admin.cache import (
     cached_query_info,
     cached_query_key_lookup_post,
     cached_query_list,
+    cached_query_purge_class_global_version,
+    cached_query_purge_global_version,
     cached_query_purge_version,
     clear_model_cache,
 )
@@ -241,6 +243,16 @@ admin_routes.add_url_rule(
 admin_routes.add_url_rule(
     "/cache/<query_class_name>/purge/<db_version>/<int:query_version>",
     view_func=cached_query_purge_version,
+)
+admin_routes.add_url_rule(
+    "/cache/<query_class_name>/purge_global/<int:db_version>",
+    methods=["POST"],
+    view_func=cached_query_purge_class_global_version,
+)
+admin_routes.add_url_rule(
+    "/cache/purge_global/<int:db_version>",
+    methods=["POST"],
+    view_func=cached_query_purge_global_version,
 )
 admin_routes.add_url_rule(
     "/cache/clear/<model_type>/<model_key>",

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -242,6 +242,7 @@ admin_routes.add_url_rule(
 )
 admin_routes.add_url_rule(
     "/cache/<query_class_name>/purge/<db_version>/<int:query_version>",
+    methods=["POST"],
     view_func=cached_query_purge_version,
 )
 admin_routes.add_url_rule(

--- a/src/backend/web/handlers/admin/cache.py
+++ b/src/backend/web/handlers/admin/cache.py
@@ -33,7 +33,18 @@ def cached_query_list() -> str:
         for c in CachedDatabaseQuery.__subclasses__()
     }
 
-    template_args = {"cached_queries": cached_queries}
+    current_db_version = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    # Generate list of versions that can be deleted (< current - 1)
+    # and versions that are protected (current and current - 1)
+    protected_versions = [current_db_version, current_db_version - 1]
+    clearable_versions = list(range(1, current_db_version - 1))
+
+    template_args = {
+        "cached_queries": cached_queries,
+        "current_db_version": current_db_version,
+        "protected_versions": protected_versions,
+        "clearable_versions": clearable_versions,
+    }
     return render_template(
         "admin/cached_query_list.html", template_values=template_args
     )

--- a/src/backend/web/handlers/admin/cache.py
+++ b/src/backend/web/handlers/admin/cache.py
@@ -4,6 +4,7 @@ from flask import abort, redirect, request, url_for
 from google.appengine.ext import ndb
 from werkzeug import Response
 
+from backend.common.helpers.deferred import defer_safe
 from backend.common.manipulators.event_details_manipulator import (
     EventDetailsManipulator,
 )
@@ -18,6 +19,20 @@ from backend.common.models.team import Team
 from backend.common.queries.database_query import CachedDatabaseQuery
 from backend.web.profiled_render import render_template
 
+DATASTORE_PAGE_SIZE = 1000
+DATASTORE_DELETE_BATCH_SIZE = 500
+
+
+def _get_cached_query_class(query_class_name: str) -> type[CachedDatabaseQuery] | None:
+    return next(
+        (
+            c
+            for c in CachedDatabaseQuery.__subclasses__()
+            if c.__name__ == query_class_name
+        ),
+        None,
+    )
+
 
 def cached_query_list() -> str:
     cached_queries = {
@@ -28,6 +43,7 @@ def cached_query_list() -> str:
         }
         for c in CachedDatabaseQuery.__subclasses__()
     }
+
     template_args = {"cached_queries": cached_queries}
     return render_template("admin/cached_query_list.html", template_args)
 
@@ -66,48 +82,38 @@ def cached_query_key_lookup_post(query_class_name: str) -> Response:
 
 
 def cached_query_detail(query_class_name: str) -> str:
-    query_class = next(
-        (
-            c
-            for c in CachedDatabaseQuery.__subclasses__()
-            if c.__name__ == query_class_name
-        ),
-        None,
-    )
+    query_class = _get_cached_query_class(query_class_name)
     if query_class is None:
         abort(404)
 
-    cache_key_splits = query_class.CACHE_KEY_FORMAT.split("_")
-    cache_key_prefix_parts = []
-    for part in cache_key_splits:
-        if "{" not in part and "}" not in part:
-            cache_key_prefix_parts.append(part)
-    cache_key_prefix = "_".join(cache_key_prefix_parts)
-    cached_item_keys = (
-        CachedQueryResult.query()
-        .filter(
-            CachedQueryResult.key  # pyre-ignore[58]
-            > ndb.Key(CachedQueryResult, cache_key_prefix)
-        )
-        .filter(
-            CachedQueryResult.key  # pyre-ignore[58]
-            < ndb.Key(CachedQueryResult, cache_key_prefix + "_:")
-        )
-        .fetch(keys_only=True)
+    cache_key_prefix = CachedQueryResult.cache_key_prefix_from_format(
+        query_class.CACHE_KEY_FORMAT
     )
 
     cached_items_by_version = defaultdict(lambda: 0)
-    for item in cached_item_keys:
-        key_split = item.string_id().split(":")
-        query_version = int(key_split[1])
-        global_version = key_split[2]
-        cached_items_by_version[(global_version, query_version)] += 1
+    db_version_counts = defaultdict(lambda: 0)
+    total_records = 0
+    for item in CachedQueryResult.iter_keys_by_cache_key_prefix(
+        cache_key_prefix, DATASTORE_PAGE_SIZE
+    ):
+        total_records += 1
+        key_string = item.string_id()
+        if key_string is None:
+            continue
+        query_version = CachedQueryResult.query_version_from_key_string(key_string)
+        db_version = CachedQueryResult.db_version_from_key_string(key_string)
+        if query_version is None or db_version is None:
+            continue
+        cached_items_by_version[(db_version, query_version)] += 1
+        db_version_counts[db_version] += 1
 
     template_args = {
         "query_class_name": query_class_name,
         "query_class": query_class,
+        "current_db_version": CachedDatabaseQuery.DATABASE_QUERY_VERSION,
+        "db_version_counts": db_version_counts,
         "cached_items_by_version": cached_items_by_version,
-        "total_records": len(cached_item_keys),
+        "total_records": total_records,
     }
     return render_template("admin/cached_query_detail.html", template_args)
 
@@ -139,47 +145,78 @@ def cached_query_delete(query_class_name: str, cache_key: str) -> Response:
 def cached_query_purge_version(
     query_class_name: str, db_version: str, query_version: int
 ) -> Response:
-    query_class = next(
-        (
-            c
-            for c in CachedDatabaseQuery.__subclasses__()
-            if c.__name__ == query_class_name
-        ),
-        None,
-    )
+    query_class = _get_cached_query_class(query_class_name)
     if query_class is None:
         abort(404)
 
-    cache_key_splits = query_class.CACHE_KEY_FORMAT.split("_")
-    cache_key_prefix_parts = []
-    for part in cache_key_splits:
-        if "{" not in part and "}" not in part:
-            cache_key_prefix_parts.append(part)
-    cache_key_prefix = "_".join(cache_key_prefix_parts)
+    target_db_version: int
+    try:
+        target_db_version = int(db_version)
+    except ValueError:
+        abort(400)
+        raise RuntimeError("unreachable")
 
-    cache_key_prefix = "_".join(cache_key_prefix_parts)
-    cached_item_keys = (
-        CachedQueryResult.query()
-        .filter(
-            CachedQueryResult.key  # pyre-ignore[58]
-            > ndb.Key(CachedQueryResult, cache_key_prefix)
-        )
-        .filter(
-            CachedQueryResult.key  # pyre-ignore[58]
-            < ndb.Key(CachedQueryResult, cache_key_prefix + "_:")
-        )
-        .fetch(keys_only=True)
+    cache_key_prefix = CachedQueryResult.cache_key_prefix_from_format(
+        query_class.CACHE_KEY_FORMAT
     )
 
     keys_to_delete = set()
-    for key in cached_item_keys:
-        key_split = key.string_id().split(":")
-        item_query_version = int(key_split[1])
-        item_db_version = key_split[2]
-        if query_version == item_query_version and item_db_version == db_version:
+    for key in CachedQueryResult.iter_keys_by_cache_key_prefix(
+        cache_key_prefix, DATASTORE_PAGE_SIZE
+    ):
+        key_string = key.string_id()
+        if key_string is None:
+            continue
+        item_query_version = CachedQueryResult.query_version_from_key_string(key_string)
+        item_db_version = CachedQueryResult.db_version_from_key_string(key_string)
+        if (
+            item_query_version is not None
+            and item_db_version is not None
+            and query_version == item_query_version
+            and item_db_version == target_db_version
+        ):
             keys_to_delete.add(key)
 
     ndb.delete_multi(keys_to_delete)
+
+    return redirect(
+        url_for("admin.cached_query_detail", query_class_name=query_class_name)
+    )
+
+
+def cached_query_purge_global_version(db_version: int) -> Response:
+    """Enqueue per-class purge tasks for the given DATABASE_QUERY_VERSION.
+
+    We enqueue one task per query class on the cache-clearing queue so each task
+    only scans/deletes one class slice.
+    """
+    for query_class in CachedDatabaseQuery.__subclasses__():
+        defer_safe(
+            CachedQueryResult.purge_query_class_global_version,
+            query_class,
+            db_version,
+            DATASTORE_PAGE_SIZE,
+            DATASTORE_DELETE_BATCH_SIZE,
+            _queue="cache-clearing",
+            _target="py3-tasks-io",
+        )
+
+    return redirect(url_for("admin.cached_query_list"))
+
+
+def cached_query_purge_class_global_version(
+    query_class_name: str, db_version: int
+) -> Response:
+    query_class = _get_cached_query_class(query_class_name)
+    if query_class is None:
+        abort(404)
+
+    CachedQueryResult.purge_query_class_global_version(
+        query_class,
+        db_version,
+        DATASTORE_PAGE_SIZE,
+        DATASTORE_DELETE_BATCH_SIZE,
+    )
 
     return redirect(
         url_for("admin.cached_query_detail", query_class_name=query_class_name)

--- a/src/backend/web/handlers/admin/cache.py
+++ b/src/backend/web/handlers/admin/cache.py
@@ -34,7 +34,9 @@ def cached_query_list() -> str:
     }
 
     template_args = {"cached_queries": cached_queries}
-    return render_template("admin/cached_query_list.html", template_args)
+    return render_template(
+        "admin/cached_query_list.html", template_values=template_args
+    )
 
 
 def cached_query_key_lookup_post(query_class_name: str) -> Response:
@@ -97,7 +99,9 @@ def cached_query_detail(query_class_name: str) -> str:
         "cached_items_by_version": cached_items_by_version,
         "total_records": total_records,
     }
-    return render_template("admin/cached_query_detail.html", template_args)
+    return render_template(
+        "admin/cached_query_detail.html", template_values=template_args
+    )
 
 
 def cached_query_info(query_class_name: str, cache_key: str) -> str:
@@ -110,7 +114,9 @@ def cached_query_info(query_class_name: str, cache_key: str) -> str:
         "cache_key": cache_key,
         "cached_query": cached_query,
     }
-    return render_template("admin/cached_query_info.html", template_args)
+    return render_template(
+        "admin/cached_query_info.html", template_values=template_args
+    )
 
 
 def cached_query_delete(query_class_name: str, cache_key: str) -> Response:

--- a/src/backend/web/handlers/admin/cache.py
+++ b/src/backend/web/handlers/admin/cache.py
@@ -224,11 +224,14 @@ def cached_query_purge_class_global_version(
     except ValueError:
         abort(400)
 
-    CachedQueryResult.purge_query_class_global_version(
+    defer_safe(
+        CachedQueryResult.purge_query_class_global_version,
         query_class,
         db_version,
         DATASTORE_PAGE_SIZE,
         DATASTORE_DELETE_BATCH_SIZE,
+        _queue="cache-clearing",
+        _target="py3-tasks-io",
     )
 
     return redirect(

--- a/src/backend/web/handlers/admin/cache.py
+++ b/src/backend/web/handlers/admin/cache.py
@@ -23,17 +23,6 @@ DATASTORE_PAGE_SIZE = 1000
 DATASTORE_DELETE_BATCH_SIZE = 500
 
 
-def _get_cached_query_class(query_class_name: str) -> type[CachedDatabaseQuery] | None:
-    return next(
-        (
-            c
-            for c in CachedDatabaseQuery.__subclasses__()
-            if c.__name__ == query_class_name
-        ),
-        None,
-    )
-
-
 def cached_query_list() -> str:
     cached_queries = {
         c.__name__: {
@@ -55,14 +44,7 @@ def cached_query_key_lookup_post(query_class_name: str) -> Response:
         abort(400)
 
     if ":" not in cache_key:
-        query_class = next(
-            (
-                c
-                for c in CachedDatabaseQuery.__subclasses__()
-                if c.__name__ == query_class_name
-            ),
-            None,
-        )
+        query_class = CachedDatabaseQuery.get_query_class_by_name(query_class_name)
         if query_class is None:
             abort(404)
 
@@ -82,7 +64,7 @@ def cached_query_key_lookup_post(query_class_name: str) -> Response:
 
 
 def cached_query_detail(query_class_name: str) -> str:
-    query_class = _get_cached_query_class(query_class_name)
+    query_class = CachedDatabaseQuery.get_query_class_by_name(query_class_name)
     if query_class is None:
         abort(404)
 
@@ -145,7 +127,7 @@ def cached_query_delete(query_class_name: str, cache_key: str) -> Response:
 def cached_query_purge_version(
     query_class_name: str, db_version: str, query_version: int
 ) -> Response:
-    query_class = _get_cached_query_class(query_class_name)
+    query_class = CachedDatabaseQuery.get_query_class_by_name(query_class_name)
     if query_class is None:
         abort(404)
 
@@ -154,7 +136,11 @@ def cached_query_purge_version(
         target_db_version = int(db_version)
     except ValueError:
         abort(400)
-        raise RuntimeError("unreachable")
+
+    try:
+        CachedDatabaseQuery.validate_db_version_for_deletion(target_db_version)
+    except ValueError:
+        abort(400)
 
     cache_key_prefix = CachedQueryResult.cache_key_prefix_from_format(
         query_class.CACHE_KEY_FORMAT
@@ -190,6 +176,11 @@ def cached_query_purge_global_version(db_version: int) -> Response:
     We enqueue one task per query class on the cache-clearing queue so each task
     only scans/deletes one class slice.
     """
+    try:
+        CachedDatabaseQuery.validate_db_version_for_deletion(db_version)
+    except ValueError:
+        abort(400)
+
     for query_class in CachedDatabaseQuery.__subclasses__():
         defer_safe(
             CachedQueryResult.purge_query_class_global_version,
@@ -207,9 +198,14 @@ def cached_query_purge_global_version(db_version: int) -> Response:
 def cached_query_purge_class_global_version(
     query_class_name: str, db_version: int
 ) -> Response:
-    query_class = _get_cached_query_class(query_class_name)
+    query_class = CachedDatabaseQuery.get_query_class_by_name(query_class_name)
     if query_class is None:
         abort(404)
+
+    try:
+        CachedDatabaseQuery.validate_db_version_for_deletion(db_version)
+    except ValueError:
+        abort(400)
 
     CachedQueryResult.purge_query_class_global_version(
         query_class,

--- a/src/backend/web/handlers/admin/tests/cache_test.py
+++ b/src/backend/web/handlers/admin/tests/cache_test.py
@@ -1,0 +1,263 @@
+from typing import Any, Generator, List
+
+from google.appengine.ext import ndb
+from werkzeug.test import Client
+
+from backend.common.helpers.deferred import run_from_task
+from backend.common.models.cached_query_result import CachedQueryResult
+from backend.common.queries.database_query import CachedDatabaseQuery
+
+# ---------------------------------------------------------------------------
+# Minimal concrete CachedDatabaseQuery subclass used only in these tests
+# ---------------------------------------------------------------------------
+
+
+class _TestCachedQuery(CachedDatabaseQuery[List[ndb.Model], None]):
+    CACHE_KEY_FORMAT = "test_admin_cache_{key}"
+    CACHE_VERSION = 1
+    DICT_CONVERTER = None
+    CACHE_WRITES_ENABLED = False  # we build keys manually
+
+    @ndb.tasklet
+    def _query_async(self, key: str) -> Generator[Any, Any, List[ndb.Model]]:  # type: ignore[override]
+        future = ndb.Future()
+        future.set_result([])
+        models = yield future
+        return models
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cache_key(partial: str, cache_version: int, db_version: int) -> str:
+    """Build a cache key string identical to CachedDatabaseQuery.cache_key."""
+    return f"{partial}:{cache_version}:{db_version}"
+
+
+def _make_dict_cache_key(
+    partial: str, cache_version: int, db_version: int, api_version: int
+) -> str:
+    """Build a dict-cache key (has a ~dictv suffix)."""
+    base = _make_cache_key(partial, cache_version, db_version)
+    return f"{base}~dictv{api_version}.0"
+
+
+# ---------------------------------------------------------------------------
+# /admin/cache  (GET)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_list_empty(web_client: Client, login_gae_admin, ndb_stub) -> None:
+    resp = web_client.get("/admin/cache")
+    assert resp.status_code == 200
+    assert b"Cached Database Queries" in resp.data
+    assert b"Query Classes" in resp.data
+
+
+def test_cache_list_does_not_render_global_version_stats(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    CachedQueryResult(id=_make_cache_key("test_admin_cache_a", 1, 1), result=None).put()
+
+    resp = web_client.get("/admin/cache")
+    assert resp.status_code == 200
+
+    body = resp.data.decode()
+    assert "Global DATABASE_QUERY_VERSION Stats" not in body
+    assert "/admin/cache/purge_global/" not in body
+
+
+def test_cache_list_renders_with_cached_entries(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    CachedQueryResult(id=_make_cache_key("test_admin_cache_a", 1, 1), result=None).put()
+    CachedQueryResult(
+        id=_make_dict_cache_key("test_admin_cache_a", 1, 1, 3), result=None
+    ).put()
+
+    resp = web_client.get("/admin/cache")
+    assert resp.status_code == 200
+    assert b"Query Classes" in resp.data
+
+
+# ---------------------------------------------------------------------------
+# /admin/cache/purge_global/<db_version>  (POST)
+# ---------------------------------------------------------------------------
+
+
+def test_purge_global_version_redirects(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = current_v - 1
+
+    CachedQueryResult(
+        id=_make_cache_key("test_admin_cache_x", 1, old_v), result=None
+    ).put()
+
+    resp = web_client.post(f"/admin/cache/purge_global/{old_v}")
+    assert resp.status_code == 302
+    assert "/admin/cache" in resp.headers["Location"]
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="cache-clearing")
+    assert len(tasks) == len(CachedDatabaseQuery.__subclasses__())
+
+
+def test_purge_global_version_deletes_old_only(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = current_v - 1
+
+    old_key1 = _make_cache_key("test_admin_cache_a", 1, old_v)
+    old_key2 = _make_cache_key("test_admin_cache_b", 2, old_v)
+    old_dict_key = _make_dict_cache_key("test_admin_cache_a", 1, old_v, 3)
+    current_key = _make_cache_key("test_admin_cache_c", 1, current_v)
+
+    CachedQueryResult(id=old_key1, result=None).put()
+    CachedQueryResult(id=old_key2, result=None).put()
+    CachedQueryResult(id=old_dict_key, result=None).put()
+    CachedQueryResult(id=current_key, result=None).put()
+
+    resp = web_client.post(f"/admin/cache/purge_global/{old_v}")
+    assert resp.status_code == 302
+
+    # Global purge now enqueues deferred tasks; nothing is deleted until they run
+    assert CachedQueryResult.get_by_id(old_key1) is not None
+    assert CachedQueryResult.get_by_id(old_key2) is not None
+    assert CachedQueryResult.get_by_id(old_dict_key) is not None
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="cache-clearing")
+    assert len(tasks) >= 1
+    for task in tasks:
+        run_from_task(task)
+
+    # Old-version entries should be gone
+    assert CachedQueryResult.get_by_id(old_key1) is None
+    assert CachedQueryResult.get_by_id(old_key2) is None
+    assert CachedQueryResult.get_by_id(old_dict_key) is None
+
+    # Current-version entry must survive
+    assert CachedQueryResult.get_by_id(current_key) is not None
+
+
+def test_purge_global_version_noop_when_no_entries(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    """Purging a version that has no entries should not raise and should redirect."""
+    # Use an old but positive version that simply has no data stored
+    old_v = max(1, CachedDatabaseQuery.DATABASE_QUERY_VERSION - 2)
+
+    resp = web_client.post(f"/admin/cache/purge_global/{old_v}")
+    assert resp.status_code == 302
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="cache-clearing")
+    assert len(tasks) == len(CachedDatabaseQuery.__subclasses__())
+
+
+def test_cached_query_detail_normalizes_dict_db_version(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = current_v - 1
+
+    CachedQueryResult(
+        id=_make_cache_key("test_admin_cache_alpha", 1, old_v), result=None
+    ).put()
+    CachedQueryResult(
+        id=_make_dict_cache_key("test_admin_cache_alpha", 1, old_v, 3), result=None
+    ).put()
+
+    resp = web_client.get("/admin/cache/_TestCachedQuery")
+    assert resp.status_code == 200
+
+    body = resp.data.decode()
+    assert f"{old_v}~dictv" not in body
+
+
+def test_purge_version_deletes_dict_entries_for_version(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    old_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION - 1
+
+    plain_key = _make_cache_key("test_admin_cache_alpha", 2, old_v)
+    dict_key = _make_dict_cache_key("test_admin_cache_alpha", 2, old_v, 3)
+    other_version_key = _make_cache_key("test_admin_cache_alpha", 2, old_v + 1)
+
+    CachedQueryResult(id=plain_key, result=None).put()
+    CachedQueryResult(id=dict_key, result=None).put()
+    CachedQueryResult(id=other_version_key, result=None).put()
+
+    resp = web_client.get(f"/admin/cache/_TestCachedQuery/purge/{old_v}/2")
+    assert resp.status_code == 302
+
+    assert CachedQueryResult.get_by_id(plain_key) is None
+    assert CachedQueryResult.get_by_id(dict_key) is None
+    assert CachedQueryResult.get_by_id(other_version_key) is not None
+
+
+def test_purge_global_version_not_accessible_without_login(
+    web_client: Client, ndb_stub
+) -> None:
+    resp = web_client.post("/admin/cache/purge_global/1")
+    assert resp.status_code == 401
+
+
+def test_purge_class_global_version_redirects(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    old_v = max(1, CachedDatabaseQuery.DATABASE_QUERY_VERSION - 1)
+
+    CachedQueryResult(
+        id=_make_cache_key("test_admin_cache_alpha", 1, old_v), result=None
+    ).put()
+
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge_global/{old_v}")
+    assert resp.status_code == 302
+    assert "/admin/cache/_TestCachedQuery" in resp.headers["Location"]
+
+
+def test_purge_class_global_version_deletes_only_matching_class_and_version(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = current_v - 1
+
+    class_old_qv1 = _make_cache_key("test_admin_cache_alpha", 1, old_v)
+    class_old_qv2 = _make_cache_key("test_admin_cache_beta", 2, old_v)
+    class_old_dict = _make_dict_cache_key("test_admin_cache_beta", 2, old_v, 3)
+
+    class_current = _make_cache_key("test_admin_cache_gamma", 1, current_v)
+    other_class_same_version = _make_cache_key("other_prefix_delta", 1, old_v)
+
+    CachedQueryResult(id=class_old_qv1, result=None).put()
+    CachedQueryResult(id=class_old_qv2, result=None).put()
+    CachedQueryResult(id=class_old_dict, result=None).put()
+    CachedQueryResult(id=class_current, result=None).put()
+    CachedQueryResult(id=other_class_same_version, result=None).put()
+
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge_global/{old_v}")
+    assert resp.status_code == 302
+
+    assert CachedQueryResult.get_by_id(class_old_qv1) is None
+    assert CachedQueryResult.get_by_id(class_old_qv2) is None
+    assert CachedQueryResult.get_by_id(class_old_dict) is None
+
+    assert CachedQueryResult.get_by_id(class_current) is not None
+    assert CachedQueryResult.get_by_id(other_class_same_version) is not None
+
+
+def test_purge_class_global_version_not_found(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    resp = web_client.post("/admin/cache/NotARealQuery/purge_global/1")
+    assert resp.status_code == 404
+
+
+def test_purge_class_global_version_not_accessible_without_login(
+    web_client: Client, ndb_stub
+) -> None:
+    resp = web_client.post("/admin/cache/_TestCachedQuery/purge_global/1")
+    assert resp.status_code == 401

--- a/src/backend/web/handlers/admin/tests/cache_test.py
+++ b/src/backend/web/handlers/admin/tests/cache_test.py
@@ -91,7 +91,7 @@ def test_purge_global_version_redirects(
     web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
 ) -> None:
     current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
-    old_v = current_v - 1
+    old_v = current_v - 2  # Must be < current_v - 1 to pass validation
 
     CachedQueryResult(
         id=_make_cache_key("test_admin_cache_x", 1, old_v), result=None
@@ -109,7 +109,7 @@ def test_purge_global_version_deletes_old_only(
     web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
 ) -> None:
     current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
-    old_v = current_v - 1
+    old_v = current_v - 2  # Must be < current_v - 1 to pass validation
 
     old_key1 = _make_cache_key("test_admin_cache_a", 1, old_v)
     old_key2 = _make_cache_key("test_admin_cache_b", 2, old_v)
@@ -180,7 +180,8 @@ def test_cached_query_detail_normalizes_dict_db_version(
 def test_purge_version_deletes_dict_entries_for_version(
     web_client: Client, login_gae_admin, ndb_stub
 ) -> None:
-    old_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION - 1
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = current_v - 2  # Must be < current_v - 1 to pass validation
 
     plain_key = _make_cache_key("test_admin_cache_alpha", 2, old_v)
     dict_key = _make_dict_cache_key("test_admin_cache_alpha", 2, old_v, 3)
@@ -208,7 +209,8 @@ def test_purge_global_version_not_accessible_without_login(
 def test_purge_class_global_version_redirects(
     web_client: Client, login_gae_admin, ndb_stub
 ) -> None:
-    old_v = max(1, CachedDatabaseQuery.DATABASE_QUERY_VERSION - 1)
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = max(1, current_v - 2)  # Must be < current_v - 1 to pass validation
 
     CachedQueryResult(
         id=_make_cache_key("test_admin_cache_alpha", 1, old_v), result=None
@@ -223,7 +225,7 @@ def test_purge_class_global_version_deletes_only_matching_class_and_version(
     web_client: Client, login_gae_admin, ndb_stub
 ) -> None:
     current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
-    old_v = current_v - 1
+    old_v = current_v - 2  # Must be < current_v - 1 to pass validation
 
     class_old_qv1 = _make_cache_key("test_admin_cache_alpha", 1, old_v)
     class_old_qv2 = _make_cache_key("test_admin_cache_beta", 2, old_v)
@@ -261,3 +263,56 @@ def test_purge_class_global_version_not_accessible_without_login(
 ) -> None:
     resp = web_client.post("/admin/cache/_TestCachedQuery/purge_global/1")
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# CachedDatabaseQuery class methods
+# ---------------------------------------------------------------------------
+
+
+def test_get_query_class_by_name_found() -> None:
+    """Test finding a query class by name."""
+    query_class = CachedDatabaseQuery.get_query_class_by_name("_TestCachedQuery")
+    assert query_class is not None
+    assert query_class.__name__ == "_TestCachedQuery"
+    assert query_class is _TestCachedQuery
+
+
+def test_get_query_class_by_name_not_found() -> None:
+    """Test that None is returned for non-existent class."""
+    query_class = CachedDatabaseQuery.get_query_class_by_name("NotARealQueryClass")
+    assert query_class is None
+
+
+def test_validate_db_version_for_deletion_valid() -> None:
+    """Test that old versions are accepted."""
+    current_version = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    # current - 2 should be safe to delete
+    CachedDatabaseQuery.validate_db_version_for_deletion(current_version - 2)
+    # current - 3 should also be safe
+    CachedDatabaseQuery.validate_db_version_for_deletion(current_version - 3)
+
+
+def test_validate_db_version_for_deletion_rejects_positive_rules() -> None:
+    """Test that versions must be positive."""
+    import pytest
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        CachedDatabaseQuery.validate_db_version_for_deletion(0)
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        CachedDatabaseQuery.validate_db_version_for_deletion(-1)
+
+
+def test_validate_db_version_for_deletion_rejects_recent() -> None:
+    """Test that recent versions (current and current-1) are rejected."""
+    import pytest
+
+    current_version = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    min_safe = current_version - 1
+
+    with pytest.raises(ValueError, match=f"must be less than {min_safe}"):
+        CachedDatabaseQuery.validate_db_version_for_deletion(current_version)
+
+    with pytest.raises(ValueError, match=f"must be less than {min_safe}"):
+        CachedDatabaseQuery.validate_db_version_for_deletion(min_safe)

--- a/src/backend/web/handlers/admin/tests/cache_test.py
+++ b/src/backend/web/handlers/admin/tests/cache_test.py
@@ -65,8 +65,27 @@ def test_cache_list_does_not_render_global_version_stats(
     assert resp.status_code == 200
 
     body = resp.data.decode()
+    # Should not show expensive global stats
     assert "Global DATABASE_QUERY_VERSION Stats" not in body
-    assert "/admin/cache/purge_global/" not in body
+    # Should show version management section
+    assert "Global Version Management" in body
+    # Should have purge buttons for clearable versions
+    assert "/admin/cache/purge_global/" in body
+
+
+def test_cache_list_version_management_shows_correct_labels(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    resp = web_client.get("/admin/cache")
+    assert resp.status_code == 200
+
+    body = resp.data.decode()
+    # Should show current version as "Current"
+    assert "Current" in body
+    # Should show prior version as "Prior (Buffer)"
+    assert "Prior (Buffer)" in body
+    # Should show clearable versions as "Clearable"
+    assert "Clearable" in body
 
 
 def test_cache_list_renders_with_cached_entries(
@@ -175,6 +194,26 @@ def test_cached_query_detail_normalizes_dict_db_version(
 
     body = resp.data.decode()
     assert f"{old_v}~dictv" not in body
+
+
+def test_cached_query_detail_breakdown_by_version_hides_protected_purge_links(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    clearable_v = current_v - 2
+
+    clearable_key = _make_cache_key("test_admin_cache_clearable", 1, clearable_v)
+    protected_key = _make_cache_key("test_admin_cache_protected", 1, current_v)
+
+    CachedQueryResult(id=clearable_key, result=None).put()
+    CachedQueryResult(id=protected_key, result=None).put()
+
+    resp = web_client.get("/admin/cache/_TestCachedQuery")
+    assert resp.status_code == 200
+
+    body = resp.data.decode()
+    assert f"/admin/cache/_TestCachedQuery/purge/{clearable_v}/1" in body
+    assert f"/admin/cache/_TestCachedQuery/purge/{current_v}/1" not in body
 
 
 def test_purge_version_deletes_dict_entries_for_version(

--- a/src/backend/web/handlers/admin/tests/cache_test.py
+++ b/src/backend/web/handlers/admin/tests/cache_test.py
@@ -230,12 +230,37 @@ def test_purge_version_deletes_dict_entries_for_version(
     CachedQueryResult(id=dict_key, result=None).put()
     CachedQueryResult(id=other_version_key, result=None).put()
 
-    resp = web_client.get(f"/admin/cache/_TestCachedQuery/purge/{old_v}/2")
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge/{old_v}/2")
     assert resp.status_code == 302
 
     assert CachedQueryResult.get_by_id(plain_key) is None
     assert CachedQueryResult.get_by_id(dict_key) is None
     assert CachedQueryResult.get_by_id(other_version_key) is not None
+
+
+def test_purge_version_rejects_protected_versions(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+
+    # current version is protected
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge/{current_v}/1")
+    assert resp.status_code == 400
+
+    # current - 1 (buffer) is also protected
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge/{current_v - 1}/1")
+    assert resp.status_code == 400
+
+    # version 0 is invalid
+    resp = web_client.post("/admin/cache/_TestCachedQuery/purge/0/1")
+    assert resp.status_code == 400
+
+
+def test_purge_version_not_accessible_without_login(
+    web_client: Client, ndb_stub
+) -> None:
+    resp = web_client.post("/admin/cache/_TestCachedQuery/purge/1/1")
+    assert resp.status_code == 401
 
 
 def test_purge_global_version_not_accessible_without_login(
@@ -246,7 +271,7 @@ def test_purge_global_version_not_accessible_without_login(
 
 
 def test_purge_class_global_version_redirects(
-    web_client: Client, login_gae_admin, ndb_stub
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
 ) -> None:
     current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
     old_v = max(1, current_v - 2)  # Must be < current_v - 1 to pass validation
@@ -261,7 +286,7 @@ def test_purge_class_global_version_redirects(
 
 
 def test_purge_class_global_version_deletes_only_matching_class_and_version(
-    web_client: Client, login_gae_admin, ndb_stub
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
 ) -> None:
     current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
     old_v = current_v - 2  # Must be < current_v - 1 to pass validation
@@ -282,12 +307,55 @@ def test_purge_class_global_version_deletes_only_matching_class_and_version(
     resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge_global/{old_v}")
     assert resp.status_code == 302
 
+    # Per-class purge is now deferred; nothing deleted until tasks run
+    assert CachedQueryResult.get_by_id(class_old_qv1) is not None
+
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="cache-clearing")
+    assert len(tasks) == 1
+    for task in tasks:
+        run_from_task(task)
+
     assert CachedQueryResult.get_by_id(class_old_qv1) is None
     assert CachedQueryResult.get_by_id(class_old_qv2) is None
     assert CachedQueryResult.get_by_id(class_old_dict) is None
 
     assert CachedQueryResult.get_by_id(class_current) is not None
     assert CachedQueryResult.get_by_id(other_class_same_version) is not None
+
+
+def test_purge_class_global_version_defers_task(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    """Per-class global purge should enqueue a task, not delete synchronously."""
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+    old_v = current_v - 2
+
+    old_key = _make_cache_key("test_admin_cache_alpha", 1, old_v)
+    CachedQueryResult(id=old_key, result=None).put()
+
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge_global/{old_v}")
+    assert resp.status_code == 302
+
+    # Must not have been deleted immediately — must be deferred
+    assert CachedQueryResult.get_by_id(old_key) is not None
+    tasks = taskqueue_stub.get_filtered_tasks(queue_names="cache-clearing")
+    assert len(tasks) == 1
+
+
+def test_purge_class_global_version_rejects_protected_versions(
+    web_client: Client, login_gae_admin, ndb_stub
+) -> None:
+    current_v = CachedDatabaseQuery.DATABASE_QUERY_VERSION
+
+    # current version is protected
+    resp = web_client.post(f"/admin/cache/_TestCachedQuery/purge_global/{current_v}")
+    assert resp.status_code == 400
+
+    # current - 1 (buffer) is also protected
+    resp = web_client.post(
+        f"/admin/cache/_TestCachedQuery/purge_global/{current_v - 1}"
+    )
+    assert resp.status_code == 400
 
 
 def test_purge_class_global_version_not_found(

--- a/src/backend/web/templates/admin/cached_query_detail.html
+++ b/src/backend/web/templates/admin/cached_query_detail.html
@@ -41,6 +41,36 @@
 </div>
 
 <div class="row">
+    <h2>Breakdown By DB Version</h2>
+    <table class="table table-striped">
+        <tr>
+            <th>DB Version</th>
+            <th>Number of Records</th>
+            <th></th>
+        </tr>
+        {% for db_version, count in db_version_counts.items() %}
+            <tr>
+                <td>{{db_version}}{% if db_version == current_db_version %} <span class="label label-success">current</span>{% endif %}</td>
+                <td>{{count}}</td>
+                <td>
+                    {% if db_version != current_db_version %}
+                        <form method="post" action="/admin/cache/{{query_class_name}}/purge_global/{{db_version}}" style="display:inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                            <button type="submit" class="btn btn-danger btn-small"
+                                    onclick="return confirm('Delete all {{ count }} record(s) for {{query_class_name}} at DB Version {{db_version}}?')">
+                                <span class="glyphicon glyphicon-trash"></span> Purge DB Version
+                            </button>
+                        </form>
+                    {% else %}
+                        <span class="text-muted">active — cannot purge</span>
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>
+
+<div class="row">
     <h2>Breakdown By Version</h2>
     <table class="table table-striped">
         <tr>

--- a/src/backend/web/templates/admin/cached_query_detail.html
+++ b/src/backend/web/templates/admin/cached_query_detail.html
@@ -53,7 +53,7 @@
                 <td>{{db_version}}{% if db_version == current_db_version %} <span class="label label-success">current</span>{% endif %}</td>
                 <td>{{count}}</td>
                 <td>
-                    {% if db_version != current_db_version %}
+                    {% if db_version < current_db_version - 1 %}
                         <form method="post" action="/admin/cache/{{query_class_name}}/purge_global/{{db_version}}" style="display:inline">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                             <button type="submit" class="btn btn-danger btn-small"
@@ -62,7 +62,7 @@
                             </button>
                         </form>
                     {% else %}
-                        <span class="text-muted">active — cannot purge</span>
+                        <span class="text-muted">protected — cannot purge</span>
                     {% endif %}
                 </td>
             </tr>
@@ -84,7 +84,13 @@
                 <td>{{db_version}}</td>
                 <td>{{query_version}}</td>
                 <td>{{count}}</td>
-                <td><a class="btn btn-danger btn-small" href="/admin/cache/{{query_class_name}}/purge/{{db_version}}/{{query_version}}"><span class="glyphicon glyphicon-trash"></span> Purge</a></td>
+                <td>
+                    {% if db_version < current_db_version - 1 %}
+                        <a class="btn btn-danger btn-small" href="/admin/cache/{{query_class_name}}/purge/{{db_version}}/{{query_version}}"><span class="glyphicon glyphicon-trash"></span> Purge</a>
+                    {% else %}
+                        <span class="text-muted">protected — cannot purge</span>
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
     </table>

--- a/src/backend/web/templates/admin/cached_query_detail.html
+++ b/src/backend/web/templates/admin/cached_query_detail.html
@@ -86,7 +86,13 @@
                 <td>{{count}}</td>
                 <td>
                     {% if db_version < current_db_version - 1 %}
-                        <a class="btn btn-danger btn-small" href="/admin/cache/{{query_class_name}}/purge/{{db_version}}/{{query_version}}"><span class="glyphicon glyphicon-trash"></span> Purge</a>
+                        <form method="post" action="/admin/cache/{{query_class_name}}/purge/{{db_version}}/{{query_version}}" style="display:inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                            <button type="submit" class="btn btn-danger btn-small"
+                                    onclick="return confirm('Delete {{ count }} record(s) for {{query_class_name}} at DB Version {{db_version}}, Query Version {{query_version}}?')">
+                                <span class="glyphicon glyphicon-trash"></span> Purge
+                            </button>
+                        </form>
                     {% else %}
                         <span class="text-muted">protected — cannot purge</span>
                     {% endif %}

--- a/src/backend/web/templates/admin/cached_query_list.html
+++ b/src/backend/web/templates/admin/cached_query_list.html
@@ -35,4 +35,48 @@
     </table>
 </div>
 
+<div class="row">
+    <h2>Global Version Management</h2>
+    <p>Manage database query cache versions globally across all query classes.</p>
+    
+    <table class="table table-striped">
+        <tr>
+            <th>DB Version</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+        <!-- Protected versions -->
+        {% for version in protected_versions | sort(reverse=True) %}
+            <tr>
+                <td>{{version}}</td>
+                <td>
+                    {% if version == current_db_version %}
+                        <span class="label label-success">Current</span>
+                    {% else %}
+                        <span class="label label-warning">Prior (Buffer)</span>
+                    {% endif %}
+                </td>
+                <td><span class="text-muted">Protected &mdash; cannot delete</span></td>
+            </tr>
+        {% endfor %}
+        <!-- Clearable versions -->
+        {% for version in clearable_versions | sort(reverse=True) %}
+            <tr>
+                <td>{{version}}</td>
+                <td><span class="label label-default">Clearable</span></td>
+                <td>
+                    <form method="post" action="/admin/cache/purge_global/{{version}}" style="display:inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                        <button type="submit" class="btn btn-danger btn-sm"
+                                onclick="return confirm('Clear all cache entries for DB Version {{version}} across all query classes?')">
+                            <span class="glyphicon glyphicon-trash"></span> Clear Version
+                        </button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>
+
 {% endblock %}
+

--- a/src/backend/web/templates/admin/cached_query_list.html
+++ b/src/backend/web/templates/admin/cached_query_list.html
@@ -6,13 +6,15 @@
 
 <h1>Cached Database Queries</h1>
 
-<table class="table table-striped">
-    <tr>
-        <th>Query Name</th>
-        <th>Cache Key Format</th>
-        <th>Version</th>
-        <th></th>
-    </tr>
+<div class="row">
+    <h2>Query Classes</h2>
+    <table class="table table-striped">
+        <tr>
+            <th>Query Name</th>
+            <th>Cache Key Format</th>
+            <th>Version</th>
+            <th></th>
+        </tr>
     {% for cached_query in cached_queries.values() %}
         <tr>
             <td><a href="/admin/cache/{{cached_query['class_name']}}">{{cached_query['class_name']}}</a></td>
@@ -30,6 +32,7 @@
             </td>
         </tr>
     {% endfor %}
-</table>
+    </table>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
We have a lot of datastore space dedicated to old `CachedQueryResult`. We should clean up old ones.

This adds some buttons to the admin panel which will let us purge old versions (we ban the current version and N-1)