### PR TITLE
Sort PWA event list sections chronologically

### DIFF
--- a/pwa/app/lib/eventUtils.test.ts
+++ b/pwa/app/lib/eventUtils.test.ts
@@ -8,6 +8,7 @@ import {
   getEventWeekString,
   getPublicAgendaUrl,
   groupEventsByParent,
+  groupEventsBySections,
   hasEventEnded,
   isEventActive,
   isEventWithinDays,
@@ -249,6 +250,155 @@ describe.concurrent('toCalendarEvent', () => {
     };
     const cal = toCalendarEvent(event);
     expect(cal.location).toBe('Boston, USA');
+  });
+});
+
+describe.concurrent('groupEventsBySections', () => {
+  function makeEvent(overrides: Partial<Event>): Event {
+    // @ts-expect-error: Don't need to fill out all the fields
+    return {
+      year: 2026,
+      event_type: EventType.REGIONAL,
+      week: null,
+      city: 'Somewhere',
+      ...overrides,
+    };
+  }
+
+  test('sections are chronological when district weeks are delayed past Championship', () => {
+    // 2026 Israel district events were postponed to weeks 17–19, after
+    // FIRST Championship. Sections must follow the calendar, not week number.
+    const events = [
+      makeEvent({ key: '2026week1', week: 0, start_date: '2026-02-25' }),
+      makeEvent({ key: '2026week7', week: 6, start_date: '2026-04-08' }),
+      makeEvent({
+        key: '2026arc',
+        event_type: EventType.CMP_DIVISION,
+        start_date: '2026-04-22',
+      }),
+      makeEvent({
+        key: '2026cmptx',
+        event_type: EventType.CMP_FINALS,
+        start_date: '2026-04-25',
+      }),
+      makeEvent({
+        key: '2026isde1',
+        event_type: EventType.DISTRICT,
+        week: 16,
+        start_date: '2026-05-18',
+      }),
+      makeEvent({
+        key: '2026iscmp',
+        event_type: EventType.DISTRICT_CMP,
+        week: 18,
+        start_date: '2026-06-01',
+      }),
+      makeEvent({
+        key: '2026offseason',
+        event_type: EventType.OFFSEASON,
+        start_date: '2026-06-15',
+      }),
+    ];
+
+    const groups = groupEventsBySections(events);
+    expect(groups.map((group) => group.groupName)).toEqual([
+      'Week 1',
+      'Week 7',
+      'FIRST Championship',
+      'Week 17',
+      'Week 19',
+      'June',
+    ]);
+    const championship = groups.find(
+      (group) => group.groupName === 'FIRST Championship',
+    );
+    expect(championship?.events.map((event) => event.key)).toEqual([
+      '2026arc',
+      '2026cmptx',
+    ]);
+  });
+
+  test('typical year keeps weeks, then Championship, then FOC', () => {
+    const events = [
+      makeEvent({ key: '2024week1', week: 0, start_date: '2024-02-28' }),
+      makeEvent({ key: '2024week6', week: 5, start_date: '2024-04-03' }),
+      makeEvent({
+        key: '2024cmptx',
+        year: 2024,
+        event_type: EventType.CMP_FINALS,
+        start_date: '2024-04-17',
+      }),
+      makeEvent({
+        key: '2024foc',
+        year: 2024,
+        event_type: EventType.FOC,
+        start_date: '2024-09-28',
+      }),
+    ];
+
+    const groups = groupEventsBySections(events);
+    expect(groups.map((group) => group.groupName)).toEqual([
+      'Week 1',
+      'Week 6',
+      'FIRST Championship',
+      'FIRST Festival of Champions',
+    ]);
+    expect(groups.every((group) => group.isOfficial)).toBe(true);
+  });
+
+  test('2017-2020 dual championships are separate sections in date order', () => {
+    const events = [
+      makeEvent({
+        key: '2019carv',
+        year: 2019,
+        event_type: EventType.CMP_DIVISION,
+        city: 'Houston',
+        start_date: '2019-04-17',
+      }),
+      makeEvent({
+        key: '2019arc',
+        year: 2019,
+        event_type: EventType.CMP_DIVISION,
+        city: 'Detroit',
+        start_date: '2019-04-24',
+      }),
+    ];
+
+    const groups = groupEventsBySections(events);
+    expect(groups.map((group) => group.groupName)).toEqual([
+      'FIRST Championship - Houston',
+      'FIRST Championship - Detroit',
+    ]);
+  });
+
+  test('unofficial events group by month after official sections', () => {
+    const events = [
+      makeEvent({
+        key: '2026pre',
+        event_type: EventType.PRESEASON,
+        start_date: '2026-01-10',
+      }),
+      makeEvent({ key: '2026week2', week: 1, start_date: '2026-03-04' }),
+      makeEvent({
+        key: '2026off1',
+        event_type: EventType.OFFSEASON,
+        start_date: '2026-07-11',
+      }),
+      makeEvent({
+        key: '2026off2',
+        event_type: EventType.OFFSEASON,
+        start_date: '2026-07-18',
+      }),
+    ];
+
+    const groups = groupEventsBySections(events);
+    expect(groups.map((group) => [group.groupName, group.isOfficial])).toEqual([
+      ['Week 2', true],
+      ['January', false],
+      ['July', false],
+    ]);
+    const july = groups.find((group) => group.groupName === 'July');
+    expect(july?.events).toHaveLength(2);
   });
 });
 

--- a/pwa/app/lib/eventUtils.ts
+++ b/pwa/app/lib/eventUtils.ts
@@ -3,6 +3,7 @@ import { Temporal } from 'temporal-polyfill';
 
 import { Event, EventType } from '~/api/tba/read';
 import { CMP_EVENT_TYPES, SEASON_EVENT_TYPES } from '~/lib/api/EventType';
+import { slugify } from '~/lib/utils';
 
 /** IANA timezone used when an event has no timezone field. */
 export const EVENT_FALLBACK_TIMEZONE = 'America/New_York';
@@ -153,6 +154,116 @@ export function getEventWeekString(event: Event) {
     default:
       return `Week ${event.week + 1}`;
   }
+}
+
+export interface EventGroup {
+  groupName: string;
+  slug: string;
+  events: Event[];
+  isOfficial: boolean;
+}
+
+function earliestStartDate(group: EventGroup): Temporal.PlainDate {
+  return group.events
+    .map((event) => Temporal.PlainDate.from(event.start_date))
+    .reduce((min, date) =>
+      Temporal.PlainDate.compare(date, min) < 0 ? date : min,
+    );
+}
+
+/**
+ * Groups events into the labeled sections shown on the events list page.
+ *
+ * Official sections (numbered weeks, FIRST Championship, Festival of
+ * Champions) are ordered chronologically by each section's earliest event
+ * start date, so Championship lands at its true position even when district
+ * weeks are delayed past it (e.g. the 2026 Israel districts in weeks 17–19).
+ * Unofficial preseason/offseason sections are grouped by month and follow, in
+ * the chronological order of the input events.
+ */
+export function groupEventsBySections(events: Event[]): EventGroup[] {
+  const eventsByWeek = new Map<string, EventGroup>();
+  const eventsByChampionship = new Map<string, EventGroup>();
+  const unofficialEventsByMonth = new Map<string, EventGroup>();
+  const FOCEvents: EventGroup = {
+    groupName: 'FIRST Festival of Champions',
+    slug: 'foc',
+    events: [],
+    isOfficial: true,
+  };
+  events.forEach((event) => {
+    // Events by week
+    const weekStr = getEventWeekString(event);
+    if (weekStr != null) {
+      const weekGroup = eventsByWeek.get(weekStr);
+      if (weekGroup) {
+        weekGroup.events.push(event);
+      } else {
+        eventsByWeek.set(weekStr, {
+          groupName: weekStr,
+          slug: slugify(weekStr),
+          events: [event],
+          isOfficial: true,
+        });
+      }
+    }
+
+    // Events by Championship
+    if (CMP_EVENT_TYPES.has(event.event_type)) {
+      const groupName =
+        event.year >= 2017 && event.year <= 2020
+          ? `FIRST Championship - ${event.city}`
+          : 'FIRST Championship';
+      const championshipGroup = eventsByChampionship.get(groupName);
+      if (championshipGroup) {
+        championshipGroup.events.push(event);
+      } else {
+        eventsByChampionship.set(groupName, {
+          groupName,
+          slug: slugify(groupName),
+          events: [event],
+          isOfficial: true,
+        });
+      }
+    }
+
+    // FOC
+    if (event.event_type === EventType.FOC) {
+      FOCEvents.events.push(event);
+    }
+
+    // Group unofficial events by month
+    if (
+      event.event_type == EventType.PRESEASON ||
+      event.event_type == EventType.OFFSEASON
+    ) {
+      const monthName = Temporal.PlainDate.from(
+        event.start_date,
+      ).toLocaleString('default', { month: 'long' });
+      const offseasonGroup = unofficialEventsByMonth.get(monthName);
+      if (offseasonGroup) {
+        offseasonGroup.events.push(event);
+      } else {
+        unofficialEventsByMonth.set(monthName, {
+          groupName: monthName,
+          slug: slugify(monthName),
+          events: [event],
+          isOfficial: false,
+        });
+      }
+    }
+  });
+
+  const officialGroups = Array.from(eventsByWeek.values()).concat(
+    Array.from(eventsByChampionship.values()),
+  );
+  if (FOCEvents.events.length > 0) {
+    officialGroups.push(FOCEvents);
+  }
+  officialGroups.sort((a, b) =>
+    Temporal.PlainDate.compare(earliestStartDate(a), earliestStartDate(b)),
+  );
+  return officialGroups.concat(Array.from(unofficialEventsByMonth.values()));
 }
 
 // Minimum overlap (in seconds) between an event's active window and the

--- a/pwa/app/lib/eventUtils.ts
+++ b/pwa/app/lib/eventUtils.ts
@@ -173,13 +173,9 @@ function earliestStartDate(group: EventGroup): Temporal.PlainDate {
 
 /**
  * Groups events into the labeled sections shown on the events list page.
- *
- * Official sections (numbered weeks, FIRST Championship, Festival of
- * Champions) are ordered chronologically by each section's earliest event
- * start date, so Championship lands at its true position even when district
- * weeks are delayed past it (e.g. the 2026 Israel districts in weeks 17–19).
- * Unofficial preseason/offseason sections are grouped by month and follow, in
- * the chronological order of the input events.
+ * Official sections are ordered by earliest event start date, not week
+ * number, so Championship stays chronological even when district weeks are
+ * delayed past it (e.g. the 2026 Israel districts in weeks 17–19).
  */
 export function groupEventsBySections(events: Event[]): EventGroup[] {
   const eventsByWeek = new Map<string, EventGroup>();

--- a/pwa/app/routes/events.{-$year}.tsx
+++ b/pwa/app/routes/events.{-$year}.tsx
@@ -6,9 +6,7 @@ import {
   useNavigate,
 } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
-import { Temporal } from 'temporal-polyfill';
 
-import { Event, EventType } from '~/api/tba/read';
 import {
   getDistrictsByYearOptions,
   getEventsByYearOptions,
@@ -27,13 +25,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select';
-import { CMP_EVENT_TYPES } from '~/lib/api/EventType';
-import { getEventWeekString, sortEventsComparator } from '~/lib/eventUtils';
+import {
+  type EventGroup,
+  groupEventsBySections,
+  sortEventsComparator,
+} from '~/lib/eventUtils';
 import {
   parseParamsForYearElseDefault,
   pluralize,
   publicCacheControlHeaders,
-  slugify,
   useValidYears,
 } from '~/lib/utils';
 
@@ -90,98 +90,6 @@ export const Route = createFileRoute('/events/{-$year}')({
   component: YearEventsPage,
 });
 
-interface EventGroup {
-  groupName: string;
-  slug: string;
-  events: Event[];
-  isOfficial: boolean;
-}
-
-function groupBySections(events: Event[]): EventGroup[] {
-  const eventsByWeek = new Map<string, EventGroup>();
-  const eventsByChampionship = new Map<string, EventGroup>();
-  const unofficialEventsByMonth = new Map<string, EventGroup>();
-  const FOCEvents: EventGroup = {
-    groupName: 'FIRST Festival of Champions',
-    slug: 'foc',
-    events: [],
-    isOfficial: true,
-  };
-  events.forEach((event) => {
-    // Events by week
-    const weekStr = getEventWeekString(event);
-    if (weekStr != null) {
-      const weekGroup = eventsByWeek.get(weekStr);
-      if (weekGroup) {
-        weekGroup.events.push(event);
-      } else {
-        eventsByWeek.set(weekStr, {
-          groupName: weekStr,
-          slug: slugify(weekStr),
-          events: [event],
-          isOfficial: true,
-        });
-      }
-    }
-
-    // Events by Championship
-    if (CMP_EVENT_TYPES.has(event.event_type)) {
-      const groupName =
-        event.year >= 2017 && event.year <= 2020
-          ? `FIRST Championship - ${event.city}`
-          : 'FIRST Championship';
-      const championshipGroup = eventsByChampionship.get(groupName);
-      if (championshipGroup) {
-        championshipGroup.events.push(event);
-      } else {
-        eventsByChampionship.set(groupName, {
-          groupName,
-          slug: slugify(groupName),
-          events: [event],
-          isOfficial: true,
-        });
-      }
-    }
-
-    // FOC
-    if (event.event_type === EventType.FOC) {
-      FOCEvents.events.push(event);
-    }
-
-    // Group unofficial events by month
-    if (
-      event.event_type == EventType.PRESEASON ||
-      event.event_type == EventType.OFFSEASON
-    ) {
-      const monthName = Temporal.PlainDate.from(
-        event.start_date,
-      ).toLocaleString('default', { month: 'long' });
-      const offseasonGroup = unofficialEventsByMonth.get(monthName);
-      if (offseasonGroup) {
-        offseasonGroup.events.push(event);
-      } else {
-        unofficialEventsByMonth.set(monthName, {
-          groupName: monthName,
-          slug: slugify(monthName),
-          events: [event],
-          isOfficial: false,
-        });
-      }
-    }
-  });
-
-  const groups = Array.from(eventsByWeek.values()).concat(
-    Array.from(eventsByChampionship.values()),
-  );
-  if (FOCEvents.events.length > 0) {
-    groups.push(FOCEvents);
-  }
-  if (unofficialEventsByMonth.size > 0) {
-    groups.push(...Array.from(unofficialEventsByMonth.values()));
-  }
-  return groups;
-}
-
 function YearEventsPage() {
   const { year } = Route.useLoaderData();
   const { data: events } = useSuspenseQuery({
@@ -195,7 +103,7 @@ function YearEventsPage() {
   const navigate = useNavigate();
 
   const sortedEvents = events.sort(sortEventsComparator);
-  const groupedEvents = groupBySections(sortedEvents);
+  const groupedEvents = groupEventsBySections(sortedEvents);
   const officialGroups = groupedEvents.filter((group) => group.isOfficial);
   const unofficialGroups = groupedEvents.filter((group) => !group.isOfficial);
 


### PR DESCRIPTION
## Problem

The 2026 Israel district events were postponed to weeks 17–19 — after FIRST Championship. The PWA events page appends all Championship sections after all week sections, so Championship renders at the very bottom of the official list, below the delayed weeks:

> …Week 6, Week 7, Week 17, Week 18, Week 19, **FIRST Championship**

The website (jinja `EventHelper.group_by_week`) orders sections chronologically instead, putting Championship between Week 7 and Week 17.

PWA port of the-blue-alliance/the-blue-alliance-android#1470, which fixed the same class of bug on Android.

## Fix

Move `groupBySections` out of the events route into `eventUtils.ts` as `groupEventsBySections`, and order official sections (numbered weeks, FIRST Championship, Festival of Champions) by each section's earliest event start date. Championship now lands at its chronological position purely from its dates:

> …Week 6, Week 7, **FIRST Championship**, Week 17, Week 18, Week 19

Unofficial preseason/offseason sections keep their existing behavior (grouped by month in the separate Unofficial Events section).

## Testing

- New `groupEventsBySections` unit tests: the delayed-Israel-week shape asserting `Week 1, Week 7, FIRST Championship, Week 17, Week 19, June`; a typical year (weeks → Championship → FOC unchanged); 2017–2020 dual championships in date order; unofficial month grouping
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format`, and `vitest` (270 passed) all green
- Verified against live production data via headless Chrome below — real 2026 data has `2026isde1/2/cmp` at weeks 16–18 with June/July start dates

## Headless Chrome screenshots (`/events/2026`, live prod data)

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/pwa-chronological-event-sections/before-championship-boundary-ed7f89e0.png" width="400"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/pwa-chronological-event-sections/after-championship-boundary-12c47a0d.png" width="400"> |

**Before:** Week 17–19 render after Week 7, with FIRST Championship dead last (see sidebar). **After:** FIRST Championship sits between Week 7 and Week 17.

## Screenshot Pages

- /events/2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)