### PR TITLE
Security: Use of eval() in bulkloader_helper.py

### DIFF
--- a/old_py2/helpers/bulkloader_helper.py
+++ b/old_py2/helpers/bulkloader_helper.py
@@ -2,6 +2,8 @@
 Provides helper functions to assist with bulkloader.yaml
 """
 
+import ast
+
 
 def fix_json(x):
     """
@@ -18,7 +20,7 @@ def fix_list(x):
     Turn a string of a list into a Python list.
     """
     if len(x) > 0:
-        y = eval(x)
+        y = ast.literal_eval(x)
         if len(y) > 0:
             return y
 


### PR DESCRIPTION
## Summary

Security: Use of eval() in bulkloader_helper.py

## Problem

**Severity**: `Critical` | **File**: `old_py2/helpers/bulkloader_helper.py:L22`

The `fix_list` function uses `eval(x)` to parse a string representation of a list. This is extremely dangerous as it allows arbitrary code execution if the input string contains malicious Python code. An attacker could craft input that executes arbitrary commands on the server.

## Solution

Replace `eval(x)` with `ast.literal_eval(x)` which safely evaluates a string containing a Python literal. Alternatively, use `json.loads()` if the input is JSON formatted.

## Changes

- `old_py2/helpers/bulkloader_helper.py` (modified)