### PR TITLE
Fix Base UI Select regressions: clipped popup list and raw-value triggers

### DIFF
--- a/pwa/app/components/tba/charts/coprScatterChart.tsx
+++ b/pwa/app/components/tba/charts/coprScatterChart.tsx
@@ -105,6 +105,13 @@ export default function CoprScatterChart({
   const [selectedYCopr, setSelectedYCopr] = useState(defaultYCopr);
   const [data, setData] = useState<Datapoint[]>([]);
 
+  // Base UI's Select.Value renders the raw value unless the items are
+  // registered on Select.Root, so provide value -> label pairs there too.
+  const coprItems = Object.keys(coprs).map((k) => ({
+    value: k,
+    label: camelCaseToHumanReadable(k),
+  }));
+
   useEffect(() => {
     const data: Datapoint[] = Object.keys(coprs[selectedXCopr])
       .map((tk) => ({
@@ -224,6 +231,7 @@ export default function CoprScatterChart({
         <div className="flex flex-row items-center">
           <div className="pr-4 font-bold">Y Axis</div>
           <Select
+            items={coprItems}
             value={selectedYCopr}
             onValueChange={(value) => value !== null && setSelectedYCopr(value)}
           >
@@ -233,9 +241,9 @@ export default function CoprScatterChart({
             <SelectContent>
               <SelectGroup>
                 <SelectLabel>Y Axis</SelectLabel>
-                {Object.keys(coprs).map((k) => (
-                  <SelectItem value={k} key={k}>
-                    {camelCaseToHumanReadable(k)}
+                {coprItems.map(({ value, label }) => (
+                  <SelectItem value={value} key={value}>
+                    {label}
                   </SelectItem>
                 ))}
               </SelectGroup>
@@ -246,6 +254,7 @@ export default function CoprScatterChart({
         <div className="flex flex-row items-center">
           <div className="pr-4 font-bold">X Axis</div>
           <Select
+            items={coprItems}
             value={selectedXCopr}
             onValueChange={(value) => value !== null && setSelectedXCopr(value)}
           >
@@ -255,9 +264,9 @@ export default function CoprScatterChart({
             <SelectContent>
               <SelectGroup>
                 <SelectLabel>X Axis</SelectLabel>
-                {Object.keys(coprs).map((k) => (
-                  <SelectItem value={k} key={k}>
-                    {camelCaseToHumanReadable(k)}
+                {coprItems.map(({ value, label }) => (
+                  <SelectItem value={value} key={value}>
+                    {label}
                   </SelectItem>
                 ))}
               </SelectGroup>

--- a/pwa/app/components/ui/select.tsx
+++ b/pwa/app/components/ui/select.tsx
@@ -98,9 +98,9 @@ function SelectContent({
       >
         <SelectPrimitive.Popup
           className={cn(
-            `relative z-50 max-h-[75vh] min-w-[8rem] overflow-hidden rounded-md
-            border bg-popover text-popover-foreground shadow-md
-            data-[side=bottom]:translate-y-1
+            `relative z-50 max-h-(--available-height) min-w-[8rem]
+            overflow-x-hidden overflow-y-auto rounded-md border bg-popover
+            text-popover-foreground shadow-md data-[side=bottom]:translate-y-1
             data-[side=bottom]:slide-in-from-top-2
             data-[side=left]:-translate-x-1
             data-[side=left]:slide-in-from-right-2
@@ -115,9 +115,7 @@ function SelectContent({
           {...props}
         >
           <SelectScrollUpButton />
-          <SelectPrimitive.List
-            className="h-(--anchor-height) w-full min-w-(--anchor-width) p-1"
-          >
+          <SelectPrimitive.List className="w-full min-w-(--anchor-width) p-1">
             {children}
           </SelectPrimitive.List>
           <SelectScrollDownButton />

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -1156,6 +1156,12 @@ function ComponentsTable({ coprs, year }: { coprs: EventCoprs; year: number }) {
     Object.values(coprs[k]).every((v) => v === 0),
   );
 
+  // Base UI's Select.Value renders the raw value unless the items are
+  // registered on Select.Root, so provide value -> label pairs there too.
+  const componentItems = Object.keys(coprs)
+    .filter((k) => !excludedComponents.includes(k))
+    .map((k) => ({ value: k, label: camelCaseToHumanReadable(k) }));
+
   const columns: ColumnDef<{ teamKey: string; value: number }>[] = [
     {
       header: 'Team',
@@ -1178,22 +1184,19 @@ function ComponentsTable({ coprs, year }: { coprs: EventCoprs; year: number }) {
             <div className="flex items-center">
               <span className="basis-1/2">Component OPRs</span>
               <Select
+                items={componentItems}
                 value={component}
                 onValueChange={(value) => value !== null && setComponent(value)}
               >
                 <SelectTrigger className="font-normal">
-                  <SelectValue
-                    placeholder={camelCaseToHumanReadable(component)}
-                  />
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {Object.keys(coprs)
-                    .filter((k) => !excludedComponents.includes(k))
-                    .map((k) => (
-                      <SelectItem key={k} value={k}>
-                        {camelCaseToHumanReadable(k)}
-                      </SelectItem>
-                    ))}
+                  {componentItems.map(({ value, label }) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/pwa/app/routes/events.{-$year}.tsx
+++ b/pwa/app/routes/events.{-$year}.tsx
@@ -135,6 +135,19 @@ function YearEventsPage() {
     return tocNodes;
   }, [officialGroups, unofficialGroups]);
 
+  // Base UI's Select.Value renders the raw value unless the items are
+  // registered on Select.Root, so provide value -> label pairs there too.
+  const districtItems = [
+    { value: 'all', label: 'All Events' },
+    ...districts
+      .slice()
+      .sort((a, b) => a.display_name.localeCompare(b.display_name))
+      .map((district) => ({
+        value: district.abbreviation,
+        label: district.display_name,
+      })),
+  ];
+
   return (
     <div className="flex flex-wrap gap-8 lg:flex-nowrap">
       <TableOfContents tocItems={tocItems} inView={inView}>
@@ -148,6 +161,7 @@ function YearEventsPage() {
           }))}
         />
         <Select
+          items={districtItems}
           defaultValue="all"
           onValueChange={(value) => {
             if (value !== 'all') {
@@ -160,19 +174,12 @@ function YearEventsPage() {
           >
             <SelectValue />
           </SelectTrigger>
-          <SelectContent className="max-h-[70vh] overflow-y-auto">
-            <SelectItem value="all">All Events</SelectItem>
-            {districts
-              .slice()
-              .sort((a, b) => a.display_name.localeCompare(b.display_name))
-              .map((district) => (
-                <SelectItem
-                  key={district.abbreviation}
-                  value={district.abbreviation}
-                >
-                  {district.display_name}
-                </SelectItem>
-              ))}
+          <SelectContent>
+            {districtItems.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </TableOfContents>

--- a/pwa/app/routes/teams.{-$pgNum}.tsx
+++ b/pwa/app/routes/teams.{-$pgNum}.tsx
@@ -66,11 +66,19 @@ function TeamsPage() {
   const { teams, pageNum, maxPageNum } = Route.useLoaderData();
   const navigate = useNavigate();
 
+  // Base UI's Select.Value renders the raw value unless the items are
+  // registered on Select.Root, so provide value -> label pairs there too.
+  const pageItems = Array.from({ length: maxPageNum }, (_, i) => ({
+    value: (i + 1).toString(),
+    label: TeamPageNumberToRange(i + 1),
+  }));
+
   return (
     <div className="flex flex-wrap gap-8 lg:flex-nowrap">
       <div className="basis-full lg:basis-1/6">
         <div className="top-14 pt-8 lg:sticky">
           <Select
+            items={pageItems}
             value={pageNum.toString()}
             onValueChange={(value) => {
               if (value === null) return;
@@ -81,17 +89,14 @@ function TeamsPage() {
             }}
           >
             <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder={pageNum} />
+              <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {Array.from({ length: maxPageNum }, (_, i) => {
-                const p = i + 1;
-                return (
-                  <SelectItem key={p} value={p.toString()}>
-                    {TeamPageNumberToRange(p)}
-                  </SelectItem>
-                );
-              })}
+              {pageItems.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/pwa/tests/select.spec.ts
+++ b/pwa/tests/select.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+
+// Regression tests for the Base UI Select migration:
+// - Select.Value must render the selected item's label, not the raw value
+//   (requires `items` on Select.Root; see resolveSelectedLabel in Base UI)
+// - The popup list must not be pinned to the trigger's height
+//   (--anchor-height) and must scroll when there are many options
+
+test('teams page selector shows range labels, not raw page numbers', async ({
+  page,
+}) => {
+  await page.goto('/teams/2');
+  await page.waitForLoadState('networkidle');
+
+  // The trigger renders the selected item's label ("1000s"), not the raw
+  // value ("2")
+  const trigger = page.getByRole('combobox');
+  await expect(trigger).toContainText('1000s');
+  await expect(trigger).not.toHaveText(/^2$/);
+});
+
+test('teams page selector opens a list taller than the trigger', async ({
+  page,
+}) => {
+  await page.goto('/teams');
+  await page.waitForLoadState('networkidle');
+
+  const trigger = page.getByRole('combobox');
+  await expect(trigger).toContainText('1-999');
+  await trigger.click();
+
+  const listbox = page.getByRole('listbox');
+  await expect(listbox).toBeVisible();
+
+  // With the list pinned to the trigger height (~40px), only the first
+  // option was visible and the rest were clipped with no scrollbar.
+  const options = listbox.getByRole('option');
+  expect(await options.count()).toBeGreaterThan(3);
+  await expect(options.nth(3)).toBeInViewport();
+});
+
+test('events page district selector shows "All Events" label', async ({
+  page,
+}) => {
+  await page.goto('/events');
+  await page.waitForLoadState('networkidle');
+
+  // The trigger renders the "All Events" label, not the raw value "all"
+  const trigger = page.getByRole('combobox').filter({ hasText: 'All Events' });
+  await expect(trigger).toBeVisible();
+});


### PR DESCRIPTION
## Description

Fixes two user-facing Select regressions introduced by the Radix → Base UI migration (#10149). Found in a post-merge review of that PR.

### 1. Every Select popup is clipped to ~40px with no scrollbar

`SelectContent` gave the `Select.List` a `h-(--anchor-height)` class. Under Base UI that variable is not "the popup's natural height":

- `useAnchorPositioning` sets `--anchor-height` on the Positioner from the **anchor's** rect (`floatingStyle.setProperty('--anchor-height', ...)` from `rects.reference`) — i.e. the trigger's height, ~40px with our `h-10` trigger.
- Base UI only applies its own intrinsic list styles (`maxHeight: 100%`, `overflowY: auto` — `LIST_FUNCTIONAL_STYLES` in `select/list/SelectList`) when `alignItemWithTrigger` is active, and our wrapper defaults `alignItemWithTrigger={false}`.
- The Popup was `overflow-hidden` with no `overflow-y-auto` anywhere.

Net effect: every Select rendered a ~40px list, clipped the rest of the options, and offered no way to scroll to them. (Radix worked because its equivalent `h-[var(--radix-select-trigger-height)]` viewport also carried Radix's inline `flex:1; overflow:auto` styles.)

**Fix** — follow the upstream shadcn `base-vega` Select template: the Popup gets `max-h-(--available-height) overflow-x-hidden overflow-y-auto`, and the List gets no height class.

### 2. Select triggers display the raw value instead of the selected label

Radix's `SelectValue` mirrored the selected `Select.Item`'s rendered label. Base UI's `Select.Value` renders `stringifyAsLabel(value)` — the raw value string — unless the items are registered on `Select.Root` via the `items` prop (`resolveSelectedLabel` in `select/value/SelectValue`; items never register their rendered children into the store).

So the teams page selector showed `3` instead of `2000s`, the events district selector showed `all` instead of `All Events`, and the COPR selects (scatter chart axes, event Component OPRs card) showed raw camelCase keys like `totalPoints` instead of `Total Points`.

**Fix** — register `value → label` items on `Select.Root` at all four call sites and render the `SelectItem`s from the same array. Placeholders that became dead code (the value is always set, so Base UI never shows them) are removed, as is the events route's local `max-h-[70vh] overflow-y-auto` override that the shared wrapper now handles.

## Evidence

Captured with Playwright against local dev servers at the pre-#10149 commit (`a0074d2^`), current `main`, and this branch ([`base-ui-fixes-evidence`](https://github.com/the-blue-alliance/the-blue-alliance/tree/base-ui-fixes-evidence/evidence/base-ui-fixes)).

### /teams — page selector open

| Before #10149 (Radix) | main (broken) | This PR |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/teams-open--1-radix-baseline.png" width="280"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/teams-open--2-main-broken.png" width="280"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/teams-open--3-fixed.png" width="280"> |
| trigger `2000s`, listbox **394px**, 12 options visible/scrollable | trigger `3`, listbox **40px**, everything past the selected option clipped | trigger `2000s`, listbox **392px**, 12 options visible/scrollable |

### /events — district selector trigger

| Before #10149 (Radix) | main (broken) | This PR |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/events-trigger--1-radix-baseline.png" width="240"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/events-trigger--2-main-broken.png" width="240"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/events-trigger--3-fixed.png" width="240"> |
| `All Events` | `all` | `All Events` |

## Testing

- New Playwright spec `tests/select.spec.ts`: trigger renders the label (not the raw value) on /teams and /events, and the open listbox shows options beyond the trigger height. Passes on this branch; the assertions match the measured regression on `main` (trigger `3`, 40px listbox).
- `pnpm run lint`, `pnpm run typecheck`, `pnpm test` all pass.

## Screenshot Pages

- /teams Teams list
- /events Events list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
