### PR TITLE
preserve first api code through datafeed

### DIFF
--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_event_list_parser.py
@@ -72,7 +72,7 @@ class FMSAPIEventListParser(
     EINSTEIN_NAME_DEFAULT = "Einstein Field"
     EINSTEIN_CODES = {"cmp", "cmpmi", "cmpmo", "cmptx"}
 
-    def __init__(self, season: Year, short: Optional[str] = None) -> None:
+    def __init__(self, season: Year, short: str | None = None) -> None:
         self.season = season
         self.event_short = short
 
@@ -297,6 +297,8 @@ class FMSAPIEventListParser(
 
             has_divisions = False
             has_division_teams_assigned = False
+            first_api_code = None
+            nexus_api_code = None
             if existing_event is not None and len(existing_event.divisions) > 0:
                 has_divisions = True
                 division_teams = EventTeam.query(
@@ -315,6 +317,9 @@ class FMSAPIEventListParser(
                     abs(end - division_end_date) < datetime.timedelta(days=1)
                     for division_end_date in cmp_division_end_dates
                 )
+            elif event_type == EventType.OFFSEASON and existing_event:
+                first_api_code = existing_event.first_code
+                nexus_api_code = existing_event.nexus_code
 
             sync_overrides = self._bootstrap_sync_overrides(
                 none_throws(event_type),
@@ -360,6 +365,8 @@ class FMSAPIEventListParser(
                     event_type_enum=event_type,
                     timezone_id=timezone,
                     official=official,
+                    first_code=first_api_code,
+                    nexus_code=nexus_api_code,
                     playoff_type=playoff_type,
                     start_date=start,
                     end_date=end,

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_event_list_parser_test.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_event_list_parser_test.py
@@ -1012,3 +1012,25 @@ def test_parse_2026_event_rich_webcasts(test_data_importer):
             date="2026-02-21",
         )
     ]
+
+
+def test_parse_offseason_preserves_first_api_code(test_data_importer):
+    path = test_data_importer._get_path(__file__, "data/2015_event_list.json")
+    with open(path, "r") as f:
+        data = json.load(f)
+
+    events, _ = FMSAPIEventListParser(2015).parse(data)
+    event = events[4]
+
+    assert event.key_name == "2015iri"
+    assert event.first_code is None
+
+    event.first_code = "synccode"
+    event.put()
+
+    # Re-parse and ensure first_code is preserved
+    events, _ = FMSAPIEventListParser(2015).parse(data)
+    event = events[4]
+
+    assert event.key_name == "2015iri"
+    assert event.first_code == "synccode"


### PR DESCRIPTION
I think we had a bug with the mod dashboard, and it would end up dropping FIRST API codes, if they were different.

The normal datafeed uses the list-based API, which would do merging of the offseasons from FIRST and the ones we already had

https://github.com/phil-lopreiato/the-blue-alliance/blob/c7a544b00ea40d232d6dfbd6b7ef131bac8ca7d8/src/backend/tasks_io/handlers/frc_api.py#L294-L308

However, the mod dashboard would trigger an individual event detail fetch

https://github.com/phil-lopreiato/the-blue-alliance/blob/c7a544b00ea40d232d6dfbd6b7ef131bac8ca7d8/src/backend/web/handlers/webcast_mod.py#L248-L253

This would, in effect, wipe the FIRST API code, because `first_code` is an "allow none" attribute, so it could get wiped.

Since the parser already fetches the "old" DB model, plumb through the `first_code` attr so it's always set here.