### PR TITLE
Fix DoubleSlider leaking Radix-named minStepsBetweenThumbs onto Base UI

### DIFF
--- a/pwa/app/components/tba/doubleSlider.tsx
+++ b/pwa/app/components/tba/doubleSlider.tsx
@@ -7,7 +7,9 @@ type SliderProps = {
   className?: string;
   min: number;
   max: number;
-  minStepsBetweenThumbs: number;
+  // Base UI's name for Radix's minStepsBetweenThumbs; forwarded explicitly
+  // so it can't silently leak to the DOM as an unknown prop
+  minStepsBetweenValues?: number;
   step: number;
   formatLabel?: (value: number) => string;
   value?: number[] | readonly number[];
@@ -19,10 +21,10 @@ function DoubleSlider({
   min,
   max,
   step,
+  minStepsBetweenValues,
   formatLabel,
   value,
   onValueChange,
-  ...props
 }: SliderProps) {
   const initialValue = Array.isArray(value) ? value : [min, max];
   const [localValues, setLocalValues] = useState(initialValue);
@@ -39,6 +41,7 @@ function DoubleSlider({
       min={min}
       max={max}
       step={step}
+      minStepsBetweenValues={minStepsBetweenValues}
       value={localValues}
       onValueChange={handleValueChange}
       thumbAlignment="edge"
@@ -46,7 +49,6 @@ function DoubleSlider({
         'relative mb-6 flex w-full touch-none items-center select-none',
         className,
       )}
-      {...props}
     >
       <SliderPrimitive.Control
         className="relative flex w-full touch-none items-center select-none"

--- a/pwa/app/routes/team.$teamNumber.stats.tsx
+++ b/pwa/app/routes/team.$teamNumber.stats.tsx
@@ -239,7 +239,7 @@ function TeamStatsPage() {
                 setMinYear(value[0]);
                 setMaxYear(value[1]);
               }}
-              minStepsBetweenThumbs={0}
+              minStepsBetweenValues={0}
               step={1}
             />
           </div>

--- a/pwa/tests/slider.spec.ts
+++ b/pwa/tests/slider.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+// Regression test for the Base UI Slider migration: DoubleSlider spread the
+// Radix-named minStepsBetweenThumbs prop onto Base UI's Slider.Root, which
+// doesn't recognize it, so it leaked into the DOM as an attribute (and any
+// nonzero value would be silently ignored — Base UI's prop is
+// minStepsBetweenValues).
+
+test('team stats year slider does not leak unknown props to the DOM', async ({
+  page,
+}) => {
+  await page.goto('/team/254/stats');
+  await page.waitForLoadState('networkidle');
+
+  // The slider renders (two thumbs for the year range)
+  await expect(page.getByRole('slider').first()).toBeVisible();
+
+  // The Radix-era prop must not end up as a DOM attribute
+  await expect(page.locator('[minstepsbetweenthumbs]')).toHaveCount(0);
+});


### PR DESCRIPTION
## Description

Fixes `DoubleSlider` forwarding the Radix-named `minStepsBetweenThumbs` prop onto Base UI's `Slider.Root`, introduced by the Radix → Base UI migration (#10149). Found in a post-merge review of that PR.

### What broke

`DoubleSlider`'s local `SliderProps` type still declared Radix's `minStepsBetweenThumbs`, didn't destructure it, and spread it onto `Slider.Root` via `{...props}`. Base UI's equivalent prop is `minStepsBetweenValues` (`slider/root/SliderRoot.d.ts`), and Base UI forwards unrecognized props to the rendered `<div>` via `useRenderElement`. Two consequences:

- **DOM leak**: `/team/{n}/stats` renders the year-range slider with a `minstepsbetweenthumbs` attribute, and React logs `React does not recognize the 'minStepsBetweenThumbs' prop on a DOM element` in dev on every render (verified, see below).
- **Silent no-op**: any nonzero value would be ignored entirely — Base UI defaults `minStepsBetweenValues` to 0 — with no type error, because the prop is declared in the local custom type so TypeScript is satisfied. Today's only caller passes `0`, so this half is a latent trap rather than a live behavior change.

### The fix

Rename the prop to Base UI's `minStepsBetweenValues`, forward it explicitly instead of via a rest spread (so a future rename mismatch is a type error, not a DOM attribute), and update the `team.$teamNumber.stats.tsx` caller.

## Evidence

Measured with Playwright on /team/254/stats ([`base-ui-fixes-evidence`](https://github.com/the-blue-alliance/the-blue-alliance/tree/base-ui-fixes-evidence/evidence/base-ui-fixes)):

| | Before #10149 (Radix) | main (broken) | This PR |
| --- | --- | --- | --- |
| elements matching `[minstepsbetweenthumbs]` | 0 | **1** | 0 |
| React console errors mentioning the prop | none | **`React does not recognize the 'minStepsBetweenThumbs' prop on a DOM element…`** | none |
| slider renders | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/team-stats-slider--1-radix-baseline.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/team-stats-slider--2-main-broken.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/team-stats-slider--3-fixed.png" width="260"> |

(The screenshots are visually identical by design — the leak is in the DOM/console, and the fix must not change rendering.)

## Testing

- New Playwright spec `tests/slider.spec.ts`: the team stats slider renders and no `[minstepsbetweenthumbs]` attribute reaches the DOM. Passes on this branch; fails on `main` (attribute count 1).
- `pnpm run lint`, `pnpm run typecheck`, `pnpm test` all pass.

## Screenshot Pages

- /team/254/stats Team 254 Stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)
