### PR TITLE
Link the beta PWA Suggestion Reviews from the web review home

### DIFF
--- a/src/backend/web/handlers/suggestions/tests/suggestion_review_home_test.py
+++ b/src/backend/web/handlers/suggestions/tests/suggestion_review_home_test.py
@@ -81,6 +81,21 @@ def test_shows_all_reviews_for_admin(
     )
 
 
+def test_shows_pwa_review_link(login_user, web_client: Client) -> None:
+    login_user.permissions = [AccountPermission.REVIEW_MEDIA]
+
+    response = web_client.get("/suggest/review")
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.data, "html.parser")
+    pwa_link_container = soup.find(id="pwa-review-link")
+    assert pwa_link_container is not None
+
+    pwa_link = pwa_link_container.find("a")
+    assert pwa_link is not None
+    assert pwa_link["href"] == "https://beta.thebluealliance.com/suggest/review"
+
+
 def test_shows_review_media_tools_for_review_media_permission(
     login_user, web_client: Client
 ) -> None:

--- a/src/backend/web/templates/suggestions/suggest_review_home.html
+++ b/src/backend/web/templates/suggestions/suggest_review_home.html
@@ -40,6 +40,10 @@
     <h1>Review Pending Suggestions</h1>
     <p>Thanks for helping us get more data!</p>
 
+    <div class="alert alert-info" id="pwa-review-link">
+      Try the <a href="https://beta.thebluealliance.com/suggest/review">beta Suggestion Reviews in the PWA</a>.
+    </div>
+
     <div class="row">
         <div class="col-xs-6">
             {% include "suggestions/pending_suggestion_rows_partial.html" %}


### PR DESCRIPTION
Adds a "Try the beta Suggestion Reviews in the PWA." banner to the top of `/suggest/review`, linking to https://beta.thebluealliance.com/suggest/review.

Final slice of the moderation API stack (#10150): **kept as a draft until the PWA review UI from #10150 is deployed to beta**, so we never advertise a flow that isn't live. The web service and the PWA deploy on different cadences, which is why this ships separately.

## Test plan
- `test_shows_pwa_review_link` asserts the banner and its href render through the real handler + template

🤖 Generated with [Claude Code](https://claude.com/claude-code)