### PR TITLE
[pwa] Align table header padding with cells

### DIFF
--- a/pwa/app/components/tba/eventListTable.tsx
+++ b/pwa/app/components/tba/eventListTable.tsx
@@ -128,7 +128,7 @@ export default function EventListTable({
                   </div>
                 )}
               </TableCell>
-              <TableCell className="mt-2 flex justify-center md:mt-1">
+              <TableCell>
                 {event.webcasts.length > 0 && (
                   <Button
                     asChild={isOnline || withinADay}

--- a/pwa/app/components/ui/table.tsx
+++ b/pwa/app/components/ui/table.tsx
@@ -78,7 +78,7 @@ const TableHead = forwardRef<
   <th
     ref={ref}
     className={cn(
-      `h-12 px-4 text-left align-middle font-medium text-muted-foreground
+      `h-12 px-1.5 text-left align-middle font-medium text-muted-foreground
       [&:has([role=checkbox])]:pr-0`,
       className,
     )}


### PR DESCRIPTION
## Summary

- Match `TableHead` horizontal padding (`px-4` → `px-1.5`) to `TableCell`'s `p-1.5` in the shared shadcn `table.tsx` primitive. The two sides have been mismatched since the file was first added in #6144, which left every table on the site with column headers offset ~10px to the right of their content.
- On the homepage event list, drop the `mt-2 flex justify-center md:mt-1` override on the Webcast cell so the button shares the same left edge as the "Webcast" header (and matches how the Event and Dates columns align).

Net effect: header text and column content now share a left edge across every table built on the shared primitive — homepage event list, district pages, team history, hall of fame, etc.

## Screenshot Pages

- /
- /events/2025
- /team/254/history
- /hall-of-fame

## Test plan

- [ ] Homepage "This Week's Events": Event / Webcast / Dates headers share left edges with their column content.
- [ ] Spot-check a few other tables (team history, district event list, hall of fame) to confirm headers align with cells and nothing visibly regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)