### PR TITLE
Fix Base UI NavigationMenu regressions: never-closed root and hover-opening hamburger

### DIFF
--- a/pwa/app/components/tba/navigation/navbar.tsx
+++ b/pwa/app/components/tba/navigation/navbar.tsx
@@ -15,13 +15,16 @@ import lamp from '~/images/tba/tba-lamp.svg';
 import { NAV_ITEMS_LIST } from '~/lib/navigation/content';
 
 export function Navbar() {
-  const [selected, setSelected] = useState<string>('');
+  // Base UI derives the menu's open state from `value != null`, so the
+  // closed state must be null — an empty string counts as "open" and keeps
+  // the popup permanently mounted (Radix used '' as its closed sentinel).
+  const [selected, setSelected] = useState<string | null>(null);
   const router = useRouter();
   const { pathname } = useLocation();
 
   useEffect(() => {
     const unsubscribe = router.subscribe('onBeforeNavigate', () => {
-      setSelected('');
+      setSelected(null);
     });
     return () => unsubscribe();
   }, [router, setSelected]);
@@ -31,7 +34,16 @@ export function Navbar() {
       <GlobalLoadingProgress />
       <NavigationMenu
         value={selected}
-        onValueChange={(value) => setSelected((value as string) ?? '')}
+        onValueChange={(value, eventDetails) => {
+          // Base UI opens NavigationMenu triggers on hover (~50ms delay)
+          // with no opt-out prop. The only trigger here is the mobile
+          // hamburger, which should be click-only, so ignore hover-driven
+          // changes (the menu is controlled, so dropping them is enough).
+          if (eventDetails.reason === 'trigger-hover') {
+            return;
+          }
+          setSelected((value as string | null) ?? null);
+        }}
         render={
           <header className="sticky top-0 z-50 h-14 w-full bg-brand shadow-md" />
         }

--- a/pwa/tests/navigation.spec.ts
+++ b/pwa/tests/navigation.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+// Regression tests for the Base UI NavigationMenu migration:
+// - Base UI derives open state from `value != null`, so controlling the
+//   menu with '' as the closed sentinel left the root permanently "open"
+//   and the popup portal permanently mounted
+// - Base UI opens triggers on hover by default (no opt-out prop); the
+//   mobile hamburger must stay click-only
+
+const viewport = { width: 500, height: 800 };
+
+test('nav popup portal is not mounted while the menu is closed', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await expect(
+    page.locator('[data-slot="navigation-menu-viewport"]'),
+  ).toHaveCount(0);
+});
+
+test.describe('hamburger menu (narrow viewport)', () => {
+  test.use({ viewport });
+
+  test('does not open on hover', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const trigger = page.getByRole('button', { name: 'Toggle Menu' });
+    await trigger.hover();
+    // Base UI's hover-open delay is 50ms; give it ample time to misfire
+    await page.waitForTimeout(400);
+
+    await expect(
+      page.locator('[data-slot="navigation-menu-viewport"]'),
+    ).toHaveCount(0);
+  });
+
+  test('opens on click and fully unmounts on second click', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const trigger = page.getByRole('button', { name: 'Toggle Menu' });
+    await trigger.click();
+    // The viewport wrapper itself is zero-height (the mobile menu content
+    // is absolutely positioned), so assert on a menu item inside the portal
+    const viewport = page.locator('[data-slot="navigation-menu-viewport"]');
+    await expect(viewport).toHaveCount(1);
+    await expect(viewport.getByRole('link').first()).toBeVisible();
+
+    await trigger.click();
+    // With '' as the controlled value the root never reached the closed
+    // state, so the portal stayed mounted forever
+    await expect(
+      page.locator('[data-slot="navigation-menu-viewport"]'),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes two NavigationMenu regressions in the navbar introduced by the Radix → Base UI migration (#10149). Found in a post-merge review of that PR. They interact, which is why they ship together.

### 1. The controlled root never reaches the closed state

Base UI derives the menu's open state from the controlled value being non-nullish — `NavigationMenuRoot` literally computes `const open = value != null` — and close paths call `onValueChange(null, …)`. The navbar kept Radix's convention: `selected` initialized to `''` and every close coerced back to `''` via `(value as string) ?? ''`.

Since `''` is non-nullish, the root was **permanently open** from first render on every page:

- the popup portal mounted immediately and never unmounted (`useTransitionStatus` unmount cleanup only runs `if (!open)`, which never fired),
- and the mobile hamburger's toggle ran a full state behind: the first tap didn't visibly open the menu, the second tap left it open showing a stale ☰ icon, with no coherent way to dismiss it.

**Fix** — use `null` as the closed sentinel (`useState<string | null>(null)`), matching Base UI's contract.

### 2. The hamburger opens on mouse hover

Radix suppressed hover-to-open on the hamburger with `onPointerMove={(e) => e.preventDefault()}` ("Disable hover to open"); the migration deleted it. Base UI's `NavigationMenu.Trigger` "opens the navigation menu popup when hovered or clicked" (default `delay` 50ms) and exposes **no** `openOnHover` opt-out — I grepped the module.

On `main` this is masked by bug 1 (the always-open root swallows the hover transition), but fixing the closed state alone would expose it: sweeping the mouse across the hamburger in a narrow window would pop the full-screen menu open.

**Fix** — the menu is controlled, so `onValueChange` simply ignores changes whose `eventDetails.reason === 'trigger-hover'` (the typed reason Base UI passes; see `internals/reason-parts`). The hamburger — the app's only NavigationMenu trigger; the desktop items are `NavigationMenuLink`s — stays click-only, exactly like the Radix version.

## Evidence

Captured with Playwright (narrow 500×800 viewport) at the pre-#10149 commit, current `main`, and this branch ([`base-ui-fixes-evidence`](https://github.com/the-blue-alliance/the-blue-alliance/tree/base-ui-fixes-evidence/evidence/base-ui-fixes)).

### Tap ☰ once (should open), tap ✕ again (should close)

| | Before #10149 (Radix) | main (broken) | This PR |
| --- | --- | --- | --- |
| after 1st tap | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/nav-open--1-radix-baseline.png" width="230"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/nav-open--2-main-broken.png" width="230"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/nav-open--3-fixed.png" width="230"> |
| after 2nd tap | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/nav-after-close--1-radix-baseline.png" width="230"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/nav-after-close--2-main-broken.png" width="230"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/nav-after-close--3-fixed.png" width="230"> |

On `main` the toggle is inverted: closed after the first tap, open (with a stale ☰ icon) after the second.

### Portal mount counts (`[data-slot="navigation-menu-viewport"]`, measured)

| state | Radix baseline | main | This PR |
| --- | --- | --- | --- |
| initial page load | 0 | **1** | 0 |
| menu open | 1 | 1 | 1 |
| after close | 0 | **1** | 0 |

## Testing

- New Playwright spec `tests/navigation.spec.ts`: the portal is not mounted while closed, the hamburger doesn't open on hover, and it opens on click / fully unmounts on the second click. All pass on this branch; on `main` the mount-count assertions fail as measured above.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm test` all pass.

## Screenshot Pages

- / Homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
