### PR TITLE
[insights] Disclaim 2024-2026 playoff ranking points like 2022/2023 (#10106)

### DIFF
--- a/src/backend/web/templates/event_partials/event_insights_2024.html
+++ b/src/backend/web/templates/event_partials/event_insights_2024.html
@@ -14,14 +14,14 @@
 
       <tbody>
         <tr>
-          <td>Melody RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Melody RP *</span></td>
           <td>{{event_insights.melody_rp_count[0]}}</td>
           <td>{{event_insights.melody_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.melody_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>Ensemble RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Ensemble RP *</span></td>
           <td>{{event_insights.ensemble_rp_count[0]}}</td>
           <td>{{event_insights.ensemble_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.ensemble_rp_count[2])}}%</td>
@@ -35,14 +35,14 @@
         </tr>
 
         <tr>
-          <td>4 RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">4 RP *</span></td>
           <td>{{event_insights.four_rp_count[0]}}</td>
           <td>{{event_insights.four_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.four_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>6 RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">6 RP *</span></td>
           <td>{{event_insights.six_rp_count[0]}}</td>
           <td>{{event_insights.six_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.six_rp_count[2])}}%</td>

--- a/src/backend/web/templates/event_partials/event_insights_2025.html
+++ b/src/backend/web/templates/event_partials/event_insights_2025.html
@@ -14,21 +14,21 @@
 
       <tbody>
         <tr>
-          <td>Auto RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Auto RP *</span></td>
           <td>{{event_insights.auto_rp_count[0]}}</td>
           <td>{{event_insights.auto_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.auto_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>Barge RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Barge RP *</span></td>
           <td>{{event_insights.barge_rp_count[0]}}</td>
           <td>{{event_insights.barge_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.barge_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>Coral RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Coral RP *</span></td>
           <td>{{event_insights.coral_rp_count[0]}}</td>
           <td>{{event_insights.coral_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.coral_rp_count[2])}}%</td>
@@ -42,14 +42,14 @@
         </tr>
 
         <tr>
-          <td>6 RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">6 RP *</span></td>
           <td>{{event_insights.six_rp_count[0]}}</td>
           <td>{{event_insights.six_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.six_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>9 RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">9 RP *</span></td>
           <td>{{event_insights.nine_rp_count[0]}}</td>
           <td>{{event_insights.nine_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(event_insights.nine_rp_count[2])}}%</td>

--- a/src/backend/web/templates/event_partials/event_insights_2026.html
+++ b/src/backend/web/templates/event_partials/event_insights_2026.html
@@ -32,35 +32,35 @@
 
       <tbody>
         <tr>
-          <td>Energized RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Energized RP *</span></td>
           <td>{{energized_rp_count[0]}}</td>
           <td>{{energized_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(energized_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>Supercharged RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Supercharged RP *</span></td>
           <td>{{supercharged_rp_count[0]}}</td>
           <td>{{supercharged_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(supercharged_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>Traversal RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">Traversal RP *</span></td>
           <td>{{traversal_rp_count[0]}}</td>
           <td>{{traversal_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(traversal_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>6 RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">6 RP *</span></td>
           <td>{{six_rp_count[0]}}</td>
           <td>{{six_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(six_rp_count[2])}}%</td>
         </tr>
 
         <tr>
-          <td>9 RP</td>
+          <td><span rel="tooltip" title="Has no real meaning for Playoff matches">9 RP *</span></td>
           <td>{{nine_rp_count[0]}}</td>
           <td>{{nine_rp_count[1]}}</td>
           <td>{{'%0.2f' | format(nine_rp_count[2])}}%</td>


### PR DESCRIPTION
Fixes #10106.

## Problem
`/insights/<year>` (and the per-event insights tab) reported ranking points as earned in **playoff** matches — e.g. the 2026 Playoff column showed `Energized RP 2 / 6300`. RPs are a qualification-only concept.

## Approach
2022 and 2023 already handle this: their bonus-RP rows still render in the Playoff column, but each label carries a `* Has no real meaning for Playoff matches` tooltip. 2024, 2025, and 2026 dropped that caveat while still reporting the values. This PR brings **2024-2026 in line with the existing 2022/2023 treatment** so every season is consistent — the RP values are still computed, but each RP row label gains the `*` + "Has no real meaning for Playoff matches" tooltip:
- **2024** — Melody / Ensemble / 4 RP / 6 RP
- **2025** — Auto / Barge / Coral / 6 RP / 9 RP
- **2026** — Energized / Supercharged / Traversal / 6 RP / 9 RP

Coopertition (2024/2025) and Auto Win Conversion (2026) are not RPs and are left unchanged. This is a template-only change to `event_insights_{2024,2025,2026}.html` — no logic or data change, consistent with how 2022/2023 are implemented.

## Visual evidence (local running site)
`/insights/<year>` → "Year Specific Statistics" → Year Aggregate. 2026 before/after shows the RP rows gaining the `*` disclaimer (the same treatment 2022/2023 already use); 2024 and 2025 after shown for coverage:

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **2026 /insights/2026 — Year Aggregate (RP rows gain the '* no real meaning for playoff' disclaimer)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-insights-2026-playoff-rp/10106b-2026-before-insights-year-aggregate-8c1334b1.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-insights-2026-playoff-rp/10106b-2026-after-insights-year-aggregate-5a21441a.png" width="300"> |

**2025 /insights/2025 — after (RP rows disclaimed)**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-insights-2026-playoff-rp/10106b-2025-after-insights-year-aggregate-5e8d1d08.png" width="320">

**2024 /insights/2024 — after (RP rows disclaimed)**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-insights-2026-playoff-rp/10106b-2024-after-insights-year-aggregate-0fb55bda.png" width="320">
<!-- screenshots:end -->

## Review
Gated on a 5-seat adversarial review panel (tech lead, PM, designer, web nerd, FRC nerd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)