### PR TITLE
Fix 2025 match breakdown score location only showing teleop for trough

### DIFF
--- a/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2025.html
+++ b/src/backend/web/templates/match_partials/match_breakdown/match_breakdown_2025.html
@@ -460,13 +460,13 @@
     </tr>
     <tr>
       <td class="red">
-        {{match.score_breakdown.red.teleopReef.trough}}
+        {{match.score_breakdown.red.autoReef.trough + match.score_breakdown.red.teleopReef.trough}}
       </td>
       <td>
         Trough (L1)
       </td>
       <td class="blue">
-        {{match.score_breakdown.blue.teleopReef.trough}}
+        {{match.score_breakdown.blue.autoReef.trough + match.score_breakdown.blue.teleopReef.trough}}
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Spotted when doing code review for https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/1087 - the scoring location breakdown for 2025 only includes the teleop trough count. Based on the levels above showing auto with the green boxes - this trough count should probably be cumulative for the entire match, not just teleop.