### PR TITLE
Apply cooldown to `npm` and `uv` package ecosystem updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: pyre-check
@@ -13,6 +15,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: swagger-ui
@@ -30,6 +34,8 @@ updates:
   directory: "/pwa"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: "@types/node"


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2026-45321 for rationale and effect of _not_ having a cooldown applied.

## Description
Applies a 7 day cooldown to all dependabot package updates (*does not apply to security updates*). Mitigation effort to reduce the change of an automatic fast spread of a compromised package version in a supply chain attack.

## Motivation and Context
Supply Chain Attacks are bad....

## How Has This Been Tested?
Config update for Dependabot. YOLO. Can be tested to ensure 7d cooldown is in effect after applied.

## Screenshots (if appropriate):

## Screenshot Pages

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
