### PR TITLE
[pwa] Add data attribution to FIRST in footer

### DIFF
--- a/pwa/app/components/tba/navigation/footer.tsx
+++ b/pwa/app/components/tba/navigation/footer.tsx
@@ -151,7 +151,16 @@ export const Footer = ({ renderTime }: { renderTime: string }) => {
           </span>
 
           <p className="text-xs text-neutral-600 dark:text-neutral-400">
-            Generated on {renderTime}. Commit:{' '}
+            Data provided by the{' '}
+            <a
+              href="https://frc-events.firstinspires.org/services/API"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="hover:underline"
+            >
+              <i>FIRST</i>® Events API
+            </a>
+            . Generated on {renderTime}. Commit:{' '}
             <a
               href={`https://github.com/the-blue-alliance/the-blue-alliance/commit/${commitHash}`}
               target="_blank"


### PR DESCRIPTION
Terms of use of the FIRST api says we should link to it, so adding it to beta

<img width="1042" height="137" alt="image" src="https://github.com/user-attachments/assets/30a7b97a-d116-46e9-9251-f393be64c900" />

