### PR TITLE
Fix dark-mode primary color contrast to meet WCAG AA

### DIFF
--- a/pwa/app/components/tba/navigation/navbar.tsx
+++ b/pwa/app/components/tba/navigation/navbar.tsx
@@ -30,7 +30,7 @@ export function Navbar() {
     <>
       <GlobalLoadingProgress />
       <NavigationMenu value={selected} onValueChange={setSelected} asChild>
-        <header className="sticky top-0 z-50 h-14 w-full bg-primary shadow-md">
+        <header className="sticky top-0 z-50 h-14 w-full bg-brand shadow-md">
           <div className="container">
             <NavigationMenuList
               asChild
@@ -66,7 +66,7 @@ export function Navbar() {
                     <NavigationMenuItem key={title}>
                       <NavigationMenuLink
                         className={`flex cursor-pointer items-center
-                        justify-start gap-2 bg-primary px-2.5 py-2 font-medium
+                        justify-start gap-2 bg-brand px-2.5 py-2 font-medium
                         text-white hover:bg-black/20 hover:text-white`}
                         asChild
                       >

--- a/pwa/app/style/theme.css
+++ b/pwa/app/style/theme.css
@@ -35,6 +35,7 @@
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-brand: var(--brand);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -91,6 +92,8 @@
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.4782 0.1589 271.4);
   --primary-foreground: oklch(0.97 0.014 254.604);
+  /* The TBA brand indigo, pinned across themes for brand surfaces (navbar) */
+  --brand: oklch(0.4782 0.1589 271.4);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0 0);
@@ -124,8 +127,13 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.287 0.004 286.09);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.4782 0.1589 271.4);
-  --primary-foreground: oklch(0.97 0.014 254.604);
+  /* Lightened from the brand indigo (oklch 0.4782), which is only 2.5:1
+     against the dark background — below WCAG AA. This indigo-300 is 4.9:1
+     for text-primary links; the foreground flips dark to stay 4.9:1 on
+     primary-filled controls. */
+  --primary: oklch(0.6382 0.1047 274.9);
+  --primary-foreground: oklch(0.2273 0.0038 286.09);
+  --brand: oklch(0.4782 0.1589 271.4);
   --secondary: oklch(0.356 0.006 286.09);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.351 0.005 286.09);


### PR DESCRIPTION
## Problem

In dark mode, `--primary` is the same brand indigo as light mode (`oklch(0.4782 0.1589 271.4)`, ≈ #3F51B5). Against the dark background that's a **2.5:1** contrast ratio — below the WCAG AA minimum of 4.5:1 for normal text (and below even the 3:1 large-text bar). Every `text-primary` hyperlink and accent in dark mode is affected, app-wide. (Bare `<a>` tags already get `dark:text-blue-400` from the base layer; this fixes the components that style with `text-primary`.)

Light mode is fine: the same indigo on white is 7.6:1.

## Fix

- Dark-mode `--primary` → `oklch(0.6382 0.1047 274.9)` (the Material indigo-300 equivalent, staying on brand hue): **4.9:1** against the dark background.
- Dark-mode `--primary-foreground` → the dark background color, so primary-filled controls (buttons, badges) keep **4.9:1**; leaving it white would have dropped button text to 3.4:1 on the lighter fill.
- The **navbar is a brand surface** and shouldn't shift with the primary accent, so it moves off `--primary` onto a new **`--brand` token** pinned to the TBA indigo in both themes (its white text is 6.9:1 on that fill). This also stops overloading `--primary` as both "brand surface" and "interactive accent."

Light mode is visually unchanged (`--brand` = `--primary` there).

## Before / After (dark mode)

Link-dense page (moderation review UI from an in-flight branch — the token change is what's shown; note the breadcrumb, card title link, and URL):

| Before (2.5:1 links) | After (4.9:1 links) |
|---|---|
| <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/dark-mode-primary-contrast/before-6a6f4730.png" width="400"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/dark-mode-primary-contrast/after-0985a5f8.png" width="400"> |

Note: the "after" capture above predates the `--brand` token, so its navbar looks washed out — with the final code the navbar keeps the brand indigo in dark mode:

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/screenshot-assets/shots/dark-mode-primary-contrast/navbar-final-c06f8826.png" width="640">

## Screenshot Pages

- /events/2026
- /team/254/2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)