### PR TITLE
Add moderation API (phase 1)

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -3,11 +3,13 @@ import logging
 from functools import wraps
 from typing import Callable, Type, TypeVar
 
-from flask import g, jsonify, request, Response
+from flask import g, jsonify, make_response, request, Response
 
+from backend.api.client_api_auth_helper import ClientApiAuthHelper
 from backend.api.client_api_types import VoidRequest
 from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
 from backend.common.auth import current_user
+from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
 from backend.common.consts.fms_report_type import FMSReportType
@@ -91,6 +93,62 @@ def require_write_auth(auth_types: set[AuthType] | None, file_param: str | None 
                 TrustedApiAuthHelper.do_trusted_api_auth(
                     event_key, fms_report_type, auth_types, file_param
                 )
+            return func(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator
+
+
+def require_moderation_permission(permissions: set[AccountPermission]):
+    """
+    Authenticate the request via a Firebase ID token in the Authorization
+    header (the same mechanism as the client API) and require the resolved
+    account to hold any of the given AccountPermissions. Admins always pass.
+    The resolved User is stored on flask.g.moderation_user.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def decorated_function(*args, **kwargs):
+            with Span("require_moderation_permission"):
+                user = ClientApiAuthHelper.get_current_user()
+                if user is None:
+                    return make_response(
+                        jsonify(
+                            {
+                                "Error": "Authorization required. Pass a Firebase ID token "
+                                "as 'Authorization: Bearer <token>'."
+                            }
+                        ),
+                        401,
+                    )
+                # Accounts are linked to tokens by email claim, so an
+                # unverified email must never confer the linked account's
+                # permissions
+                if not user.email_verified:
+                    return make_response(
+                        jsonify(
+                            {
+                                "Error": "Moderation requires a verified email on your "
+                                "sign-in provider."
+                            }
+                        ),
+                        403,
+                    )
+                if not user.is_admin and not permissions.intersection(
+                    user.permissions or []
+                ):
+                    return make_response(
+                        jsonify(
+                            {
+                                "Error": "You do not have permission to moderate suggestions. "
+                                "If this is incorrect, please contact TBA admins."
+                            }
+                        ),
+                        403,
+                    )
+                g.moderation_user = user
             return func(*args, **kwargs)
 
         return decorated_function

--- a/src/backend/api/handlers/moderation.py
+++ b/src/backend/api/handlers/moderation.py
@@ -1,0 +1,662 @@
+import datetime
+import json
+import logging
+import re
+from difflib import SequenceMatcher
+from typing import Any, Dict, List, Optional
+
+from flask import g, jsonify, make_response, request, Response
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+
+from backend.api.handlers.decorators import require_moderation_permission
+from backend.common.consts.account_permission import SUGGESTION_PERMISSIONS
+from backend.common.consts.auth_type import WRITE_TYPE_NAMES
+from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import IMAGE_TYPES
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.consts.suggestion_type import SuggestionType, TYPE_NAMES
+from backend.common.datafeeds.datafeed_youtube import YoutubeVideoDetailsDatafeed
+from backend.common.helpers.outgoing_notification_helper import (
+    OutgoingNotificationHelper,
+)
+from backend.common.helpers.suggestion_fetcher import SuggestionFetcher
+from backend.common.memcache import MemcacheClient
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.district import District
+from backend.common.models.event import Event
+from backend.common.models.media import Media
+from backend.common.models.suggestion import Suggestion
+from backend.common.models.user import User
+from backend.common.queries.event_query import EventListQuery
+from backend.common.sitevars.google_api_secret import GoogleApiSecret
+from backend.common.sitevars.slack_hook_urls import SlackHookUrls
+from backend.common.suggestions.suggestion_reviewer import (
+    REQUIRED_REVIEW_PERMISSIONS,
+    SuggestionReviewer,
+    SuggestionReviewResult,
+)
+
+MAX_SUGGESTIONS_PER_PAGE = 100
+MAX_REJECT_BATCH = 500
+
+# HTTP status for each review outcome (accept/reject endpoints return the
+# outcome per suggestion; single-suggestion endpoints map it to the response
+# status)
+_OUTCOME_STATUS_CODES = {
+    SuggestionReviewResult.ACCEPTED: 200,
+    SuggestionReviewResult.REJECTED: 200,
+    SuggestionReviewResult.NOT_FOUND: 404,
+    SuggestionReviewResult.ALREADY_REVIEWED: 409,
+    SuggestionReviewResult.INVALID: 400,
+    SuggestionReviewResult.FORBIDDEN: 403,
+}
+
+
+@require_moderation_permission(SUGGESTION_PERMISSIONS)
+def moderation_queue() -> Response:
+    """Pending suggestion counts per type, filtered to what the caller can review."""
+    user: User = g.moderation_user
+
+    count_futures = {}
+    for suggestion_type in SuggestionType:
+        if SuggestionReviewer.user_can_review(user, suggestion_type):
+            count_futures[suggestion_type] = SuggestionFetcher.count_async(
+                SuggestionState.REVIEW_PENDING, suggestion_type.value
+            )
+
+    return jsonify(
+        {
+            "counts": {
+                suggestion_type.value: future.get_result()
+                for suggestion_type, future in count_futures.items()
+            },
+            "type_names": {
+                suggestion_type.value: TYPE_NAMES[suggestion_type]
+                for suggestion_type in count_futures.keys()
+            },
+        }
+    )
+
+
+@require_moderation_permission(SUGGESTION_PERMISSIONS)
+def moderation_suggestion_list(suggestion_type: str) -> Response:
+    """Pending suggestions of one type, decorated with review metadata."""
+    user: User = g.moderation_user
+
+    try:
+        stype = SuggestionType(suggestion_type)
+    except ValueError:
+        return make_response(
+            jsonify({"Error": f"Unknown suggestion type {suggestion_type}"}), 404
+        )
+
+    if not SuggestionReviewer.user_can_review(user, stype):
+        return make_response(
+            jsonify(
+                {
+                    "Error": f"Reviewing {suggestion_type} suggestions requires the "
+                    f"{REQUIRED_REVIEW_PERMISSIONS[stype].name} permission"
+                }
+            ),
+            403,
+        )
+
+    limit = max(
+        1,
+        min(request.args.get("limit", default=50, type=int), MAX_SUGGESTIONS_PER_PAGE),
+    )
+    total_future = SuggestionFetcher.count_async(
+        SuggestionState.REVIEW_PENDING, stype.value
+    )
+    suggestions = (
+        Suggestion.query()
+        .filter(Suggestion.review_state == SuggestionState.REVIEW_PENDING)
+        .filter(Suggestion.target_model == stype.value)
+        .fetch(limit=limit)
+    )
+
+    # Group images first, matching the web review UI
+    if stype in (SuggestionType.MEDIA, SuggestionType.EVENT_MEDIA):
+        suggestions = sorted(
+            suggestions,
+            key=lambda x: 0 if x.contents["media_type_enum"] in IMAGE_TYPES else 1,
+        )
+
+    author_keys = list({s.author for s in suggestions})
+    authors = ndb.get_multi(author_keys)
+    authors_by_key = {none_throws(a.key): a for a in authors if a is not None}
+    review_counts = _author_review_counts(author_keys)
+
+    serialized = [
+        _serialize_suggestion(
+            s, authors_by_key.get(s.author), review_counts.get(s.author)
+        )
+        for s in suggestions
+    ]
+    _add_type_specific_metadata(stype, suggestions, serialized)
+
+    return jsonify({"suggestions": serialized, "total": total_future.get_result()})
+
+
+@require_moderation_permission(SUGGESTION_PERMISSIONS)
+def moderation_suggestion_accept(suggestion_key: str) -> Response:
+    """Accept a single pending suggestion, with optional type-specific overrides."""
+    user: User = g.moderation_user
+    overrides = request.get_json(silent=True) or {}
+    if not isinstance(overrides, dict):
+        return make_response(
+            jsonify({"Error": "Request body must be a JSON object"}), 400
+        )
+
+    outcome = SuggestionReviewer.accept_suggestion(
+        suggestion_key, user, overrides=overrides, endpoint=request.endpoint or ""
+    )
+    if outcome.result == SuggestionReviewResult.ACCEPTED:
+        _send_apiwrite_review_alert(
+            suggestion_key,
+            user,
+            verdict="accepted",
+            user_message=overrides.get("user_message"),
+            auth_id=outcome.created_target_key,
+        )
+    response: Dict[str, Any] = {
+        "result": outcome.result.value,
+        "suggestion_key": outcome.suggestion_key,
+    }
+    if outcome.created_target_key:
+        response["created_target_key"] = outcome.created_target_key
+    if outcome.message:
+        response["message"] = outcome.message
+    return make_response(jsonify(response), _OUTCOME_STATUS_CODES[outcome.result])
+
+
+@require_moderation_permission(SUGGESTION_PERMISSIONS)
+def moderation_suggestions_reject() -> Response:
+    """Reject a batch of pending suggestions."""
+    user: User = g.moderation_user
+    body = request.get_json(silent=True) or {}
+    suggestion_keys = body.get("suggestion_keys")
+    if not isinstance(suggestion_keys, list) or not all(
+        isinstance(k, str) for k in suggestion_keys
+    ):
+        return make_response(
+            jsonify({"Error": "Request body must include suggestion_keys: [str]"}),
+            400,
+        )
+    if len(suggestion_keys) > MAX_REJECT_BATCH:
+        return make_response(
+            jsonify({"Error": f"At most {MAX_REJECT_BATCH} suggestions per request"}),
+            400,
+        )
+
+    outcomes = SuggestionReviewer.reject_suggestions(
+        suggestion_keys, user, endpoint=request.endpoint or ""
+    )
+    for outcome in outcomes:
+        if outcome.result == SuggestionReviewResult.REJECTED:
+            _send_apiwrite_review_alert(
+                outcome.suggestion_key,
+                user,
+                verdict="rejected",
+                user_message=body.get("user_message"),
+            )
+    return jsonify(
+        {
+            "results": [
+                {
+                    "result": outcome.result.value,
+                    "suggestion_key": outcome.suggestion_key,
+                    **({"message": outcome.message} if outcome.message else {}),
+                }
+                for outcome in outcomes
+            ]
+        }
+    )
+
+
+def _get_suggestion_for_alert(suggestion_key: str) -> Optional[Suggestion]:
+    try:
+        return Suggestion.get_by_id(int(suggestion_key))
+    except ValueError:
+        return Suggestion.get_by_id(suggestion_key)
+
+
+def _send_apiwrite_review_alert(
+    suggestion_key: str,
+    user: User,
+    verdict: str,
+    user_message: Optional[str],
+    auth_id: Optional[str] = None,
+) -> None:
+    """
+    Admin alert for reviewed Trusted API key requests, carrying forward the
+    web review controller's (never-ported) admin email as a Slack alert on
+    the existing suggestion-nag channel. Only apiwrite suggestions alert.
+    """
+    suggestion = _get_suggestion_for_alert(suggestion_key)
+    if suggestion is None or suggestion.target_model != "api_auth_access":
+        return
+    channel_url = SlackHookUrls.url_for("suggestion-nag")
+    if not channel_url:
+        return
+
+    event_key = suggestion.contents.get("event_key")
+    # The default message mirrors the prefilled textarea on the review forms
+    message = user_message or "Thanks for helping make TBA better!"
+    body = (
+        f"*Trusted API Key Request for {event_key}*\n"
+        f"{user.display_name} ({user.email}) has {verdict} the request "
+        f"with the following message:\n{message}"
+    )
+    if auth_id:
+        body += (
+            "\n<https://www.thebluealliance.com/admin/api_auth/edit/"
+            f"{auth_id}|View the key>"
+        )
+    OutgoingNotificationHelper.send_slack_alert(channel_url, body)
+
+
+AUTHOR_REVIEW_COUNT_CACHE_SECONDS = 60 * 60
+
+
+def _author_review_counts(
+    author_keys: List[ndb.Key],
+) -> Dict[ndb.Key, Dict[str, int]]:
+    """Lifetime accepted/rejected counts per author — a cheap reputation signal
+    so reviewers can tell trusted suggesters from brand-new accounts.
+
+    Counts are datastore count queries over each author's full suggestion
+    history, so they're memcached for an hour; hour-stale reputation is fine.
+    """
+    if not author_keys:
+        return {}
+    cache = MemcacheClient.get()
+    cache_keys = {
+        author_key: f"moderation_author_review_counts:{author_key.id()}".encode()
+        for author_key in author_keys
+    }
+    cached = cache.get_multi(list(cache_keys.values()))
+
+    counts: Dict[ndb.Key, Dict[str, int]] = {}
+    count_futures = {}
+    for author_key, cache_key in cache_keys.items():
+        hit = cached.get(cache_key)
+        if isinstance(hit, dict):
+            counts[author_key] = hit
+        else:
+            count_futures[author_key] = (
+                Suggestion.query(
+                    Suggestion.author == author_key,
+                    Suggestion.review_state == SuggestionState.REVIEW_ACCEPTED,
+                ).count_async(),
+                Suggestion.query(
+                    Suggestion.author == author_key,
+                    Suggestion.review_state == SuggestionState.REVIEW_REJECTED,
+                ).count_async(),
+            )
+
+    to_cache = {}
+    for author_key, (accepted_future, rejected_future) in count_futures.items():
+        value = {
+            "accepted_count": accepted_future.get_result(),
+            "rejected_count": rejected_future.get_result(),
+        }
+        counts[author_key] = value
+        to_cache[cache_keys[author_key]] = value
+    if to_cache:
+        cache.set_multi(to_cache, time=AUTHOR_REVIEW_COUNT_CACHE_SECONDS)
+    return counts
+
+
+def _serialize_suggestion(
+    suggestion: Suggestion,
+    author: Optional[Any],
+    author_review_counts: Optional[Dict[str, int]] = None,
+) -> Dict[str, Any]:
+    serialized: Dict[str, Any] = {
+        "key": str(none_throws(suggestion.key.id())),
+        "target_model": suggestion.target_model,
+        "target_key": suggestion.target_key,
+        "created": suggestion.created.isoformat() if suggestion.created else None,
+        "contents": suggestion.contents,
+        "author": (
+            {
+                "nickname": author.nickname,
+                "email": author.email,
+                **(author_review_counts or {}),
+            }
+            if author
+            else None
+        ),
+    }
+
+    # Parsed details + thumbnail for image suggestions, matching the web UI
+    details_json = suggestion.contents.get("details_json")
+    if details_json:
+        try:
+            details = json.loads(details_json)
+        except ValueError:
+            details = None
+        if isinstance(details, dict):
+            if "image_partial" in details:
+                details["thumbnail"] = details["image_partial"].replace("_l", "_m")
+            serialized["details"] = details
+
+    # A preview of the Media that would be created, for media-backed types
+    if "media_type_enum" in suggestion.contents:
+        serialized["candidate_media"] = _serialize_candidate_media(suggestion)
+
+    return serialized
+
+
+def _serialize_candidate_media(suggestion: Suggestion) -> Dict[str, Any]:
+    media = suggestion.candidate_media
+    serialized = {
+        "key": media.key_name,
+        "media_type_enum": media.media_type_enum,
+        "type_name": media.type_name,
+        "slug_name": media.slug_name,
+        "foreign_key": media.foreign_key,
+        "is_image": media.is_image,
+        # view_image_url is an absolute URL; Media.external_link is just the
+        # bare foreign key and would render as a broken relative link.
+        # view_image_url doesn't cover videos, so link YouTube directly.
+        "external_link": media.view_image_url
+        or (media.youtube_url_link if media.slug_name == "youtube" else None),
+    }
+    if media.is_image:
+        serialized["view_image_url"] = media.view_image_url
+        serialized["image_direct_url"] = media.image_direct_url_med
+    if suggestion.contents.get("is_social"):
+        serialized["social_profile_url"] = media.social_profile_url
+    return serialized
+
+
+def _add_type_specific_metadata(
+    stype: SuggestionType,
+    suggestions: List[Suggestion],
+    serialized: List[Dict[str, Any]],
+) -> None:
+    """Decorate serialized suggestions with the context the web review UIs show."""
+    if stype in (
+        SuggestionType.MEDIA,
+        SuggestionType.SOCIAL_MEDIA,
+        SuggestionType.ROBOT,
+        SuggestionType.EVENT_MEDIA,
+    ):
+        _add_reference_metadata(stype, suggestions, serialized)
+    elif stype == SuggestionType.MATCH:
+        _add_match_metadata(suggestions, serialized)
+    elif stype == SuggestionType.EVENT:
+        _add_webcast_metadata(suggestions, serialized)
+    elif stype == SuggestionType.OFFSEASON_EVENT:
+        _add_offseason_metadata(suggestions, serialized)
+    elif stype == SuggestionType.API_AUTH_ACCESS:
+        _add_apiwrite_metadata(suggestions, serialized)
+
+
+def _serialize_reference(reference: Optional[Any]) -> Optional[Dict[str, Any]]:
+    if reference is None:
+        return None
+    if isinstance(reference, Event):
+        return {
+            "type": "event",
+            "key": reference.key_name,
+            "name": reference.name,
+            "year": reference.year,
+            "start_date": (
+                reference.start_date.date().isoformat()
+                if reference.start_date
+                else None
+            ),
+            "end_date": (
+                reference.end_date.date().isoformat() if reference.end_date else None
+            ),
+        }
+    return {
+        "type": "team",
+        "key": reference.key_name,
+        "team_number": reference.team_number,
+        "nickname": reference.nickname,
+    }
+
+
+def _add_reference_metadata(
+    stype: SuggestionType,
+    suggestions: List[Suggestion],
+    serialized: List[Dict[str, Any]],
+) -> None:
+    """The referenced Team/Event, plus existing preferred images for team media."""
+    reference_keys = [
+        Media.create_reference(
+            s.contents["reference_type"], s.contents["reference_key"]
+        )
+        for s in suggestions
+    ]
+    reference_futures = ndb.get_multi_async(reference_keys)
+
+    existing_preferred_futures = None
+    if stype == SuggestionType.MEDIA:
+        existing_preferred_futures = [
+            Media.query(
+                Media.media_type_enum.IN(IMAGE_TYPES),  # pyre-ignore[16]
+                Media.references == reference,
+                Media.preferred_references == reference,
+                Media.year == suggestion.contents["year"],
+            ).fetch_async()
+            for reference, suggestion in zip(reference_keys, suggestions)
+        ]
+
+    for i, future in enumerate(reference_futures):
+        serialized[i]["reference"] = _serialize_reference(future.get_result())
+
+    if existing_preferred_futures is not None:
+        for i, future in enumerate(existing_preferred_futures):
+            existing = future.get_result()
+            serialized[i]["existing_preferred"] = [
+                {
+                    "key": media.key_name,
+                    "foreign_key": media.foreign_key,
+                    "media_type_enum": media.media_type_enum,
+                    "view_image_url": media.view_image_url,
+                    "image_direct_url": media.image_direct_url_med,
+                }
+                for media in existing
+            ]
+            serialized[i]["max_preferred"] = Media.MAX_PREFERRED
+
+
+def _uses_official_webcast_unit(event: Optional[Event]) -> bool:
+    if event and event.event_district_key:
+        district = District.get_by_id(event.event_district_key)
+        if district:
+            return bool(district.uses_official_webcast_unit)
+    return False
+
+
+def _clean_youtube_id(raw_video_id: str) -> str:
+    """Strip timestamp/query suffixes ("abc123?t=42") down to the bare video id."""
+    return re.split(r"[?&#]", raw_video_id)[0]
+
+
+def _fetch_youtube_video_details(video_ids: List[str]) -> Dict[str, Any]:
+    """Title/duration for videos, batched 50 per API call (the API's cap).
+
+    Assistive metadata only: returns {} when no YouTube API key is
+    configured (dev environments) and never fails the queue on API errors.
+    """
+    if not video_ids or not GoogleApiSecret.secret_key():
+        return {}
+    details: Dict[str, Any] = {}
+    try:
+        for start in range(0, len(video_ids), 50):
+            chunk = video_ids[start : start + 50]
+            result = YoutubeVideoDetailsDatafeed(chunk).fetch_async().get_result()
+            if result:
+                details.update(result)
+    except Exception:
+        logging.warning("Failed to fetch YouTube video details", exc_info=True)
+    return details
+
+
+def _add_match_metadata(
+    suggestions: List[Suggestion], serialized: List[Dict[str, Any]]
+) -> None:
+    """The match's event, official-webcast-unit warning flag, and YouTube
+    title/duration so clients can flag suspicious video suggestions."""
+    event_futures = [
+        Event.get_by_id_async(none_throws(s.target_key).split("_")[0])
+        for s in suggestions
+    ]
+
+    raw_video_ids = []
+    for suggestion in suggestions:
+        videos = suggestion.contents.get("youtube_videos") or []
+        raw_video_ids.append(videos[0] if videos and isinstance(videos[0], str) else "")
+    video_details = _fetch_youtube_video_details(
+        sorted({_clean_youtube_id(raw) for raw in raw_video_ids if raw})
+    )
+
+    for i, future in enumerate(event_futures):
+        event = future.get_result()
+        serialized[i]["event"] = _serialize_reference(event)
+        serialized[i]["uses_official_webcast_unit"] = _uses_official_webcast_unit(event)
+        serialized[i]["has_first_official_webcast"] = (
+            event.has_first_official_webcast if event else False
+        )
+        details = (
+            video_details.get(_clean_youtube_id(raw_video_ids[i]))
+            if raw_video_ids[i]
+            else None
+        )
+        if details:
+            serialized[i]["video_title"] = details.get("title")
+            serialized[i]["video_duration_seconds"] = details.get("duration_seconds")
+
+
+def _add_webcast_metadata(
+    suggestions: List[Suggestion], serialized: List[Dict[str, Any]]
+) -> None:
+    """The event, existing webcasts (to catch duplicates), and warning flags."""
+    event_futures = [
+        Event.get_by_id_async(none_throws(s.target_key)) for s in suggestions
+    ]
+    for i, future in enumerate(event_futures):
+        event = future.get_result()
+        serialized[i]["event"] = _serialize_reference(event)
+        serialized[i]["uses_official_webcast_unit"] = _uses_official_webcast_unit(event)
+        serialized[i]["existing_webcasts"] = (
+            list(event.webcast) if event and event.webcast else []
+        )
+
+
+def _normalized_event_name(name: str) -> str:
+    return " ".join(re.sub(r"[^a-z0-9]+", " ", name.lower()).split())
+
+
+def _find_similar_events(
+    name: str, events: List[Event], limit: int = 5
+) -> List[Dict[str, str]]:
+    """
+    Offseason events whose name or short name resembles the suggested name.
+    Comparison is case/punctuation-insensitive; containment (either direction)
+    counts as a strong match. Results are strongest-match first.
+    """
+    normalized = _normalized_event_name(name)
+    if not normalized:
+        return []
+    scored = []
+    for event in events:
+        best = 0.0
+        for candidate in (event.name, event.short_name):
+            if not candidate:
+                continue
+            normalized_candidate = _normalized_event_name(candidate)
+            if not normalized_candidate:
+                continue
+            score = SequenceMatcher(a=normalized, b=normalized_candidate).ratio()
+            if normalized in normalized_candidate or normalized_candidate in normalized:
+                score = max(score, 0.9)
+            best = max(best, score)
+        if best > 0.5:
+            scored.append((best, event))
+    scored.sort(key=lambda pair: -pair[0])
+    return [{"key": e.key_name, "name": e.name} for _, e in scored[:limit]]
+
+
+def _suggested_event_year(suggestion: Suggestion) -> int:
+    """The year of the suggested event's start date, falling back to today's."""
+    start_date = suggestion.contents.get("start_date") or ""
+    try:
+        return datetime.datetime.strptime(start_date, "%Y-%m-%d").year
+    except ValueError:
+        return datetime.datetime.now().year
+
+
+def _add_offseason_metadata(
+    suggestions: List[Suggestion], serialized: List[Dict[str, Any]]
+) -> None:
+    """Similar-named offseason events in the suggested year and the year before."""
+    years = {
+        y
+        for suggestion in suggestions
+        for base_year in [_suggested_event_year(suggestion)]
+        for y in (base_year, base_year - 1)
+    }
+    event_futures = {year: EventListQuery(year).fetch_async() for year in years}
+    offseason_events_by_year = {
+        year: [
+            e for e in future.get_result() if e.event_type_enum == EventType.OFFSEASON
+        ]
+        for year, future in event_futures.items()
+    }
+
+    for i, suggestion in enumerate(suggestions):
+        name = suggestion.contents.get("name") or ""
+        year = _suggested_event_year(suggestion)
+        serialized[i]["similar_events"] = _find_similar_events(
+            name, offseason_events_by_year[year]
+        )
+        serialized[i]["similar_events_last_year"] = _find_similar_events(
+            name, offseason_events_by_year[year - 1]
+        )
+
+
+def _add_apiwrite_metadata(
+    suggestions: List[Suggestion], serialized: List[Dict[str, Any]]
+) -> None:
+    """The event, requested auth types by name, and existing keys for the event."""
+    for i, suggestion in enumerate(suggestions):
+        event_key = suggestion.contents["event_key"]
+        serialized[i]["event"] = _serialize_reference(Event.get_by_id(event_key))
+        serialized[i]["requested_auth_types"] = [
+            {"type": int(t), "name": WRITE_TYPE_NAMES[t]}
+            for t in suggestion.contents.get("auth_types", [])
+            if t in WRITE_TYPE_NAMES
+        ]
+
+        existing_keys = ApiAuthAccess.query(
+            ApiAuthAccess.event_list == ndb.Key(Event, event_key)
+        ).fetch()
+        existing_owners = ndb.get_multi(
+            [key.owner for key in existing_keys if key.owner]
+        )
+        owners_by_key = {
+            none_throws(o.key): o for o in existing_owners if o is not None
+        }
+        serialized[i]["existing_auth"] = [
+            {
+                "owner_email": (
+                    owners_by_key[key.owner].email
+                    if key.owner and key.owner in owners_by_key
+                    else None
+                ),
+                "auth_types": [
+                    {"type": int(t), "name": WRITE_TYPE_NAMES[t]}
+                    for t in key.auth_types_enum
+                    if t in WRITE_TYPE_NAMES
+                ],
+            }
+            for key in existing_keys
+        ]

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -910,6 +910,48 @@ def test_accept_event_webcast_requires_fields(
     assert resp.json["result"] == "invalid"
 
 
+def test_accept_offseason_event_requires_dates(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    # Dateless events violate the APIv3 contract and break strict clients
+    moderator([AccountPermission.REVIEW_OFFSEASON_EVENTS])
+    suggestion_id = create_suggestion(
+        author,
+        "offseason-event",
+        None,
+        {"name": "Dateless Offseason", "website": "https://example.com"},
+        suggestion_id="dateless_offseason",
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"event_short": "dateless"},
+    )
+    assert resp.status_code == 400
+    assert resp.json["result"] == "invalid"
+    assert "start_date and end_date are required" in resp.json["message"]
+
+    suggestion = Suggestion.get_by_id("dateless_offseason")
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_PENDING
+    assert Event.query().count() == 0
+
+    # Reviewer-provided dates satisfy the requirement
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={
+            "event_short": "dateless",
+            "start_date": "2016-10-01",
+            "end_date": "2016-10-02",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json["result"] == "accepted"
+    event = Event.get_by_id("2016dateless")
+    assert event is not None
+    assert event.start_date is not None
+
+
 def test_accept_offseason_event(
     api_client: Client, moderator, author: Account, taskqueue_stub
 ) -> None:

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -1,0 +1,1288 @@
+import json
+from datetime import datetime, timedelta
+from typing import Any, cast, Dict, List, Optional
+
+import pytest
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+from werkzeug.test import Client
+
+from backend.api.client_api_auth_helper import ClientApiAuthHelper
+from backend.api.handlers.moderation import (
+    _find_similar_events,
+    _suggested_event_year,
+)
+from backend.common.consts.account_permission import AccountPermission
+from backend.common.consts.auth_type import AuthType
+from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import MediaType
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.helpers.outgoing_notification_helper import (
+    OutgoingNotificationHelper,
+)
+from backend.common.memcache import MemcacheClient
+from backend.common.models.account import Account
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.audit_log_entry import AuditLogEntry
+from backend.common.models.event import Event
+from backend.common.models.match import Match
+from backend.common.models.media import Media
+from backend.common.models.suggestion import Suggestion
+from backend.common.models.suggestion_dict import SuggestionDict
+from backend.common.models.user import User
+from backend.common.sitevars.slack_hook_urls import SlackHookUrls
+from backend.common.suggestions.suggestion_creator import (
+    SuggestionCreationStatus,
+    SuggestionCreator,
+)
+
+BASE_URL = "/api/moderation/v1"
+
+
+@pytest.fixture
+def author(ndb_stub) -> Account:
+    account = Account(
+        id="author_uid",
+        email="author@tba.com",
+        nickname="Suggestion Author",
+        registered=True,
+    )
+    account.put()
+    return account
+
+
+@pytest.fixture
+def moderator(ndb_stub, monkeypatch: pytest.MonkeyPatch):
+    """Returns a factory to authenticate future requests as a moderator with
+    the given permissions."""
+
+    def _make(
+        permissions: List[AccountPermission],
+        is_admin: bool = False,
+        email_verified: bool = True,
+    ) -> User:
+        account = Account.get_by_id("moderator_uid")
+        if account is None:
+            account = Account(
+                id="moderator_uid",
+                email="moderator@tba.com",
+                nickname="Moderator",
+                registered=True,
+            )
+        account.permissions = permissions
+        account.put()
+
+        claims: Dict[str, Any] = {
+            "email": "moderator@tba.com",
+            "uid": "moderator_uid",
+            "email_verified": email_verified,
+        }
+        if is_admin:
+            claims["admin"] = True
+        user = User(claims)
+
+        monkeypatch.setattr(
+            ClientApiAuthHelper, "get_current_user", staticmethod(lambda: user)
+        )
+        return user
+
+    return _make
+
+
+@pytest.fixture
+def event(ndb_stub) -> Event:
+    event = Event(
+        id="2016necmp",
+        name="New England District Championship",
+        event_type_enum=EventType.DISTRICT_CMP,
+        short_name="New England",
+        event_short="necmp",
+        year=2016,
+        start_date=datetime(2016, 3, 24),
+        end_date=datetime(2016, 3, 27),
+        official=False,
+        city="Hartford",
+        state_prov="CT",
+        country="USA",
+        webcast_json="",
+        website="https://www.firstsv.org",
+    )
+    event.put()
+    return event
+
+
+@pytest.fixture
+def match(ndb_stub, event: Event) -> Match:
+    match = Match(
+        id="2016necmp_f1m1",
+        event=ndb.Key(Event, "2016necmp"),
+        year=2016,
+        comp_level="f",
+        set_number=1,
+        match_number=1,
+        team_key_names=["frc846", "frc2135", "frc971", "frc254", "frc1678", "frc973"],
+        youtube_videos=["JbwUzl3W9ug"],
+        alliances_json=json.dumps(
+            {
+                "blue": {"score": 270, "teams": ["frc846", "frc2135", "frc971"]},
+                "red": {"score": 310, "teams": ["frc254", "frc1678", "frc973"]},
+            }
+        ),
+    )
+    match.put()
+    return match
+
+
+def create_match_video_suggestion(author: Account) -> str:
+    status = SuggestionCreator.createMatchVideoYouTubeSuggestion(
+        author.key, "H-54KMwMKY0", "2016necmp_f1m1"
+    )
+    assert status == SuggestionCreationStatus.SUCCESS
+    return Suggestion.render_media_key_name(
+        2016, "match", "2016necmp_f1m1", "youtube", "H-54KMwMKY0"
+    )
+
+
+def create_suggestion(
+    author: Account,
+    target_model: str,
+    target_key: Optional[str],
+    contents: dict,
+    suggestion_id: Optional[str] = None,
+) -> str:
+    suggestion = Suggestion(
+        id=suggestion_id,
+        author=author.key,
+        target_model=target_model,
+        target_key=target_key,
+    )
+    suggestion.contents = cast(SuggestionDict, contents)
+    key = suggestion.put()
+    return str(key.id())
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_queue_unauthenticated(api_client: Client) -> None:
+    resp = api_client.get(f"{BASE_URL}/queue")
+    assert resp.status_code == 401
+
+
+def test_list_unauthenticated(api_client: Client) -> None:
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.status_code == 401
+
+
+def test_accept_unauthenticated(api_client: Client) -> None:
+    resp = api_client.post(f"{BASE_URL}/suggestions/abc/accept")
+    assert resp.status_code == 401
+
+
+def test_reject_unauthenticated(api_client: Client) -> None:
+    resp = api_client.post(f"{BASE_URL}/suggestions/reject")
+    assert resp.status_code == 401
+
+
+def test_queue_no_permissions(api_client: Client, moderator) -> None:
+    moderator([])
+    resp = api_client.get(f"{BASE_URL}/queue")
+    assert resp.status_code == 403
+
+
+def test_unverified_email_forbidden(api_client: Client, moderator) -> None:
+    # Accounts are linked to tokens by email, so an unverified email must
+    # not confer the linked account's permissions — even for admins
+    moderator([AccountPermission.REVIEW_MEDIA], email_verified=False)
+    resp = api_client.get(f"{BASE_URL}/queue")
+    assert resp.status_code == 403
+
+    moderator([], is_admin=True, email_verified=False)
+    resp = api_client.post(f"{BASE_URL}/suggestions/abc/accept")
+    assert resp.status_code == 403
+
+
+def test_list_requires_type_permission(api_client: Client, moderator) -> None:
+    # REVIEW_MEDIA does not grant access to the offseason event queue
+    moderator([AccountPermission.REVIEW_MEDIA])
+    resp = api_client.get(f"{BASE_URL}/suggestions/offseason-event")
+    assert resp.status_code == 403
+
+
+def test_list_unknown_type(api_client: Client, moderator) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    resp = api_client.get(f"{BASE_URL}/suggestions/not-a-type")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Queue counts
+# ---------------------------------------------------------------------------
+
+
+def test_queue_counts_filtered_by_permission(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    create_match_video_suggestion(author)
+
+    resp = api_client.get(f"{BASE_URL}/queue")
+    assert resp.status_code == 200
+    counts = resp.json["counts"]
+    assert counts["match"] == 1
+    assert counts["media"] == 0
+    # REVIEW_MEDIA covers match/media/social-media/event; not these:
+    assert "offseason-event" not in counts
+    assert "api_auth_access" not in counts
+    assert "robot" not in counts
+    assert "event_media" not in counts
+
+
+def test_queue_counts_admin_sees_all(api_client: Client, moderator) -> None:
+    moderator([], is_admin=True)
+    resp = api_client.get(f"{BASE_URL}/queue")
+    assert resp.status_code == 200
+    assert set(resp.json["counts"].keys()) == {
+        "event",
+        "match",
+        "media",
+        "social-media",
+        "offseason-event",
+        "api_auth_access",
+        "robot",
+        "event_media",
+    }
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+def test_list_match_suggestions(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.status_code == 200
+    suggestions = resp.json["suggestions"]
+    assert len(suggestions) == 1
+    suggestion = suggestions[0]
+    assert suggestion["key"] == suggestion_id
+    assert suggestion["target_key"] == "2016necmp_f1m1"
+    assert suggestion["contents"]["youtube_videos"] == ["H-54KMwMKY0"]
+    assert suggestion["author"]["nickname"] == "Suggestion Author"
+    assert suggestion["author"]["email"] == "author@tba.com"
+    assert suggestion["event"]["key"] == "2016necmp"
+    assert suggestion["uses_official_webcast_unit"] is False
+    assert suggestion["has_first_official_webcast"] is False
+    assert resp.json["total"] == 1
+    # No YouTube API key configured, so no video metadata
+    assert "video_title" not in suggestion
+
+
+def test_list_total_exceeds_page(
+    api_client: Client, moderator, author: Account, event: Event
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    for i in range(3):
+        create_suggestion(
+            author,
+            "event",
+            "2016necmp",
+            {"webcast_url": f"https://twitch.tv/channel{i}"},
+            suggestion_id=f"webcast_{i}",
+        )
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/event?limit=2")
+    assert resp.status_code == 200
+    assert len(resp.json["suggestions"]) == 2
+    assert resp.json["total"] == 3
+
+
+def test_list_author_reputation_counts(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {"webcast_url": "https://twitch.tv/accepted"},
+        suggestion_id="prior_accepted",
+    )
+    accepted = Suggestion.get_by_id("prior_accepted")
+    assert accepted is not None
+    accepted.review_state = SuggestionState.REVIEW_ACCEPTED
+    accepted.put()
+    create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {"webcast_url": "https://twitch.tv/rejected"},
+        suggestion_id="prior_rejected",
+    )
+    rejected = Suggestion.get_by_id("prior_rejected")
+    assert rejected is not None
+    rejected.review_state = SuggestionState.REVIEW_REJECTED
+    rejected.put()
+    create_match_video_suggestion(author)
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.status_code == 200
+    suggestion_author = resp.json["suggestions"][0]["author"]
+    assert suggestion_author["accepted_count"] == 1
+    assert suggestion_author["rejected_count"] == 1
+
+
+def test_list_author_reputation_counts_cached(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    create_match_video_suggestion(author)
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.json["suggestions"][0]["author"]["accepted_count"] == 0
+
+    # A newly accepted suggestion doesn't appear until the hour-long
+    # reputation cache expires
+    create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {"webcast_url": "https://twitch.tv/accepted"},
+        suggestion_id="accepted_after_cache",
+    )
+    accepted = Suggestion.get_by_id("accepted_after_cache")
+    assert accepted is not None
+    accepted.review_state = SuggestionState.REVIEW_ACCEPTED
+    accepted.put()
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.json["suggestions"][0]["author"]["accepted_count"] == 0
+
+    MemcacheClient.get().delete_multi(
+        [f"moderation_author_review_counts:{author.key.id()}".encode()]
+    )
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.json["suggestions"][0]["author"]["accepted_count"] == 1
+
+
+def test_list_match_video_metadata(
+    api_client: Client,
+    moderator,
+    author: Account,
+    event: Event,
+    match: Match,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from backend.api.handlers import moderation
+    from backend.common.sitevars.google_api_secret import GoogleApiSecret
+
+    moderator([AccountPermission.REVIEW_MEDIA])
+    create_match_video_suggestion(author)
+
+    monkeypatch.setattr(GoogleApiSecret, "secret_key", staticmethod(lambda: "key"))
+
+    class FakeFuture:
+        def get_result(self):
+            return {
+                "H-54KMwMKY0": {
+                    "video_id": "H-54KMwMKY0",
+                    "title": "Full Event Stream Day 2",
+                    "duration_seconds": 29700,
+                }
+            }
+
+    monkeypatch.setattr(
+        moderation.YoutubeVideoDetailsDatafeed,
+        "fetch_async",
+        lambda self: FakeFuture(),
+    )
+    monkeypatch.setattr(
+        moderation.YoutubeVideoDetailsDatafeed, "__init__", lambda self, ids: None
+    )
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.status_code == 200
+    suggestion = resp.json["suggestions"][0]
+    assert suggestion["video_title"] == "Full Event Stream Day 2"
+    assert suggestion["video_duration_seconds"] == 29700
+
+
+def test_list_match_suggestions_first_webcast_flag(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    # Events webcast by FIRST get a stream-rip warning flag
+    moderator([AccountPermission.REVIEW_MEDIA])
+    event.webcast_json = json.dumps([{"type": "twitch", "channel": "firstinspires12"}])
+    event.put()
+    create_match_video_suggestion(author)
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/match")
+    assert resp.status_code == 200
+    assert resp.json["suggestions"][0]["has_first_official_webcast"] is True
+
+
+def test_list_webcast_suggestions_existing_webcasts(
+    api_client: Client, moderator, author: Account, event: Event
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    event.webcast_json = json.dumps([{"type": "twitch", "channel": "tbagameday"}])
+    event.put()
+    create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {"webcast_url": "https://twitch.tv/other_channel"},
+    )
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/event")
+    assert resp.status_code == 200
+    suggestion = resp.json["suggestions"][0]
+    assert suggestion["existing_webcasts"] == [
+        {"type": "twitch", "channel": "tbagameday"}
+    ]
+    assert suggestion["event"]["start_date"] == "2016-03-24"
+    assert suggestion["event"]["end_date"] == "2016-03-27"
+
+
+def test_list_team_media_suggestions_includes_reference_and_preferred(
+    api_client: Client, moderator, author: Account
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    create_suggestion(
+        author,
+        "media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.IMGUR,
+            "foreign_key": "abc123",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+            "details_json": json.dumps({"image_partial": "abc123_l.jpg"}),
+        },
+    )
+
+    resp = api_client.get(f"{BASE_URL}/suggestions/media")
+    assert resp.status_code == 200
+    suggestion = resp.json["suggestions"][0]
+    assert suggestion["candidate_media"]["is_image"] is True
+    assert suggestion["candidate_media"]["slug_name"] == "imgur"
+    assert suggestion["details"]["thumbnail"] == "abc123_m.jpg"
+    assert suggestion["existing_preferred"] == []
+    assert suggestion["max_preferred"] == Media.MAX_PREFERRED
+
+
+# ---------------------------------------------------------------------------
+# Accept: match video
+# ---------------------------------------------------------------------------
+
+
+def test_accept_match_video(
+    api_client: Client,
+    moderator,
+    author: Account,
+    event: Event,
+    match: Match,
+    taskqueue_stub,
+) -> None:
+    user = moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+    assert resp.json["result"] == "accepted"
+    assert resp.json["created_target_key"] == "2016necmp_f1m1"
+
+    suggestion = Suggestion.get_by_id(suggestion_id)
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_ACCEPTED
+    assert suggestion.reviewer == user.account_key
+
+    match = none_throws(Match.get_by_id("2016necmp_f1m1"))
+    assert "H-54KMwMKY0" in match.youtube_videos
+
+    audit_logs = AuditLogEntry.query().fetch()
+    assert len(audit_logs) == 1
+    assert audit_logs[0].account == user.account_key
+
+
+def test_accept_match_video_new_target_key(
+    api_client: Client,
+    moderator,
+    author: Account,
+    event: Event,
+    match: Match,
+    taskqueue_stub,
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_match_video_suggestion(author)
+
+    match2 = Match(
+        id="2016necmp_f1m2",
+        event=ndb.Key(Event, "2016necmp"),
+        year=2016,
+        comp_level="f",
+        set_number=1,
+        match_number=2,
+        team_key_names=["frc846", "frc2135", "frc971", "frc254", "frc1678", "frc973"],
+        alliances_json=json.dumps(
+            {
+                "blue": {"score": 270, "teams": ["frc846", "frc2135", "frc971"]},
+                "red": {"score": 310, "teams": ["frc254", "frc1678", "frc973"]},
+            }
+        ),
+    )
+    match2.put()
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"target_match_key": "2016necmp_f1m2"},
+    )
+    assert resp.status_code == 200
+
+    match2 = Match.get_by_id("2016necmp_f1m2")
+    assert match2 is not None
+    assert "H-54KMwMKY0" in match2.youtube_videos
+    match1 = Match.get_by_id("2016necmp_f1m1")
+    assert match1 is not None
+    assert "H-54KMwMKY0" not in match1.youtube_videos
+
+
+def test_accept_match_video_bad_target(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"target_match_key": "2016necmp_f1m3"},
+    )
+    assert resp.status_code == 400
+    assert resp.json["result"] == "invalid"
+
+    suggestion = Suggestion.get_by_id(suggestion_id)
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_PENDING
+
+
+def test_accept_twice_conflicts(
+    api_client: Client,
+    moderator,
+    author: Account,
+    event: Event,
+    match: Match,
+    taskqueue_stub,
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 409
+    assert resp.json["result"] == "already_reviewed"
+
+
+def test_accept_not_found(api_client: Client, moderator) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    resp = api_client.post(f"{BASE_URL}/suggestions/nonexistent/accept")
+    assert resp.status_code == 404
+
+
+def test_accept_requires_type_permission(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    # REVIEW_DESIGNS cannot accept a match video suggestion
+    moderator([AccountPermission.REVIEW_DESIGNS])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 403
+    assert resp.json["result"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# Accept: media types
+# ---------------------------------------------------------------------------
+
+
+def test_accept_team_media_with_preferred(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.IMGUR,
+            "foreign_key": "abc123",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"set_preferred": True},
+    )
+    assert resp.status_code == 200
+
+    media = Media.get_by_id("imgur_abc123")
+    assert media is not None
+    assert media.year == 2016
+    team_ref = Media.create_reference("team", "frc1124")
+    assert team_ref in media.references
+    assert team_ref in media.preferred_references
+
+
+def test_accept_team_media_honors_default_preferred(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    # When the reviewer doesn't override, the suggester's default_preferred
+    # request applies
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.IMGUR,
+            "foreign_key": "abc123",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+            "default_preferred": True,
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+
+    media = Media.get_by_id("imgur_abc123")
+    assert media is not None
+    team_ref = Media.create_reference("team", "frc1124")
+    assert team_ref in media.preferred_references
+
+
+def test_accept_team_media_reviewer_overrides_default_preferred(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.IMGUR,
+            "foreign_key": "abc123",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+            "default_preferred": True,
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"set_preferred": False},
+    )
+    assert resp.status_code == 200
+
+    media = Media.get_by_id("imgur_abc123")
+    assert media is not None
+    assert media.preferred_references == []
+
+
+def test_accept_team_media_year_override(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.IMGUR,
+            "foreign_key": "abc123",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept", json={"year": 2017}
+    )
+    assert resp.status_code == 200
+
+    media = Media.get_by_id("imgur_abc123")
+    assert media is not None
+    assert media.year == 2017
+    assert media.preferred_references == []
+
+
+def test_accept_team_media_replace_preferred(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    team_ref = Media.create_reference("team", "frc1124")
+    existing = Media(
+        id="imgur_existing",
+        media_type_enum=MediaType.IMGUR,
+        foreign_key="existing",
+        year=2016,
+        references=[team_ref],
+        preferred_references=[team_ref],
+    )
+    existing.put()
+
+    suggestion_id = create_suggestion(
+        author,
+        "media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.IMGUR,
+            "foreign_key": "abc123",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"replace_preferred_media_key": "imgur_existing"},
+    )
+    assert resp.status_code == 200
+
+    existing = Media.get_by_id("imgur_existing")
+    assert existing is not None
+    assert team_ref not in existing.preferred_references
+    new_media = Media.get_by_id("imgur_abc123")
+    assert new_media is not None
+    assert team_ref in new_media.preferred_references
+
+
+def test_accept_social_media(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "social-media",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.GITHUB_PROFILE,
+            "foreign_key": "uberasaurus",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "is_social": True,
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+
+    media = Media.get_by_id("github-profile_uberasaurus")
+    assert media is not None
+    assert media.year is None
+
+
+def test_accept_robot_cad(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_DESIGNS])
+    suggestion_id = create_suggestion(
+        author,
+        "robot",
+        "frc1124",
+        {
+            "media_type_enum": MediaType.GRABCAD,
+            "foreign_key": "some-model",
+            "reference_type": "team",
+            "reference_key": "frc1124",
+            "year": 2016,
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+    assert Media.get_by_id("grabcad_some-model") is not None
+
+
+def test_accept_event_media(
+    api_client: Client, moderator, author: Account, event: Event, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_EVENT_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "event_media",
+        "2016necmp",
+        {
+            "media_type_enum": MediaType.YOUTUBE_VIDEO,
+            "foreign_key": "H-54KMwMKY0",
+            "reference_type": "event",
+            "reference_key": "2016necmp",
+            "year": 2016,
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+
+    media = Media.get_by_id("youtube_H-54KMwMKY0")
+    assert media is not None
+    assert Media.create_reference("event", "2016necmp") in media.references
+    assert media.preferred_references == []
+
+
+# ---------------------------------------------------------------------------
+# Accept: webcast, offseason event, apiwrite
+# ---------------------------------------------------------------------------
+
+
+def test_accept_event_webcast(
+    api_client: Client, moderator, author: Account, event: Event, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {
+            "webcast_url": "https://twitch.tv/frcgamesense",
+            "webcast_dict": {"type": "twitch", "channel": "frcgamesense"},
+            "webcast_date": "",
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+
+    event = none_throws(Event.get_by_id("2016necmp"))
+    assert event.webcast == [{"type": "twitch", "channel": "frcgamesense"}]
+
+
+def test_accept_event_webcast_with_overrides(
+    api_client: Client, moderator, author: Account, event: Event, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {"webcast_url": "https://somesite.com/stream"},
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"webcast_type": "youtube", "webcast_channel": "someyoutubechannel"},
+    )
+    assert resp.status_code == 200
+
+    event = none_throws(Event.get_by_id("2016necmp"))
+    assert event.webcast == [{"type": "youtube", "channel": "someyoutubechannel"}]
+
+
+def test_accept_event_webcast_requires_fields(
+    api_client: Client, moderator, author: Account, event: Event
+) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_suggestion(
+        author,
+        "event",
+        "2016necmp",
+        {"webcast_url": "https://somesite.com/stream"},
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 400
+    assert resp.json["result"] == "invalid"
+
+
+def test_accept_offseason_event(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_OFFSEASON_EVENTS])
+    suggestion_id = create_suggestion(
+        author,
+        "offseason-event",
+        None,
+        {
+            "name": "The Best Offseason Event",
+            "start_date": "2016-10-01",
+            "end_date": "2016-10-02",
+            "website": "https://example.com",
+            "venue_name": "Venue",
+            "address": "123 Fake St",
+            "city": "New York",
+            "state": "NY",
+            "country": "USA",
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"event_short": "bestoff"},
+    )
+    assert resp.status_code == 200
+    assert resp.json["created_target_key"] == "2016bestoff"
+
+    created = Event.get_by_id("2016bestoff")
+    assert created is not None
+    assert created.name == "The Best Offseason Event"
+    assert created.event_type_enum == EventType.OFFSEASON
+    assert created.official is False
+
+
+def test_accept_offseason_event_requires_event_short(
+    api_client: Client, moderator, author: Account
+) -> None:
+    moderator([AccountPermission.REVIEW_OFFSEASON_EVENTS])
+    suggestion_id = create_suggestion(
+        author,
+        "offseason-event",
+        None,
+        {
+            "name": "The Best Offseason Event",
+            "start_date": "2016-10-01",
+            "end_date": "2016-10-02",
+            "website": "https://example.com",
+            "venue_name": "Venue",
+            "address": "123 Fake St",
+            "city": "New York",
+            "state": "NY",
+            "country": "USA",
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 400
+
+    suggestion = Suggestion.get_by_id(int(suggestion_id))
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_PENDING
+
+
+def test_accept_apiwrite(
+    api_client: Client, moderator, author: Account, event: Event, taskqueue_stub
+) -> None:
+    moderator([AccountPermission.REVIEW_APIWRITE])
+    suggestion_id = create_suggestion(
+        author,
+        "api_auth_access",
+        "2016necmp",
+        {
+            "event_key": "2016necmp",
+            "affiliation": "Team 1124",
+            "auth_types": [
+                int(AuthType.MATCH_VIDEO),
+                int(AuthType.EVENT_TEAMS),
+            ],
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"auth_types": [int(AuthType.MATCH_VIDEO)], "expiration_days": 30},
+    )
+    assert resp.status_code == 200
+    auth_id = resp.json["created_target_key"]
+
+    auth = ApiAuthAccess.get_by_id(auth_id)
+    assert auth is not None
+    assert auth.owner == author.key
+    assert auth.auth_types_enum == [AuthType.MATCH_VIDEO]
+    assert auth.event_list == [ndb.Key(Event, "2016necmp")]
+    assert auth.expiration is not None
+
+
+def test_accept_apiwrite_default_expiration_past_event(
+    api_client: Client, moderator, author: Account, event: Event, taskqueue_stub
+) -> None:
+    # 2016necmp ended long ago, so the default expiration is "never"
+    moderator([AccountPermission.REVIEW_APIWRITE])
+    suggestion_id = create_suggestion(
+        author,
+        "api_auth_access",
+        "2016necmp",
+        {
+            "event_key": "2016necmp",
+            "affiliation": "Team 1124",
+            "auth_types": [int(AuthType.MATCH_VIDEO)],
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+
+    auth = ApiAuthAccess.get_by_id(resp.json["created_target_key"])
+    assert auth is not None
+    assert auth.expiration is None
+
+
+def test_accept_apiwrite_default_expiration_future_event(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    # While event end + 7 days is in the future, default to expiring then
+    moderator([AccountPermission.REVIEW_APIWRITE])
+    end_date = datetime.now() + timedelta(days=30)
+    Event(
+        id="2099necmp",
+        name="Future District Championship",
+        event_type_enum=EventType.DISTRICT_CMP,
+        short_name="Future",
+        event_short="necmp",
+        year=2099,
+        start_date=end_date - timedelta(days=2),
+        end_date=end_date,
+        official=False,
+    ).put()
+    suggestion_id = create_suggestion(
+        author,
+        "api_auth_access",
+        "2099necmp",
+        {
+            "event_key": "2099necmp",
+            "affiliation": "Team 1124",
+            "auth_types": [int(AuthType.MATCH_VIDEO)],
+        },
+    )
+
+    resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    assert resp.status_code == 200
+
+    auth = ApiAuthAccess.get_by_id(resp.json["created_target_key"])
+    assert auth is not None
+    assert auth.expiration is not None
+    assert auth.expiration == end_date + timedelta(days=8)
+
+
+def test_accept_apiwrite_sends_admin_alert(
+    api_client: Client,
+    moderator,
+    author: Account,
+    event: Event,
+    taskqueue_stub,
+    monkeypatch,
+) -> None:
+    moderator([AccountPermission.REVIEW_APIWRITE])
+    sent = []
+    monkeypatch.setattr(
+        SlackHookUrls, "url_for", staticmethod(lambda channel: "http://hook")
+    )
+    monkeypatch.setattr(
+        OutgoingNotificationHelper,
+        "send_slack_alert",
+        classmethod(lambda cls, url, body: sent.append((url, body))),
+    )
+    suggestion_id = create_suggestion(
+        author,
+        "api_auth_access",
+        "2016necmp",
+        {
+            "event_key": "2016necmp",
+            "affiliation": "Team 1124",
+            "auth_types": [int(AuthType.MATCH_VIDEO)],
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"user_message": "Enjoy the keys!"},
+    )
+    assert resp.status_code == 200
+
+    assert len(sent) == 1
+    url, body = sent[0]
+    assert url == "http://hook"
+    assert "Trusted API Key Request for 2016necmp" in body
+    assert "accepted" in body
+    assert "Enjoy the keys!" in body
+    assert resp.json["created_target_key"] in body
+
+
+def test_reject_apiwrite_sends_admin_alert(
+    api_client: Client, moderator, author: Account, event: Event, monkeypatch
+) -> None:
+    moderator([AccountPermission.REVIEW_APIWRITE])
+    sent = []
+    monkeypatch.setattr(
+        SlackHookUrls, "url_for", staticmethod(lambda channel: "http://hook")
+    )
+    monkeypatch.setattr(
+        OutgoingNotificationHelper,
+        "send_slack_alert",
+        classmethod(lambda cls, url, body: sent.append((url, body))),
+    )
+    suggestion_id = create_suggestion(
+        author,
+        "api_auth_access",
+        "2016necmp",
+        {
+            "event_key": "2016necmp",
+            "affiliation": "Team 1124",
+            "auth_types": [int(AuthType.MATCH_VIDEO)],
+        },
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/reject",
+        json={"suggestion_keys": [suggestion_id], "user_message": "Not this one"},
+    )
+    assert resp.status_code == 200
+
+    assert len(sent) == 1
+    url, body = sent[0]
+    assert url == "http://hook"
+    assert "Trusted API Key Request for 2016necmp" in body
+    assert "rejected" in body
+    assert "Not this one" in body
+
+
+# ---------------------------------------------------------------------------
+# Similar offseason event matching
+# ---------------------------------------------------------------------------
+
+
+def _offseason_event(key: str, name: str, short_name: str = "") -> Event:
+    return Event(
+        id=key,
+        name=name,
+        short_name=short_name or name,
+        event_short=key[4:],
+        event_type_enum=EventType.OFFSEASON,
+        year=int(key[:4]),
+    )
+
+
+def test_find_similar_events_case_insensitive(ndb_stub) -> None:
+    events = [_offseason_event("2016cc", "CHEZY CHAMPS")]
+    assert _find_similar_events("chezy champs", events) == [
+        {"key": "2016cc", "name": "CHEZY CHAMPS"}
+    ]
+
+
+def test_find_similar_events_matches_short_name(ndb_stub) -> None:
+    events = [
+        _offseason_event(
+            "2016bb", "Southern California Robotics Invitational", "Beach Blitz"
+        )
+    ]
+    assert _find_similar_events("Beach Blitz", events) == [
+        {"key": "2016bb", "name": "Southern California Robotics Invitational"}
+    ]
+
+
+def test_find_similar_events_containment(ndb_stub) -> None:
+    events = [_offseason_event("2016iri", "IROC - Indiana Robotics Off-Season")]
+    assert _find_similar_events("IROC", events) == [
+        {"key": "2016iri", "name": "IROC - Indiana Robotics Off-Season"}
+    ]
+
+
+def test_find_similar_events_excludes_dissimilar(ndb_stub) -> None:
+    events = [_offseason_event("2016cc", "Chezy Champs")]
+    assert _find_similar_events("Ranger Rumble", events) == []
+
+
+def test_find_similar_events_strongest_first_and_capped(ndb_stub) -> None:
+    events = [
+        _offseason_event(f"2016ev{i}", f"Chezy Champs Qualifier {i}") for i in range(6)
+    ]
+    events.append(_offseason_event("2016cc", "Chezy Champs"))
+    results = _find_similar_events("Chezy Champs", events)
+    assert len(results) == 5
+    assert results[0] == {"key": "2016cc", "name": "Chezy Champs"}
+
+
+def test_suggested_event_year(ndb_stub) -> None:
+    suggestion = Suggestion()
+    suggestion.contents = cast(SuggestionDict, {"start_date": "2027-10-01"})
+    assert _suggested_event_year(suggestion) == 2027
+
+    suggestion = Suggestion()
+    suggestion.contents = cast(SuggestionDict, {"start_date": "sometime"})
+    assert _suggested_event_year(suggestion) == datetime.now().year
+
+
+# ---------------------------------------------------------------------------
+# Reject
+# ---------------------------------------------------------------------------
+
+
+def test_reject_batch(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    user = moderator([AccountPermission.REVIEW_MEDIA])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/reject",
+        json={"suggestion_keys": [suggestion_id, "nonexistent"]},
+    )
+    assert resp.status_code == 200
+    results = {r["suggestion_key"]: r["result"] for r in resp.json["results"]}
+    assert results[suggestion_id] == "rejected"
+    assert results["nonexistent"] == "not_found"
+
+    suggestion = Suggestion.get_by_id(suggestion_id)
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_REJECTED
+    assert suggestion.reviewer == user.account_key
+
+    # No video was added
+    match = none_throws(Match.get_by_id("2016necmp_f1m1"))
+    assert "H-54KMwMKY0" not in match.youtube_videos
+
+
+def test_reject_requires_body(api_client: Client, moderator) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    resp = api_client.post(f"{BASE_URL}/suggestions/reject", json={})
+    assert resp.status_code == 400
+
+
+def test_reject_requires_type_permission(
+    api_client: Client, moderator, author: Account, event: Event, match: Match
+) -> None:
+    # REVIEW_DESIGNS cannot reject a match video suggestion; the write path
+    # re-checks per-suggestion permissions independently of the read path
+    moderator([AccountPermission.REVIEW_DESIGNS])
+    suggestion_id = create_match_video_suggestion(author)
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/reject", json={"suggestion_keys": [suggestion_id]}
+    )
+    assert resp.status_code == 200
+    results = {r["suggestion_key"]: r["result"] for r in resp.json["results"]}
+    assert results[suggestion_id] == "forbidden"
+
+    suggestion = Suggestion.get_by_id(suggestion_id)
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_PENDING
+
+
+def test_reject_batch_capped(api_client: Client, moderator) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/reject",
+        json={"suggestion_keys": [str(i) for i in range(501)]},
+    )
+    assert resp.status_code == 400
+
+
+def test_list_clamps_negative_limit(api_client: Client, moderator) -> None:
+    moderator([AccountPermission.REVIEW_MEDIA])
+    resp = api_client.get(f"{BASE_URL}/suggestions/match?limit=-5")
+    assert resp.status_code == 200
+    assert resp.json["suggestions"] == []

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -1052,7 +1052,9 @@ def test_accept_apiwrite(
 def test_accept_apiwrite_default_expiration_past_event(
     api_client: Client, moderator, author: Account, event: Event, taskqueue_stub
 ) -> None:
-    # 2016necmp ended long ago, so the default expiration is "never"
+    # 2016necmp ended long ago. The default is still 7 days -- counted from
+    # the grant, since that is later than event end + 7. Never-expiring keys
+    # are a deliberate exception, not a default.
     moderator([AccountPermission.REVIEW_APIWRITE])
     suggestion_id = create_suggestion(
         author,
@@ -1065,12 +1067,15 @@ def test_accept_apiwrite_default_expiration_past_event(
         },
     )
 
+    before = datetime.now()
     resp = api_client.post(f"{BASE_URL}/suggestions/{suggestion_id}/accept")
+    after = datetime.now()
     assert resp.status_code == 200
 
     auth = ApiAuthAccess.get_by_id(resp.json["created_target_key"])
     assert auth is not None
-    assert auth.expiration is None
+    expiration = none_throws(auth.expiration)
+    assert before + timedelta(days=7) <= expiration <= after + timedelta(days=7)
 
 
 def test_accept_apiwrite_default_expiration_future_event(

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -6,6 +6,7 @@ from backend.api.apiv3_main import api_v3
 from backend.api.client_api_main import client_api
 from backend.api.eventwizard_api_main import eventwizard_api
 from backend.api.handlers.error import handle_404
+from backend.api.moderation_api_main import moderation_api
 from backend.api.trusted_api_main import trusted_api
 from backend.common.flask_cache import configure_flask_cache
 from backend.common.logging import configure_logging
@@ -43,4 +44,5 @@ app.register_blueprint(api_v3)
 app.register_blueprint(eventwizard_api)
 app.register_blueprint(trusted_api)
 app.register_blueprint(client_api)
+app.register_blueprint(moderation_api)
 app.register_error_handler(404, handle_404)

--- a/src/backend/api/moderation_api_main.py
+++ b/src/backend/api/moderation_api_main.py
@@ -1,0 +1,40 @@
+from flask import Blueprint
+from flask_cors import CORS
+
+from backend.api.handlers.moderation import (
+    moderation_queue,
+    moderation_suggestion_accept,
+    moderation_suggestion_list,
+    moderation_suggestions_reject,
+)
+
+# Authenticated API for site moderators to review the suggestion queue.
+# Auth is a Firebase ID token (Authorization: Bearer), the same mechanism as
+# the client API; authorization is the account's AccountPermission flags.
+moderation_api = Blueprint("moderation_api", __name__, url_prefix="/api/moderation/v1")
+CORS(
+    moderation_api,
+    origins="*",
+    methods=["OPTIONS", "GET", "POST"],
+    allow_headers=["Content-Type", "Authorization"],
+)
+moderation_api.add_url_rule(
+    "/queue",
+    methods=["GET"],
+    view_func=moderation_queue,
+)
+moderation_api.add_url_rule(
+    "/suggestions/<suggestion_type>",
+    methods=["GET"],
+    view_func=moderation_suggestion_list,
+)
+moderation_api.add_url_rule(
+    "/suggestions/<suggestion_key>/accept",
+    methods=["POST"],
+    view_func=moderation_suggestion_accept,
+)
+moderation_api.add_url_rule(
+    "/suggestions/reject",
+    methods=["POST"],
+    view_func=moderation_suggestions_reject,
+)

--- a/src/backend/common/models/user.py
+++ b/src/backend/common/models/user.py
@@ -142,6 +142,15 @@ class User:
     def is_admin(self) -> bool:
         return self._session_claims.get("admin", False)
 
+    @property
+    def email_verified(self) -> bool:
+        """
+        Whether the identity provider has verified the token's email claim.
+        Accounts are linked to tokens by email, so anything granting
+        privileges based on that link must require a verified email.
+        """
+        return bool(self._session_claims.get("email_verified", False))
+
     def register(self, display_name: str) -> None:
         if self._account is None:
             return

--- a/src/backend/common/suggestions/suggestion_reviewer.py
+++ b/src/backend/common/suggestions/suggestion_reviewer.py
@@ -1,0 +1,518 @@
+import datetime
+import enum
+import json
+import random
+import string
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+
+from backend.common.consts.account_permission import AccountPermission
+from backend.common.consts.auth_type import AuthType, WRITE_TYPE_NAMES
+from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import IMAGE_TYPES
+from backend.common.consts.string_enum import StrEnum
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.consts.suggestion_type import SuggestionType
+from backend.common.consts.webcast_type import WebcastType
+from backend.common.helpers.event_webcast_adder import EventWebcastAdder
+from backend.common.helpers.match_suggestion_accepter import MatchSuggestionAccepter
+from backend.common.manipulators.event_manipulator import EventManipulator
+from backend.common.manipulators.media_manipulator import MediaManipulator
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.audit_log_entry import AuditLogEntry
+from backend.common.models.event import Event
+from backend.common.models.match import Match
+from backend.common.models.media import Media
+from backend.common.models.suggestion import Suggestion
+from backend.common.models.user import User
+from backend.common.models.webcast import Webcast
+from backend.common.suggestions.media_creator import MediaCreator
+
+# The AccountPermission required to review each type of suggestion. This
+# mirrors the REQUIRED_PERMISSIONS on the web review controllers in
+# backend/web/handlers/suggestions/.
+REQUIRED_REVIEW_PERMISSIONS: Dict[SuggestionType, AccountPermission] = {
+    SuggestionType.EVENT: AccountPermission.REVIEW_MEDIA,
+    SuggestionType.MATCH: AccountPermission.REVIEW_MEDIA,
+    SuggestionType.MEDIA: AccountPermission.REVIEW_MEDIA,
+    SuggestionType.SOCIAL_MEDIA: AccountPermission.REVIEW_MEDIA,
+    SuggestionType.OFFSEASON_EVENT: AccountPermission.REVIEW_OFFSEASON_EVENTS,
+    SuggestionType.API_AUTH_ACCESS: AccountPermission.REVIEW_APIWRITE,
+    SuggestionType.ROBOT: AccountPermission.REVIEW_DESIGNS,
+    SuggestionType.EVENT_MEDIA: AccountPermission.REVIEW_EVENT_MEDIA,
+}
+
+# The NDB model kind name for the entity targeted by each suggestion type,
+# used when writing AuditLogEntry records. This mirrors _audit_target_kind on
+# the web review controllers. None means the target key is only known after
+# the model is created (offseason events).
+AUDIT_TARGET_KINDS: Dict[SuggestionType, Optional[str]] = {
+    SuggestionType.EVENT: "Event",
+    SuggestionType.MATCH: "Match",
+    SuggestionType.MEDIA: "Team",
+    SuggestionType.SOCIAL_MEDIA: "Team",
+    SuggestionType.OFFSEASON_EVENT: None,
+    SuggestionType.API_AUTH_ACCESS: "Event",
+    SuggestionType.ROBOT: "Team",
+    SuggestionType.EVENT_MEDIA: "Team",
+}
+
+
+@enum.unique
+class SuggestionReviewResult(StrEnum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    NOT_FOUND = "not_found"
+    ALREADY_REVIEWED = "already_reviewed"
+    INVALID = "invalid"
+    FORBIDDEN = "forbidden"
+
+
+class ReviewOutcome(NamedTuple):
+    result: SuggestionReviewResult
+    suggestion_key: str
+    created_target_key: Optional[str] = None
+    message: Optional[str] = None
+
+
+class SuggestionReviewer:
+    """
+    Shared accept/reject logic for Suggestions, decoupled from any request
+    context so it can back both the web review controllers and the
+    moderation API.
+
+    Accepts run one at a time in an XG transaction with a REVIEW_PENDING
+    re-check so that concurrent reviews of the same suggestion no-op safely.
+    Type-specific reviewer inputs (year overrides, webcast fields, etc.) are
+    passed as an explicit `overrides` dict; see _create_target_model for the
+    keys each suggestion type understands.
+    """
+
+    @classmethod
+    def user_can_review(cls, user: User, suggestion_type: SuggestionType) -> bool:
+        if user.is_admin:
+            return True
+        required = REQUIRED_REVIEW_PERMISSIONS[suggestion_type]
+        return required in (user.permissions or [])
+
+    @classmethod
+    def accept_suggestion(
+        cls,
+        suggestion_key: str,
+        user: User,
+        overrides: Optional[Dict[str, Any]] = None,
+        endpoint: str = "",
+    ) -> ReviewOutcome:
+        """Accept a single pending Suggestion, creating its target model."""
+        suggestion = cls._get_suggestion(suggestion_key)
+        if suggestion is None:
+            return ReviewOutcome(SuggestionReviewResult.NOT_FOUND, suggestion_key)
+
+        suggestion_type = SuggestionType(suggestion.target_model)
+        if not cls.user_can_review(user, suggestion_type):
+            return ReviewOutcome(SuggestionReviewResult.FORBIDDEN, suggestion_key)
+
+        return cls._accept_in_transaction(
+            none_throws(suggestion.key), user, overrides or {}, endpoint
+        )
+
+    @classmethod
+    @ndb.transactional(xg=True)
+    def _accept_in_transaction(
+        cls,
+        suggestion_ndb_key: ndb.Key,
+        user: User,
+        overrides: Dict[str, Any],
+        endpoint: str,
+    ) -> ReviewOutcome:
+        suggestion: Optional[Suggestion] = suggestion_ndb_key.get()
+        suggestion_key = str(suggestion_ndb_key.id())
+        if suggestion is None:
+            return ReviewOutcome(SuggestionReviewResult.NOT_FOUND, suggestion_key)
+
+        # Make sure the Suggestion hasn't been processed (by another thread)
+        if suggestion.review_state != SuggestionState.REVIEW_PENDING:
+            return ReviewOutcome(
+                SuggestionReviewResult.ALREADY_REVIEWED, suggestion_key
+            )
+
+        try:
+            created_key, error = cls._create_target_model(suggestion, overrides)
+        except (KeyError, TypeError, ValueError) as e:
+            return ReviewOutcome(
+                SuggestionReviewResult.INVALID,
+                suggestion_key,
+                message=f"Invalid accept payload: {e}",
+            )
+        if created_key is None:
+            return ReviewOutcome(
+                SuggestionReviewResult.INVALID, suggestion_key, message=error
+            )
+
+        suggestion.review_state = SuggestionState.REVIEW_ACCEPTED
+        suggestion.reviewer = user.account_key
+        suggestion.reviewed_at = datetime.datetime.now()
+        suggestion.put()
+
+        cls._write_audit_log(suggestion, user, endpoint, overrides, created_key)
+        return ReviewOutcome(
+            SuggestionReviewResult.ACCEPTED,
+            suggestion_key,
+            created_target_key=created_key,
+        )
+
+    @classmethod
+    def reject_suggestions(
+        cls,
+        suggestion_keys: List[str],
+        user: User,
+        endpoint: str = "",
+    ) -> List[ReviewOutcome]:
+        """
+        Reject a batch of pending Suggestions. Each rejection runs in its own
+        transaction; rejects create/delete no domain entities.
+        """
+        outcomes = []
+        for suggestion_key in suggestion_keys:
+            suggestion = cls._get_suggestion(suggestion_key)
+            if suggestion is None:
+                outcomes.append(
+                    ReviewOutcome(SuggestionReviewResult.NOT_FOUND, suggestion_key)
+                )
+                continue
+
+            suggestion_type = SuggestionType(suggestion.target_model)
+            if not cls.user_can_review(user, suggestion_type):
+                outcomes.append(
+                    ReviewOutcome(SuggestionReviewResult.FORBIDDEN, suggestion_key)
+                )
+                continue
+
+            outcomes.append(
+                cls._reject_in_transaction(none_throws(suggestion.key), user, endpoint)
+            )
+        return outcomes
+
+    @classmethod
+    @ndb.transactional(xg=True)
+    def _reject_in_transaction(
+        cls, suggestion_ndb_key: ndb.Key, user: User, endpoint: str
+    ) -> ReviewOutcome:
+        suggestion: Optional[Suggestion] = suggestion_ndb_key.get()
+        suggestion_key = str(suggestion_ndb_key.id())
+        if suggestion is None:
+            return ReviewOutcome(SuggestionReviewResult.NOT_FOUND, suggestion_key)
+
+        if suggestion.review_state != SuggestionState.REVIEW_PENDING:
+            return ReviewOutcome(
+                SuggestionReviewResult.ALREADY_REVIEWED, suggestion_key
+            )
+
+        suggestion.review_state = SuggestionState.REVIEW_REJECTED
+        suggestion.reviewer = user.account_key
+        suggestion.reviewed_at = datetime.datetime.now()
+        suggestion.put()
+
+        cls._write_audit_log(suggestion, user, endpoint, {}, None)
+        return ReviewOutcome(SuggestionReviewResult.REJECTED, suggestion_key)
+
+    @classmethod
+    def _create_target_model(
+        cls, suggestion: Suggestion, overrides: Dict[str, Any]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Create the domain entity for an accepted suggestion. Ported from the
+        create_target_model implementations on the web review controllers.
+        Returns (created_target_key, error_message).
+        """
+        suggestion_type = SuggestionType(suggestion.target_model)
+
+        if suggestion_type == SuggestionType.MATCH:
+            return cls._accept_match_video(suggestion, overrides)
+        if suggestion_type == SuggestionType.MEDIA:
+            return cls._accept_team_media(suggestion, overrides)
+        if suggestion_type in (SuggestionType.SOCIAL_MEDIA, SuggestionType.ROBOT):
+            media = MediaCreator.from_suggestion(suggestion)
+            return str(none_throws(media.key.id())), None
+        if suggestion_type == SuggestionType.EVENT_MEDIA:
+            event_reference = Media.create_reference(
+                suggestion.contents["reference_type"],
+                suggestion.contents["reference_key"],
+            )
+            media = MediaCreator.create_media_model(suggestion, event_reference, [])
+            media = MediaManipulator.createOrUpdate(media)
+            return str(none_throws(media.key.id())), None
+        if suggestion_type == SuggestionType.EVENT:
+            return cls._accept_event_webcast(suggestion, overrides)
+        if suggestion_type == SuggestionType.OFFSEASON_EVENT:
+            return cls._accept_offseason_event(suggestion, overrides)
+        if suggestion_type == SuggestionType.API_AUTH_ACCESS:
+            return cls._accept_api_write(suggestion, overrides)
+
+        return None, f"Unsupported suggestion type {suggestion_type}"
+
+    @classmethod
+    def _accept_match_video(
+        cls, suggestion: Suggestion, overrides: Dict[str, Any]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        # The reviewer may redirect the video to a different match
+        target_key = overrides.get("target_match_key") or suggestion.target_key or ""
+        match = Match.get_by_id(target_key)
+        if not match:
+            return None, f"Match {target_key} not found"
+        MatchSuggestionAccepter.accept_suggestion(match, suggestion)
+        return target_key, None
+
+    @classmethod
+    def _accept_team_media(
+        cls, suggestion: Suggestion, overrides: Dict[str, Any]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        # Reviewer inputs: year (int), set_preferred (bool),
+        # replace_preferred_media_key (an existing Media key id to demote)
+        to_replace_id: Optional[str] = overrides.get("replace_preferred_media_key")
+        year = int(overrides.get("year") or none_throws(suggestion.contents["year"]))
+
+        # Override year if necessary
+        suggestion.contents["year"] = year
+        suggestion.contents_json = json.dumps(suggestion.contents)
+        suggestion._contents = None
+
+        # Remove preferred reference from another Media if specified
+        team_reference = Media.create_reference(
+            suggestion.contents["reference_type"],
+            suggestion.contents["reference_key"],
+        )
+        to_replace: Optional[Media] = None
+        if to_replace_id:
+            to_replace = Media.get_by_id(to_replace_id)
+            if to_replace is None:
+                return None, f"Media {to_replace_id} not found"
+            if team_reference not in to_replace.preferred_references:
+                # Preferred reference must have been edited earlier
+                return None, f"Media {to_replace_id} is not preferred for this team"
+            to_replace.preferred_references.remove(team_reference)
+
+        # Only images can be preferred. When the reviewer doesn't say either
+        # way, honor the suggester's default_preferred request.
+        set_preferred = overrides.get("set_preferred")
+        if set_preferred is None:
+            set_preferred = bool(suggestion.contents.get("default_preferred"))
+        media_type_enum = suggestion.contents["media_type_enum"]
+        preferred_references = []
+        if media_type_enum in IMAGE_TYPES and (set_preferred or to_replace_id):
+            preferred_references = [team_reference]
+
+        media = MediaCreator.create_media_model(
+            suggestion, team_reference, preferred_references
+        )
+
+        if to_replace:
+            MediaManipulator.createOrUpdate(to_replace, auto_union=False)
+        media = MediaManipulator.createOrUpdate(media)
+        return str(none_throws(media.key.id())), None
+
+    @classmethod
+    def _accept_event_webcast(
+        cls, suggestion: Suggestion, overrides: Dict[str, Any]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        # Reviewer inputs: webcast_type, webcast_channel, webcast_file,
+        # webcast_date. Defaults come from the parsed webcast_dict when the
+        # suggested URL was cleanly parseable.
+        webcast_dict = suggestion.contents.get("webcast_dict") or {}
+        webcast_type = overrides.get("webcast_type") or webcast_dict.get("type")
+        webcast_channel = overrides.get("webcast_channel") or webcast_dict.get(
+            "channel"
+        )
+        if not webcast_type or not webcast_channel:
+            return None, "webcast_type and webcast_channel are required"
+        try:
+            webcast = Webcast(
+                type=WebcastType(webcast_type),
+                channel=webcast_channel,
+            )
+        except ValueError:
+            return None, f"Invalid webcast_type {webcast_type}"
+
+        webcast_file = overrides.get("webcast_file") or webcast_dict.get("file")
+        if webcast_file:
+            webcast["file"] = webcast_file
+        webcast_date = overrides.get("webcast_date") or suggestion.contents.get(
+            "webcast_date"
+        )
+        if webcast_date:
+            webcast["date"] = webcast_date
+
+        event_key = overrides.get("event_key") or suggestion.target_key or ""
+        event = Event.get_by_id(event_key)
+        if not event:
+            return None, f"Event {event_key} not found"
+
+        EventWebcastAdder.add_webcast(event, webcast)
+        return event_key, None
+
+    @classmethod
+    def _accept_offseason_event(
+        cls, suggestion: Suggestion, overrides: Dict[str, Any]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        # Reviewer inputs: event_short (required), plus optional overrides of
+        # every event field. Everything else defaults from the suggestion.
+        contents = suggestion.contents
+        event_short = (overrides.get("event_short") or "").lower()
+        if not event_short:
+            return None, "event_short is required to accept an offseason event"
+
+        start_date_str = overrides.get("start_date") or contents.get("start_date")
+        end_date_str = overrides.get("end_date") or contents.get("end_date")
+        start_date = (
+            datetime.datetime.strptime(start_date_str, "%Y-%m-%d")
+            if start_date_str
+            else None
+        )
+        end_date = (
+            datetime.datetime.strptime(end_date_str, "%Y-%m-%d")
+            if end_date_str
+            else None
+        )
+
+        year = int(overrides.get("year") or (start_date.year if start_date else 0))
+        event_key = f"{year}{event_short}"
+        if not Event.validate_key_name(event_key):
+            return None, f"Bad event key {event_key}"
+        if Event.get_by_id(event_key):
+            return None, f"Event {event_key} already exists"
+
+        first_code = overrides.get("first_code") or contents.get("first_code")
+        if first_code:
+            first_code = first_code.upper()
+        event_type_enum = EventType(
+            int(overrides.get("event_type_enum", EventType.OFFSEASON))
+        )
+
+        event = Event(
+            id=event_key,
+            end_date=end_date,
+            event_short=event_short,
+            event_type_enum=event_type_enum,
+            district_key=None,
+            venue=overrides.get("venue") or contents.get("venue_name"),
+            venue_address=overrides.get("venue_address") or contents.get("address"),
+            city=overrides.get("city") or contents.get("city"),
+            state_prov=overrides.get("state") or contents.get("state"),
+            country=overrides.get("country") or contents.get("country"),
+            name=overrides.get("name") or contents.get("name"),
+            short_name=overrides.get("short_name"),
+            start_date=start_date,
+            website=overrides.get("website") or contents.get("website"),
+            year=year,
+            first_code=first_code,
+            official=(first_code is not None and first_code != ""),
+        )
+        EventManipulator.createOrUpdate(event)
+        return event_key, None
+
+    @classmethod
+    def _accept_api_write(
+        cls, suggestion: Suggestion, overrides: Dict[str, Any]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        # Reviewer inputs: auth_types (list of AuthType ints; defaults to the
+        # requested types), expiration_days (int; -1 = no expiration; defaults
+        # to 7 while event end + 7 days is still in the future)
+        event_key = suggestion.contents["event_key"]
+        event = Event.get_by_id(event_key)
+        if not event:
+            return None, f"Event {event_key} not found"
+        author = none_throws(suggestion.author.get())
+
+        requested_auth_types = suggestion.contents.get("auth_types", [])
+        auth_types = overrides.get("auth_types")
+        if auth_types is None:
+            auth_types = requested_auth_types
+        clean_auth_types = [
+            AuthType(int(t)) for t in auth_types if int(t) in WRITE_TYPE_NAMES.keys()
+        ]
+
+        raw_expiration_days = overrides.get("expiration_days")
+        if raw_expiration_days is None:
+            # end_date is midnight starting the last event day, so +8 days is
+            # the end of "event end + 7 days"
+            if (
+                event.end_date
+                and event.end_date + datetime.timedelta(days=8)
+                > datetime.datetime.now()
+            ):
+                raw_expiration_days = 7
+            else:
+                raw_expiration_days = -1
+        expiration_days = int(raw_expiration_days)
+        if expiration_days != -1:
+            expiration_event_end = event.end_date + datetime.timedelta(
+                days=expiration_days + 1
+            )
+            expiration_now = datetime.datetime.now() + datetime.timedelta(
+                days=expiration_days
+            )
+            expiration = max(expiration_event_end, expiration_now)
+        else:
+            expiration = None
+
+        auth_id = "".join(
+            random.choice(
+                string.ascii_lowercase + string.ascii_uppercase + string.digits
+            )
+            for _ in range(16)
+        )
+        auth = ApiAuthAccess(
+            id=auth_id,
+            description="{} @ {}".format(author.display_name, event_key),
+            secret="".join(
+                random.choice(
+                    string.ascii_lowercase + string.ascii_uppercase + string.digits
+                )
+                for _ in range(64)
+            ),
+            event_list=[ndb.Key(Event, event_key)],
+            auth_types_enum=clean_auth_types,
+            owner=suggestion.author,
+            expiration=expiration,
+        )
+        auth.put()
+        return auth_id, None
+
+    @classmethod
+    def _get_suggestion(cls, suggestion_key: str) -> Optional[Suggestion]:
+        suggestion = Suggestion.get_by_id(suggestion_key)
+        if suggestion is None and suggestion_key.isdigit():
+            # Some suggestion types (offseason events, apiwrite) have
+            # auto-allocated integer IDs
+            suggestion = Suggestion.get_by_id(int(suggestion_key))
+        return suggestion
+
+    @classmethod
+    def _write_audit_log(
+        cls,
+        suggestion: Suggestion,
+        user: User,
+        endpoint: str,
+        overrides: Dict[str, Any],
+        created_key: Optional[str],
+    ) -> None:
+        suggestion_type = SuggestionType(suggestion.target_model)
+        kind = AUDIT_TARGET_KINDS[suggestion_type]
+        if kind is not None and suggestion.target_key:
+            target_key = ndb.Key(kind, suggestion.target_key)
+        elif suggestion_type == SuggestionType.OFFSEASON_EVENT and created_key:
+            # The event only exists once the suggestion is accepted
+            target_key = ndb.Key(Event, created_key)
+        else:
+            return
+        AuditLogEntry(
+            account=user.account_key,
+            endpoint=endpoint,
+            target_key=target_key,
+            url_args={},
+            form_params={
+                str(k): [str(v)] for k, v in overrides.items() if v is not None
+            },
+        ).put()

--- a/src/backend/common/suggestions/suggestion_reviewer.py
+++ b/src/backend/common/suggestions/suggestion_reviewer.py
@@ -375,8 +375,15 @@ class SuggestionReviewer:
             if end_date_str
             else None
         )
+        # Dateless events violate the APIv3 contract (start_date/end_date are
+        # non-nullable) and break strict API clients, so refuse to create one
+        if start_date is None or end_date is None:
+            return (
+                None,
+                "start_date and end_date are required to accept an offseason event",
+            )
 
-        year = int(overrides.get("year") or (start_date.year if start_date else 0))
+        year = int(overrides.get("year") or start_date.year)
         event_key = f"{year}{event_short}"
         if not Event.validate_key_name(event_key):
             return None, f"Bad event key {event_key}"

--- a/src/backend/common/suggestions/suggestion_reviewer.py
+++ b/src/backend/common/suggestions/suggestion_reviewer.py
@@ -425,7 +425,11 @@ class SuggestionReviewer:
     ) -> Tuple[Optional[str], Optional[str]]:
         # Reviewer inputs: auth_types (list of AuthType ints; defaults to the
         # requested types), expiration_days (int; -1 = no expiration; defaults
-        # to 7 while event end + 7 days is still in the future)
+        # to 7). The key stays valid until `expiration_days` after the event
+        # end *or* after the grant, whichever is later, so a key approved long
+        # after an event has finished is still usable rather than dead on
+        # arrival. Never-expiring keys are a deliberate exception, not a
+        # default.
         event_key = suggestion.contents["event_key"]
         event = Event.get_by_id(event_key)
         if not event:
@@ -441,18 +445,7 @@ class SuggestionReviewer:
         ]
 
         raw_expiration_days = overrides.get("expiration_days")
-        if raw_expiration_days is None:
-            # end_date is midnight starting the last event day, so +8 days is
-            # the end of "event end + 7 days"
-            if (
-                event.end_date
-                and event.end_date + datetime.timedelta(days=8)
-                > datetime.datetime.now()
-            ):
-                raw_expiration_days = 7
-            else:
-                raw_expiration_days = -1
-        expiration_days = int(raw_expiration_days)
+        expiration_days = 7 if raw_expiration_days is None else int(raw_expiration_days)
         if expiration_days != -1:
             expiration_event_end = event.end_date + datetime.timedelta(
                 days=expiration_days + 1

--- a/src/backend/web/handlers/admin/blueprint.py
+++ b/src/backend/web/handlers/admin/blueprint.py
@@ -103,6 +103,10 @@ from backend.web.handlers.admin.sitevars import (
     sitevar_edit_post,
     sitevars_list,
 )
+from backend.web.handlers.admin.suggestions_seed import (
+    suggestion_seed_get,
+    suggestion_seed_post,
+)
 from backend.web.handlers.admin.team import (
     team_detail,
     team_list,
@@ -490,6 +494,12 @@ admin_routes.add_url_rule(
     "/mobile_clients/dedupe",
     view_func=mobile_clients_dedupe_post,
     methods=["POST"],
+)
+admin_routes.add_url_rule(
+    "/suggestions/seed", view_func=suggestion_seed_get, methods=["GET"]
+)
+admin_routes.add_url_rule(
+    "/suggestions/seed", view_func=suggestion_seed_post, methods=["POST"]
 )
 admin_routes.add_url_rule("/user/<user_id>", view_func=user_detail)
 admin_routes.add_url_rule("/user/edit/<user_id>", methods=["GET"], view_func=user_edit)

--- a/src/backend/web/handlers/admin/suggestions_seed.py
+++ b/src/backend/web/handlers/admin/suggestions_seed.py
@@ -1,0 +1,481 @@
+import datetime
+import json
+import random
+import string
+from typing import List, Optional, Tuple
+
+from flask import abort, request
+from google.appengine.ext import ndb
+
+from backend.common.consts.account_permission import SUGGESTION_PERMISSIONS
+from backend.common.consts.auth_type import AuthType
+from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import MediaType, PROFILE_URLS
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.consts.suggestion_type import SUGGESTION_TYPES, TYPE_NAMES
+from backend.common.consts.webcast_type import WebcastType
+from backend.common.environment.environment import Environment
+from backend.common.helpers.suggestion_fetcher import SuggestionFetcher
+from backend.common.manipulators.event_manipulator import EventManipulator
+from backend.common.manipulators.match_manipulator import MatchManipulator
+from backend.common.manipulators.team_manipulator import TeamManipulator
+from backend.common.models.account import Account
+from backend.common.models.event import Event
+from backend.common.models.match import Match
+from backend.common.models.suggestion import Suggestion
+from backend.common.models.team import Team
+from backend.common.suggestions.suggestion_creator import (
+    SuggestionCreationStatus,
+    SuggestionCreator,
+)
+from backend.web.profiled_render import render_template
+
+SEED_AUTHOR_ACCOUNT_ID = "suggestion-seed-bot"
+
+# Real media so seeded suggestions preview properly in review UIs. Video
+# suggestion keys are deterministic per video+target, so repeat seeding walks
+# this pool of embeddable FIRST game animations and only falls back to a
+# random (unavailable) ID once the pool is exhausted.
+SEED_YOUTUBE_VIDEO_IDS = [
+    "_fybREErgyM",  # 2026 REBUILT
+    "9keeDyFxzY4",  # 2024 CRESCENDO
+    "0zpflsYc4PA",  # 2023 CHARGED UP
+    "LgniEjI9cCM",  # 2022 RAPID REACT
+]
+SEED_YOUTUBE_VIDEO_ID = SEED_YOUTUBE_VIDEO_IDS[0]
+SEED_TWITCH_CHANNEL = "firstinspires"
+SEED_IMGUR_IMAGE_ID = "2xhn4BX"
+SEED_INSTAGRAM_POST_ID = "C4bhT7FsmAW"
+# Real FRC-community GitHub orgs; repeat seeding walks the pool for variety
+SEED_GITHUB_USERS = [
+    "the-blue-alliance",
+    "wpilibsuite",
+    "frc971",
+    "frc1678",
+    "team254",
+    "Mechanical-Advantage",
+]
+SEED_GITHUB_USER = SEED_GITHUB_USERS[0]
+# (media_type, foreign_key, site_name, profile_url override or None)
+SEED_SOCIAL_PROFILES = [
+    (MediaType.FACEBOOK_PROFILE, "thebluealliance", "Facebook", None),
+    (
+        MediaType.TWITTER_PROFILE,
+        "thebluealliance",
+        "X",
+        "https://x.com/thebluealliance",
+    ),
+    (MediaType.INSTAGRAM_PROFILE, "the_blue_alliance", "Instagram", None),
+    (MediaType.YOUTUBE_CHANNEL, "@FIRSTRoboticsCompetition", "YouTube", None),
+    # Malformed on purpose: personal-profile and video links, not usernames,
+    # to exercise the review UI's malformed-submission warnings
+    (
+        MediaType.FACEBOOK_PROFILE,
+        "profile.php?id=100064531607957",
+        "Facebook",
+        None,
+    ),
+    (MediaType.YOUTUBE_CHANNEL, "watch?v=_fybREErgyM", "YouTube", None),
+]
+
+# Mocked entities the seeds target by default
+SEED_TEAM_KEY = "frc2"
+SEED_TEAM_NICKNAME = "The Reindeer"
+SEED_EVENT_NAME = "North Pole Regional"
+SEED_EVENT_SHORT_NAME = "North Pole"
+SEED_EVENT_SHORT = "np"
+
+
+def _random_id(length: int) -> str:
+    return "".join(
+        random.choice(string.ascii_letters + string.digits) for _ in range(length)
+    )
+
+
+def _seed_author() -> Account:
+    return Account.get_or_insert(
+        SEED_AUTHOR_ACCOUNT_ID,
+        email="seed-bot@thebluealliance.com",
+        nickname="Suggestion Seed Bot",
+        display_name="Suggestion Seed Bot",
+        registered=True,
+        permissions=[],
+    )
+
+
+def _ensure_team(team_key: str) -> Tuple[Team, bool]:
+    team = Team.get_by_id(team_key)
+    if team:
+        # The seed team always presents as the mocked data team, even if the
+        # dev datastore already has an entity for it
+        if team_key == SEED_TEAM_KEY and team.nickname != SEED_TEAM_NICKNAME:
+            team.nickname = SEED_TEAM_NICKNAME
+            team.name = SEED_TEAM_NICKNAME
+            team = TeamManipulator.createOrUpdate(team)
+        return team, False
+    nickname = SEED_TEAM_NICKNAME if team_key == SEED_TEAM_KEY else "Seeded Test Team"
+    team = Team(
+        id=team_key,
+        team_number=int(team_key[3:]),
+        nickname=nickname,
+        name=nickname,
+        city="North Pole",
+        state_prov="AK",
+        country="USA",
+    )
+    return TeamManipulator.createOrUpdate(team), True
+
+
+def _ensure_event(event_key: str) -> Tuple[Optional[Event], bool]:
+    event = Event.get_by_id(event_key)
+    if event:
+        if event.event_short == SEED_EVENT_SHORT and event.name != SEED_EVENT_NAME:
+            event.name = SEED_EVENT_NAME
+            event.short_name = SEED_EVENT_SHORT_NAME
+            event = EventManipulator.createOrUpdate(event)
+        return event, False
+    if not Event.validate_key_name(event_key):
+        return None, False
+    year = int(event_key[:4])
+    start = datetime.datetime(year, 10, 1)
+    event = Event(
+        id=event_key,
+        name=SEED_EVENT_NAME,
+        short_name=SEED_EVENT_SHORT_NAME,
+        event_short=event_key[4:],
+        event_type_enum=EventType.OFFSEASON,
+        year=year,
+        start_date=start,
+        end_date=start + datetime.timedelta(days=1),
+        official=False,
+        city="North Pole",
+        state_prov="AK",
+        country="USA",
+        venue="Santa's Workshop",
+        venue_address="Santa's Workshop, North Pole, AK, USA",
+        website="https://www.thebluealliance.com",
+        webcast_json="",
+    )
+    return EventManipulator.createOrUpdate(event), True
+
+
+def _ensure_match(match_key: str) -> Tuple[Optional[Match], bool]:
+    match = Match.get_by_id(match_key)
+    if match:
+        return match, False
+    event_key = match_key.split("_")[0]
+    event, _ = _ensure_event(event_key)
+    if event is None:
+        return None, False
+    match = Match(
+        id=match_key,
+        event=ndb.Key(Event, event_key),
+        year=event.year,
+        comp_level="qm",
+        set_number=1,
+        match_number=int(match_key.split("qm")[-1]) if "qm" in match_key else 1,
+        team_key_names=[
+            SEED_TEAM_KEY,
+            "frc1678",
+            "frc973",
+            "frc846",
+            "frc2135",
+            "frc971",
+        ],
+        alliances_json=json.dumps(
+            {
+                "red": {"score": 100, "teams": [SEED_TEAM_KEY, "frc1678", "frc973"]},
+                "blue": {"score": 90, "teams": ["frc846", "frc2135", "frc971"]},
+            }
+        ),
+    )
+    return MatchManipulator.createOrUpdate(match), True
+
+
+def _seed_media_suggestion(
+    author: Account, target_model: str, team_key: str
+) -> Tuple[str, str]:
+    """Seed team media (image/video/instagram), social media, or CAD suggestions."""
+    foreign_key = f"seed{_random_id(6)}"
+    year = datetime.datetime.now().year
+    contents_list = []
+    if target_model == "media":
+        # Media URLs render from foreign_key, so real media previews properly.
+        # Suggestions get auto ids, so repeat seeding of the same media is fine.
+        contents_list = [
+            {
+                "media_type_enum": int(MediaType.IMGUR),
+                "foreign_key": SEED_IMGUR_IMAGE_ID,
+                "reference_type": "team",
+                "reference_key": team_key,
+                "year": year,
+                "details_json": json.dumps(
+                    {"image_partial": f"{SEED_IMGUR_IMAGE_ID}l.jpg"}
+                ),
+                "site_name": "Imgur",
+            },
+            {
+                "media_type_enum": int(MediaType.YOUTUBE_VIDEO),
+                "foreign_key": SEED_YOUTUBE_VIDEO_ID,
+                "reference_type": "team",
+                "reference_key": team_key,
+                "year": year,
+                "site_name": "YouTube",
+            },
+            {
+                "media_type_enum": int(MediaType.INSTAGRAM_IMAGE),
+                "foreign_key": SEED_INSTAGRAM_POST_ID,
+                "reference_type": "team",
+                "reference_key": team_key,
+                "year": year,
+                "site_name": "Instagram",
+            },
+        ]
+    elif target_model == "social-media":
+        # One of each platform per round, all real profiles. GitHub cycles
+        # through real orgs so repeat seeding shows varied live cards.
+        pending_social = SuggestionFetcher.count_async(
+            SuggestionState.REVIEW_PENDING, "social-media"
+        ).get_result()
+        github_user = SEED_GITHUB_USERS[pending_social % len(SEED_GITHUB_USERS)]
+        contents_list = [
+            {
+                "media_type_enum": int(MediaType.GITHUB_PROFILE),
+                "foreign_key": github_user,
+                "reference_type": "team",
+                "reference_key": team_key,
+                "is_social": True,
+                "site_name": "GitHub",
+                "profile_url": f"https://github.com/{github_user}",
+            }
+        ] + [
+            {
+                "media_type_enum": int(media_type),
+                "foreign_key": profile_key,
+                "reference_type": "team",
+                "reference_key": team_key,
+                "is_social": True,
+                "site_name": site_name,
+                "profile_url": profile_url
+                or PROFILE_URLS[media_type].format(profile_key),
+            }
+            for media_type, profile_key, site_name, profile_url in SEED_SOCIAL_PROFILES
+        ]
+    else:  # robot / CAD
+        contents_list = [
+            {
+                "media_type_enum": int(MediaType.GRABCAD),
+                "foreign_key": foreign_key,
+                "reference_type": "team",
+                "reference_key": team_key,
+                "year": year,
+                "details_json": json.dumps(
+                    {
+                        "model_name": f"Seeded CAD Model {foreign_key}",
+                        "model_description": "A seeded robot CAD model for moderation testing",
+                        "model_image": f"https://i.imgur.com/{SEED_IMGUR_IMAGE_ID}l.jpg",
+                        "model_created": datetime.datetime.now().isoformat(),
+                    }
+                ),
+            }
+        ]
+    for suggestion_contents in contents_list:
+        suggestion = Suggestion(
+            author=author.key,
+            target_model=target_model,
+            target_key=team_key,
+        )
+        suggestion.contents = suggestion_contents
+        suggestion.put()
+    return SuggestionCreationStatus.SUCCESS, foreign_key
+
+
+def _seed_event_media_suggestion(author: Account, event_key: str) -> str:
+    status = SuggestionCreationStatus.SUCCESS
+    for youtube_id in (*SEED_YOUTUBE_VIDEO_IDS, _random_youtube_id()):
+        status, _ = SuggestionCreator.createEventMediaSuggestion(
+            author.key,
+            f"https://www.youtube.com/watch?v={youtube_id}",
+            event_key,
+        ).get_result()
+        if status == SuggestionCreationStatus.SUCCESS:
+            break
+    return status
+
+
+def _random_youtube_id() -> str:
+    # YouTube IDs are 11 chars; a random one previews as unavailable but
+    # keeps repeat seeding unique once the real video is taken
+    return _random_id(11)
+
+
+def _seed_webcast_suggestion(author: Account, event_key: str) -> str:
+    suggestion = Suggestion(
+        author=author.key,
+        target_model="event",
+        target_key=event_key,
+    )
+    suggestion.contents = {
+        "webcast_url": f"https://twitch.tv/{SEED_TWITCH_CHANNEL}",
+        "webcast_dict": {
+            "type": WebcastType.TWITCH,
+            "channel": SEED_TWITCH_CHANNEL,
+        },
+        "webcast_date": "",
+    }
+    suggestion.put()
+    return SuggestionCreationStatus.SUCCESS
+
+
+def _seed_offseason_suggestion(author: Account) -> str:
+    year = datetime.datetime.now().year
+    suffix = _random_id(4)
+    status, _ = SuggestionCreator.createOffseasonEventSuggestion(
+        author_account_key=author.key,
+        name=f"Seeded Offseason Invitational {suffix}",
+        start_date=f"{year}-10-15",
+        end_date=f"{year}-10-16",
+        website="https://www.thebluealliance.com",
+        venue_name="Seeded Venue",
+        address="123 Fake St",
+        city="San Jose",
+        state="CA",
+        country="USA",
+    )
+    return status
+
+
+def _seed_apiwrite_suggestion(author: Account, event_key: str) -> str:
+    return SuggestionCreator.createApiWriteSuggestion(
+        author_account_key=author.key,
+        event_key=event_key,
+        affiliation=f"Seeded Robotics {_random_id(4)}",
+        auth_types=[
+            int(AuthType.EVENT_TEAMS),
+            int(AuthType.EVENT_MATCHES),
+            int(AuthType.MATCH_VIDEO),
+        ],
+    )
+
+
+def _pending_counts() -> dict:
+    futures = {
+        suggestion_type: SuggestionFetcher.count_async(
+            SuggestionState.REVIEW_PENDING, suggestion_type
+        )
+        for suggestion_type in SUGGESTION_TYPES
+    }
+    return {
+        suggestion_type: future.get_result()
+        for suggestion_type, future in futures.items()
+    }
+
+
+def _default_keys() -> Tuple[str, str, str]:
+    year = datetime.datetime.now().year
+    event_key = f"{year}{SEED_EVENT_SHORT}"
+    return SEED_TEAM_KEY, event_key, f"{event_key}_qm1"
+
+
+def _abort_in_prod() -> None:
+    # Seeding fabricates suggestions and grants review permissions; it is
+    # dev-environment tooling and must never run against production data
+    if Environment.is_prod():
+        abort(404)
+
+
+def suggestion_seed_get() -> str:
+    _abort_in_prod()
+    team_key, event_key, match_key = _default_keys()
+    template_values = {
+        "type_names": TYPE_NAMES,
+        "pending_counts": _pending_counts(),
+        "default_team_key": team_key,
+        "default_event_key": event_key,
+        "default_match_key": match_key,
+    }
+    return render_template("admin/suggestion_seed.html", template_values)
+
+
+def suggestion_seed_post() -> str:
+    _abort_in_prod()
+    author = _seed_author()
+    types = request.form.getlist("types")
+    team_key = request.form.get("team_key") or _default_keys()[0]
+    event_key = request.form.get("event_key") or _default_keys()[1]
+    match_key = request.form.get("match_key") or _default_keys()[2]
+
+    results: List[Tuple[str, str]] = []
+
+    # Make sure targets exist so accepts work on an empty dev datastore
+    _, team_created = _ensure_team(team_key)
+    if team_created:
+        results.append(("setup", f"Created team {team_key}"))
+    event, event_created = _ensure_event(event_key)
+    if event_created:
+        results.append(("setup", f"Created event {event_key}"))
+    match, match_created = _ensure_match(match_key)
+    if match_created:
+        results.append(("setup", f"Created match {match_key}"))
+
+    for suggestion_type in types:
+        if suggestion_type not in SUGGESTION_TYPES:
+            results.append((suggestion_type, "unknown type, skipped"))
+            continue
+        if suggestion_type in ("media", "social-media", "robot"):
+            status, _ = _seed_media_suggestion(author, suggestion_type, team_key)
+        elif suggestion_type == "event_media":
+            if event is None:
+                status = f"skipped: event {event_key} unavailable"
+            else:
+                status = _seed_event_media_suggestion(author, event_key)
+        elif suggestion_type == "event":
+            if event is None:
+                status = f"skipped: event {event_key} unavailable"
+            else:
+                status = _seed_webcast_suggestion(author, event_key)
+        elif suggestion_type == "match":
+            if match is None:
+                status = f"skipped: match {match_key} unavailable"
+            else:
+                status = SuggestionCreationStatus.VIDEO_EXISTS
+                for youtube_id in (*SEED_YOUTUBE_VIDEO_IDS, _random_youtube_id()):
+                    status = SuggestionCreator.createMatchVideoYouTubeSuggestion(
+                        author.key, youtube_id, match_key
+                    )
+                    if status == SuggestionCreationStatus.SUCCESS:
+                        break
+        elif suggestion_type == "offseason-event":
+            status = _seed_offseason_suggestion(author)
+        else:  # api_auth_access
+            if event is None:
+                status = f"skipped: event {event_key} unavailable"
+            else:
+                status = _seed_apiwrite_suggestion(author, event_key)
+        results.append((suggestion_type, str(status)))
+
+    grant_email = request.form.get("grant_email")
+    if grant_email:
+        accounts = Account.query(Account.email == grant_email).fetch()
+        if accounts:
+            account = accounts[0]
+            account.permissions = list(SUGGESTION_PERMISSIONS)
+            account.put()
+            results.append(
+                ("permissions", f"Granted all review permissions to {grant_email}")
+            )
+        else:
+            results.append(
+                ("permissions", f"No account found for {grant_email} (log in first)")
+            )
+
+    team_key_default, event_key_default, match_key_default = _default_keys()
+    template_values = {
+        "type_names": TYPE_NAMES,
+        "pending_counts": _pending_counts(),
+        "default_team_key": team_key_default,
+        "default_event_key": event_key_default,
+        "default_match_key": match_key_default,
+        "results": results,
+    }
+    return render_template("admin/suggestion_seed.html", template_values)

--- a/src/backend/web/handlers/admin/tests/suggestions_seed_test.py
+++ b/src/backend/web/handlers/admin/tests/suggestions_seed_test.py
@@ -1,0 +1,156 @@
+from werkzeug.test import Client
+
+from backend.common.consts.account_permission import SUGGESTION_PERMISSIONS
+from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.consts.suggestion_type import SUGGESTION_TYPES
+from backend.common.models.account import Account
+from backend.common.models.event import Event
+from backend.common.models.match import Match
+from backend.common.models.suggestion import Suggestion
+from backend.common.models.team import Team
+from backend.web.handlers.admin.suggestions_seed import (
+    SEED_EVENT_NAME,
+    SEED_IMGUR_IMAGE_ID,
+    SEED_INSTAGRAM_POST_ID,
+    SEED_TEAM_NICKNAME,
+    SEED_TWITCH_CHANNEL,
+    SEED_YOUTUBE_VIDEO_ID,
+)
+
+
+def test_seed_page_requires_admin(web_client: Client) -> None:
+    resp = web_client.get("/admin/suggestions/seed")
+    assert resp.status_code == 401
+
+
+def test_seed_page_renders(web_client: Client, login_gae_admin) -> None:
+    resp = web_client.get("/admin/suggestions/seed")
+    assert resp.status_code == 200
+    assert b"Seed Suggestions" in resp.data
+
+
+def test_seed_all_types(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    resp = web_client.post(
+        "/admin/suggestions/seed",
+        data={
+            "types": SUGGESTION_TYPES,
+            "team_key": "frc2",
+            "event_key": "2020np",
+            "match_key": "2020np_qm1",
+        },
+    )
+    assert resp.status_code == 200
+
+    # Target entities were created as the mocked data team/event
+    team = Team.get_by_id("frc2")
+    assert team is not None
+    assert team.nickname == SEED_TEAM_NICKNAME
+    event = Event.get_by_id("2020np")
+    assert event is not None
+    assert event.name == SEED_EVENT_NAME
+    match = Match.get_by_id("2020np_qm1")
+    assert match is not None
+    assert "frc2" in match.team_key_names
+
+    # One pending suggestion of every type exists
+    suggestions = Suggestion.query(
+        Suggestion.review_state == SuggestionState.REVIEW_PENDING
+    ).fetch()
+    seeded_types = {s.target_model for s in suggestions}
+    assert seeded_types == set(SUGGESTION_TYPES)
+
+
+def test_seed_is_repeatable(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    for _ in range(2):
+        resp = web_client.post(
+            "/admin/suggestions/seed",
+            data={
+                "types": ["media", "match", "offseason-event"],
+                "team_key": "frc2",
+                "event_key": "2020np",
+                "match_key": "2020np_qm1",
+            },
+        )
+        assert resp.status_code == 200
+
+    suggestions = Suggestion.query(
+        Suggestion.review_state == SuggestionState.REVIEW_PENDING
+    ).fetch()
+    by_type = {}
+    for s in suggestions:
+        by_type.setdefault(s.target_model, []).append(s)
+    # Each media seeding creates an image, a video, and an instagram photo
+    assert len(by_type["media"]) == 6
+    assert len(by_type["match"]) == 2
+    assert len(by_type["offseason-event"]) == 2
+
+
+def test_seed_uses_real_media_examples(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    resp = web_client.post(
+        "/admin/suggestions/seed",
+        data={
+            "types": ["match", "event_media", "event", "media"],
+            "team_key": "frc2",
+            "event_key": "2020np",
+            "match_key": "2020np_qm1",
+        },
+    )
+    assert resp.status_code == 200
+
+    suggestions = Suggestion.query(
+        Suggestion.review_state == SuggestionState.REVIEW_PENDING
+    ).fetch()
+    by_type = {}
+    for s in suggestions:
+        by_type.setdefault(s.target_model, []).append(s)
+    assert by_type["match"][0].contents["youtube_videos"] == [SEED_YOUTUBE_VIDEO_ID]
+    assert by_type["event_media"][0].contents["foreign_key"] == SEED_YOUTUBE_VIDEO_ID
+    assert (
+        by_type["event"][0].contents["webcast_dict"]["channel"] == SEED_TWITCH_CHANNEL
+    )
+    media_foreign_keys = {s.contents["foreign_key"] for s in by_type["media"]}
+    assert media_foreign_keys == {
+        SEED_IMGUR_IMAGE_ID,
+        SEED_YOUTUBE_VIDEO_ID,
+        SEED_INSTAGRAM_POST_ID,
+    }
+
+
+def test_grant_permissions(
+    web_client: Client, login_gae_admin, ndb_stub, taskqueue_stub
+) -> None:
+    Account(id="mod_uid", email="mod@example.com", registered=True).put()
+
+    resp = web_client.post(
+        "/admin/suggestions/seed",
+        data={"grant_email": "mod@example.com"},
+    )
+    assert resp.status_code == 200
+
+    account = Account.get_by_id("mod_uid")
+    assert account is not None
+    assert set(account.permissions) == SUGGESTION_PERMISSIONS
+
+
+def test_seed_blocked_in_prod(web_client: Client, login_gae_admin) -> None:
+    # Seeding fabricates data and grants permissions; it must 404 in prod
+    # even for GAE admins. The GAE request middleware rebuilds os.environ
+    # from the WSGI environ, so GAE_ENV is injected per-request here (as
+    # the production runtime does) rather than via monkeypatch.setenv.
+    prod_environ = {"GAE_ENV": "standard"}
+
+    resp = web_client.get("/admin/suggestions/seed", environ_overrides=prod_environ)
+    assert resp.status_code == 404
+
+    resp = web_client.post(
+        "/admin/suggestions/seed",
+        data={"types": ["match"]},
+        environ_overrides=prod_environ,
+    )
+    assert resp.status_code == 404

--- a/src/backend/web/static/swagger/api_moderation_v1.json
+++ b/src/backend/web/static/swagger/api_moderation_v1.json
@@ -1,0 +1,791 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "TBA Moderation API",
+    "version": "v1",
+    "description": "Authenticated API for The Blue Alliance site moderators to review the suggestion queue. Authenticate with a Firebase ID token as 'Authorization: Bearer <token>'; authorization comes from the account's review permissions."
+  },
+  "servers": [
+    {
+      "url": "https://www.thebluealliance.com/api/moderation/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Firebase ID token of a signed-in TBA user with review permissions"
+      }
+    },
+    "schemas": {
+      "SuggestionType": {
+        "type": "string",
+        "enum": [
+          "event",
+          "match",
+          "media",
+          "social-media",
+          "offseason-event",
+          "api_auth_access",
+          "robot",
+          "event_media"
+        ],
+        "description": "The type of suggestion (event=Webcasts, match=Match Videos, media=Team Media, social-media=Social Media, offseason-event=Offseason Events, api_auth_access=API Key Requests, robot=CAD Models, event_media=Event Videos)"
+      },
+      "QueueResponse": {
+        "type": "object",
+        "properties": {
+          "counts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Pending suggestion count per suggestion type, limited to types the caller can review"
+          },
+          "type_names": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Human-readable name per suggestion type"
+          }
+        },
+        "required": [
+          "counts",
+          "type_names"
+        ]
+      },
+      "SuggestionAuthor": {
+        "type": "object",
+        "properties": {
+          "nickname": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "accepted_count": {
+            "type": "integer",
+            "description": "Lifetime count of this author's accepted suggestions (reputation signal)"
+          },
+          "rejected_count": {
+            "type": "integer",
+            "description": "Lifetime count of this author's rejected suggestions (reputation signal)"
+          }
+        }
+      },
+      "CandidateMedia": {
+        "type": "object",
+        "description": "A preview of the Media entity that accepting this suggestion would create",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "media_type_enum": {
+            "type": "integer"
+          },
+          "type_name": {
+            "type": "string"
+          },
+          "slug_name": {
+            "type": "string"
+          },
+          "foreign_key": {
+            "type": "string"
+          },
+          "is_image": {
+            "type": "boolean"
+          },
+          "external_link": {
+            "type": "string"
+          },
+          "view_image_url": {
+            "type": "string"
+          },
+          "image_direct_url": {
+            "type": "string"
+          },
+          "social_profile_url": {
+            "type": "string"
+          }
+        }
+      },
+      "SuggestionReference": {
+        "type": "object",
+        "description": "The Team or Event this suggestion is attached to",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "team",
+              "event"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "year": {
+            "type": "integer"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date",
+            "description": "First day of the event (events only)"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Last day of the event (events only)"
+          },
+          "team_number": {
+            "type": "integer"
+          },
+          "nickname": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "key"
+        ]
+      },
+      "ExistingPreferredMedia": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "foreign_key": {
+            "type": "string"
+          },
+          "media_type_enum": {
+            "type": "integer"
+          },
+          "view_image_url": {
+            "type": "string"
+          },
+          "image_direct_url": {
+            "type": "string"
+          }
+        }
+      },
+      "AuthTypeInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ExistingAuth": {
+        "type": "object",
+        "properties": {
+          "owner_email": {
+            "type": "string"
+          },
+          "auth_types": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuthTypeInfo"
+            }
+          }
+        }
+      },
+      "SimilarEvent": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ModerationSuggestion": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The suggestion's key, used for accept/reject calls"
+          },
+          "target_model": {
+            "$ref": "#/components/schemas/SuggestionType"
+          },
+          "target_key": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "contents": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "The raw suggested contents (shape varies by suggestion type)"
+          },
+          "author": {
+            "$ref": "#/components/schemas/SuggestionAuthor"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Parsed details_json, with a derived thumbnail for images"
+          },
+          "candidate_media": {
+            "$ref": "#/components/schemas/CandidateMedia"
+          },
+          "reference": {
+            "$ref": "#/components/schemas/SuggestionReference"
+          },
+          "event": {
+            "$ref": "#/components/schemas/SuggestionReference"
+          },
+          "uses_official_webcast_unit": {
+            "type": "boolean"
+          },
+          "existing_preferred": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExistingPreferredMedia"
+            }
+          },
+          "max_preferred": {
+            "type": "integer"
+          },
+          "similar_events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimilarEvent"
+            }
+          },
+          "similar_events_last_year": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimilarEvent"
+            }
+          },
+          "requested_auth_types": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuthTypeInfo"
+            }
+          },
+          "existing_auth": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExistingAuth"
+            }
+          },
+          "has_first_official_webcast": {
+            "type": "boolean",
+            "description": "match: the event has a FIRST official webcast; suggested videos may be stream rips"
+          },
+          "existing_webcasts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "event: the event's current webcasts, to catch duplicate suggestions"
+          },
+          "video_title": {
+            "type": "string",
+            "description": "match: YouTube title of the suggested video, when a YouTube API key is configured"
+          },
+          "video_duration_seconds": {
+            "type": "integer",
+            "nullable": true,
+            "description": "match: duration of the suggested video in seconds, when a YouTube API key is configured"
+          }
+        },
+        "required": [
+          "key",
+          "target_model",
+          "contents"
+        ]
+      },
+      "SuggestionListResponse": {
+        "type": "object",
+        "properties": {
+          "suggestions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModerationSuggestion"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total pending suggestions of this type, which may exceed the page returned"
+          }
+        },
+        "required": [
+          "suggestions",
+          "total"
+        ]
+      },
+      "AcceptRequest": {
+        "type": "object",
+        "description": "Type-specific reviewer overrides. All fields optional; which fields apply depends on the suggestion type.",
+        "properties": {
+          "target_match_key": {
+            "type": "string",
+            "description": "match: redirect the video to a different match key"
+          },
+          "year": {
+            "type": "integer",
+            "description": "media: override the media year"
+          },
+          "set_preferred": {
+            "type": "boolean",
+            "description": "media: set as preferred team image (defaults to the suggester\u2019s default_preferred request)"
+          },
+          "replace_preferred_media_key": {
+            "type": "string",
+            "description": "media: demote this existing preferred Media and prefer the new one"
+          },
+          "webcast_type": {
+            "type": "string",
+            "description": "event (webcast): webcast type, e.g. twitch/youtube"
+          },
+          "webcast_channel": {
+            "type": "string",
+            "description": "event (webcast): channel identifier"
+          },
+          "webcast_file": {
+            "type": "string",
+            "description": "event (webcast): optional file identifier"
+          },
+          "webcast_date": {
+            "type": "string",
+            "description": "event (webcast): optional YYYY-MM-DD date for date-specific webcasts"
+          },
+          "event_key": {
+            "type": "string",
+            "description": "event (webcast): override the target event"
+          },
+          "event_short": {
+            "type": "string",
+            "description": "offseason-event: REQUIRED event short code, forms the event key"
+          },
+          "name": {
+            "type": "string",
+            "description": "offseason-event: override event name"
+          },
+          "short_name": {
+            "type": "string",
+            "description": "offseason-event: event short display name"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "offseason-event: override start date (YYYY-MM-DD)"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "offseason-event: override end date (YYYY-MM-DD)"
+          },
+          "website": {
+            "type": "string",
+            "description": "offseason-event: override website"
+          },
+          "venue": {
+            "type": "string",
+            "description": "offseason-event: override venue name"
+          },
+          "venue_address": {
+            "type": "string",
+            "description": "offseason-event: override venue address"
+          },
+          "city": {
+            "type": "string",
+            "description": "offseason-event: override city"
+          },
+          "state": {
+            "type": "string",
+            "description": "offseason-event: override state/province"
+          },
+          "country": {
+            "type": "string",
+            "description": "offseason-event: override country"
+          },
+          "first_code": {
+            "type": "string",
+            "description": "offseason-event: official FIRST event code, if any"
+          },
+          "event_type_enum": {
+            "type": "integer",
+            "description": "offseason-event: override the event type enum"
+          },
+          "auth_types": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "api_auth_access: auth types to grant (defaults to the requested types)"
+          },
+          "expiration_days": {
+            "type": "integer",
+            "description": "api_auth_access: days after event end until the key expires; -1 for no expiration. Defaults to 7 while event end + 7 days is still in the future, otherwise -1"
+          },
+          "user_message": {
+            "type": "string",
+            "description": "api_auth_access: message for the requesting user, included in the admin alert email"
+          }
+        }
+      },
+      "AcceptResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/ReviewResult"
+          },
+          "suggestion_key": {
+            "type": "string"
+          },
+          "created_target_key": {
+            "type": "string",
+            "description": "The key of the created entity (Media key, event key, match key, or auth id)"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "result",
+          "suggestion_key"
+        ]
+      },
+      "ReviewResult": {
+        "type": "string",
+        "enum": [
+          "accepted",
+          "rejected",
+          "not_found",
+          "already_reviewed",
+          "invalid",
+          "forbidden"
+        ]
+      },
+      "RejectRequest": {
+        "type": "object",
+        "properties": {
+          "suggestion_keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "user_message": {
+            "type": "string",
+            "description": "Message for the suggesting user; included in the admin alert email for api_auth_access rejections"
+          }
+        },
+        "required": [
+          "suggestion_keys"
+        ]
+      },
+      "RejectResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptResponse"
+            }
+          }
+        },
+        "required": [
+          "results"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "Error": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "paths": {
+    "/queue": {
+      "get": {
+        "summary": "Pending suggestion counts per type the caller can review",
+        "operationId": "getModerationQueue",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Firebase ID token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Account has no review permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/suggestions/{suggestion_type}": {
+      "get": {
+        "summary": "List pending suggestions of one type with review metadata",
+        "operationId": "listModerationSuggestions",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "suggestion_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SuggestionType"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Firebase ID token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing the review permission for this suggestion type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown suggestion type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/suggestions/{suggestion_key}/accept": {
+      "post": {
+        "summary": "Accept a pending suggestion, creating its target entity",
+        "operationId": "acceptModerationSuggestion",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "suggestion_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Suggestion accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid accept payload for this suggestion type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing the review permission for this suggestion's type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Suggestion not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Suggestion was already reviewed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/suggestions/reject": {
+      "post": {
+        "summary": "Reject a batch of pending suggestions",
+        "operationId": "rejectModerationSuggestions",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RejectRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-suggestion outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RejectResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Firebase ID token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/backend/web/static/swagger/api_moderation_v1.json
+++ b/src/backend/web/static/swagger/api_moderation_v1.json
@@ -446,7 +446,7 @@
           },
           "expiration_days": {
             "type": "integer",
-            "description": "api_auth_access: days after event end until the key expires; -1 for no expiration. Defaults to 7 while event end + 7 days is still in the future, otherwise -1"
+            "description": "api_auth_access: days until the key expires, counted from event end or from the grant, whichever is later; -1 for no expiration. Defaults to 7."
           },
           "user_message": {
             "type": "string",

--- a/src/backend/web/templates/admin/suggestion_seed.html
+++ b/src/backend/web/templates/admin/suggestion_seed.html
@@ -1,0 +1,62 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Seed Suggestions{% endblock %}
+
+{% block content %}
+
+<h1>Seed Suggestions</h1>
+
+<p>Create pending suggestions of each type for testing the moderation queue
+(web review UI, moderation API, and PWA review UI). Suggestions are authored
+by a <code>Suggestion Seed Bot</code> account. Missing target entities
+(team/event/match) are created automatically.</p>
+
+{% if results %}
+<div class="alert alert-info">
+    <h4>Seed results</h4>
+    <ul>
+        {% for type, status in results %}
+        <li><strong>{{ type }}</strong>: {{ status }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+<div class="row">
+    <div class="col-sm-6">
+        <h3>Create suggestions</h3>
+        <form method="post" action="/admin/suggestions/seed">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <div class="form-group">
+                {% for type, name in type_names.items() %}
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" name="types" value="{{ type }}" checked>
+                        {{ name }} (<code>{{ type }}</code>) &mdash; {{ pending_counts[type] }} pending
+                    </label>
+                </div>
+                {% endfor %}
+            </div>
+            <div class="form-group">
+                <label for="team_key">Target team key</label>
+                <input class="form-control" type="text" name="team_key" id="team_key" value="{{ default_team_key }}">
+            </div>
+            <div class="form-group">
+                <label for="event_key">Target event key</label>
+                <input class="form-control" type="text" name="event_key" id="event_key" value="{{ default_event_key }}">
+            </div>
+            <div class="form-group">
+                <label for="match_key">Target match key</label>
+                <input class="form-control" type="text" name="match_key" id="match_key" value="{{ default_match_key }}">
+            </div>
+            <div class="form-group">
+                <label for="grant_email">Grant all review permissions to account email (optional)</label>
+                <input class="form-control" type="text" name="grant_email" id="grant_email" placeholder="moderator@example.com">
+                <span class="help-block">The account must exist already (log in once first).</span>
+            </div>
+            <button class="btn btn-primary" type="submit">Seed Selected Suggestions</button>
+        </form>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Phase 1 of the moderation API: a Firebase-Bearer-authenticated `/api/moderation/v1` for reviewing the suggestion queue. **Backend only** — split per review feedback; the PWA review UI that consumes this API is #10187.

**PR stack:** #10160 (YouTube duration parsing, land first) → **this PR** (API) → #10187 (PWA UI) → #10161 (web review home "try the beta" banner, draft until the UI deploys to beta). #10178 (require offseason dates) is stacked on this branch.

## Reviewer's guide

The fastest way to review is one type end-to-end — the other seven follow the same pattern:

1. `require_moderation_permission` in `src/backend/api/handlers/decorators.py` (auth: Firebase Bearer, verified email, permission gate)
2. `SuggestionReviewer.accept_suggestion` → `_accept_match_video` in `src/backend/common/suggestions/suggestion_reviewer.py` (per-type permission re-check, XG transaction, audit log)
3. `moderation_suggestion_list` + `_add_match_metadata` in `src/backend/api/handlers/moderation.py` (serialization + review metadata)

## What's here

**API** (`src/backend/api/handlers/moderation.py`, blueprint in `moderation_api_main.py`):
- `GET /queue` — pending counts per type, filtered to the caller's permissions
- `GET /suggestions/<type>` — pending suggestions with rich review metadata (candidate media, target team/event, existing preferred images/webcasts/API keys, similar offseason events, author reputation, YouTube title/duration) plus a `total` for capped pages
- `POST /suggestions/<key>/accept` — transactional accept with type-specific overrides
- `POST /suggestions/reject` — batch reject (capped at 500)

All accept/reject logic lives in a shared `SuggestionReviewer` service ported from the 8 web review controllers (which can migrate onto it in a follow-up), with `AuditLogEntry` writes and the Trusted-API-key admin alert delivered to Slack (`suggestion-nag`) since the old admin-email path was never wired up.

**Admin seed page** (`/admin/suggestions/seed`, gated out of prod): one pending suggestion of every type with real, embeddable media so review UIs preview properly; can grant review permissions to a local test account.

## Security posture

All enforcement is server-side; clients are untrusted.

- **Transport/routing**: `/api/moderation/v1/*` is served only by the api service (dispatch.yaml); all 4 routes are wrapped in `@require_moderation_permission`.
- **Authentication**: Firebase ID token via `Authorization: Bearer` only, verified with `verify_id_token(check_revoked=True)` (signature, audience, expiry, revocation). No cookie/session fallback → no ambient credentials → CSRF-immune; `CORS *` is safe because credentials are never implicit. Tokens with unverified emails are rejected (accounts are linked to tokens by email claim).
- **Authorization (read)**: decorator requires a review AccountPermission (or the server-set `admin` custom claim); queue counts and lists are filtered/403'd per-type.
- **Authorization (write)**: `SuggestionReviewer` independently re-checks the per-type permission derived from the stored suggestion's `target_model` (never client input), per suggestion, inside the service layer — the write path does not trust the route gate.
- **Integrity**: accept/reject run in XG transactions with a REVIEW_PENDING re-check (no double-review); every decision writes an AuditLogEntry.
- **Input**: type-specific override allowlists (no mass assignment), enum validation, list limit clamped to 1–100, reject batches capped at 500.
- **Seeding**: the admin seed page 404s in production (`Environment.is_prod()`), even for GAE admins.
- **Tests**: 401 on all endpoints, 403 for missing/wrong/unverified auth on read and write paths, replay conflict, and cap behavior.

## Deployment notes

- Match-video title/duration enrichment uses the existing `GoogleApiSecret` sitevar (`videos.list`, 1 quota unit per 50 videos); when unset (dev), the fields are simply absent. Duration requires #10160.
- Author reputation counts are equality-only queries on existing indexed properties (`author` + `review_state`, same shape as the account page) — no new composite index — and are memcached for an hour.

## Test plan

- 54 moderation API tests, 7 seed tests; `pyre`, `black`, `flake8` clean
- Full e2e against the local dev stack (docker datastore + Firebase auth emulator) driving the PWA UI (#10187) through seed → sign-in → grant → review for all 8 types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
