### PR TITLE
[pwa] Animate event page tabs

### DIFF
--- a/pwa/app/components/ui/animated-tabs.tsx
+++ b/pwa/app/components/ui/animated-tabs.tsx
@@ -1,0 +1,79 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { LayoutGroup, motion } from 'motion/react';
+import {
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  createContext,
+  forwardRef,
+  useContext,
+  useState,
+} from 'react';
+
+import { Tabs, TabsTrigger } from '~/components/ui/tabs';
+import { cn } from '~/lib/utils';
+
+const AnimatedTabsContext = createContext<{ activeValue: string | undefined }>({
+  activeValue: undefined,
+});
+
+const AnimatedTabs = forwardRef<
+  ElementRef<typeof TabsPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+>(({ defaultValue, value, onValueChange, ...props }, ref) => {
+  const [internalValue, setInternalValue] = useState<string | undefined>(
+    value ?? defaultValue,
+  );
+  const activeValue = value ?? internalValue;
+
+  return (
+    <AnimatedTabsContext.Provider value={{ activeValue }}>
+      <LayoutGroup>
+        <Tabs
+          ref={ref}
+          defaultValue={defaultValue}
+          value={value}
+          onValueChange={(v) => {
+            setInternalValue(v);
+            onValueChange?.(v);
+          }}
+          {...props}
+        />
+      </LayoutGroup>
+    </AnimatedTabsContext.Provider>
+  );
+});
+AnimatedTabs.displayName = 'AnimatedTabs';
+
+const AnimatedTabsTrigger = forwardRef<
+  ElementRef<typeof TabsPrimitive.Trigger>,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, children, value, ...props }, ref) => {
+  const { activeValue } = useContext(AnimatedTabsContext);
+  const isActive = value !== undefined && activeValue === value;
+
+  return (
+    <TabsTrigger
+      ref={ref}
+      value={value}
+      className={cn(
+        `relative data-[state=active]:bg-transparent
+        data-[state=active]:shadow-none`,
+        className,
+      )}
+      {...props}
+    >
+      {isActive && (
+        <motion.span
+          layoutId="tab-indicator"
+          initial={false}
+          className="absolute inset-0 rounded-sm bg-background shadow-xs"
+          transition={{ type: 'spring', bounce: 0.15, duration: 0.4 }}
+        />
+      )}
+      <span className="relative z-10">{children}</span>
+    </TabsTrigger>
+  );
+});
+AnimatedTabsTrigger.displayName = 'AnimatedTabsTrigger';
+
+export { AnimatedTabs, AnimatedTabsTrigger };

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -90,6 +90,10 @@ import TeamAvatar from '~/components/tba/teamAvatar';
 import { TeamLinkWithTooltip } from '~/components/tba/teamTooltip';
 import TraditionalBracket from '~/components/tba/traditionalBracket';
 import { YoutubeEmbed } from '~/components/tba/videoEmbeds';
+import {
+  AnimatedTabs,
+  AnimatedTabsTrigger,
+} from '~/components/ui/animated-tabs';
 import { Avatar, AvatarImage } from '~/components/ui/avatar';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
@@ -129,7 +133,7 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui/table';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { TabsContent, TabsList } from '~/components/ui/tabs';
 import { DISTRICT_EVENT_TYPES, SEASON_EVENT_TYPES } from '~/lib/api/EventType';
 import { TRADITIONAL_BRACKET_TYPES } from '~/lib/api/PlayoffType';
 import { sortAwardsComparator } from '~/lib/awardUtils';
@@ -556,7 +560,7 @@ function EventPage() {
           )}
       </div>
 
-      <Tabs
+      <AnimatedTabs
         defaultValue={matches.length > 0 ? 'results' : 'teams'}
         className="mt-4"
       >
@@ -565,33 +569,33 @@ function EventPage() {
             *:basis-1/2 lg:*:basis-1"
         >
           {(matches.length > 0 || alliances.length > 0) && (
-            <TabsTrigger value="results">
+            <AnimatedTabsTrigger value="results">
               <InlineIcon>
                 <ResultsIcon />
                 Results
               </InlineIcon>
-            </TabsTrigger>
+            </AnimatedTabsTrigger>
           )}
           {(shouldPreviewRankingsTab ||
             (rankingsQuery.data && rankingsQuery.data.rankings.length > 0)) && (
-            <TabsTrigger value="rankings">
+            <AnimatedTabsTrigger value="rankings">
               <InlineIcon>
                 <RankingsIcon />
                 Rankings
               </InlineIcon>
-            </TabsTrigger>
+            </AnimatedTabsTrigger>
           )}
           {((shouldPreviewAwardsTab && awardsQuery.isPending) ||
             (awardsQuery.data !== undefined &&
               awardsQuery.data.length > 0)) && (
-            <TabsTrigger value="awards">
+            <AnimatedTabsTrigger value="awards">
               <InlineIcon>
                 <AwardsIcon />
                 Awards
               </InlineIcon>
-            </TabsTrigger>
+            </AnimatedTabsTrigger>
           )}
-          <TabsTrigger value="teams">
+          <AnimatedTabsTrigger value="teams">
             <InlineIcon>
               <TeamsIcon />
               Teams
@@ -599,48 +603,48 @@ function EventPage() {
                 {teamsQuery.data?.length ?? '-'}
               </Badge>
             </InlineIcon>
-          </TabsTrigger>
+          </AnimatedTabsTrigger>
           {((shouldPreviewInsightsTab &&
             (coprsQuery.isPending || colorsQuery.isPending)) ||
             (coprsQuery.data && colorsQuery.data)) &&
             matches.length > 0 && (
-              <TabsTrigger value="insights">
+              <AnimatedTabsTrigger value="insights">
                 <InlineIcon>
                   <InsightsIcon />
                   Insights
                 </InlineIcon>
-              </TabsTrigger>
+              </AnimatedTabsTrigger>
             )}
           {districtPointsQuery.data &&
             DISTRICT_EVENT_TYPES.has(event.event_type) && (
-              <TabsTrigger value="district-points">
+              <AnimatedTabsTrigger value="district-points">
                 <InlineIcon>
                   <DistrictPointsIcon />
                   District Points
                 </InlineIcon>
-              </TabsTrigger>
+              </AnimatedTabsTrigger>
             )}
           {event.event_type === EventType.REGIONAL &&
             (event.year >= 2025 || regionalAdvancementQuery.data != null) && (
-              <TabsTrigger value="champs-qual-points">
+              <AnimatedTabsTrigger value="champs-qual-points">
                 <InlineIcon>
                   <ChampsQualPointsIcon />
                   Champs Qual Points
                 </InlineIcon>
-              </TabsTrigger>
+              </AnimatedTabsTrigger>
             )}
-          <TabsTrigger value="media">
+          <AnimatedTabsTrigger value="media">
             <InlineIcon>
               <MediaIcon />
               Media
             </InlineIcon>
-          </TabsTrigger>
-          <TabsTrigger value="scouting">
+          </AnimatedTabsTrigger>
+          <AnimatedTabsTrigger value="scouting">
             <InlineIcon>
               <ScoutingIcon />
               Scouting
             </InlineIcon>
-          </TabsTrigger>
+          </AnimatedTabsTrigger>
         </TabsList>
 
         <TabsContent
@@ -685,7 +689,11 @@ function EventPage() {
           )}
         </TabsContent>
 
-        <TabsContent value="insights">
+        <TabsContent
+          value="insights"
+          forceMount
+          className="data-[state=inactive]:hidden"
+        >
           <MatchStatsTable
             matches={sortedMatches.filter(
               (m) =>
@@ -749,7 +757,7 @@ function EventPage() {
             />
           )}
         </TabsContent>
-      </Tabs>
+      </AnimatedTabs>
     </div>
   );
 }

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -67,6 +67,7 @@
     "lodash-es": "4.18.1",
     "lru-cache": "11.3.6",
     "morgan": "1.10.1",
+    "motion": "12.40.0",
     "pino": "10.3.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       morgan:
         specifier: 1.10.1
         version: 1.10.1
+      motion:
+        specifier: 12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pino:
         specifier: 10.3.1
         version: 10.3.1
@@ -5170,6 +5173,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -6325,6 +6342,26 @@ packages:
   morgan@1.10.1:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
+
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.40.0:
+    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -13898,6 +13935,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   fresh@2.0.0: {}
 
   fs-extra@11.3.5:
@@ -15293,6 +15339,20 @@ snapshots:
       on-headers: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      framer-motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   ms@2.0.0: {}
 


### PR DESCRIPTION
<img width="1252" height="225" alt="firefox_LVi2vDuEtk" src="https://github.com/user-attachments/assets/c89a3b2d-f7b3-4379-8daa-ffde85c8a488" />

This also pulls in `motion` which is a very popular animation library -- https://motion.dev/

We will likely use more of Motion than just this so I feel its justified. I wrapped `Tabs` in a new component `AnimatedTabs` so that we could pull in updates for `Tabs` from shadcn periodically if we want to.