### PR TITLE
[data] Don't label Einstein matches as qualification matches (#10102)

### DIFF
--- a/src/backend/common/helpers/playoff_type_helper.py
+++ b/src/backend/common/helpers/playoff_type_helper.py
@@ -1,6 +1,7 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 from backend.common.consts.comp_level import CompLevel
+from backend.common.consts.event_type import EventType
 from backend.common.consts.playoff_type import (
     BRACKET_ELIM_MAPPING,
     BRACKET_OCTO_ELIM_MAPPING,
@@ -16,9 +17,20 @@ from backend.common.consts.playoff_type import (
 class PlayoffTypeHelper:
     @classmethod
     def get_comp_level(
-        cls, playoff_type: PlayoffType, match_level: str, match_number: int
+        cls,
+        playoff_type: PlayoffType,
+        match_level: str,
+        match_number: int,
+        event_type: Optional[EventType] = None,
     ) -> CompLevel:
-        if match_level == "Qualification":
+        # Championship (Einstein) events have no qualification phase, but the
+        # FMS feed sometimes tags their playoff matches as "Qualification".
+        # Those must be routed through the playoff logic below rather than
+        # mislabeled as qualification matches (#10102). Only CMP_FINALS is
+        # special-cased: a non-split DISTRICT_CMP runs real qualification
+        # matches, so it can't be blanket-skipped. (Split district-champ finals
+        # fields share this FMS mistag but are not handled here.)
+        if match_level == "Qualification" and event_type != EventType.CMP_FINALS:
             return CompLevel.QM
         else:
             if playoff_type == PlayoffType.AVG_SCORE_8_TEAM:

--- a/src/backend/common/helpers/tests/playoff_type_helper_test.py
+++ b/src/backend/common/helpers/tests/playoff_type_helper_test.py
@@ -1,5 +1,6 @@
 from backend.common.consts.comp_level import CompLevel
-from backend.common.consts.playoff_type import PlayoffType
+from backend.common.consts.event_type import EventType
+from backend.common.consts.playoff_type import DOUBLE_ELIM_MAPPING, PlayoffType
 from backend.common.helpers.playoff_type_helper import PlayoffTypeHelper
 
 
@@ -128,3 +129,50 @@ def test_ROUND_ROBIN_6_TEAM() -> None:
         1,
         3,
     )
+
+
+def test_einstein_qualification_tagged_matches_route_to_playoff() -> None:
+    # Championship (Einstein) events have no qualification phase, but the FMS
+    # feed sometimes tags their playoff matches as "Qualification". At a
+    # CMP_FINALS event those must map to the playoff bracket, not qm (#10102).
+    # 2026 Einstein is an 8-alliance double-elimination bracket.
+    playoff_type = PlayoffType.DOUBLE_ELIM_8_TEAM
+    for i in range(1, 17):
+        einstein = PlayoffTypeHelper.get_comp_level(
+            playoff_type, "Qualification", i, EventType.CMP_FINALS
+        )
+        # Identical to the same match arriving tagged "Playoff".
+        assert einstein == PlayoffTypeHelper.get_comp_level(playoff_type, "Playoff", i)
+        assert einstein in (CompLevel.SF, CompLevel.F)
+        assert einstein != CompLevel.QM
+        # And the set/match numbering is the double-elim mapping, not the qm
+        # (1, i) numbering it would have gotten while mislabeled.
+        expected_level, expected_set, expected_match = DOUBLE_ELIM_MAPPING[i]
+        assert einstein == expected_level
+        assert PlayoffTypeHelper.get_set_match_number(playoff_type, einstein, i) == (
+            expected_set,
+            expected_match,
+        )
+
+
+def test_qualification_still_qm_for_non_cmp_finals_events() -> None:
+    # Regression: real qualification matches at ordinary events are unaffected,
+    # including championship DIVISIONS (which do run qualification matches) and
+    # the default (no event_type) call path used everywhere else.
+    playoff_type = PlayoffType.DOUBLE_ELIM_8_TEAM
+    for i in range(1, 50):
+        assert (
+            PlayoffTypeHelper.get_comp_level(playoff_type, "Qualification", i)
+            == CompLevel.QM
+        )
+        for event_type in (
+            EventType.REGIONAL,
+            EventType.DISTRICT,
+            EventType.CMP_DIVISION,
+        ):
+            assert (
+                PlayoffTypeHelper.get_comp_level(
+                    playoff_type, "Qualification", i, event_type
+                )
+                == CompLevel.QM
+            )

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/fms_api_match_parser.py
@@ -95,7 +95,7 @@ class FMSAPIHybridScheduleParser(
             else:  # 2015
                 level = match["level"]
             comp_level = PlayoffTypeHelper.get_comp_level(
-                event.playoff_type, level, match["matchNumber"]
+                event.playoff_type, level, match["matchNumber"], event.event_type_enum
             )
             set_number, match_number = PlayoffTypeHelper.get_set_match_number(
                 event.playoff_type, comp_level, match["matchNumber"]
@@ -388,6 +388,7 @@ class FMSAPIMatchDetailsParser(
                 event.playoff_type,
                 none_throws(match["matchLevel"]),
                 none_throws(match["matchNumber"]),
+                event.event_type_enum,
             )
             set_number, match_number = PlayoffTypeHelper.get_set_match_number(
                 event.playoff_type, comp_level, match["matchNumber"]

--- a/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_hybrid_schedule_parser_test.py
+++ b/src/backend/tasks_io/datafeeds/parsers/fms_api/tests/fms_api_hybrid_schedule_parser_test.py
@@ -263,6 +263,47 @@ def test_parse_2champs_einstein(ndb_stub, test_data_importer) -> None:
         assert len(clean_matches[CompLevel.F]) == 3
 
 
+def test_parse_modern_einstein_qualification_tagged(
+    ndb_stub, test_data_importer
+) -> None:
+    # Regression for #10102: modern Championship (Einstein) is an 8-alliance
+    # double-elimination event, and the FMS feed can tag its matches with
+    # tournamentLevel "Qualification" even though Einstein has no quals. Those
+    # must parse as playoff matches (sf/f), not qualification (qm).
+    event = Event(
+        id="2026cmptx",
+        name="Einstein Field",
+        event_type_enum=EventType.CMP_FINALS,
+        short_name="Einstein",
+        event_short="cmptx",
+        year=2026,
+        end_date=datetime(2026, 4, 18),
+        official=True,
+        start_date=datetime(2026, 4, 15),
+        timezone_id="America/New_York",
+        playoff_type=PlayoffType.DOUBLE_ELIM_8_TEAM,
+    )
+    event.put()
+
+    # Reuse real match structures, re-tagged "Qualification" with modern
+    # double-elim numbering (1-13 -> sf, 14-16 -> f).
+    path = test_data_importer._get_path(
+        __file__, "data/2017cmptx_staging_playoff_schedule.json"
+    )
+    with open(path, "r") as f:
+        schedule = json.loads(f.read())["Schedule"][:16]
+    for i, match in enumerate(schedule):
+        match["tournamentLevel"] = "Qualification"
+        match["matchNumber"] = i + 1
+
+    matches, _ = FMSAPIHybridScheduleParser(2026, "cmptx").parse({"Schedule": schedule})
+
+    _, clean_matches = MatchHelper.organized_matches(matches)
+    assert len(clean_matches[CompLevel.QM]) == 0
+    assert len(clean_matches[CompLevel.SF]) == 13
+    assert len(clean_matches[CompLevel.F]) == 3
+
+
 def test_parse_foc_b05(ndb_stub, test_data_importer) -> None:
     event = Event(
         id="2017nhfoc",

--- a/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/nexus_api/queue_status_parser.py
@@ -115,7 +115,7 @@ class NexusAPIQueueStatusParser(ParserBase[EventStatus, Optional[EventQueueStatu
 
         try:
             comp_level = PlayoffTypeHelper.get_comp_level(
-                self.event.playoff_type, level, level_number
+                self.event.playoff_type, level, level_number, self.event.event_type_enum
             )
             set_number, match_number = PlayoffTypeHelper.get_set_match_number(
                 self.event.playoff_type, comp_level, level_number


### PR DESCRIPTION
Fixes the Einstein-matches-shown-as-qualification half of #10102 (see Notes for the rest).

## Problem
On the 2026 Einstein Field event (`2026cmptx`), the Einstein matches were shown under **Qualification** instead of the playoff bracket ([CD #89](https://www.chiefdelphi.com/t/the-blue-alliance-2026-site-updates-features/515744/89)). Einstein has no qualification phase.

## Root cause (ground-truth verified)
2026 Einstein is an 8-alliance **double-elimination** bracket (not a round robin). `PlayoffTypeHelper.get_comp_level` returned `CompLevel.QM` for any match whose `tournamentLevel` is `"Qualification"` *before* considering the event. The FMS feed sometimes tags Einstein (a `CMP_FINALS` event, which has no quals) playoff matches as `"Qualification"`, so they were ingested as `qm` and rendered under "Qualification Results". Production has since re-synced to the correct `sf`/`f`, but the modeling bug recurs every championship.

## Fix
Add an optional `event_type` to `get_comp_level` and skip the `Qualification → qm` short-circuit when `event_type == CMP_FINALS`, so Einstein matches fall through to the existing playoff logic (`DOUBLE_ELIM_MAPPING → sf/f`). `event_type` defaults to `None`, preserving all existing behavior; championship **divisions** (which run real quals) are explicitly unaffected. The three callers (`fms_api_match_parser` ×2, nexus `queue_status_parser`) now pass `event.event_type_enum`.

## Tests
- Unit: `Qualification`-tagged `CMP_FINALS` matches map to the double-elim `sf`/`f` (asserted against `DOUBLE_ELIM_MAPPING`), while `REGIONAL` / `DISTRICT` / `CMP_DIVISION` quals stay `qm`.
- Parser: a 2026 `CMP_FINALS` double-elim hybrid schedule re-tagged `"Qualification"` parses to **0 qm / 13 sf / 3 f**. The legacy 2017 round-robin Einstein parse is unchanged. (22 tests pass; black + flake8 clean. Local pyre couldn't run — the dev container's `pyre.bin` is the wrong CPU arch; CI runs pyre.)

## Visual evidence (local running site)
The same 16 Einstein matches (real `2026cmptx` data), rendered with the buggy `qm` comp_level vs the fixed `sf`/`f`:

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Einstein matches on the event page (Results tab)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-einstein-comp-level/10102-before-event-results-d4204158.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/fix-einstein-comp-level/10102-after-event-results-501d5d72.png" width="300"> |
<!-- screenshots:end -->

**Before** — Einstein matches under "Qualification Results" (Quals 1-16), the reported bug (seeded with the buggy-parser `qm` output). **After** — the same matches under "Playoff Results" + the double-elim "Playoff Bracket" on the real `/event/2026cmptx`.

## Notes / scope
- The **second half** of #10102 (all champ teams shown on Einstein before divisions are released / premature "Einstein" name flip) was **already fixed** in April 2026 (#9681 / #9719 / #9741 / #9742).
- Split district-championship finals fields share the same FMS mistag but are a `DISTRICT_CMP` event (which runs real quals), so they can't be blanket-skipped — called out in a code comment as a known follow-up.
- Past `CMP_FINALS` events already stored as `qm` will correct on the next re-sync of those events.

## Review
Gated on a 5-seat adversarial review panel (tech lead, PM, designer, web nerd, FRC nerd) — all five approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)