### PR TITLE
[pwa] increase delay on team tooltip hover

### DIFF
--- a/pwa/app/components/tba/teamTooltip.tsx
+++ b/pwa/app/components/tba/teamTooltip.tsx
@@ -38,7 +38,7 @@ export function TeamLinkWithTooltip({
   const teamNumber = teamKey.substring(3);
 
   return (
-    <Tooltip>
+    <Tooltip delayDuration={1000}>
       <TooltipTrigger asChild>
         <TeamLink teamOrKey={teamKey} year={year} {...props}>
           {isWinner ? (


### PR DESCRIPTION
makes it take longer (default 700ms) to show the tooltip. it was a little too fast and just moving your mouse past a number could show the tooltip in some cases.