### PR TITLE
Add code in trusted API to remove invalid matches like f1m3 for offseason events

### DIFF
--- a/src/backend/api/handlers/tests/update_event_matches_test.py
+++ b/src/backend/api/handlers/tests/update_event_matches_test.py
@@ -351,6 +351,127 @@ def test_matches_update(api_client: Client) -> None:
     assert match.alliances[AllianceColor.BLUE]["dqs"] == []
 
 
+def test_unplayed_finals_match_cleaned_up(api_client: Client) -> None:
+    setup_event()
+    setup_auth(access_types=[AuthType.EVENT_MATCHES])
+
+    # Red sweeps finals 2-0; uploader still posts an unplayed f1m3 placeholder.
+    matches = [
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 1,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": 100},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": 50},
+            },
+        },
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 2,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": 100},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": 50},
+            },
+        },
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 3,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": -1},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": -1},
+            },
+        },
+    ]
+    request_body = json.dumps(matches)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+    assert response.status_code == 200
+
+    event = none_throws(Event.get_by_id("2014casj"))
+    db_match_keys = [m.key.id() for m in Match.query(Match.event == event.key).fetch()]
+    assert "2014casj_f1m1" in db_match_keys
+    assert "2014casj_f1m2" in db_match_keys
+    assert "2014casj_f1m3" not in db_match_keys
+
+
+def test_unplayed_finals_match_cleaned_up_on_followup_upload(
+    api_client: Client,
+) -> None:
+    setup_event()
+    setup_auth(access_types=[AuthType.EVENT_MATCHES])
+
+    # Initial upload: bracket pre-created with f1m1 played + unplayed f1m2/f1m3.
+    initial = [
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 1,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": 100},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": 50},
+            },
+        },
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 2,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": -1},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": -1},
+            },
+        },
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 3,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": -1},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": -1},
+            },
+        },
+    ]
+    request_body = json.dumps(initial)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+    assert response.status_code == 200
+
+    # Follow-up upload: only f1m2 is sent (now played, red wins again).
+    # f1m3 should be cleaned up by merging with existing matches.
+    followup = [
+        {
+            "comp_level": "f",
+            "set_number": 1,
+            "match_number": 2,
+            "alliances": {
+                "red": {"teams": ["frc1", "frc2", "frc3"], "score": 100},
+                "blue": {"teams": ["frc4", "frc5", "frc6"], "score": 50},
+            },
+        },
+    ]
+    request_body = json.dumps(followup)
+    response = api_client.post(
+        REQUEST_PATH,
+        headers=get_auth_headers(REQUEST_PATH, request_body),
+        data=request_body,
+    )
+    assert response.status_code == 200
+
+    event = none_throws(Event.get_by_id("2014casj"))
+    db_match_keys = [m.key.id() for m in Match.query(Match.event == event.key).fetch()]
+    assert "2014casj_f1m1" in db_match_keys
+    assert "2014casj_f1m2" in db_match_keys
+    assert "2014casj_f1m3" not in db_match_keys
+
+
 def test_calculate_match_time(api_client: Client) -> None:
     setup_event()
     setup_auth(access_types=[AuthType.EVENT_MATCHES])

--- a/src/backend/api/handlers/tests/update_event_matches_test.py
+++ b/src/backend/api/handlers/tests/update_event_matches_test.py
@@ -12,6 +12,7 @@ from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_type import EventType
 from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.cached_query_result import CachedQueryResult
 from backend.common.models.event import Event
 from backend.common.models.match import Match
 
@@ -443,6 +444,11 @@ def test_unplayed_finals_match_cleaned_up_on_followup_upload(
         data=request_body,
     )
     assert response.status_code == 200
+
+    # Cache invalidation runs on a deferred queue that doesn't fire in tests,
+    # so manually clear cached query results to simulate the production state
+    # where the followup upload sees fresh matches via EventMatchesQuery.
+    ndb.delete_multi(CachedQueryResult.query().fetch(keys_only=True))
 
     # Follow-up upload: only f1m2 is sent (now played, red wins again).
     # f1m3 should be cleaned up by merging with existing matches.

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -325,6 +325,19 @@ def update_event_matches(event_key: EventKey) -> Response:
 
     if event.remap_teams:
         EventRemapTeamsHelper.remapteams_matches(matches, event.remap_teams)
+
+    # Merge with existing matches so delete_invalid_matches can see the full
+    # set and identify unplayed elim matches whose set has already been
+    # decided (e.g. an f1m3 placeholder when finals ended 2-0).
+    new_match_keys = {m.key.id() for m in matches}
+    existing_matches = Match.query(Match.event == event.key).fetch()
+    for existing_match in existing_matches:
+        if existing_match.key.id() not in new_match_keys:
+            matches.append(existing_match)
+
+    matches, keys_to_delete = MatchHelper.delete_invalid_matches(matches, event)
+
+    MatchManipulator.delete_keys(keys_to_delete)
     MatchManipulator.createOrUpdate(matches)
 
     return profiled_jsonify({"Success": "Matches successfully updated"})

--- a/src/backend/api/handlers/trusted.py
+++ b/src/backend/api/handlers/trusted.py
@@ -54,6 +54,7 @@ from backend.common.models.match import Match
 from backend.common.models.media import Media
 from backend.common.models.team import Team
 from backend.common.models.zebra_motionworks import ZebraMotionWorks
+from backend.common.queries.match_query import EventMatchesQuery
 
 
 @require_write_auth({AuthType.EVENT_TEAMS})
@@ -330,7 +331,7 @@ def update_event_matches(event_key: EventKey) -> Response:
     # set and identify unplayed elim matches whose set has already been
     # decided (e.g. an f1m3 placeholder when finals ended 2-0).
     new_match_keys = {m.key.id() for m in matches}
-    existing_matches = Match.query(Match.event == event.key).fetch()
+    existing_matches = EventMatchesQuery(event_key=event_key).fetch()
     for existing_match in existing_matches:
         if existing_match.key.id() not in new_match_keys:
             matches.append(existing_match)


### PR DESCRIPTION
Was spot-checking some matches today to try to find one with an unplayed match and I found a few for 2025. All of these were offseason matches and they were all f1m3.

| Match Key | Event Key |
|---|---|
| 2025cabl_f1m3 | 2025cabl |
| 2025cacc_f1m3 | 2025cacc |
| 2025cacg_f1m3 | 2025cacg |
| 2025cafb_f1m3 | 2025cafb |
| 2025catt_f1m3 | 2025catt |
| 2025iltrr_f1m3 | 2025iltrr |
| 2025ncfay_f1m3 | 2025ncfay |
| 2025nmrc_f1m3 | 2025nmrc |

The trusted API doesn't do any sort of match cleanup like we do for official FRC events. This PR adds a call to `MatchHelper.delete_invalid_matches` in the trusted API to try to help clean up these invalid matches before they enter our system.