### PR TITLE
Restore dialog content-focus-on-open via a shared DialogContent prop

### DIFF
--- a/pwa/app/components/tba/gameday/ChatSidebar.tsx
+++ b/pwa/app/components/tba/gameday/ChatSidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import ChevronUpIcon from '~icons/lucide/chevron-up';
 import MessageSquareIcon from '~icons/lucide/message-square';
@@ -17,7 +17,6 @@ const SIDEBAR_WIDTH = 300;
 export function ChatSidebar() {
   const { state, setCurrentChat } = useGameday();
   const [selectorOpen, setSelectorOpen] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
 
   if (!state.chatSidebarVisible) return null;
 
@@ -81,11 +80,7 @@ export function ChatSidebar() {
 
       {/* Chat selector dialog */}
       <Dialog open={selectorOpen} onOpenChange={setSelectorOpen}>
-        <DialogContent
-          ref={contentRef}
-          initialFocus={contentRef}
-          className="max-w-sm p-0"
-        >
+        <DialogContent focusContentOnOpen className="max-w-sm p-0">
           <DialogHeader className="border-b px-4 py-3">
             <DialogTitle>Select a chat</DialogTitle>
           </DialogHeader>

--- a/pwa/app/components/tba/gameday/SwapPositionDialog.tsx
+++ b/pwa/app/components/tba/gameday/SwapPositionDialog.tsx
@@ -1,5 +1,3 @@
-import { useRef } from 'react';
-
 import {
   Dialog,
   DialogContent,
@@ -46,7 +44,6 @@ export function SwapPositionDialog({
   onPositionSelected: (position: number) => void;
 }) {
   const { state } = useGameday();
-  const contentRef = useRef<HTMLDivElement>(null);
 
   const layout = getLayoutById(state.layoutId);
   if (!layout) return null;
@@ -62,11 +59,7 @@ export function SwapPositionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        ref={contentRef}
-        initialFocus={contentRef}
-        className="max-w-md p-0"
-      >
+      <DialogContent focusContentOnOpen className="max-w-md p-0">
         <DialogHeader className="border-b px-4 py-3">
           <DialogTitle>Select a position to swap with</DialogTitle>
         </DialogHeader>

--- a/pwa/app/components/tba/gameday/WebcastSelectorDialog.tsx
+++ b/pwa/app/components/tba/gameday/WebcastSelectorDialog.tsx
@@ -1,5 +1,3 @@
-import { useRef } from 'react';
-
 import HelpCircleIcon from '~icons/lucide/help-circle';
 import VideoIcon from '~icons/lucide/video';
 import VideoOffIcon from '~icons/lucide/video-off';
@@ -27,7 +25,6 @@ export function WebcastSelectorDialog({
   onWebcastSelected: (webcastId: string) => void;
 }) {
   const { availableWebcasts } = useGameday();
-  const contentRef = useRef<HTMLDivElement>(null);
 
   // Group webcasts by special vs regular, then by online/offline status
   const specialWebcasts = availableWebcasts.filter(
@@ -45,11 +42,7 @@ export function WebcastSelectorDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        ref={contentRef}
-        initialFocus={contentRef}
-        className="max-w-md p-0"
-      >
+      <DialogContent focusContentOnOpen className="max-w-md p-0">
         <DialogHeader className="border-b px-4 py-3">
           <DialogTitle>Select a webcast</DialogTitle>
         </DialogHeader>

--- a/pwa/app/components/tba/match/matchModal.tsx
+++ b/pwa/app/components/tba/match/matchModal.tsx
@@ -50,7 +50,8 @@ export function MatchModal() {
 
   return (
     <Credenza open={isOpen} onOpenChange={handleOpenChange}>
-      <CredenzaContent className="max-w-5xl sm:max-w-5xl">
+      {/* Focus the content area and not the first element */}
+      <CredenzaContent className="max-w-5xl sm:max-w-5xl" focusContentOnOpen>
         {displayMatchKey && (
           <Suspense fallback={<MatchModalSpinner />}>
             <MatchModalContent matchKey={displayMatchKey} />

--- a/pwa/app/components/ui/credenza.tsx
+++ b/pwa/app/components/ui/credenza.tsx
@@ -114,16 +114,41 @@ const CredenzaClose = ({
 const CredenzaContent = ({
   className,
   children,
+  focusContentOnOpen,
   ...props
 }: Omit<ComponentProps<typeof DialogContent>, 'className' | 'style'> &
   CredenzaProps) => {
   const isDesktop = useContext(CredenzaIsDesktopContext);
-  const CredenzaContent = isDesktop ? DialogContent : DrawerContent;
+
+  if (isDesktop) {
+    return (
+      <DialogContent
+        className={className}
+        focusContentOnOpen={focusContentOnOpen}
+        {...props}
+      >
+        {children}
+      </DialogContent>
+    );
+  }
 
   return (
-    <CredenzaContent className={className} {...props}>
+    <DrawerContent
+      className={className}
+      // vaul's Content is Radix-based; translate focusContentOnOpen to the
+      // equivalent Radix escape hatch so mobile matches the desktop dialog
+      onOpenAutoFocus={
+        focusContentOnOpen
+          ? (e) => {
+              e.preventDefault();
+              (e.currentTarget as HTMLElement | null)?.focus();
+            }
+          : undefined
+      }
+      {...props}
+    >
       {children}
-    </CredenzaContent>
+    </DrawerContent>
   );
 };
 

--- a/pwa/app/components/ui/dialog.tsx
+++ b/pwa/app/components/ui/dialog.tsx
@@ -1,4 +1,5 @@
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { useRef } from 'react';
 
 import XIcon from '~icons/lucide/x';
 
@@ -49,15 +50,37 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  focusContentOnOpen = false,
+  initialFocus,
+  ref,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Popup> & {
   showCloseButton?: boolean;
+  /**
+   * Focus the popup container itself when the dialog opens instead of Base
+   * UI's default (the first tabbable element inside the popup). Ignored
+   * when an explicit `initialFocus` is passed.
+   */
+  focusContentOnOpen?: boolean;
 }) {
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
+        ref={(node) => {
+          popupRef.current = node;
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref) {
+            ref.current = node;
+          }
+        }}
+        initialFocus={
+          initialFocus ?? (focusContentOnOpen ? popupRef : undefined)
+        }
         className={cn(
           `fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)]
           translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border

--- a/pwa/tests/dialog-focus.spec.ts
+++ b/pwa/tests/dialog-focus.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+// Regression test for the Base UI Dialog migration: the match modal used
+// Radix's onOpenAutoFocus to focus the dialog content container instead of
+// the first tabbable element (which shows a focus ring and, in a tall
+// modal, scrolls the popup to that element). The migration dropped it; the
+// shared DialogContent now restores it via the focusContentOnOpen prop.
+
+test('match modal focuses the dialog content container on open', async ({
+  page,
+}) => {
+  await page.goto('/event/2024mil');
+  await page.waitForLoadState('networkidle');
+
+  // Open the match modal via a match link (adds ?matchKey= search param)
+  await page.getByRole('link', { name: 'Quals 1', exact: true }).click();
+
+  const content = page.locator('[data-slot="dialog-content"]');
+  await expect(content).toBeVisible();
+  await expect(content).toBeFocused();
+});


### PR DESCRIPTION
## Description

Restores the match modal's "focus the content area and not first element" behavior that the Radix → Base UI migration (#10149) dropped, and centralizes the recipe the same PR hand-copied into three gameday dialogs. Found in a post-merge review of that PR.

### What broke

Pre-migration, `matchModal.tsx` passed Radix's `onOpenAutoFocus` escape hatch:

```tsx
// Auto focus on the content area and not first element
onOpenAutoFocus={(e) => {
  e.preventDefault();
  (e.currentTarget as HTMLElement)?.focus();
}}
```

The migration deleted it with no replacement, so Base UI's default applies: focus the first tabbable element inside the popup. Opening a match modal now focuses the match title link — a visible focus ring, and in a tall modal the browser scrolls the popup to that element instead of starting at the top.

Meanwhile the three gameday dialogs (`ChatSidebar`, `SwapPositionDialog`, `WebcastSelectorDialog`) each re-established the behavior with an identical three-line copy of `const contentRef = useRef(...)` + `ref={contentRef} initialFocus={contentRef}` — a per-call-site recipe that the next dialog author has to rediscover (as the match modal demonstrates).

### The fix

Implement it once in the shared wrapper: `DialogContent` gains a `focusContentOnOpen` prop that wires Base UI's `initialFocus` to the popup's own element (Base UI accepts a `RefObject` there; an explicit `initialFocus` from the caller still wins). Then:

- `matchModal.tsx` passes `focusContentOnOpen` — restoring the dropped behavior. `CredenzaContent` forwards it: on desktop straight to `DialogContent`; on the mobile drawer path it translates to vaul's Radix-based `onOpenAutoFocus`, so both form factors behave the same (the pre-#10149 code worked on both for the same reason).
- The three gameday dialogs drop their hand-rolled `contentRef` plumbing for the same prop. Net: the behavior lives in one place, and three copies become three one-word props.

## Evidence

`document.activeElement` after opening the match modal from /event/2024mil, measured with Playwright ([`base-ui-fixes-evidence`](https://github.com/the-blue-alliance/the-blue-alliance/tree/base-ui-fixes-evidence/evidence/base-ui-fixes)):

| | Before #10149 (Radix) | main (broken) | This PR |
| --- | --- | --- | --- |
| focused element | `DIV[data-slot=dialog-content]` (the popup) | **`A` — the "Quals 1 – Milstein Division 2024" title link** | `DIV[data-slot=dialog-content]` (the popup) |
| screenshot | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/match-modal--1-radix-baseline.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/match-modal--2-main-broken.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/match-modal--3-fixed.png" width="260"> |

## Testing

- New Playwright spec `tests/dialog-focus.spec.ts`: opening the match modal focuses the dialog content container. Passes on this branch; on `main` the focused element is the title link as measured above.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm test` all pass.

## Screenshot Pages

- /event/2024mil 2024 Milstein Division

🤖 Generated with [Claude Code](https://claude.com/claude-code)
