### PR TITLE
Limit the size of v2 insights

### DIFF
--- a/src/backend/common/helpers/insights_v2/compute.py
+++ b/src/backend/common/helpers/insights_v2/compute.py
@@ -20,6 +20,7 @@ from backend.common.queries.district_query import AllDistrictTeamsQuery
 from backend.common.queries.event_query import EventListQuery
 
 LEADERBOARD_TOP_N = 25
+LEADERBOARD_MAX_KEYS_PER_RANKING = 10
 
 
 def build_leaderboard_rankings(
@@ -40,6 +41,7 @@ def build_leaderboard_rankings(
             value=value,
         )
         for value, keys in sorted(value_to_keys.items(), reverse=True)
+        if value > 1 and len(keys) <= LEADERBOARD_MAX_KEYS_PER_RANKING
     ][:top_n]
 
 
@@ -64,6 +66,7 @@ def build_leaderboard_pair_rankings(
             value=value,
         )
         for value, pairs in sorted(value_to_pairs.items(), reverse=True)
+        if value > 1 and len(pairs) <= LEADERBOARD_MAX_KEYS_PER_RANKING
     ][:top_n]
 
 

--- a/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/blue_banners_test.py
@@ -12,7 +12,8 @@ def test_blue_banners_year(ndb_stub, test_data_importer) -> None:
     insight = insights[0]
     assert insight.name == "blue_banners"
     assert insight.display_name == "Total Blue Banners"
-    assert len(insight.data["rankings"]) > 0
+    # A single event yields value=1 per team, which is filtered out by design
+    assert insight.data["rankings"] == []
 
 
 def test_blue_banners_overall(ndb_stub, test_data_importer) -> None:

--- a/src/backend/common/helpers/tests/insights_v2/leaderboard_v2_calculator_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboard_v2_calculator_test.py
@@ -4,7 +4,9 @@ from google.appengine.ext import ndb
 
 from backend.common.helpers.insights_v2.compute import (
     _build_team_district_map,
+    build_leaderboard_pair_rankings,
     build_leaderboard_rankings,
+    LEADERBOARD_MAX_KEYS_PER_RANKING,
     LeaderboardV2Calculator,
 )
 from backend.common.models.district import District
@@ -105,6 +107,44 @@ def test_district_key_name(ndb_stub) -> None:
         "2024_v2_leaderboard_most_matches_played",
         "2024_v2_leaderboard_most_matches_played_ne",
     }
+
+
+def test_rankings_excludes_value_of_one() -> None:
+    assert build_leaderboard_rankings({"frc1": 1, "frc2": 2}) == [
+        LeaderboardRankingV2(keys=["frc2"], value=2),
+    ]
+
+
+def test_rankings_excludes_groups_exceeding_max_keys() -> None:
+    counts = {f"frc{i}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING + 1)}
+    assert build_leaderboard_rankings(counts) == []
+
+
+def test_rankings_includes_group_at_max_keys() -> None:
+    counts = {f"frc{i}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING)}
+    result = build_leaderboard_rankings(counts)
+    assert len(result) == 1
+    assert len(result[0]["keys"]) == LEADERBOARD_MAX_KEYS_PER_RANKING
+
+
+def test_pair_rankings_excludes_value_of_one() -> None:
+    assert build_leaderboard_pair_rankings({"frc1|frc2": 1, "frc3|frc4": 2}) == [
+        LeaderboardRankingV2(keys=[["frc3", "frc4"]], value=2),
+    ]
+
+
+def test_pair_rankings_excludes_groups_exceeding_max_keys() -> None:
+    counts = {
+        f"frc{i}|frc{i + 1}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING + 1)
+    }
+    assert build_leaderboard_pair_rankings(counts) == []
+
+
+def test_pair_rankings_includes_group_at_max_keys() -> None:
+    counts = {f"frc{i}|frc{i + 1}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING)}
+    result = build_leaderboard_pair_rankings(counts)
+    assert len(result) == 1
+    assert len(result[0]["keys"]) == LEADERBOARD_MAX_KEYS_PER_RANKING
 
 
 def test_district_uses_most_recent_district_team(ndb_stub) -> None:


### PR DESCRIPTION
The 'most matches played together' insight I added yesterday has a boatload of team pairs that only played 1 match together. this solution is 2 pronged - make sure any insight has >1 value and make sure that there are not more than 10 teams/pairs/whatever involved. if its extremely common, its probably not worth showing