### PR TITLE
Parse video duration from YouTube video details API

### DIFF
--- a/src/backend/common/datafeeds/datafeed_youtube.py
+++ b/src/backend/common/datafeeds/datafeed_youtube.py
@@ -89,7 +89,7 @@ class YoutubeVideoDetailsDatafeed(YoutubeApiBase[Dict[str, ParsedVideoDetails]])
 
     def url_params(self) -> Dict[str, str]:
         return {
-            "part": "snippet,liveStreamingDetails",
+            "part": "snippet,contentDetails,liveStreamingDetails",
             "id": ",".join(self.video_ids),
         }
 

--- a/src/backend/common/datafeeds/parsers/youtube/tests/youtube_video_details_parser_test.py
+++ b/src/backend/common/datafeeds/parsers/youtube/tests/youtube_video_details_parser_test.py
@@ -1,0 +1,41 @@
+from backend.common.datafeeds.parsers.youtube.youtube_video_details_parser import (
+    _parse_iso8601_duration,
+    YoutubeVideoDetailsParser,
+)
+
+
+def test_parse_iso8601_duration() -> None:
+    assert _parse_iso8601_duration("PT3M2S") == 182
+    assert _parse_iso8601_duration("PT1H2M30S") == 3750
+    assert _parse_iso8601_duration("PT8H") == 28800
+    assert _parse_iso8601_duration("P1DT2H") == 93600
+    assert _parse_iso8601_duration("PT45S") == 45
+    assert _parse_iso8601_duration("") is None
+    assert _parse_iso8601_duration("garbage") is None
+    assert _parse_iso8601_duration("P") is None
+
+
+def test_parse_video_details_with_content_details() -> None:
+    response = {
+        "items": [
+            {
+                "id": "abc123",
+                "snippet": {"title": "2016 F1M1 - NE Championship"},
+                "contentDetails": {"duration": "PT3M2S"},
+            },
+            {
+                "id": "def456",
+                "snippet": {"title": "Full day stream"},
+                "contentDetails": {"duration": "PT8H15M"},
+            },
+            {
+                "id": "nodetails",
+                "snippet": {"title": "No content details"},
+            },
+        ]
+    }
+    parsed = YoutubeVideoDetailsParser().parse(response)
+    assert parsed["abc123"]["title"] == "2016 F1M1 - NE Championship"
+    assert parsed["abc123"]["duration_seconds"] == 182
+    assert parsed["def456"]["duration_seconds"] == 29700
+    assert "duration_seconds" not in parsed["nodetails"]

--- a/src/backend/common/datafeeds/parsers/youtube/youtube_video_details_parser.py
+++ b/src/backend/common/datafeeds/parsers/youtube/youtube_video_details_parser.py
@@ -4,6 +4,7 @@ Follows YouTube Data API v3 schema:
 https://developers.google.com/youtube/v3/docs/videos/list
 """
 
+import re
 from datetime import datetime
 from typing import Any, cast, Dict, List, NotRequired, Optional, TypedDict
 
@@ -29,11 +30,18 @@ class _LiveStreamingDetails(TypedDict):
     concurrentViewers: NotRequired[str]
 
 
+class _ContentDetails(TypedDict):
+    """Content details for a video."""
+
+    duration: NotRequired[str]
+
+
 class _VideoItem(TypedDict):
     """A single item from the videos list response."""
 
     id: str
     snippet: NotRequired[_VideoSnippet]
+    contentDetails: NotRequired[_ContentDetails]
     liveStreamingDetails: NotRequired[_LiveStreamingDetails]
 
 
@@ -51,6 +59,7 @@ class ParsedVideoDetails(TypedDict):
     title: str
     channel_id: NotRequired[Optional[str]]
     description: NotRequired[str]
+    duration_seconds: NotRequired[Optional[int]]
     scheduled_start_time: NotRequired[Optional[str]]
     actual_start_time: NotRequired[Optional[str]]
     concurrent_viewers: NotRequired[Optional[int]]
@@ -67,6 +76,20 @@ def _parse_timestamp(timestamp: str) -> Optional[str]:
         return dt.strftime("%Y-%m-%d")
     except (ValueError, AttributeError):
         return None
+
+
+def _parse_iso8601_duration(duration: str) -> Optional[int]:
+    """Parse an ISO 8601 duration (e.g. PT1H2M30S) into total seconds.
+
+    Returns None if the duration cannot be parsed.
+    """
+    match = re.fullmatch(
+        r"P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?", duration
+    )
+    if not match or not any(match.groups()):
+        return None
+    days, hours, minutes, seconds = (int(g) if g else 0 for g in match.groups())
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
 
 
 def _parse_video_item(item: _VideoItem) -> Optional[ParsedVideoDetails]:
@@ -86,6 +109,12 @@ def _parse_video_item(item: _VideoItem) -> Optional[ParsedVideoDetails]:
         description = snippet.get("description")
         if description:
             result["description"] = description
+
+    content_details = item.get("contentDetails")
+    if content_details:
+        duration = content_details.get("duration")
+        if duration:
+            result["duration_seconds"] = _parse_iso8601_duration(duration)
 
     live_details = item.get("liveStreamingDetails")
     if live_details:

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_youtube_video_live_details_batch_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_youtube_video_live_details_batch_test.py
@@ -21,7 +21,7 @@ class TestYoutubeVideoDetailsDatafeedBatch:
             datafeed = YoutubeVideoDetailsDatafeed(["video1", "video2"])
             params = datafeed.url_params()
 
-            assert params["part"] == "snippet,liveStreamingDetails"
+            assert params["part"] == "snippet,contentDetails,liveStreamingDetails"
             assert params["id"] == "video1,video2"
 
     def test_url_and_headers(self) -> None:
@@ -31,7 +31,7 @@ class TestYoutubeVideoDetailsDatafeedBatch:
             query = parse_qs(parsed.query)
 
             assert parsed.path == "/youtube/v3/videos"
-            assert query["part"] == ["snippet,liveStreamingDetails"]
+            assert query["part"] == ["snippet,contentDetails,liveStreamingDetails"]
             assert query["id"] == ["video1,video2"]
             assert "key" not in query
             assert datafeed.headers() == {"X-goog-api-key": "test_key"}

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_youtube_video_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_youtube_video_test.py
@@ -223,7 +223,7 @@ class TestYoutubeVideoDetailsDatafeed:
             datafeed = YoutubeVideoDetailsDatafeed(["video_456"])
             params = datafeed.url_params()
 
-            assert params["part"] == "snippet,liveStreamingDetails"
+            assert params["part"] == "snippet,contentDetails,liveStreamingDetails"
             assert params["id"] == "video_456"
 
     def test_datafeed_url_params_multiple(self) -> None:
@@ -232,7 +232,7 @@ class TestYoutubeVideoDetailsDatafeed:
             datafeed = YoutubeVideoDetailsDatafeed(["video_1", "video_2"])
             params = datafeed.url_params()
 
-            assert params["part"] == "snippet,liveStreamingDetails"
+            assert params["part"] == "snippet,contentDetails,liveStreamingDetails"
             assert params["id"] == "video_1,video_2"
 
     def test_datafeed_url_construction(self) -> None:
@@ -243,7 +243,7 @@ class TestYoutubeVideoDetailsDatafeed:
 
             assert "videos" in url
             assert "video_789" in url
-            assert "snippet,liveStreamingDetails" in url
+            assert "snippet,contentDetails,liveStreamingDetails" in url
 
     def test_datafeed_parser(self) -> None:
         """Test datafeed returns correct parser instance."""


### PR DESCRIPTION
Adds `contentDetails` to the `YoutubeVideoDetailsDatafeed` request and parses the ISO 8601 duration (`PT1H2M30S`) into `duration_seconds` on `ParsedVideoDetails`.

First slice of the moderation API stack (#10150 has the full context): the moderation review API uses this to flag suggested match videos that are hours-long stream uploads rather than single-match clips. Standalone and useful on its own — `videos.list` cost is unchanged (1 quota unit regardless of parts).

## Test plan
- New parser tests covering ISO 8601 duration parsing (hours/minutes/seconds/days, garbage input) and `contentDetails` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)