### PR TITLE
[pwa] Fix search modal off-by-one navigation (#10104)

### DIFF
--- a/pwa/app/components/tba/navigation/searchModal.tsx
+++ b/pwa/app/components/tba/navigation/searchModal.tsx
@@ -25,12 +25,22 @@ import { Kbd, KbdGroup } from '~/components/ui/kbd';
 import { Spinner } from '~/components/ui/spinner';
 import FuzzysortFilterer, {
   FilteredSearchIndex,
+  firstSearchResult,
+  keyToPath,
 } from '~/lib/search/fuzzysortFilterer';
 import { cn } from '~/lib/utils';
 
 export function SearchModal({ ...props }: DialogProps) {
   const [open, setOpen] = useState<boolean>(false);
   const [query, setQuery] = useState<string>('');
+  // cmdk's selected item, controlled so Enter navigates to exactly what is
+  // highlighted — regardless of how it got there (typing, arrows, vim keys, or
+  // pointer hover, which all report through onValueChange) — instead of cmdk's
+  // asynchronously-committed DOM selection that can lag a keystroke (#10104).
+  const [selection, setSelection] = useState<{ query: string; value: string }>({
+    query: '',
+    value: '',
+  });
   const searchIndexQuery = useQuery(getSearchIndexOptions({}));
   const filterer = useMemo(() => new FuzzysortFilterer(), []);
   const navigate = useNavigate();
@@ -45,6 +55,15 @@ export function SearchModal({ ...props }: DialogProps) {
     }
     return filterer.filter(searchIndexQuery.data, query);
   }, [query, searchIndexQuery.data, filterer]);
+
+  // The first result in display order is the default highlight. The user's own
+  // selection (captured via the controlled value's onValueChange) takes over
+  // until the query changes, at which point we fall back to the fresh top
+  // result — computed during render so it never lags a keystroke.
+  const topValue = searchResults
+    ? (firstSearchResult(searchResults)?.value ?? '')
+    : '';
+  const selectedValue = selection.query === query ? selection.value : topValue;
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -121,12 +140,35 @@ export function SearchModal({ ...props }: DialogProps) {
             **:data-[slot=command-input-wrapper]:border-input
             **:data-[slot=command-input-wrapper]:bg-transparent"
           shouldFilter={false}
+          value={selectedValue}
+          onValueChange={(value) => {
+            setSelection({ query, value });
+          }}
         >
           <div className="relative">
             <CommandInput
               placeholder="Search teams and events..."
               value={query}
               onValueChange={setQuery}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter' || e.nativeEvent.isComposing) {
+                  return;
+                }
+                // Navigate to whatever is highlighted, read from our controlled
+                // React selection rather than cmdk's async DOM selection, so a
+                // fast type-then-Enter can't land on a stale, off-by-one item
+                // (#10104). The highlight is the deterministic top result for a
+                // fresh query, or the user's own pick via arrows/vim/pointer.
+                if (!selectedValue) {
+                  return;
+                }
+                // Stop cmdk's root keydown handler from also navigating to its
+                // (possibly stale) aria-selected item.
+                e.preventDefault();
+                e.stopPropagation();
+                void navigate({ to: keyToPath(selectedValue) });
+                setOpen(false);
+              }}
               className="h-20 text-base"
             />
             {searchIndexQuery.isLoading && (
@@ -159,9 +201,7 @@ export function SearchModal({ ...props }: DialogProps) {
                               key={team.key}
                               value={team.key}
                               onSelect={() => {
-                                void navigate({
-                                  to: `/team/${team.key.substring(3)}`,
-                                });
+                                void navigate({ to: keyToPath(team.key) });
                                 setOpen(false);
                               }}
                             >
@@ -183,7 +223,7 @@ export function SearchModal({ ...props }: DialogProps) {
                               key={event.key}
                               value={event.key}
                               onSelect={() => {
-                                void navigate({ to: `/event/${event.key}` });
+                                void navigate({ to: keyToPath(event.key) });
                                 setOpen(false);
                               }}
                             >

--- a/pwa/app/lib/search/fuzzysortFilterer.test.ts
+++ b/pwa/app/lib/search/fuzzysortFilterer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { firstSearchResult, keyToPath } from '~/lib/search/fuzzysortFilterer';
+
+const team = (key: string) => ({ key, nickname: '' });
+const event = (key: string) => ({ key, name: '' });
+
+describe('keyToPath', () => {
+  it('maps a team key to its team route', () => {
+    expect(keyToPath('frc254')).toBe('/team/254');
+    expect(keyToPath('frc10221')).toBe('/team/10221');
+  });
+
+  it('maps an event key to its event route', () => {
+    expect(keyToPath('2024casj')).toBe('/event/2024casj');
+  });
+});
+
+describe('firstSearchResult', () => {
+  it('returns the top team when teamsFirst is set', () => {
+    expect(
+      firstSearchResult({
+        teams: [team('frc1022'), team('frc10221')],
+        events: [event('2024casj')],
+        teamsFirst: true,
+      }),
+    ).toEqual({ type: 'team', value: 'frc1022', path: '/team/1022' });
+  });
+
+  it('returns the top event when not teamsFirst, even if a team also matches', () => {
+    // cmdk shows the higher-scoring group first; Enter must follow that, not
+    // unconditionally prefer a team the way the /search-route helper does.
+    expect(
+      firstSearchResult({
+        teams: [team('frc254')],
+        events: [event('2024casj')],
+        teamsFirst: false,
+      }),
+    ).toEqual({ type: 'event', value: '2024casj', path: '/event/2024casj' });
+  });
+
+  it('falls back to the other group when the preferred group is empty', () => {
+    expect(
+      firstSearchResult({
+        teams: [],
+        events: [event('2024casj')],
+        teamsFirst: true,
+      }),
+    ).toEqual({ type: 'event', value: '2024casj', path: '/event/2024casj' });
+
+    expect(
+      firstSearchResult({
+        teams: [team('frc254')],
+        events: [],
+        teamsFirst: false,
+      }),
+    ).toEqual({ type: 'team', value: 'frc254', path: '/team/254' });
+  });
+
+  it('returns null when there are no results', () => {
+    expect(
+      firstSearchResult({ teams: [], events: [], teamsFirst: true }),
+    ).toBeNull();
+  });
+});

--- a/pwa/app/lib/search/fuzzysortFilterer.ts
+++ b/pwa/app/lib/search/fuzzysortFilterer.ts
@@ -78,3 +78,45 @@ export default class FuzzysortFilterer implements SearchDataFilterer {
     };
   }
 }
+
+/**
+ * Maps a search-index key to its route path. Team keys look like "frc254"
+ * (-> /team/254); event keys look like "2024casj" (-> /event/2024casj). Single
+ * source of truth for both the rendered result links and Enter navigation.
+ */
+export function keyToPath(key: string): string {
+  return key.startsWith('frc') ? `/team/${key.substring(3)}` : `/event/${key}`;
+}
+
+export interface TopSearchResult {
+  type: 'team' | 'event';
+  /** The result's search-index key (matches the cmdk item value). */
+  value: string;
+  path: string;
+}
+
+/**
+ * Returns the first result in display order — i.e. the item shown highlighted
+ * at the top of the list, honoring `teamsFirst` — or null if there are no
+ * results. Used to seed the controlled cmdk selection so a freshly-typed
+ * query's default highlight (and therefore Enter) always matches what the user
+ * sees, rather than trusting cmdk's asynchronously-committed selection (#10104).
+ */
+export function firstSearchResult(
+  results: FilteredSearchIndex,
+): TopSearchResult | null {
+  const order: ('teams' | 'events')[] = results.teamsFirst
+    ? ['teams', 'events']
+    : ['events', 'teams'];
+  for (const group of order) {
+    const item = group === 'teams' ? results.teams[0] : results.events[0];
+    if (item) {
+      return {
+        type: group === 'teams' ? 'team' : 'event',
+        value: item.key,
+        path: keyToPath(item.key),
+      };
+    }
+  }
+  return null;
+}

--- a/pwa/app/lib/search/searchRedirect.test.ts
+++ b/pwa/app/lib/search/searchRedirect.test.ts
@@ -105,6 +105,34 @@ describe('getSearchRedirect', () => {
     });
   });
 
+  describe('numeric prefix collisions (#10104)', () => {
+    // When a team number is a prefix of a longer one, fuzzysort must rank the
+    // shorter exact match first. Both getSearchRedirect (the /search route) and
+    // the search modal rely on this ranking via FuzzysortFilterer, so these
+    // cases lock it in: "1022" resolves to team 1022, never 10221.
+    const collisionIndex: SearchIndex = {
+      teams: [
+        { key: 'frc1022', nickname: 'Titan Robotics' },
+        { key: 'frc10221', nickname: 'RoboLords' },
+        { key: 'frc254', nickname: 'The Cheesy Poofs' },
+        { key: 'frc2543', nickname: 'PETRONAS Mustangs' },
+      ],
+      events: [],
+    };
+
+    it('should redirect "1022" to team 1022, not 10221', () => {
+      const result = getSearchRedirect(collisionIndex, '1022');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/1022');
+    });
+
+    it('should redirect "254" to team 254, not 2543', () => {
+      const result = getSearchRedirect(collisionIndex, '254');
+      expect(result.type).toBe('team');
+      expect(result.path).toBe('/team/254');
+    });
+  });
+
   describe('priority logic', () => {
     it('should prefer team when both team and event match', () => {
       // When searching for something that could match both, teams should win

--- a/pwa/tests/search.spec.ts
+++ b/pwa/tests/search.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+// Regression tests for #10104: in the search modal, pressing Enter must
+// navigate to the result that is highlighted — the visibly-first result for a
+// freshly typed query (the bug: "1022" navigated to team 10221), and the item
+// the user moved to via arrows, vim keys (Ctrl+N/J/P/K), or pointer hover. The
+// search index is mocked so the colliding team numbers and a known event are
+// guaranteed present and the assertions are deterministic.
+
+const SEARCH_INDEX = {
+  teams: [
+    { key: 'frc1022', nickname: 'Titan Robotics' },
+    { key: 'frc10221', nickname: 'RoboLords' },
+    { key: 'frc254', nickname: 'The Cheesy Poofs' },
+    { key: 'frc2543', nickname: 'PETRONAS Mustangs' },
+  ],
+  events: [{ key: '2024casj', name: 'Silicon Valley Regional' }],
+};
+
+test.describe('search modal navigation (#10104)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/search_index*', async (route) => {
+      await route.fulfill({ json: SEARCH_INDEX });
+    });
+    await page.goto('/');
+    await page.locator('body[data-hydrated]').waitFor();
+    await page
+      .getByRole('button', { name: 'Search teams and events...' })
+      .click();
+    await expect(
+      page.getByPlaceholder('Search teams and events...'),
+    ).toBeFocused();
+  });
+
+  test('typing a team number navigates to that exact team, not the next one', async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder('Search teams and events...');
+    // Type then immediately commit, with no settle time, to hit the race window.
+    await input.pressSequentially('1022');
+    await input.press('Enter');
+    await expect(page).toHaveURL(/\/team\/1022$/);
+  });
+
+  test('typing a longer team number still reaches the longer team', async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder('Search teams and events...');
+    await input.pressSequentially('10221');
+    await input.press('Enter');
+    await expect(page).toHaveURL(/\/team\/10221$/);
+  });
+
+  test('arrowing to a lower result and pressing Enter honors that selection', async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder('Search teams and events...');
+    await input.pressSequentially('254');
+    await expect(page.getByRole('option', { name: /2543/ })).toBeVisible();
+    await input.press('ArrowDown');
+    await expect(page.getByRole('option', { name: /2543/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await input.press('Enter');
+    await expect(page).toHaveURL(/\/team\/2543$/);
+  });
+
+  test('vim-key navigation (Ctrl+N) and Enter honors the moved selection', async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder('Search teams and events...');
+    await input.pressSequentially('254');
+    await expect(page.getByRole('option', { name: /2543/ })).toBeVisible();
+    await input.press('Control+n');
+    await expect(page.getByRole('option', { name: /2543/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await input.press('Enter');
+    await expect(page).toHaveURL(/\/team\/2543$/);
+  });
+
+  test('hovering a result then pressing Enter honors the hovered item', async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder('Search teams and events...');
+    await input.pressSequentially('254');
+    const lower = page.getByRole('option', { name: /2543/ });
+    await expect(lower).toBeVisible();
+    await lower.hover();
+    await expect(lower).toHaveAttribute('aria-selected', 'true');
+    await input.press('Enter');
+    await expect(page).toHaveURL(/\/team\/2543$/);
+  });
+
+  test('typing an event key navigates to that event', async ({ page }) => {
+    const input = page.getByPlaceholder('Search teams and events...');
+    await input.pressSequentially('2024casj');
+    await input.press('Enter');
+    await expect(page).toHaveURL(/\/event\/2024casj$/);
+  });
+});


### PR DESCRIPTION
Fixes #10104.

## Problem
Typing a team number into the global search modal and pressing Enter could navigate to the **next** team — e.g. "1022" showed `1022` in the box but went to `/team/10221`. Reported on [Chief Delphi](https://www.chiefdelphi.com/t/the-blue-alliance-2026-site-updates-features/515744/57) (~1 in 7 attempts, most often on the first keystroke after focusing, on Firefox).

## Root cause
The modal left Enter entirely to `cmdk`, which commits its highlighted item **asynchronously** (a layout-effect scheduler) while the result list is reordered **synchronously** on every keystroke. Pressing Enter in that window navigated to `cmdk`'s stale, off-by-one selection. (#9934 recently added per-keystroke score reordering, which widened the window.)

## Fix
Control `cmdk`'s selected value from React state instead of trusting its async DOM selection:
- `selectedValue` is derived during render — it defaults to the **visibly-first** result (`firstSearchResult`, honoring the same `teamsFirst` ordering the list renders) for the current query, and follows the user's own pick once they move it.
- Because `cmdk` reports **all** selection movement — arrow keys, vim keys (Ctrl+N/J/P/K), and pointer hover — through `onValueChange`, Enter navigates to exactly what's highlighted regardless of how it got there.
- Enter navigates to `keyToPath(selectedValue)` with `preventDefault`+`stopPropagation` so `cmdk`'s own (possibly stale) Enter handler doesn't also fire.
- Path construction is unified in a single `keyToPath` helper shared by the rendered links and Enter.

`getSearchRedirect` (the `/search` route helper) is unchanged.

## Tests
- Unit (`fuzzysortFilterer.test.ts`, `searchRedirect.test.ts`): `keyToPath`, `firstSearchResult` (incl. event-first ordering), and numeric-prefix collisions (1022 vs 10221, 254 vs 2543) — 24/24 pass.
- Playwright (`tests/search.spec.ts`): type-then-Enter, longer-sibling, and Enter honoring **arrow / vim (Ctrl+N) / pointer-hover** selection, plus event-key navigation.

## Visual evidence
The original symptom is an intermittent timing race (~1/7, Firefox); it does **not** reproduce in headless Chrome automation (verified 30/30 correct even on the unfixed build with burst + backspace-reorder patterns), so a static "before" capture of the misnavigation isn't reproducible in CI — see the [original CD report](https://www.chiefdelphi.com/t/the-blue-alliance-2026-site-updates-features/515744/57) for the reporter's screenshot. The fix removes the dependency on cmdk's async selection entirely; the shots below show the corrected behavior, validated end-to-end in Chrome.

<!-- screenshots:start -->
## Screenshots

**Typing "1022" — top result 1022 highlighted; Enter now navigates here**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-pwa-search-off-by-one/after-1022-modal-2cd3d856.png" width="320">

**Lands on Team 1022 (not the off-by-one 10221)**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-pwa-search-off-by-one/after-1022-landed-a095b639.png" width="320">

**Keyboard/vim/pointer selection still honored — 2543 highlighted then Enter goes to /team/2543**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-pwa-search-off-by-one/after-254-arrowed-73a0e0db.png" width="320">
<!-- screenshots:end -->

### Behavior validation (system Chrome, prod build, search index mocked)
| Scenario | Result |
|---|---|
| type `1022` + immediate Enter ×20 | `/team/1022` (0 wrong) |
| type `10221` + Enter | `/team/10221` |
| type `254` + ArrowDown + Enter | `/team/2543` |
| type `254` + Ctrl+N (vim) + Enter | `/team/2543` |
| type `254` + hover 2543 + Enter | `/team/2543` |
| type `2024casj` + Enter | `/event/2024casj` |

## Review
Gated on a 5-seat adversarial review panel (tech lead, PM, designer, web nerd, FRC nerd) — all five approve. An earlier revision was blocked for breaking keyboard/vim/pointer selection; this controlled-selection approach resolves that and is the version here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)