### PR TITLE
Make min_count on v2 insights configurable

### DIFF
--- a/src/backend/common/helpers/insights_v2/leaderboards/blue_banners.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/blue_banners.py
@@ -20,7 +20,7 @@ class BlueBannersV2Calculator(LeaderboardV2Calculator):
         return "team"
 
     def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRanking]:
-        return build_leaderboard_rankings(counts)
+        return build_leaderboard_rankings(counts, min_count=self.min_count)
 
     def on_event(self, event: Event) -> None:
         for award in event.awards:

--- a/src/backend/common/helpers/insights_v2/leaderboards/calculator.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/calculator.py
@@ -22,7 +22,10 @@ LEADERBOARD_MAX_KEYS_PER_RANKING = 10
 
 
 def build_leaderboard_rankings(
-    counts: Dict[str, int], top_n: int = LEADERBOARD_TOP_N
+    counts: Dict[str, int],
+    top_n: int = LEADERBOARD_TOP_N,
+    *,
+    min_count: int,
 ) -> List[LeaderboardRanking]:
     """
     Converts a {team_key: count} dict into a sorted list of LeaderboardRankingV2,
@@ -39,13 +42,16 @@ def build_leaderboard_rankings(
             value=value,
         )
         for value, keys in sorted(value_to_keys.items(), reverse=True)
-        if value > 1 and len(keys) <= LEADERBOARD_MAX_KEYS_PER_RANKING
+        if value >= min_count and len(keys) <= LEADERBOARD_MAX_KEYS_PER_RANKING
     ]
     return result[:top_n]
 
 
 def build_leaderboard_event_list_rankings(
-    team_events: Dict[str, List[str]], top_n: int = LEADERBOARD_TOP_N
+    team_events: Dict[str, List[str]],
+    top_n: int = LEADERBOARD_TOP_N,
+    *,
+    min_count: int,
 ) -> List[LeaderboardRanking]:
     """
     Converts a {team_key: [event_key, ...]} dict into a sorted list of
@@ -59,7 +65,7 @@ def build_leaderboard_event_list_rankings(
 
     result: List[LeaderboardRanking] = []
     for count, team_keys in sorted(counts_to_teams.items(), reverse=True):
-        if count <= 1:
+        if count < min_count:
             continue
         if len(team_keys) > LEADERBOARD_MAX_KEYS_PER_RANKING:
             continue
@@ -78,7 +84,10 @@ def build_leaderboard_event_list_rankings(
 
 
 def build_leaderboard_pair_rankings(
-    counts: Dict[str, int], top_n: int = LEADERBOARD_TOP_N
+    counts: Dict[str, int],
+    top_n: int = LEADERBOARD_TOP_N,
+    *,
+    min_count: int,
 ) -> List[LeaderboardRanking]:
     """
     Converts a {"frcA|frcB": count} dict into a sorted list of LeaderboardRankingV2.
@@ -98,7 +107,7 @@ def build_leaderboard_pair_rankings(
             value=value,
         )
         for value, pairs in sorted(value_to_pairs.items(), reverse=True)
-        if value > 1 and len(pairs) <= LEADERBOARD_MAX_KEYS_PER_RANKING
+        if value >= min_count and len(pairs) <= LEADERBOARD_MAX_KEYS_PER_RANKING
     ]
     return result[:top_n]
 
@@ -118,6 +127,10 @@ class LeaderboardV2Calculator(InsightV2Calculator):
     @property
     def context_type(self) -> LeaderboardContextType:
         return "none"
+
+    @property
+    def min_count(self) -> int:
+        return 2
 
     @abstractmethod
     def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRanking]:
@@ -220,4 +233,4 @@ class EventListLeaderboardV2Calculator(LeaderboardV2Calculator):
 
     def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRanking]:
         filtered = {k: self._team_events[k] for k in counts}
-        return build_leaderboard_event_list_rankings(filtered)
+        return build_leaderboard_event_list_rankings(filtered, min_count=self.min_count)

--- a/src/backend/common/helpers/insights_v2/leaderboards/most_cmp_finals_appearances.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/most_cmp_finals_appearances.py
@@ -19,6 +19,10 @@ class MostCmpFinalsAppearancesV2Calculator(EventListLeaderboardV2Calculator):
     def key_type(self) -> LeaderboardKeyType:
         return "team"
 
+    @property
+    def min_count(self) -> int:
+        return 1
+
     def on_event(self, event: Event) -> None:
         if event.event_type_enum != EventType.CMP_FINALS:
             return

--- a/src/backend/common/helpers/insights_v2/leaderboards/most_cmp_wins.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/most_cmp_wins.py
@@ -17,6 +17,10 @@ class MostCmpWinsV2Calculator(EventListLeaderboardV2Calculator):
     def key_type(self) -> LeaderboardKeyType:
         return "team"
 
+    @property
+    def min_count(self) -> int:
+        return 1
+
     def on_event(self, event: Event) -> None:
         if event.event_type_enum != EventType.CMP_FINALS:
             return

--- a/src/backend/common/helpers/insights_v2/leaderboards/most_division_finals_appearances.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/most_division_finals_appearances.py
@@ -19,6 +19,10 @@ class MostDivisionFinalsAppearancesV2Calculator(EventListLeaderboardV2Calculator
     def key_type(self) -> LeaderboardKeyType:
         return "team"
 
+    @property
+    def min_count(self) -> int:
+        return 1
+
     def on_event(self, event: Event) -> None:
         if event.event_type_enum != EventType.CMP_DIVISION:
             return

--- a/src/backend/common/helpers/insights_v2/leaderboards/most_division_wins.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/most_division_wins.py
@@ -17,6 +17,10 @@ class MostDivisionWinsV2Calculator(EventListLeaderboardV2Calculator):
     def key_type(self) -> LeaderboardKeyType:
         return "team"
 
+    @property
+    def min_count(self) -> int:
+        return 1
+
     def on_event(self, event: Event) -> None:
         if event.event_type_enum != EventType.CMP_DIVISION:
             return

--- a/src/backend/common/helpers/insights_v2/leaderboards/most_matches_played.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/most_matches_played.py
@@ -19,7 +19,7 @@ class MostMatchesPlayedV2Calculator(LeaderboardV2Calculator):
         return "team"
 
     def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRanking]:
-        return build_leaderboard_rankings(counts)
+        return build_leaderboard_rankings(counts, min_count=self.min_count)
 
     def on_event(self, event: Event) -> None:
         for match in event.matches:

--- a/src/backend/common/helpers/insights_v2/leaderboards/most_matches_played_together.py
+++ b/src/backend/common/helpers/insights_v2/leaderboards/most_matches_played_together.py
@@ -29,7 +29,7 @@ class MostMatchesPlayedTogetherV2Calculator(LeaderboardV2Calculator):
         return keys
 
     def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRanking]:
-        return build_leaderboard_pair_rankings(counts)
+        return build_leaderboard_pair_rankings(counts, min_count=self.min_count)
 
     def _get_district(
         self, key: str, team_to_district: Dict[str, str]

--- a/src/backend/common/helpers/tests/insights_v2/leaderboards/calculator_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboards/calculator_test.py
@@ -34,7 +34,7 @@ class _StubLeaderboard(LeaderboardV2Calculator):
         return "team"
 
     def _build_rankings(self, counts: Dict[str, int]) -> List[LeaderboardRanking]:
-        return build_leaderboard_rankings(counts)
+        return build_leaderboard_rankings(counts, min_count=self.min_count)
 
     def on_event(self, event: Event) -> None:
         pass
@@ -110,25 +110,27 @@ def test_district_key_name(ndb_stub) -> None:
 
 
 def test_rankings_excludes_value_of_one() -> None:
-    assert build_leaderboard_rankings({"frc1": 1, "frc2": 2}) == [
+    assert build_leaderboard_rankings({"frc1": 1, "frc2": 2}, min_count=2) == [
         LeaderboardRankingV2(keys=["frc2"], value=2),
     ]
 
 
 def test_rankings_excludes_groups_exceeding_max_keys() -> None:
     counts = {f"frc{i}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING + 1)}
-    assert build_leaderboard_rankings(counts) == []
+    assert build_leaderboard_rankings(counts, min_count=2) == []
 
 
 def test_rankings_includes_group_at_max_keys() -> None:
     counts = {f"frc{i}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING)}
-    result = build_leaderboard_rankings(counts)
+    result = build_leaderboard_rankings(counts, min_count=2)
     assert len(result) == 1
     assert len(result[0]["keys"]) == LEADERBOARD_MAX_KEYS_PER_RANKING
 
 
 def test_pair_rankings_excludes_value_of_one() -> None:
-    assert build_leaderboard_pair_rankings({"frc1|frc2": 1, "frc3|frc4": 2}) == [
+    assert build_leaderboard_pair_rankings(
+        {"frc1|frc2": 1, "frc3|frc4": 2}, min_count=2
+    ) == [
         LeaderboardRankingV2(keys=[["frc3", "frc4"]], value=2),
     ]
 
@@ -137,12 +139,12 @@ def test_pair_rankings_excludes_groups_exceeding_max_keys() -> None:
     counts = {
         f"frc{i}|frc{i + 1}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING + 1)
     }
-    assert build_leaderboard_pair_rankings(counts) == []
+    assert build_leaderboard_pair_rankings(counts, min_count=2) == []
 
 
 def test_pair_rankings_includes_group_at_max_keys() -> None:
     counts = {f"frc{i}|frc{i + 1}": 5 for i in range(LEADERBOARD_MAX_KEYS_PER_RANKING)}
-    result = build_leaderboard_pair_rankings(counts)
+    result = build_leaderboard_pair_rankings(counts, min_count=2)
     assert len(result) == 1
     assert len(result[0]["keys"]) == LEADERBOARD_MAX_KEYS_PER_RANKING
 

--- a/src/backend/common/helpers/tests/insights_v2/leaderboards/most_cmp_finals_appearances_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboards/most_cmp_finals_appearances_test.py
@@ -40,14 +40,15 @@ def _put_award(
     ).put()
 
 
-def test_single_appearance_excluded(ndb_stub) -> None:
+def test_single_appearance_included(ndb_stub) -> None:
     _put_event("2022cmptx", 2022, EventType.CMP_FINALS)
     _put_award("2022cmptx", 2022, ["frc254"], AwardType.WINNER, EventType.CMP_FINALS)
 
     insights = compute_insights_for_year(2022, [MostCmpFinalsAppearancesV2Calculator()])
 
     assert len(insights) == 1
-    assert insights[0].data["rankings"] == []
+    assert insights[0].data["rankings"][0]["keys"] == ["frc254"]
+    assert insights[0].data["rankings"][0]["value"] == 1
 
 
 def test_two_appearances_shown_in_rankings(ndb_stub) -> None:

--- a/src/backend/common/helpers/tests/insights_v2/leaderboards/most_cmp_wins_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboards/most_cmp_wins_test.py
@@ -40,14 +40,15 @@ def _put_award(
     ).put()
 
 
-def test_single_win_excluded(ndb_stub) -> None:
+def test_single_win_included(ndb_stub) -> None:
     _put_event("2022cmptx", 2022, EventType.CMP_FINALS)
     _put_award("2022cmptx", 2022, ["frc254"], AwardType.WINNER, EventType.CMP_FINALS)
 
     insights = compute_insights_for_year(2022, [MostCmpWinsV2Calculator()])
 
     assert len(insights) == 1
-    assert insights[0].data["rankings"] == []
+    assert insights[0].data["rankings"][0]["keys"] == ["frc254"]
+    assert insights[0].data["rankings"][0]["value"] == 1
 
 
 def test_two_wins_shown_in_rankings(ndb_stub) -> None:

--- a/src/backend/common/helpers/tests/insights_v2/leaderboards/most_division_finals_appearances_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboards/most_division_finals_appearances_test.py
@@ -40,7 +40,7 @@ def _put_award(
     ).put()
 
 
-def test_single_event_excluded(ndb_stub) -> None:
+def test_single_event_included(ndb_stub) -> None:
     _put_event("2022micmp1", 2022, EventType.CMP_DIVISION)
     _put_award("2022micmp1", 2022, ["frc254"], AwardType.WINNER, EventType.CMP_DIVISION)
 
@@ -49,7 +49,8 @@ def test_single_event_excluded(ndb_stub) -> None:
     )
 
     assert len(insights) == 1
-    assert insights[0].data["rankings"] == []
+    assert insights[0].data["rankings"][0]["keys"] == ["frc254"]
+    assert insights[0].data["rankings"][0]["value"] == 1
 
 
 def test_two_events_shown_in_rankings(ndb_stub) -> None:

--- a/src/backend/common/helpers/tests/insights_v2/leaderboards/most_division_wins_test.py
+++ b/src/backend/common/helpers/tests/insights_v2/leaderboards/most_division_wins_test.py
@@ -40,14 +40,15 @@ def _put_award(
     ).put()
 
 
-def test_single_win_excluded(ndb_stub) -> None:
+def test_single_win_included(ndb_stub) -> None:
     _put_event("2022micmp1", 2022, EventType.CMP_DIVISION)
     _put_award("2022micmp1", 2022, ["frc254"], AwardType.WINNER, EventType.CMP_DIVISION)
 
     insights = compute_insights_for_year(2022, [MostDivisionWinsV2Calculator()])
 
     assert len(insights) == 1
-    assert insights[0].data["rankings"] == []
+    assert insights[0].data["rankings"][0]["keys"] == ["frc254"]
+    assert insights[0].data["rankings"][0]["value"] == 1
 
 
 def test_two_wins_shown_in_rankings(ndb_stub) -> None:


### PR DESCRIPTION
this fixes the issue where it says ontario / pnw / etc dont have any worlds winners because they only have teams that have won it once each