### PR TITLE
[pwa] Document format:fix in AGENTS.md Running commands

### DIFF
--- a/pwa/AGENTS.md
+++ b/pwa/AGENTS.md
@@ -99,6 +99,7 @@ Each line is `- /path` optionally followed by a display name. If no name is give
 pnpm run dev              # Development server
 pnpm run typecheck        # Type checking
 pnpm run lint             # Lint code
+pnpm run format:fix       # Auto-format (Prettier; also sorts Tailwind classes) — run before pushing, CI checks `format`
 pnpm dlx playwright test  # E2E tests
 ```
 


### PR DESCRIPTION
## Summary

CI's `[pwa] Format & Lint` job runs `prettier --check`, which (via `prettier-plugin-tailwindcss`) also enforces Tailwind utility-class ordering. The `## Running` command list in `pwa/AGENTS.md` listed `dev`, `typecheck`, `lint`, and `playwright`, but not the formatter — so it was easy to push hand-edited code (e.g. with classes in a non-canonical order) that then failed the lint check.

This adds `pnpm run format:fix` to that list with a note to run it before pushing.

## Test plan

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)