### PR TITLE
Allow for devices to be removed via ping. Add backend endpoint to dry run to remove unregistered devices

### DIFF
--- a/src/backend/api/handlers/client_api.py
+++ b/src/backend/api/handlers/client_api.py
@@ -149,9 +149,13 @@ def ping_mobile_client(req: PingRequest) -> BaseResponse:
         )
     else:
         client: MobileClient = clients[0]
-        success, valid_client = TBANSHelper.ping(client)
-        if success:
+        result = TBANSHelper.ping(client)
+        if result == "sent":
             return BaseResponse(code=200, message="Ping sent")
+        elif result == "deleted":
+            return BaseResponse(
+                code=410, message="Token was unregistered; client removed"
+            )
         else:
             return BaseResponse(code=500, message="Failed to ping client")
 

--- a/src/backend/api/handlers/tests/client_api_ping_test.py
+++ b/src/backend/api/handlers/tests/client_api_ping_test.py
@@ -39,7 +39,7 @@ def test_ping_client(api_client: Client, mock_clientapi_auth: User, ndb_stub) ->
     ).put()
 
     with patch.object(TBANSHelper, "ping") as mock_ping:
-        mock_ping.return_value = (True, True)
+        mock_ping.return_value = "sent"
         req = PingRequest(
             mobile_id="abc123",
         )
@@ -61,10 +61,34 @@ def test_ping_client_fails(
     ).put()
 
     with patch.object(TBANSHelper, "ping") as mock_ping:
-        mock_ping.return_value = (False, False)
+        mock_ping.return_value = "failed"
         req = PingRequest(
             mobile_id="abc123",
         )
         resp = make_clientapi_request(api_client, "/ping", req)
 
     assert resp["code"] == 500
+
+
+def test_ping_client_deleted(
+    api_client: Client, mock_clientapi_auth: User, ndb_stub
+) -> None:
+    """When TBANSHelper.ping cleans up a dead token, the API returns 410 Gone
+    so the calling client can react (e.g. drop its cached token)."""
+    MobileClient(
+        parent=mock_clientapi_auth.account_key,
+        user_id=str(mock_clientapi_auth.uid),
+        messaging_id="abc123",
+        client_type=ClientType.TEST,
+        device_uuid="asdf",
+        display_name="Test Device",
+    ).put()
+
+    with patch.object(TBANSHelper, "ping") as mock_ping:
+        mock_ping.return_value = "deleted"
+        req = PingRequest(
+            mobile_id="abc123",
+        )
+        resp = make_clientapi_request(api_client, "/ping", req)
+
+    assert resp["code"] == 410

--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import logging
 import time
+from typing import Literal
 
 import firebase_admin
 from firebase_admin.exceptions import FirebaseError
@@ -13,6 +14,7 @@ from backend.common.consts.notification_type import (
     ENABLED_TEAM_NOTIFICATIONS,
     NotificationType,
 )
+from backend.common.environment import Environment
 from backend.common.helpers.deferred import defer_safe
 from backend.common.models.district import District
 from backend.common.models.event import Event
@@ -48,6 +50,10 @@ from backend.common.queries.mobile_client_query import MobileClientQuery
 
 MAXIMUM_BACKOFF = 32
 MATCH_UPCOMING_MINUTES = datetime.timedelta(minutes=-7)
+
+# `"deleted"` means the ping surfaced a token-dead FCM error (UnregisteredError /
+# SenderIdMismatchError) and the MobileClient was removed as a side effect.
+PingResult = Literal["sent", "deleted", "failed"]
 
 
 class _NotificationMode(enum.Flag):
@@ -511,42 +517,136 @@ class TBANSHelper:
         )
 
     @staticmethod
-    def ping(client: MobileClient) -> tuple[bool, bool]:
-        """Immediately dispatch a Ping to either FCM or a webhook"""
+    def ping(client: MobileClient) -> PingResult:
+        """Immediately dispatch a Ping to either FCM or a webhook.
+
+        Returns `"deleted"` when an FCM ping surfaces a token-dead error and
+        the MobileClient row was removed as a result. Webhooks never return
+        `"deleted"` — webhook failure semantics aren't FCM-shaped.
+        """
         if client.client_type == ClientType.WEBHOOK:
             return TBANSHelper._ping_webhook(client)
         else:
             return TBANSHelper._ping_client(client)
 
     @staticmethod
-    def _ping_client(client: MobileClient) -> tuple[bool, bool]:
+    def _ping_client(client: MobileClient) -> PingResult:
         client_type = client.client_type
-        if client_type in FCM_CLIENTS:
-            notification = PingNotification()
-
-            fcm_request = FCMRequest(
-                firebase_app,
-                notification,
-                tokens=[client.messaging_id],
-            )
-
-            batch_response = fcm_request.send()
-            if batch_response.failure_count > 0:
-                return (False, False)
-        else:
+        if client_type not in FCM_CLIENTS:
             raise Exception("Unsupported FCM client type: {}".format(client_type))
 
-        return (True, True)
+        # Local-dev shortcut: prefix a MobileClient's messaging_id with one of
+        # these tokens in the dev datastore to exercise each PingResult path
+        # without needing FCM behavior. No-op outside `GAE_ENV=localdev`.
+        #
+        #   DEBUG_SENT_*    -> "sent"     (success banner)
+        #   DEBUG_FAILED_*  -> "failed"   (red banner)
+        #   DEBUG_DELETED_* -> "deleted"  (yellow banner; row removed)
+        if Environment.is_dev() and client.messaging_id.startswith("DEBUG_"):
+            if client.messaging_id.startswith("DEBUG_DELETED"):
+                logging.warning(
+                    f"[DEV PING SHORTCUT] simulating 'deleted' for {client.messaging_id}"
+                )
+                MobileClientQuery.delete_for_messaging_id(client.messaging_id)
+                return "deleted"
+            if client.messaging_id.startswith("DEBUG_FAILED"):
+                logging.warning(
+                    f"[DEV PING SHORTCUT] simulating 'failed' for {client.messaging_id}"
+                )
+                return "failed"
+            if client.messaging_id.startswith("DEBUG_SENT"):
+                logging.warning(
+                    f"[DEV PING SHORTCUT] simulating 'sent' for {client.messaging_id}"
+                )
+                return "sent"
 
-    @staticmethod
-    def _ping_webhook(client: MobileClient) -> tuple[bool, bool]:
-        notification = PingNotification()
-
-        webhook_request = WebhookRequest(
-            notification, client.messaging_id, client.secret
+        fcm_request = FCMRequest(
+            firebase_app,
+            PingNotification(),
+            tokens=[client.messaging_id],
         )
 
-        return webhook_request.send()
+        batch_response = fcm_request.send()
+        if batch_response.failure_count == 0:
+            return "sent"
+
+        # Mirror the cleanup behavior in `_send_fcm`: a ping that surfaces a
+        # token-dead error means the device is no longer reachable, so prune it
+        # from the user's Connected Devices list.
+        from firebase_admin.messaging import (
+            SenderIdMismatchError,
+            UnregisteredError,
+        )
+
+        exception = batch_response.responses[0].exception
+        if isinstance(exception, (UnregisteredError, SenderIdMismatchError)):
+            logging.info(f"Ping deleting mobile client with ID: {client.messaging_id}")
+            MobileClientQuery.delete_for_messaging_id(client.messaging_id)
+            return "deleted"
+
+        return "failed"
+
+    @staticmethod
+    def _ping_webhook(client: MobileClient) -> PingResult:
+        webhook_request = WebhookRequest(
+            PingNotification(), client.messaging_id, client.secret
+        )
+        success, _valid_url = webhook_request.send()
+        return "sent" if success else "failed"
+
+    @classmethod
+    def probe_and_cleanup_fcm_clients(cls, clients: list[MobileClient]) -> int:
+        """Send a dry-run FCM probe to each FCM client and delete the ones
+        whose tokens come back as `UnregisteredError` or
+        `SenderIdMismatchError`.
+
+        Returns the count of deleted clients.
+        """
+        fcm_clients = [c for c in clients if c.client_type in FCM_CLIENTS]
+        if not fcm_clients:
+            return 0
+
+        # Local-dev shortcut: skip the real FCM probe and treat anything with
+        # `DEBUG_DELETED` in its messaging_id as a dead token. Lets the admin
+        # button be exercised end-to-end without working FCM credentials.
+        if Environment.is_dev():
+            deleted = 0
+            for client in fcm_clients:
+                if client.messaging_id.startswith("DEBUG_DELETED"):
+                    logging.warning(
+                        f"[DEV PROBE SHORTCUT] deleting {client.messaging_id}"
+                    )
+                    MobileClientQuery.delete_for_messaging_id(client.messaging_id)
+                    deleted += 1
+            return deleted
+
+        fcm_request = FCMRequest(
+            firebase_app,
+            PingNotification(),
+            tokens=[c.messaging_id for c in fcm_clients],
+            dry_run=True,
+        )
+        batch_response = fcm_request.send()
+
+        from firebase_admin.messaging import (
+            SenderIdMismatchError,
+            UnregisteredError,
+        )
+
+        deleted = 0
+        for index, response in enumerate(batch_response.responses):
+            if response.success:
+                continue
+            client = fcm_clients[index]
+            if isinstance(
+                response.exception, (UnregisteredError, SenderIdMismatchError)
+            ):
+                logging.info(
+                    f"Probe deleting mobile client with ID: {client.messaging_id}"
+                )
+                MobileClientQuery.delete_for_messaging_id(client.messaging_id)
+                deleted += 1
+        return deleted
 
     @classmethod
     def schedule_upcoming_match(cls, match_key: str) -> None:

--- a/src/backend/common/helpers/tests/tbans_helper_test.py
+++ b/src/backend/common/helpers/tests/tbans_helper_test.py
@@ -881,11 +881,11 @@ class TestTBANSHelper(unittest.TestCase):
         )
 
         with patch.object(
-            TBANSHelper, "_ping_client", return_value=True
+            TBANSHelper, "_ping_client", return_value="sent"
         ) as mock_ping_client:
-            success = TBANSHelper.ping(client)
+            result = TBANSHelper.ping(client)
             mock_ping_client.assert_called_once_with(client)
-            assert success
+            assert result == "sent"
 
     def test_ping_webhook(self):
         client = MobileClient(
@@ -898,11 +898,11 @@ class TestTBANSHelper(unittest.TestCase):
         )
 
         with patch.object(
-            TBANSHelper, "_ping_webhook", return_value=True
+            TBANSHelper, "_ping_webhook", return_value="sent"
         ) as mock_ping_webhook:
-            success = TBANSHelper.ping(client)
+            result = TBANSHelper.ping(client)
             mock_ping_webhook.assert_called_once_with(client)
-            assert success
+            assert result == "sent"
 
     def test_ping_fcm(self):
         client = MobileClient(
@@ -925,11 +925,11 @@ class TestTBANSHelper(unittest.TestCase):
             ) as mock_fcm_request_constructor,
             patch.object(FCMRequest, "send", return_value=batch_response) as mock_send,
         ):
-            success = TBANSHelper._ping_client(client)
+            result = TBANSHelper._ping_client(client)
 
             mock_fcm_request_constructor.assert_called_once()
             mock_send.assert_called_once()
-            assert success
+            assert result == "sent"
 
     def test_ping_fcm_fail(self):
         client = MobileClient(
@@ -945,10 +945,76 @@ class TestTBANSHelper(unittest.TestCase):
             [messaging.SendResponse(None, FirebaseError(500, "testing"))]
         )
         with patch.object(FCMRequest, "send", return_value=batch_response) as mock_send:
-            success, is_valid = TBANSHelper._ping_client(client)
+            result = TBANSHelper._ping_client(client)
             mock_send.assert_called_once()
-            assert not success
-            assert not is_valid
+            assert result == "failed"
+
+    def test_ping_fcm_unregistered_deletes(self):
+        """A ping that comes back UnregisteredError prunes the MobileClient row
+        and returns "deleted", so the user-facing UI can surface the cleanup."""
+        account_key = ndb.Key(Account, "user_id")
+        client = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="token",
+            client_type=ClientType.OS_IOS,
+            device_uuid="uuid",
+            display_name="Phone",
+        )
+        client.put()
+
+        batch_response = messaging.BatchResponse(
+            [messaging.SendResponse(None, UnregisteredError("code", "message"))]
+        )
+        with patch.object(FCMRequest, "send", return_value=batch_response):
+            result = TBANSHelper._ping_client(client)
+
+        assert result == "deleted"
+        assert MobileClient.query(ancestor=account_key).count() == 0
+
+    def test_ping_fcm_sender_mismatch_deletes(self):
+        account_key = ndb.Key(Account, "user_id")
+        client = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="token",
+            client_type=ClientType.OS_IOS,
+            device_uuid="uuid",
+            display_name="Phone",
+        )
+        client.put()
+
+        batch_response = messaging.BatchResponse(
+            [messaging.SendResponse(None, SenderIdMismatchError("code", "message"))]
+        )
+        with patch.object(FCMRequest, "send", return_value=batch_response):
+            result = TBANSHelper._ping_client(client)
+
+        assert result == "deleted"
+        assert MobileClient.query(ancestor=account_key).count() == 0
+
+    def test_ping_fcm_transient_error_does_not_delete(self):
+        """Transient FCM errors (InternalError, UnavailableError) should NOT
+        prune the row — the device may still be reachable on retry."""
+        account_key = ndb.Key(Account, "user_id")
+        client = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="token",
+            client_type=ClientType.OS_IOS,
+            device_uuid="uuid",
+            display_name="Phone",
+        )
+        client.put()
+
+        batch_response = messaging.BatchResponse(
+            [messaging.SendResponse(None, InternalError("internal-fcm-error"))]
+        )
+        with patch.object(FCMRequest, "send", return_value=batch_response):
+            result = TBANSHelper._ping_client(client)
+
+        assert result == "failed"
+        assert MobileClient.query(ancestor=account_key).count() == 1
 
     def test_ping_webhook_success(self):
         client = MobileClient(
@@ -967,10 +1033,9 @@ class TestTBANSHelper(unittest.TestCase):
         with patch.object(
             WebhookRequest, "send", return_value=(True, True)
         ) as mock_send:
-            success, is_valid = TBANSHelper._ping_webhook(client)
+            result = TBANSHelper._ping_webhook(client)
             mock_send.assert_called_once()
-            assert success
-            assert is_valid
+            assert result == "sent"
 
     def test_ping_webhook_failure(self):
         client = MobileClient(
@@ -986,10 +1051,119 @@ class TestTBANSHelper(unittest.TestCase):
             WebhookRequest,
         )
 
-        with patch.object(WebhookRequest, "send", return_value=False) as mock_send:
-            success = TBANSHelper._ping_webhook(client)
+        with patch.object(
+            WebhookRequest, "send", return_value=(False, False)
+        ) as mock_send:
+            result = TBANSHelper._ping_webhook(client)
             mock_send.assert_called_once()
-            assert not success
+            assert result == "failed"
+
+    def test_probe_and_cleanup_no_clients(self):
+        with patch.object(FCMRequest, "send") as mock_send:
+            deleted = TBANSHelper.probe_and_cleanup_fcm_clients([])
+        assert deleted == 0
+        mock_send.assert_not_called()
+
+    def test_probe_and_cleanup_skips_webhooks(self):
+        """Webhook clients are filtered out before the FCM call — webhook failure
+        semantics aren't FCM-shaped and a homelab outage shouldn't drop a hook."""
+        webhook = MobileClient(
+            parent=ndb.Key(Account, "user_id"),
+            user_id="user_id",
+            messaging_id="https://example.com/webhook",
+            client_type=ClientType.WEBHOOK,
+            display_name="Webhook",
+        )
+        with patch.object(FCMRequest, "send") as mock_send:
+            deleted = TBANSHelper.probe_and_cleanup_fcm_clients([webhook])
+        assert deleted == 0
+        mock_send.assert_not_called()
+
+    def test_probe_and_cleanup_deletes_unregistered(self):
+        account_key = ndb.Key(Account, "user_id")
+        valid = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="valid-token",
+            client_type=ClientType.OS_IOS,
+            device_uuid="uuid-a",
+            display_name="iPhone",
+        )
+        unregistered = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="dead-token",
+            client_type=ClientType.OS_IOS,
+            device_uuid="uuid-b",
+            display_name="iPhone",
+        )
+        sender_mismatch = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="mismatch-token",
+            client_type=ClientType.OS_ANDROID_FCM,
+            device_uuid="uuid-c",
+            display_name="Pixel",
+        )
+        valid.put()
+        unregistered.put()
+        sender_mismatch.put()
+
+        batch_response = messaging.BatchResponse(
+            [
+                messaging.SendResponse({"name": "msg-1"}, None),
+                messaging.SendResponse(None, UnregisteredError("code", "message")),
+                messaging.SendResponse(None, SenderIdMismatchError("code", "message")),
+            ]
+        )
+
+        captured_kwargs = {}
+
+        def capture_init(self, app, notification, tokens=None, dry_run=False):
+            captured_kwargs["tokens"] = tokens
+            captured_kwargs["dry_run"] = dry_run
+
+        with (
+            patch.object(FCMRequest, "__init__", capture_init),
+            patch.object(FCMRequest, "send", return_value=batch_response),
+        ):
+            deleted = TBANSHelper.probe_and_cleanup_fcm_clients(
+                [valid, unregistered, sender_mismatch]
+            )
+
+        assert deleted == 2
+        assert captured_kwargs["dry_run"] is True
+        assert captured_kwargs["tokens"] == [
+            "valid-token",
+            "dead-token",
+            "mismatch-token",
+        ]
+        remaining = MobileClient.query(ancestor=account_key).fetch()
+        assert len(remaining) == 1
+        assert remaining[0].messaging_id == "valid-token"
+
+    def test_probe_and_cleanup_keeps_clients_on_transient_error(self):
+        """InternalError / UnavailableError mean FCM had a hiccup, not that the
+        token is dead. Don't delete on those."""
+        account_key = ndb.Key(Account, "user_id")
+        client = MobileClient(
+            parent=account_key,
+            user_id="user_id",
+            messaging_id="token",
+            client_type=ClientType.OS_IOS,
+            device_uuid="uuid",
+            display_name="iPhone",
+        )
+        client.put()
+
+        batch_response = messaging.BatchResponse(
+            [messaging.SendResponse(None, InternalError("internal-fcm-error"))]
+        )
+        with patch.object(FCMRequest, "send", return_value=batch_response):
+            deleted = TBANSHelper.probe_and_cleanup_fcm_clients([client])
+
+        assert deleted == 0
+        assert MobileClient.query(ancestor=account_key).count() == 1
 
     def test_send_webhook_test_not_webhook_client(self):
         client = MobileClient(

--- a/src/backend/common/models/notifications/requests/fcm_request.py
+++ b/src/backend/common/models/notifications/requests/fcm_request.py
@@ -14,7 +14,7 @@ class FCMRequest(Request):
         tokens (list, string): The FCM registration tokens (up to 500) to send a message to.
     """
 
-    def __init__(self, app, notification, tokens=None):
+    def __init__(self, app, notification, tokens=None, dry_run: bool = False):
         """
         Note:
             Should only supply one delivery method - either token, topic, or connection.
@@ -22,6 +22,9 @@ class FCMRequest(Request):
             app (firebase_admin.App): The Firebase app to send to.
             notification (Notification): The Notification to send.
             tokens (list, string): The FCM registration tokens (up to 100) to send a message to.
+            dry_run (bool): If True, validate tokens with FCM without delivering. Used by
+                cleanup probes to check token validity silently; success/error responses
+                mirror a real send (UnregisteredError still surfaces).
         """
         super(FCMRequest, self).__init__(notification=notification)
 
@@ -35,10 +38,11 @@ class FCMRequest(Request):
             )
 
         self.tokens = tokens
+        self.dry_run = dry_run
 
     def __str__(self):
-        return "FCMRequest(tokens={}, notification={})".format(
-            self.tokens, str(self.notification)
+        return "FCMRequest(tokens={}, notification={}, dry_run={})".format(
+            self.tokens, str(self.notification), self.dry_run
         )
 
     def send(self):
@@ -46,8 +50,10 @@ class FCMRequest(Request):
         Returns:
             messaging.BatchResponse - Batch response object for the messages sent.
         """
-        response = messaging.send_each_for_multicast(self._fcm_message(), app=self._app)
-        if response.success_count > 0:
+        response = messaging.send_each_for_multicast(
+            self._fcm_message(), app=self._app, dry_run=self.dry_run
+        )
+        if response.success_count > 0 and not self.dry_run:
             try:
                 self.defer_track_notification(response.success_count)
             except Exception:

--- a/src/backend/common/models/notifications/requests/tests/fcm_request_test.py
+++ b/src/backend/common/models/notifications/requests/tests/fcm_request_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 from firebase_admin import messaging
@@ -48,7 +48,10 @@ def test_init_delivery_too_many_tokens(fcm_app):
 
 def test_str(fcm_app):
     request = FCMRequest(fcm_app, notification=MockNotification(), tokens=["abc"])
-    assert "FCMRequest(tokens=['abc'], notification=MockNotification())" == str(request)
+    assert (
+        "FCMRequest(tokens=['abc'], notification=MockNotification(), dry_run=False)"
+        == str(request)
+    )
 
 
 def test_send(fcm_app):
@@ -104,6 +107,28 @@ def test_send_failed_partial(fcm_app):
         response = request.send()
     mock_send.assert_called_once()
     mock_track.assert_called_once_with(1)
+    assert response == batch_response
+
+
+def test_send_dry_run_passes_kwarg_and_skips_tracking(fcm_app):
+    """A dry-run send goes through the same FCM path but must (a) pass
+    `dry_run=True` so FCM validates without delivering, and (b) skip the
+    notification-tracking deferred so probe runs don't pollute metrics."""
+    batch_response = messaging.BatchResponse(
+        [messaging.SendResponse({"name": "abc"}, None)]
+    )
+    request = FCMRequest(
+        fcm_app, notification=MockNotification(), tokens=["abc"], dry_run=True
+    )
+    with (
+        patch.object(
+            messaging, "send_each_for_multicast", return_value=batch_response
+        ) as mock_send,
+        patch.object(request, "defer_track_notification") as mock_track,
+    ):
+        response = request.send()
+    mock_send.assert_called_once_with(ANY, app=fcm_app, dry_run=True)
+    mock_track.assert_not_called()
     assert response == batch_response
 
 

--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -57,7 +57,7 @@ def overview() -> str:
         "webhook_verification_success": request.args.get(
             "webhook_verification_success"
         ),
-        "ping_sent": session.pop("ping_sent", None),
+        "ping_result": session.pop("ping_result", None),
         "ping_enabled": NotificationsEnable.notifications_enabled(),
         "auth_write_type_names": AUTH_TYPE_WRITE_TYPE_NAMES,
     }
@@ -550,17 +550,12 @@ def ping():
         int(mobile_client_id), parent=none_throws(user.account_key)
     )
     if client is None:
-        session["ping_sent"] = "0"
+        session["ping_result"] = "failed"
         return response
 
     from backend.common.helpers.tbans_helper import TBANSHelper
 
-    success, valid_url = TBANSHelper.ping(client)
-    if success:
-        session["ping_sent"] = "1"
-    else:
-        session["ping_sent"] = "0"
-
+    session["ping_result"] = TBANSHelper.ping(client)
     return response
 
 

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -94,6 +94,7 @@ from backend.web.handlers.admin.media import (
 from backend.web.handlers.admin.mobile_clients import (
     mobile_clients_dashboard,
     mobile_clients_dedupe_post,
+    mobile_clients_probe_cleanup_post,
 )
 from backend.web.handlers.admin.regional_champs_pool import regional_champs_pool_list
 from backend.web.handlers.admin.sitevars import (
@@ -483,6 +484,11 @@ admin_routes.add_url_rule(
 admin_routes.add_url_rule(
     "/mobile_clients/dedupe",
     view_func=mobile_clients_dedupe_post,
+    methods=["POST"],
+)
+admin_routes.add_url_rule(
+    "/mobile_clients/probe_cleanup",
+    view_func=mobile_clients_probe_cleanup_post,
     methods=["POST"],
 )
 admin_routes.add_url_rule("/user/<user_id>", view_func=user_detail)

--- a/src/backend/web/handlers/admin/mobile_clients.py
+++ b/src/backend/web/handlers/admin/mobile_clients.py
@@ -8,9 +8,11 @@ from werkzeug import Response
 from backend.common.consts.client_type import ClientType, NAMES as CLIENT_TYPE_NAMES
 from backend.common.helpers.deferred import defer_safe
 from backend.common.models.mobile_client import MobileClient
+from backend.common.models.notifications.requests.fcm_request import MAXIMUM_TOKENS
 from backend.web.profiled_render import render_template
 
 DEDUPE_PAGE_SIZE = 500
+PROBE_PAGE_SIZE = MAXIMUM_TOKENS
 
 
 def mobile_clients_dashboard() -> str:
@@ -111,4 +113,65 @@ def _dedupe_mobile_clients(
         )
     else:
         logging.info(f"MobileClient dedupe complete: {total_deleted} deleted")
+    return total_deleted
+
+
+def mobile_clients_probe_cleanup_post() -> Response:
+    defer_safe(
+        _probe_and_cleanup_mobile_clients,
+        _queue="admin",
+        _target="py3-tasks-io",
+    )
+    flash(
+        "Enqueued MobileClient probe-and-cleanup task. Pages self-defer; "
+        "watch logs for per-page deletion counts."
+    )
+    return redirect(url_for("admin.mobile_clients_dashboard"))
+
+
+def _probe_and_cleanup_mobile_clients(
+    cursor_urlsafe: str | None = None,
+    page_size: int = PROBE_PAGE_SIZE,
+    total_deleted: int = 0,
+) -> int:
+    """
+    Paginated scan over MobileClient: each page is sent to FCM as a
+    `dry_run=True` multicast probe. Tokens that come back with
+    `UnregisteredError` or `SenderIdMismatchError` are dead and the
+    corresponding rows are deleted via `MobileClientQuery.delete_for_messaging_id`
+    (cross-account-safe — FCM tokens are globally unique).
+
+    Webhooks are filtered out before the FCM call (see
+    `TBANSHelper.probe_and_cleanup_fcm_clients`); webhook failure semantics
+    aren't FCM-shaped and we don't want a homelab outage to drop registrations.
+
+    Self-defers the next page until the scan completes. Returns the running
+    deletion total (the cumulative total is logged on completion).
+    """
+    from backend.common.helpers.tbans_helper import TBANSHelper
+
+    # pyre-ignore[16]: pyre stubs don't list ndb.Cursor, but it exists at runtime
+    cursor = ndb.Cursor(urlsafe=cursor_urlsafe) if cursor_urlsafe else None
+    page, next_cursor, more = MobileClient.query().fetch_page(
+        page_size, start_cursor=cursor
+    )
+
+    deleted = TBANSHelper.probe_and_cleanup_fcm_clients(list(page))
+    total_deleted += deleted
+    logging.info(
+        f"MobileClient probe page: deleted {deleted} "
+        f"(running total: {total_deleted})"
+    )
+
+    if more and next_cursor is not None:
+        defer_safe(
+            _probe_and_cleanup_mobile_clients,
+            cursor_urlsafe=next_cursor.urlsafe(),
+            page_size=page_size,
+            total_deleted=total_deleted,
+            _queue="admin",
+            _target="py3-tasks-io",
+        )
+    else:
+        logging.info(f"MobileClient probe complete: {total_deleted} deleted")
     return total_deleted

--- a/src/backend/web/handlers/admin/tests/mobile_clients_test.py
+++ b/src/backend/web/handlers/admin/tests/mobile_clients_test.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch
+
+from firebase_admin import messaging
+from firebase_admin.exceptions import InternalError
+from firebase_admin.messaging import UnregisteredError
 from google.appengine.ext import ndb
 from werkzeug.test import Client
 
@@ -5,7 +10,11 @@ from backend.common.consts.client_type import ClientType
 from backend.common.helpers.deferred import run_from_task
 from backend.common.models.account import Account
 from backend.common.models.mobile_client import MobileClient
-from backend.web.handlers.admin.mobile_clients import _dedupe_mobile_clients
+from backend.common.models.notifications.requests.fcm_request import FCMRequest
+from backend.web.handlers.admin.mobile_clients import (
+    _dedupe_mobile_clients,
+    _probe_and_cleanup_mobile_clients,
+)
 
 
 def test_dashboard_requires_admin(web_client: Client) -> None:
@@ -197,3 +206,141 @@ def test_dedupe_paginates(ndb_stub, taskqueue_stub) -> None:
     assert rows_one[0].messaging_id == "token-a"
     assert len(rows_two) == 1
     assert rows_two[0].messaging_id == "token-b"
+
+
+def test_probe_cleanup_post_enqueues_task(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    account_key = ndb.Key(Account, "user1")
+    MobileClient(
+        parent=account_key,
+        user_id="user1",
+        messaging_id="dead-token",
+        client_type=ClientType.OS_IOS,
+        device_uuid="uuid-a",
+        display_name="iPhone",
+    ).put()
+
+    batch_response = messaging.BatchResponse(
+        [messaging.SendResponse(None, UnregisteredError("code", "message"))]
+    )
+    with patch.object(FCMRequest, "send", return_value=batch_response):
+        resp = web_client.post("/admin/mobile_clients/probe_cleanup")
+        assert resp.status_code == 302
+
+        tasks = taskqueue_stub.get_filtered_tasks(queue_names="admin")
+        assert len(tasks) == 1
+        run_from_task(tasks[0])
+
+    rows = MobileClient.query(ancestor=account_key).fetch()
+    assert len(rows) == 0
+
+
+def test_probe_cleanup_skips_webhooks(ndb_stub) -> None:
+    """Webhooks must not be probed via FCM — their failure semantics are
+    different. The probe helper filters them out before the FCM call, so
+    a page containing only webhooks doesn't trigger a send at all."""
+    account_key = ndb.Key(Account, "user1")
+    MobileClient(
+        parent=account_key,
+        user_id="user1",
+        messaging_id="https://example.com/webhook",
+        client_type=ClientType.WEBHOOK,
+        device_uuid="",
+        display_name="Webhook",
+    ).put()
+
+    with patch.object(FCMRequest, "send") as mock_send:
+        deleted = _probe_and_cleanup_mobile_clients()
+
+    assert deleted == 0
+    mock_send.assert_not_called()
+    rows = MobileClient.query(ancestor=account_key).fetch()
+    assert len(rows) == 1
+
+
+def test_probe_cleanup_keeps_valid_clients(ndb_stub) -> None:
+    """Mixed page: an FCM success leaves the row, an UnregisteredError prunes
+    it, a transient InternalError keeps it (the next probe run can retry)."""
+    account_key = ndb.Key(Account, "user1")
+    MobileClient(
+        parent=account_key,
+        user_id="user1",
+        messaging_id="valid",
+        client_type=ClientType.OS_IOS,
+        device_uuid="uuid-a",
+        display_name="iPhone",
+    ).put()
+    MobileClient(
+        parent=account_key,
+        user_id="user1",
+        messaging_id="dead",
+        client_type=ClientType.OS_IOS,
+        device_uuid="uuid-b",
+        display_name="iPhone",
+    ).put()
+    MobileClient(
+        parent=account_key,
+        user_id="user1",
+        messaging_id="hiccup",
+        client_type=ClientType.OS_ANDROID_FCM,
+        device_uuid="uuid-c",
+        display_name="Pixel",
+    ).put()
+
+    batch_response = messaging.BatchResponse(
+        [
+            messaging.SendResponse({"name": "msg-1"}, None),
+            messaging.SendResponse(None, UnregisteredError("code", "message")),
+            messaging.SendResponse(None, InternalError("internal-fcm-error")),
+        ]
+    )
+    with patch.object(FCMRequest, "send", return_value=batch_response):
+        deleted = _probe_and_cleanup_mobile_clients()
+
+    assert deleted == 1
+    remaining = MobileClient.query(ancestor=account_key).fetch()
+    assert sorted(c.messaging_id for c in remaining) == ["hiccup", "valid"]
+
+
+def test_probe_cleanup_paginates(ndb_stub, taskqueue_stub) -> None:
+    """With more rows than page_size, probe self-defers and the deferred
+    tasks complete the scan."""
+    account_key = ndb.Key(Account, "user1")
+    for i in range(3):
+        MobileClient(
+            parent=account_key,
+            user_id="user1",
+            messaging_id=f"token-{i}",
+            client_type=ClientType.OS_IOS,
+            device_uuid=f"uuid-{i}",
+            display_name="iPhone",
+        ).put()
+
+    # Force two-row pages so 3 rows → 2 pages.
+    with patch.object(FCMRequest, "send") as mock_send:
+        # Page 1: two rows → two error responses.
+        # Page 2: one row → one error response.
+        mock_send.side_effect = [
+            messaging.BatchResponse(
+                [
+                    messaging.SendResponse(None, UnregisteredError("c", "m")),
+                    messaging.SendResponse(None, UnregisteredError("c", "m")),
+                ]
+            ),
+            messaging.BatchResponse(
+                [messaging.SendResponse(None, UnregisteredError("c", "m"))]
+            ),
+        ]
+        _probe_and_cleanup_mobile_clients(page_size=2)
+
+        # Drain the self-deferred follow-up page.
+        while True:
+            tasks = taskqueue_stub.get_filtered_tasks(queue_names="admin")
+            if not tasks:
+                break
+            for task in tasks:
+                run_from_task(task)
+            taskqueue_stub.FlushQueue("admin")
+
+    assert MobileClient.query(ancestor=account_key).count() == 0

--- a/src/backend/web/handlers/tests/account_overview_test.py
+++ b/src/backend/web/handlers/tests/account_overview_test.py
@@ -89,7 +89,7 @@ def test_overview(
     context_keys = {
         "status",
         "webhook_verification_success",
-        "ping_sent",
+        "ping_result",
         "ping_enabled",
         "auth_write_type_names",
         "user",
@@ -222,17 +222,31 @@ def test_overview_no_webhook_verification_success(
     assert webhook_row is None
 
 
-@pytest.mark.parametrize("ping_sent, success", [("1", True), ("0", False)])
-def test_overview_ping_sent(
+@pytest.mark.parametrize(
+    "ping_result, alert_class, title, message",
+    [
+        ("sent", "alert-success", "Success!", "Ping was sent."),
+        (
+            "deleted",
+            "alert-warning",
+            "Device unreachable",
+            "We removed it from your Connected Devices.",
+        ),
+        ("failed", "alert-danger", "Failure", "Failed to send ping."),
+    ],
+)
+def test_overview_ping_result(
     login_user,
-    ping_sent: str,
-    success: bool,
+    ping_result: str,
+    alert_class: str,
+    title: str,
+    message: str,
     captured_templates: List[CapturedTemplate],
     web_client: FlaskClient,
 ) -> None:
     with web_client:
         with web_client.session_transaction() as session:
-            session["ping_sent"] = ping_sent
+            session["ping_result"] = ping_result
         response = web_client.get("/account")
 
     assert response.status_code == 200
@@ -241,20 +255,17 @@ def test_overview_ping_sent(
     template = captured_templates[0][0]
     context = captured_templates[0][1]
     assert template.name == "account_overview.html"
-    assert context["ping_sent"] == ping_sent
+    assert context["ping_result"] == ping_result
 
     soup = bs4.BeautifulSoup(response.data, "html.parser")
     ping_row = soup.find(id="ping-row", attrs={"class": "row"})
     ping_alert = ping_row.find("div", attrs={"class": "alert"})
-    assert_alert(
-        ping_alert,
-        ("Success!" if success else "Failure"),
-        ("Ping was sent." if success else "Failed to send ping."),
-        success,
-    )
+    assert alert_class in ping_alert.attrs["class"]
+    assert ping_alert.find("h4").text == title
+    assert ping_alert.find("p").text == message
 
 
-def test_overview_no_ping_sent(
+def test_overview_no_ping_result(
     login_user,
     captured_templates: List[CapturedTemplate],
     web_client: FlaskClient,
@@ -267,7 +278,7 @@ def test_overview_no_ping_sent(
     template = captured_templates[0][0]
     context = captured_templates[0][1]
     assert template.name == "account_overview.html"
-    assert context["ping_sent"] is None
+    assert context["ping_result"] is None
 
     soup = bs4.BeautifulSoup(response.data, "html.parser")
     ping_row = soup.find(id="ping-row", attrs={"class": "row"})

--- a/src/backend/web/handlers/tests/account_test.py
+++ b/src/backend/web/handlers/tests/account_test.py
@@ -636,12 +636,9 @@ def test_mytba(
     assert context["year"] == mock_year
 
 
-@pytest.mark.parametrize(
-    "ping_sent, expected", [((True, True), "1"), ((False, True), "0")]
-)
+@pytest.mark.parametrize("ping_result", ["sent", "deleted", "failed"])
 def test_ping_client(
-    ping_sent,
-    expected,
+    ping_result,
     login_user,
     captured_templates: List[CapturedTemplate],
     web_client: FlaskClient,
@@ -656,7 +653,7 @@ def test_ping_client(
 
     with (
         web_client,
-        patch.object(TBANSHelper, "ping", return_value=ping_sent) as mock_ping,
+        patch.object(TBANSHelper, "ping", return_value=ping_result) as mock_ping,
     ):
         response = web_client.post(
             "/account/ping", data={"mobile_client_id": c1.key.id()}
@@ -665,7 +662,7 @@ def test_ping_client(
     mock_ping.assert_called_with(c1)
 
     with web_client.session_transaction() as session:
-        assert session.get("ping_sent") == expected
+        assert session.get("ping_result") == ping_result
 
     assert response.status_code == 302
     parsed_response = urlparse(response.headers["Location"])
@@ -693,7 +690,7 @@ def test_ping_not_our_client(
 
     with (
         web_client,
-        patch.object(TBANSHelper, "ping", return_value=(True, True)) as mock_ping,
+        patch.object(TBANSHelper, "ping", return_value="sent") as mock_ping,
     ):
         response = web_client.post(
             "/account/ping", data={"mobile_client_id": c1.key.id()}
@@ -702,7 +699,7 @@ def test_ping_not_our_client(
     mock_ping.assert_not_called()
 
     with web_client.session_transaction() as session:
-        assert session.get("ping_sent") == "0"
+        assert session.get("ping_result") == "failed"
 
     assert response.status_code == 302
     parsed_response = urlparse(response.headers["Location"])

--- a/src/backend/web/local/blueprint.py
+++ b/src/backend/web/local/blueprint.py
@@ -318,6 +318,46 @@ def create_test_event(event_key: str) -> Response:
     )
 
 
+@local_routes.route(
+    "/seed_debug_mobile_clients/<string:account_id>", methods=["GET", "POST"]
+)
+def seed_debug_mobile_clients(account_id: str) -> Response:
+    """Insert MobileClient rows whose `messaging_id` triggers each PingResult
+    branch in `_ping_client` / `probe_and_cleanup_fcm_clients`. Hit this once
+    in dev, then exercise the Connected Devices UI / admin probe button."""
+    from google.appengine.ext import ndb
+
+    from backend.common.consts.client_type import ClientType
+    from backend.common.models.account import Account
+    from backend.common.models.mobile_client import MobileClient
+
+    parent_key = ndb.Key(Account, account_id)
+    rows = [
+        ("DEBUG_SENT_zach1", "Debug iPhone (sent)", ClientType.OS_IOS),
+        ("DEBUG_FAILED_zach1", "Debug iPhone (failed)", ClientType.OS_IOS),
+        ("DEBUG_DELETED_zach1", "Debug iPhone (deleted)", ClientType.OS_IOS),
+        (
+            "DEBUG_DELETED_zach2",
+            "Debug Android (deleted)",
+            ClientType.OS_ANDROID_FCM,
+        ),
+    ]
+    created = []
+    for messaging_id, name, ctype in rows:
+        mc = MobileClient(
+            parent=parent_key,
+            user_id=account_id,
+            messaging_id=messaging_id,
+            client_type=ctype,
+            device_uuid=f"uuid-{messaging_id}",
+            display_name=name,
+            verified=True,
+        )
+        mc.put()
+        created.append({"messaging_id": messaging_id, "key_id": mc.key.id()})
+    return jsonify({"account_id": account_id, "created": created})
+
+
 local_routes.add_url_rule(
     "/seed_test_event",
     view_func=seed_test_event,

--- a/src/backend/web/templates/account_overview.html
+++ b/src/backend/web/templates/account_overview.html
@@ -61,16 +61,22 @@
     </div>
   </div>
   {% endif %}
-  {% if ping_sent %}
+  {% if ping_result %}
   <div id="ping-row" class="row">
     <div class="col-md-10 col-md-offset-1">
-      {% if ping_sent == '1' %}
+      {% if ping_result == 'sent' %}
       <div class="alert alert-success">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <h4>Success!</h4>
         <p>Ping was sent.</p>
       </div>
-      {% elif ping_sent == '0' %}
+      {% elif ping_result == 'deleted' %}
+      <div class="alert alert-warning">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <h4>Device unreachable</h4>
+        <p>We removed it from your Connected Devices.</p>
+      </div>
+      {% elif ping_result == 'failed' %}
       <div class="alert alert-danger">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <h4>Failure</h4>
@@ -289,6 +295,7 @@
       <p class="notifications-enabled-visible">Push notifications (beta) for this device are <strong>enabled</strong>! <a class="btn btn-danger" role="button" onclick="disableMessaging()">Disable</a></p> -->
       {% if user.mobile_clients %}
       <p>All devices will appear below, whether or not push notifications are enabled or disabled for a specific device.</p>
+      <p class="text-muted"><small>Use <strong>Test connection</strong> to send a ping. If a device can't be reached, we'll remove it from your list automatically.</small></p>
       <table class="table table-striped">
         <tr>
           <th>Type</th>
@@ -314,7 +321,7 @@
               <td><form action="{{ url_for('account.ping') }}" method="post">
                 <input name="mobile_client_id" type="hidden" value="{{ client.key.id() }}" />
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                <button type="submit" class="ping btn btn-default" {{ '' if ping_enabled else 'disabled' }}><span class="glyphicon glyphicon-cloud"></span> Ping</button>
+                <button type="submit" class="ping btn btn-default" {{ '' if ping_enabled else 'disabled' }}><span class="glyphicon glyphicon-cloud"></span> Test connection</button>
               </form></td>
               <td>
                 {% if client.is_webhook %}

--- a/src/backend/web/templates/admin/mobile_clients.html
+++ b/src/backend/web/templates/admin/mobile_clients.html
@@ -48,4 +48,23 @@
   </div>
 </div>
 
+<div class="panel panel-warning">
+  <div class="panel-heading">
+    <h3 class="panel-title">Probe &amp; remove unregistered clients</h3>
+  </div>
+  <div class="panel-body">
+    <p>
+      Sends a <code>dry_run</code> FCM multicast to every <code>MobileClient</code>
+      and deletes the ones whose tokens come back as <code>UnregisteredError</code>
+      or <code>SenderIdMismatchError</code>. Webhooks are skipped. The task
+      self-defers across pages of 500 entities; watch logs for per-page deletion
+      counts.
+    </p>
+    <form action="{{ url_for('admin.mobile_clients_probe_cleanup_post') }}" method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <button type="submit" class="btn btn-danger">Probe &amp; remove unregistered clients</button>
+    </form>
+  </div>
+</div>
+
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/the-blue-alliance/the-blue-alliance/issues/1093

This PR is a little large but it breaks down into two similar ideas. The first is that "Ping" is now "Test connection" in the Mobile Clients list. If a device is unregistered, we'll remove it from the list. This is kind of splitting the difference on the ticket above - if the mobile device is still valid, removing it might cause some weirdness with platforms. So this feels safe.

The second is adding an admin cleanup to do a FCM dry run just to look for unregistered messaging IDs from FCM. This should allow us to do cleanups of defunct mobile devices that will never respond to FCM queries.