### PR TITLE
PWA: fix advancement in 4-team double-elim bracket

### DIFF
--- a/pwa/app/components/tba/doubleElim4TeamBracket.tsx
+++ b/pwa/app/components/tba/doubleElim4TeamBracket.tsx
@@ -41,10 +41,10 @@ type MatchLabel4 =
   | 'Finals';
 
 const WINNER_LINKS: WinnerLink[] = [
-  { from: 'Match 1', to: 'Match 4' },
-  { from: 'Match 2', to: 'Match 4' },
-  { from: 'Match 3', to: 'Match 5' },
-  { from: 'Match 4', to: 'Finals' },
+  { from: 'Match 1', to: 'Match 3' },
+  { from: 'Match 2', to: 'Match 3' },
+  { from: 'Match 3', to: 'Finals' },
+  { from: 'Match 4', to: 'Match 5' },
   { from: 'Match 5', to: 'Finals' },
 ];
 
@@ -460,10 +460,10 @@ export default function DoubleElim4TeamBracket({
                     <div className="h-8"></div>
                     <BracketMatch
                       ref={(node) => {
-                        matchRefs.current['Match 4'] = node;
+                        matchRefs.current['Match 3'] = node;
                       }}
-                      matchLabel="Match 4"
-                      matches={matchesBySet[4]}
+                      matchLabel="Match 3"
+                      matches={matchesBySet[3]}
                       event={event}
                       hoveredAlliance={hoveredAlliance}
                       setHoveredAlliance={setHoveredAlliance}
@@ -507,10 +507,10 @@ export default function DoubleElim4TeamBracket({
                   <div className="space-y-4">
                     <BracketMatch
                       ref={(node) => {
-                        matchRefs.current['Match 3'] = node;
+                        matchRefs.current['Match 4'] = node;
                       }}
-                      matchLabel="Match 3"
-                      matches={matchesBySet[3]}
+                      matchLabel="Match 4"
+                      matches={matchesBySet[4]}
                       event={event}
                       hoveredAlliance={hoveredAlliance}
                       setHoveredAlliance={setHoveredAlliance}


### PR DESCRIPTION
Matches 3 and 4 were swapped

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the position of matches 3 and 4 in a 4-team double-elim bracket as specified by 2026 figure 11-1. Example event: `2026micmp`

## Motivation and Context
Matches 3 and 4 were swapped (both in their position and connections to other matches)

## How Has This Been Tested?
Local

## Screenshots (if appropriate):

Before:

<img width="1176" height="544" alt="image" src="https://github.com/user-attachments/assets/c6cb9997-b548-4e3a-8327-49d2265adaf6" />

After:

<img width="1176" height="544" alt="image" src="https://github.com/user-attachments/assets/3436832c-6adb-4e6c-b0f3-847cc259fa94" />


## Screenshot Pages
<!--- For PRs that touch pwa/ files, list additional pages to screenshot. -->
<!--- Each line: - /event/2026micmp Optional Display Name -->
<!--- Example: - /match/2024mil_f1m2 Match Page -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
