### PR TITLE
Insight v2 bugfixes

### DIFF
--- a/src/backend/common/helpers/insights_v2/compute.py
+++ b/src/backend/common/helpers/insights_v2/compute.py
@@ -5,6 +5,7 @@ from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Set, Tuple
 from google.appengine.ext import ndb
 
 from backend.common.consts.event_type import SEASON_EVENT_TYPES
+from backend.common.consts.renamed_districts import RenamedDistricts
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.event import Event
 from backend.common.models.insight_v2 import (
@@ -85,7 +86,9 @@ def _build_team_district_map(team_keys: Iterable[str]) -> Dict[str, str]:
             team_district_teams[str(dt.team.id())].append(dt)
 
     return {
-        team_key: str(max(dts, key=lambda dt: dt.year).district_key.id())[4:]
+        team_key: RenamedDistricts.get_latest_code(
+            str(max(dts, key=lambda dt: dt.year).district_key.id())[4:]
+        )
         for team_key, dts in team_district_teams.items()
     }
 

--- a/src/backend/common/helpers/insights_v2/qualifying_event_streak.py
+++ b/src/backend/common/helpers/insights_v2/qualifying_event_streak.py
@@ -1,17 +1,10 @@
-from typing import Dict, List, Set
+from typing import Set
 
 from backend.common.consts.award_type import AwardType
 from backend.common.consts.event_type import EventType
 from backend.common.helpers.insights_v2.streak_calculator import StreakV2Calculator
 from backend.common.models.event import Event
-from backend.common.models.insight_v2 import (
-    InsightCategory,
-    InsightV2,
-    InsightV2NameEntry,
-    InsightV2Names,
-    StreakData,
-)
-from backend.common.models.keys import Year
+from backend.common.models.insight_v2 import InsightV2NameEntry, InsightV2Names
 
 _QUALIFYING_EVENT_TYPES = {EventType.REGIONAL, EventType.DISTRICT}
 
@@ -42,42 +35,3 @@ class LongestQualifyingEventStreakV2Calculator(StreakV2Calculator):
             for team_key in match.team_key_names:
                 if team_key not in winners:
                     self._reset_streak(team_key)
-
-    def make_insights(
-        self, year: Year, team_to_district: Dict[str, str]
-    ) -> List[InsightV2]:
-        # Build the full sorted list once; use it for both global and district scopes
-        all_entries = self._build_streak_entries()
-        if not all_entries:
-            return []
-
-        name = self.insight_name
-        insights: List[InsightV2] = [
-            InsightV2(
-                id=InsightV2.render_key_name(year, InsightCategory.STREAK, name.name),
-                name=name.name,
-                display_name=name.display_name,
-                year=year,
-                category=InsightCategory.STREAK,
-                data_json=StreakData(entries=all_entries),
-            )
-        ]
-
-        for district_abbrev, d_entries in sorted(
-            self._build_district_entries(all_entries, team_to_district).items()
-        ):
-            insights.append(
-                InsightV2(
-                    id=InsightV2.render_key_name(
-                        year, InsightCategory.STREAK, name.name, district_abbrev
-                    ),
-                    name=name.name,
-                    display_name=name.display_name,
-                    year=year,
-                    category=InsightCategory.STREAK,
-                    district_abbreviation=district_abbrev,
-                    data_json=StreakData(entries=d_entries),
-                )
-            )
-
-        return insights

--- a/src/backend/common/helpers/insights_v2/streak_calculator.py
+++ b/src/backend/common/helpers/insights_v2/streak_calculator.py
@@ -3,7 +3,13 @@ from collections import defaultdict
 from typing import Dict, List, NamedTuple, Set
 
 from backend.common.helpers.insights_v2.compute import InsightV2Calculator
-from backend.common.models.insight_v2 import InsightV2, StreakEntry
+from backend.common.models.insight_v2 import (
+    InsightCategory,
+    InsightV2,
+    InsightV2NameEntry,
+    StreakData,
+    StreakEntry,
+)
 from backend.common.models.keys import Year
 
 STREAK_TOP_N = 25
@@ -27,6 +33,10 @@ class StreakV2Calculator(InsightV2Calculator):
         self._best: Dict[str, _StreakRecord] = {}
 
     @property
+    @abstractmethod
+    def insight_name(self) -> InsightV2NameEntry: ...
+
+    @property
     def team_keys(self) -> Set[str]:
         return set(self._best.keys())
 
@@ -46,10 +56,11 @@ class StreakV2Calculator(InsightV2Calculator):
         """Break key's active streak."""
         self._active.pop(key, None)
 
-    def _build_streak_entries(self, top_n: int = STREAK_TOP_N) -> List[StreakEntry]:
+    def _build_streak_entries(self) -> List[StreakEntry]:
         """
-        Returns up to top_n StreakEntry items, sorted by streak_length descending
-        then by team number ascending. Flushes still-active streaks first.
+        Returns all StreakEntry items sorted by streak_length descending then by
+        team number ascending. Callers are responsible for slicing to their desired
+        top-N. Flushes still-active streaks first.
         """
         for key, active in self._active.items():
             if key not in self._best or active.length > self._best[key].length:
@@ -75,7 +86,7 @@ class StreakV2Calculator(InsightV2Calculator):
             )
 
         entries.sort(key=lambda e: (-e["streak_length"], int(e["key"][3:])))
-        return entries[:top_n]
+        return entries
 
     def _build_district_entries(
         self,
@@ -95,7 +106,42 @@ class StreakV2Calculator(InsightV2Calculator):
                     bucket.append(entry)
         return dict(district_entries)
 
-    @abstractmethod
     def make_insights(
         self, year: Year, team_to_district: Dict[str, str]
-    ) -> List[InsightV2]: ...
+    ) -> List[InsightV2]:
+        # Build all entries sorted; slice to top-N for global, but pass the full
+        # list to district grouping so each district gets its own independent top-N.
+        all_entries = self._build_streak_entries()
+        if not all_entries:
+            return []
+
+        name = self.insight_name
+        insights: List[InsightV2] = [
+            InsightV2(
+                id=InsightV2.render_key_name(year, InsightCategory.STREAK, name.name),
+                name=name.name,
+                display_name=name.display_name,
+                year=year,
+                category=InsightCategory.STREAK,
+                data_json=StreakData(entries=all_entries[:STREAK_TOP_N]),
+            )
+        ]
+
+        for district_abbrev, d_entries in sorted(
+            self._build_district_entries(all_entries, team_to_district).items()
+        ):
+            insights.append(
+                InsightV2(
+                    id=InsightV2.render_key_name(
+                        year, InsightCategory.STREAK, name.name, district_abbrev
+                    ),
+                    name=name.name,
+                    display_name=name.display_name,
+                    year=year,
+                    category=InsightCategory.STREAK,
+                    district_abbreviation=district_abbrev,
+                    data_json=StreakData(entries=d_entries),
+                )
+            )
+
+        return insights

--- a/src/backend/common/helpers/tests/insights_v2/leaderboard_v2_calculator_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboard_v2_calculator_test.py
@@ -147,6 +147,36 @@ def test_pair_rankings_includes_group_at_max_keys() -> None:
     assert len(result[0]["keys"]) == LEADERBOARD_MAX_KEYS_PER_RANKING
 
 
+def test_renamed_district_normalized_to_latest_code(ndb_stub) -> None:
+    # Teams whose most recent DistrictTeam record uses the old abbreviation (e.g. "chs")
+    # should be normalized to the current abbreviation ("fch") so they are bucketed
+    # together with teams whose records already use the new code.
+    district_key_old = "2022chs"
+    district_key_new = "2024fch"
+    District(id=district_key_old, year=2022, abbreviation="chs").put()
+    District(id=district_key_new, year=2024, abbreviation="fch").put()
+
+    # frc1 last seen under the old "chs" code
+    DistrictTeam(
+        id=f"{district_key_old}_frc1",
+        team=ndb.Key(Team, "frc1"),
+        year=2022,
+        district_key=ndb.Key(District, district_key_old),
+    ).put()
+
+    # frc2 already on the new "fch" code
+    DistrictTeam(
+        id=f"{district_key_new}_frc2",
+        team=ndb.Key(Team, "frc2"),
+        year=2024,
+        district_key=ndb.Key(District, district_key_new),
+    ).put()
+
+    result = _build_team_district_map(["frc1", "frc2"])
+    # Both teams must map to the canonical "fch" abbreviation, not split across "chs"/"fch"
+    assert result == {"frc1": "fch", "frc2": "fch"}
+
+
 def test_district_uses_most_recent_district_team(ndb_stub) -> None:
     district_key_ont = "2018ont"
     district_key_ne = "2024ne"

--- a/src/backend/common/helpers/tests/insights_v2/qualifying_event_streak_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/qualifying_event_streak_test.py
@@ -52,11 +52,6 @@ def _put_match(event_key: str, year: int, team_keys: list) -> None:
     ).put()
 
 
-def test_no_insights_for_specific_year(ndb_stub) -> None:
-    calc = LongestQualifyingEventStreakV2Calculator()
-    assert calc.make_insights(2024, {}) == []
-
-
 def test_consecutive_wins_build_streak(ndb_stub) -> None:
     _put_event("2022nyny", 2022, EventType.REGIONAL)
     _put_winner_award("2022nyny", 2022, ["frc254"])
@@ -71,9 +66,7 @@ def test_consecutive_wins_build_streak(ndb_stub) -> None:
     )
 
     assert len(insights) == 1
-    entries = insights[0].data["entries"]
-    assert len(entries) >= 1
-    top = entries[0]
+    top = insights[0].data["entries"][0]
     assert top["key"] == "frc254"
     assert top["key_type"] == "team"
     assert top["streak_length"] == 2
@@ -209,30 +202,6 @@ def test_district_events_count_toward_streak(ndb_stub) -> None:
     top = insights[0].data["entries"][0]
     assert top["key"] == "frc254"
     assert top["streak_length"] == 2
-
-
-def test_insight_uses_streak_category(ndb_stub) -> None:
-    _put_event("2022nyny", 2022, EventType.REGIONAL)
-    _put_winner_award("2022nyny", 2022, ["frc254"])
-    _put_match("2022nyny", 2022, ["frc254", "frc1", "frc2", "frc3", "frc4", "frc5"])
-
-    insights = compute_insights_for_year(
-        0, [LongestQualifyingEventStreakV2Calculator()]
-    )
-
-    assert insights[0].category == "streak"
-    assert insights[0].name == "qualifying_event_win_streak"
-
-
-def test_key_name(ndb_stub) -> None:
-    _put_event("2022nyny", 2022, EventType.REGIONAL)
-    _put_winner_award("2022nyny", 2022, ["frc254"])
-    _put_match("2022nyny", 2022, ["frc254", "frc1", "frc2", "frc3", "frc4", "frc5"])
-
-    insights = compute_insights_for_year(
-        0, [LongestQualifyingEventStreakV2Calculator()]
-    )
-    assert insights[0].key_name == "0_v2_streak_qualifying_event_win_streak"
 
 
 def test_real_data_frc1796_streak(ndb_stub, test_data_importer) -> None:

--- a/src/backend/common/helpers/tests/insights_v2/streak_v2_calculator_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/streak_v2_calculator_test.py
@@ -1,0 +1,164 @@
+from google.appengine.ext import ndb
+
+from backend.common.helpers.insights_v2.compute import _build_team_district_map
+from backend.common.helpers.insights_v2.streak_calculator import (
+    STREAK_TOP_N,
+    StreakV2Calculator,
+)
+from backend.common.models.district import District
+from backend.common.models.district_team import DistrictTeam
+from backend.common.models.event import Event
+from backend.common.models.insight_v2 import (
+    InsightCategory,
+    InsightV2NameEntry,
+    InsightV2Names,
+)
+from backend.common.models.team import Team
+
+
+class _StubStreak(StreakV2Calculator):
+    """Minimal concrete subclass used to exercise base-class behaviour."""
+
+    @property
+    def insight_name(self) -> InsightV2NameEntry:
+        return InsightV2Names.QUALIFYING_EVENT_WIN_STREAK
+
+    def on_event(self, event: Event) -> None:
+        pass
+
+
+def test_no_data_returns_no_insights() -> None:
+    assert _StubStreak().make_insights(2024, {}) == []
+
+
+def test_advance_streak_builds_entry(ndb_stub) -> None:
+    calc = _StubStreak()
+    calc._advance_streak("frc1", "2024eve1")
+    calc._advance_streak("frc1", "2024eve2")
+
+    entries = calc.make_insights(2024, {})[0].data["entries"]
+    assert entries[0]["key"] == "frc1"
+    assert entries[0]["key_type"] == "team"
+    assert entries[0]["streak_length"] == 2
+    assert entries[0]["start"] == "2024eve1"
+    assert entries[0]["end"] == "2024eve2"
+    assert entries[0]["is_active"] is True
+
+
+def test_reset_streak_marks_inactive_and_preserves_best(ndb_stub) -> None:
+    calc = _StubStreak()
+    calc._advance_streak("frc1", "2023eve1")
+    calc._advance_streak("frc1", "2023eve2")
+    calc._reset_streak("frc1")
+
+    entries = calc.make_insights(2024, {})[0].data["entries"]
+    assert entries[0]["streak_length"] == 2
+    assert entries[0]["start"] == "2023eve1"
+    assert entries[0]["end"] == "2023eve2"
+    assert entries[0]["is_active"] is False
+
+
+def test_entries_sorted_by_length_then_team_number(ndb_stub) -> None:
+    calc = _StubStreak()
+    calc._advance_streak("frc100", "e1")
+    calc._advance_streak("frc5", "e1")
+    calc._advance_streak("frc5", "e2")
+
+    entries = calc.make_insights(2024, {})[0].data["entries"]
+    assert [e["key"] for e in entries] == ["frc5", "frc100"]
+
+
+def test_entries_with_equal_length_sorted_by_team_number(ndb_stub) -> None:
+    calc = _StubStreak()
+    for team in ["frc100", "frc5", "frc50"]:
+        calc._advance_streak(team, "e1")
+
+    entries = calc.make_insights(2024, {})[0].data["entries"]
+    assert [e["key"] for e in entries] == ["frc5", "frc50", "frc100"]
+
+
+def test_global_top_n_truncates(ndb_stub) -> None:
+    calc = _StubStreak()
+    for i in range(STREAK_TOP_N + 5):
+        calc._advance_streak(f"frc{i + 1}", "e1")
+
+    entries = calc.make_insights(2024, {})[0].data["entries"]
+    assert len(entries) == STREAK_TOP_N
+
+
+def test_district_insight_created(ndb_stub) -> None:
+    calc = _StubStreak()
+    calc._advance_streak("frc1", "e1")
+    calc._advance_streak("frc1", "e2")
+    calc._advance_streak("frc2", "e1")
+
+    insights = calc.make_insights(2024, {"frc1": "ne", "frc2": "ne"})
+    assert len(insights) == 2
+    district_insight = next(i for i in insights if i.district_abbreviation == "ne")
+    assert [e["key"] for e in district_insight.data["entries"]] == ["frc1", "frc2"]
+
+
+def test_district_top_n_independent_of_global_top_n(ndb_stub) -> None:
+    calc = _StubStreak()
+    # Fill the global top-N with non-district teams at streak length 3
+    for i in range(STREAK_TOP_N):
+        for label in ["e1", "e2", "e3"]:
+            calc._advance_streak(f"frc{9000 + i}", label)
+    # District team with streak 2 ranks outside the global top-N
+    calc._advance_streak("frc1", "e1")
+    calc._advance_streak("frc1", "e2")
+
+    insights = calc.make_insights(2024, {"frc1": "ne"})
+    global_insight = next(i for i in insights if i.district_abbreviation is None)
+    district_insight = next(i for i in insights if i.district_abbreviation == "ne")
+
+    assert "frc1" not in [e["key"] for e in global_insight.data["entries"]]
+    assert district_insight.data["entries"][0]["key"] == "frc1"
+
+
+def test_insight_category_is_streak(ndb_stub) -> None:
+    calc = _StubStreak()
+    calc._advance_streak("frc1", "e1")
+    assert calc.make_insights(2024, {})[0].category == InsightCategory.STREAK
+
+
+def test_key_name(ndb_stub) -> None:
+    calc = _StubStreak()
+    calc._advance_streak("frc1", "e1")
+    insights = calc.make_insights(2024, {"frc1": "ne"})
+    assert {i.key_name for i in insights} == {
+        "2024_v2_streak_qualifying_event_win_streak",
+        "2024_v2_streak_qualifying_event_win_streak_ne",
+    }
+
+
+def test_renamed_district_normalized_to_latest_code(ndb_stub) -> None:
+    # frc1 last seen under the old "chs" code; frc2 already on the renamed "fch" code.
+    # Both teams should be grouped into a single district insight under "fch".
+    District(id="2022chs", year=2022, abbreviation="chs").put()
+    District(id="2024fch", year=2024, abbreviation="fch").put()
+    DistrictTeam(
+        id="2022chs_frc1",
+        team=ndb.Key(Team, "frc1"),
+        year=2022,
+        district_key=ndb.Key(District, "2022chs"),
+    ).put()
+    DistrictTeam(
+        id="2024fch_frc2",
+        team=ndb.Key(Team, "frc2"),
+        year=2024,
+        district_key=ndb.Key(District, "2024fch"),
+    ).put()
+
+    calc = _StubStreak()
+    calc._advance_streak("frc1", "e1")
+    calc._advance_streak("frc1", "e2")
+    calc._advance_streak("frc2", "e1")
+
+    team_to_district = _build_team_district_map(calc.team_keys)
+    insights = calc.make_insights(2024, team_to_district)
+
+    district_insights = [i for i in insights if i.district_abbreviation is not None]
+    assert len(district_insights) == 1
+    assert district_insights[0].district_abbreviation == "fch"
+    assert {e["key"] for e in district_insights[0].data["entries"]} == {"frc1", "frc2"}


### PR DESCRIPTION
- supports renamed districts
- now have N longest streaks per district, rather than taking the N longest global streaks and grouping them by district