### PR TITLE
[pwa] Fix event page performance issue

### DIFF
--- a/pwa/app/components/tba/rpDot.tsx
+++ b/pwa/app/components/tba/rpDot.tsx
@@ -2,7 +2,6 @@ import { Match } from '~/api/tba/read';
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from '~/components/ui/tooltip';
 import {
@@ -18,30 +17,28 @@ function RpDot({
   achieved: boolean;
 }) {
   return (
-    <TooltipProvider delayDuration={100}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <svg
-            className="size-1"
-            viewBox="0 0 5 5"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle
-              cx={2.5}
-              cy={2.5}
-              r={achieved ? 2.5 : 2}
-              fill={achieved ? 'currentColor' : 'none'}
-              stroke={achieved ? 'none' : '#9ca3af'}
-              strokeWidth={achieved ? 0 : 1}
-            />
-          </svg>
-        </TooltipTrigger>
-        <TooltipContent>
-          <span className="font-normal">{tooltipText}</span>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <svg
+          className="size-1"
+          viewBox="0 0 5 5"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx={2.5}
+            cy={2.5}
+            r={achieved ? 2.5 : 2}
+            fill={achieved ? 'currentColor' : 'none'}
+            stroke={achieved ? 'none' : '#9ca3af'}
+            strokeWidth={achieved ? 0 : 1}
+          />
+        </svg>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span className="font-normal">{tooltipText}</span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/pwa/app/components/tba/tableOfContents.tsx
+++ b/pwa/app/components/tba/tableOfContents.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from '@tanstack/react-router';
 import {
   createContext,
+  startTransition,
   useCallback,
   useContext,
   useEffect,
@@ -189,13 +190,17 @@ export function TableOfContentsSection({
       className={cn('scroll-mt-12 lg:scroll-mt-4', className)}
       rootMargin="-15% 0px 0px 0px"
       onChange={(inView) => {
-        setInView((prev) => {
-          if (inView) {
-            prev.add(id);
-          } else {
-            prev.delete(id);
-          }
-          return new Set(prev);
+        // Low-priority update so pointer events/hover aren't blocked by the re-render
+        startTransition(() => {
+          setInView((prev) => {
+            const next = new Set(prev);
+            if (inView) {
+              next.add(id);
+            } else {
+              next.delete(id);
+            }
+            return next;
+          });
         });
       }}
       {...props}

--- a/pwa/app/components/tba/teamTooltip.tsx
+++ b/pwa/app/components/tba/teamTooltip.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { ComponentProps, Suspense, useMemo } from 'react';
 
 import BiTrophy from '~icons/bi/trophy';
@@ -27,6 +27,113 @@ export interface TeamTooltipProps {
 }
 
 export function TeamLinkWithTooltip({
+  teamKey,
+  year,
+  disqualified,
+  surrogate,
+  isWinner,
+  isCaptain,
+  ...props
+}: TeamTooltipProps & Omit<ComponentProps<typeof TeamLink>, 'teamOrKey'>) {
+  const teamNumber = teamKey.substring(3);
+  const { data: searchIndex } = useQuery(getSearchIndexOptions({}));
+  const teamName = useMemo(
+    () => searchIndex?.teams.find((t) => t.key === teamKey)?.nickname,
+    [searchIndex, teamKey],
+  );
+
+  const label = (
+    <>
+      {isWinner ? (
+        <InlineIcon className="relative right-[1ch] justify-center">
+          <BiTrophy />
+          {teamNumber}
+          {isCaptain && (
+            <sup className="ml-[0.1em] text-[0.6em] text-muted-foreground">
+              C
+            </sup>
+          )}
+        </InlineIcon>
+      ) : isCaptain ? (
+        <>
+          {teamNumber}
+          <sup className="ml-[0.1em] text-[0.6em] text-muted-foreground">C</sup>
+        </>
+      ) : (
+        <>{teamNumber}</>
+      )}
+    </>
+  );
+
+  if (!teamName) {
+    return (
+      <TeamLink teamOrKey={teamKey} year={year} {...props}>
+        {label}
+      </TeamLink>
+    );
+  }
+
+  return (
+    <Tooltip delayDuration={1500}>
+      <TooltipTrigger asChild>
+        <TeamLink teamOrKey={teamKey} year={year} {...props}>
+          {label}
+        </TeamLink>
+      </TooltipTrigger>
+      <TooltipContent>
+        {disqualified
+          ? `${teamName} (DQ)`
+          : surrogate
+            ? `${teamName} (surrogate)`
+            : teamName}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function TeamTooltip({
+  teamKey,
+  year,
+  disqualified,
+  surrogate,
+}: TeamTooltipProps) {
+  const { data: media } = useSuspenseQuery(
+    getTeamMediaByYearOptions({ path: { team_key: teamKey, year } }),
+  );
+
+  const { data: searchIndex } = useSuspenseQuery(getSearchIndexOptions({}));
+
+  const team = useMemo(
+    () => searchIndex && searchIndex.teams.find((t) => t.key === teamKey),
+    [searchIndex, teamKey],
+  );
+
+  const maybeAvatar = useMemo(
+    () => media && media.find((m): m is MediaAvatar => m.type === 'avatar'),
+    [media],
+  );
+
+  if (!team) return null;
+
+  return (
+    <div>
+      {maybeAvatar && <TeamAvatar media={maybeAvatar} />}
+      <h1>{team.nickname}</h1>
+      {disqualified && (
+        <i>
+          <h1>Disqualified</h1>
+        </i>
+      )}
+      {surrogate && (
+        <i>
+          <h1>Surrogate</h1>
+        </i>
+      )}
+    </div>
+  );
+}
+
+export function TeamLinkWithAvatarTooltip({
   teamKey,
   year,
   disqualified,
@@ -74,47 +181,5 @@ export function TeamLinkWithTooltip({
         </TooltipContent>
       </Suspense>
     </Tooltip>
-  );
-}
-
-export function TeamTooltip({
-  teamKey,
-  year,
-  disqualified,
-  surrogate,
-}: TeamTooltipProps) {
-  const { data: media } = useSuspenseQuery(
-    getTeamMediaByYearOptions({ path: { team_key: teamKey, year } }),
-  );
-
-  const { data: searchIndex } = useSuspenseQuery(getSearchIndexOptions({}));
-
-  const team = useMemo(
-    () => searchIndex && searchIndex.teams.find((t) => t.key === teamKey),
-    [searchIndex, teamKey],
-  );
-
-  const maybeAvatar = useMemo(
-    () => media && media.find((m): m is MediaAvatar => m.type === 'avatar'),
-    [media],
-  );
-
-  if (!team) return null;
-
-  return (
-    <div>
-      {maybeAvatar && <TeamAvatar media={maybeAvatar} />}
-      <h1>{team.nickname}</h1>
-      {disqualified && (
-        <i>
-          <h1>Disqualified</h1>
-        </i>
-      )}
-      {surrogate && (
-        <i>
-          <h1>Surrogate</h1>
-        </i>
-      )}
-    </div>
   );
 }

--- a/pwa/app/components/ui/tooltip.tsx
+++ b/pwa/app/components/ui/tooltip.tsx
@@ -17,11 +17,7 @@ function TooltipProvider({
 }
 
 function Tooltip({ ...props }: ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({

--- a/pwa/app/routes/__root.tsx
+++ b/pwa/app/routes/__root.tsx
@@ -21,6 +21,7 @@ import { Footer } from '~/components/tba/navigation/footer';
 import { Navbar } from '~/components/tba/navigation/navbar';
 import { TOCRendererProvider } from '~/components/tba/tableOfContents';
 import { Toaster } from '~/components/ui/sonner';
+import { TooltipProvider } from '~/components/ui/tooltip';
 import appleTouchIcon180 from '~/images/apple-splash/apple-touch-icon-180.png?url&no-inline';
 import { ApiError } from '~/lib/apiError';
 import { APPLE_SPLASH_STARTUP_LINKS } from '~/lib/appleSplashLinks';
@@ -187,30 +188,32 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <AuthContextProvider>
-            {isFullscreen ? (
-              <Outlet />
-            ) : (
-              <>
-                <Navbar />
-                <TOCRendererProvider>
-                  <div
-                    className={cn(
-                      !isFullwidth && 'container mx-auto',
-                      `min-h-[calc(100vh-var(--header-height)-var(--footer-min-height)-var(--footer-inset-top))]
-                        px-4 text-sm`,
-                    )}
-                  >
-                    <div vaul-drawer-wrapper="" className="bg-background">
-                      <Outlet />
-                      <MatchModal />
+          <TooltipProvider delayDuration={300} skipDelayDuration={0}>
+            <AuthContextProvider>
+              {isFullscreen ? (
+                <Outlet />
+              ) : (
+                <>
+                  <Navbar />
+                  <TOCRendererProvider>
+                    <div
+                      className={cn(
+                        !isFullwidth && 'container mx-auto',
+                        `min-h-[calc(100vh-var(--header-height)-var(--footer-min-height)-var(--footer-inset-top))]
+                          px-4 text-sm`,
+                      )}
+                    >
+                      <div vaul-drawer-wrapper="" className="bg-background">
+                        <Outlet />
+                        <MatchModal />
+                      </div>
                     </div>
-                  </div>
-                </TOCRendererProvider>
-                <Footer renderTime={renderTime} />
-              </>
-            )}
-          </AuthContextProvider>
+                  </TOCRendererProvider>
+                  <Footer renderTime={renderTime} />
+                </>
+              )}
+            </AuthContextProvider>
+          </TooltipProvider>
           <Toaster />
         </ThemeProvider>
         <TanStackRouterDevtools position="bottom-right" />


### PR DESCRIPTION
## Fix scroll freeze and navigation lag on event pages

**Root cause**: The event results page was mounting thousands of expensive React components on load. Two main offenders:

1. **`TooltipProvider` explosion** — each `RpDot` created two nested providers (one explicit, one implicit inside `Tooltip`), and each team number link created another. For a typical district event (~72 qual matches), this produced ~1,200+ `TooltipProvider` instances. Each is a React context with state management, and any hover event cascaded re-renders through all of them.

2. **600 `Suspense` boundaries** — `TeamLinkWithTooltip` wrapped every tooltip in `<Suspense>` to lazy-load the team avatar. React tracks each boundary as a potential suspension point; having 600 of them added overhead to every reconciliation pass and pointer event dispatch.

**Changes:**

- **`__root.tsx`** — single `TooltipProvider` at the app root (`delayDuration={300}`, `skipDelayDuration={0}`); all tooltips share it
- **`tooltip.tsx`** — removed the implicit per-`Tooltip` provider wrapper (root handles it)
- **`rpDot.tsx`** — removed the explicit `TooltipProvider` from `RpDot`
- **`teamTooltip.tsx`** — `TeamLinkWithTooltip` now uses `useQuery` for the already-cached search index and shows just the team nickname; no `Suspense`, no per-team media fetch. The old avatar tooltip is preserved as `TeamLinkWithAvatarTooltip` for use in non-list contexts
- **`tableOfContents.tsx`** — wrapped `setInView` in `startTransition` so IntersectionObserver callbacks don't block pointer event processing; fixed a state mutation bug (was mutating `prev` Set before copying it)

This was always present but became noticeable in #9850
