### PR TITLE
Move link content inside Base UI render anchors (drops 12 eslint suppressions)

### DIFF
--- a/pwa/app/components/tba/addToCalendarLinks.tsx
+++ b/pwa/app/components/tba/addToCalendarLinks.tsx
@@ -40,45 +40,42 @@ export default function AddToCalendarLinks({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             render={
-              // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from DropdownMenuItem's own children, merged onto this element by Base UI's render prop
               <a
                 href={google(calEvent)}
                 target="_blank"
                 rel="noreferrer"
                 className="cursor-pointer gap-2"
-              />
+              >
+                <GoogleCalendarIcon className="size-4" />
+                Google Calendar
+              </a>
             }
-          >
-            <GoogleCalendarIcon className="size-4" />
-            Google Calendar
-          </DropdownMenuItem>
+          />
           <DropdownMenuItem
             render={
-              // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from DropdownMenuItem's own children, merged onto this element by Base UI's render prop
               <a
                 href={ics(calEvent)}
                 download={`${event.key}.ics`}
                 className="cursor-pointer gap-2"
-              />
+              >
+                <AppleIcon className="size-4 dark:invert" />
+                Apple Calendar
+              </a>
             }
-          >
-            <AppleIcon className="size-4 dark:invert" />
-            Apple Calendar
-          </DropdownMenuItem>
+          />
           <DropdownMenuItem
             render={
-              // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from DropdownMenuItem's own children, merged onto this element by Base UI's render prop
               <a
                 href={outlook(calEvent)}
                 target="_blank"
                 rel="noreferrer"
                 className="cursor-pointer gap-2"
-              />
+              >
+                <OutlookIcon className="size-4" />
+                Outlook
+              </a>
             }
-          >
-            <OutlookIcon className="size-4" />
-            Outlook
-          </DropdownMenuItem>
+          />
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/pwa/app/components/tba/eventListTable.tsx
+++ b/pwa/app/components/tba/eventListTable.tsx
@@ -86,6 +86,14 @@ export default function EventListTable({
           const districtColor = getDistrictColorClass(
             event.district?.abbreviation,
           );
+          const watchButtonContent = (
+            <InlineIcon iconSize="large">
+              <MdiVideo />
+              <span className="hidden md:contents">
+                {isOnline ? 'Watch Now' : 'Offline'}
+              </span>
+            </InlineIcon>
+          );
           return (
             <TableRow
               key={event.key}
@@ -133,13 +141,14 @@ export default function EventListTable({
                   <Button
                     render={
                       isOnline || withinADay ? (
-                        // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
                         <a
                           href={`/gameday/${event.key}`}
                           target="_blank"
                           rel="noreferrer"
                           className="hover:no-underline"
-                        />
+                        >
+                          {watchButtonContent}
+                        </a>
                       ) : undefined
                     }
                     variant={isOnline ? 'success' : 'secondary'}
@@ -149,12 +158,7 @@ export default function EventListTable({
                         !isOnline && !withinADay,
                     })}
                   >
-                    <InlineIcon iconSize="large">
-                      <MdiVideo />
-                      <span className="hidden md:contents">
-                        {isOnline ? 'Watch Now' : 'Offline'}
-                      </span>
-                    </InlineIcon>
+                    {watchButtonContent}
                   </Button>
                 )}
               </TableCell>

--- a/pwa/app/components/tba/match/matchRows.tsx
+++ b/pwa/app/components/tba/match/matchRows.tsx
@@ -483,18 +483,17 @@ export function BreakRow({
                     <DropdownMenuItem
                       key={url}
                       render={
-                        // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from DropdownMenuItem's own children, merged onto this element by Base UI's render prop
                         <a
                           href={url}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="flex cursor-pointer items-center gap-2"
-                        />
+                        >
+                          <YoutubeIcon className="size-3.5" />
+                          {label}
+                        </a>
                       }
-                    >
-                      <YoutubeIcon className="size-3.5" />
-                      {label}
-                    </DropdownMenuItem>
+                    />
                   ))}
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/pwa/app/routes/about.tsx
+++ b/pwa/app/routes/about.tsx
@@ -39,16 +39,15 @@ function About(): React.JSX.Element {
             <Button
               size="sm"
               render={
-                // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
                 <a
                   href="https://github.com/the-blue-alliance"
                   target="_blank"
                   rel="noreferrer"
-                />
+                >
+                  Contribute on GitHub
+                </a>
               }
-            >
-              Contribute on GitHub
-            </Button>
+            />
             <Button size="sm" render={<Link to="/donate" />}>
               Donate with PayPal
             </Button>
@@ -85,16 +84,15 @@ function About(): React.JSX.Element {
           <Button
             size="sm"
             render={
-              // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
               <a
                 href="http://www.firstinspires.org"
                 target="_blank"
                 rel="noreferrer"
-              />
+              >
+                Join the movement
+              </a>
             }
-          >
-            Join the movement
-          </Button>
+          />
         </section>
 
         <section className="py-6">

--- a/pwa/app/routes/contact.tsx
+++ b/pwa/app/routes/contact.tsx
@@ -96,25 +96,22 @@ function Contact(): React.JSX.Element {
           <h3 className="text-2xl">Everything else...</h3>
           <p>Feel free to reach out to us!</p>
           <Button
-            // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
-            render={<a href="mailto:contact@thebluealliance.com" />}
-          >
-            Email Us!
-          </Button>
+            render={<a href="mailto:contact@thebluealliance.com">Email Us!</a>}
+          />
           <Button
             render={
-              // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
-              <a href="https://groups.google.com/forum/#!forum/thebluealliance-developers" />
+              <a href="https://groups.google.com/forum/#!forum/thebluealliance-developers">
+                Join our Developer Mailing List!
+              </a>
             }
-          >
-            Join our Developer Mailing List!
-          </Button>
+          />
           <Button
-            // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
-            render={<a href="https://www.chiefdelphi.com/" />}
-          >
-            Ask Chief Delphi Fourms!
-          </Button>
+            render={
+              <a href="https://www.chiefdelphi.com/">
+                Ask Chief Delphi Fourms!
+              </a>
+            }
+          />
         </div>
       </div>
     </>

--- a/pwa/app/routes/donate.tsx
+++ b/pwa/app/routes/donate.tsx
@@ -47,12 +47,11 @@ function Donate(): React.JSX.Element {
           </p>
           <Button
             render={
-              // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
-              <a href="https://www.paypal.com/donate/?hosted_button_id=RNFK8Y7FU9VX8" />
+              <a href="https://www.paypal.com/donate/?hosted_button_id=RNFK8Y7FU9VX8">
+                Donate on PayPal!
+              </a>
             }
-          >
-            Donate on PayPal!
-          </Button>
+          />
         </div>
       </div>
     </>

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -1453,14 +1453,13 @@ function MediaTab({
         <Button
           variant="secondary"
           render={
-            // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
             <a
               href={`https://www.thebluealliance.com/suggest/event/webcast?event_key=${eventKey}`}
-            />
+            >
+              Add Webcast
+            </a>
           }
-        >
-          Add Webcast
-        </Button>
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Pure refactor, no behavior change. The Radix → Base UI migration (#10149) converted `asChild` anchors to Base UI `render` props as **empty** `<a />` elements with the content left on the host component — which trips `jsx-a11y/anchor-has-content`, so each of the **12 call sites across 7 files** carried an identical suppression comment:

```tsx
<Button
  render={
    // eslint-disable-next-line jsx-a11y/anchor-has-content -- content comes from Button's own children, merged onto this element by Base UI's render prop
    <a href="https://www.paypal.com/donate/..." />
  }
>
  Donate on PayPal!
</Button>
```

But the empty anchor isn't required by Base UI in the first place. `render` clones the element with `mergeProps(componentProps, render.props)` (`evaluateRenderProp` → `React.cloneElement`), and the render element's own props — **children included** — take precedence over the host's. So the content can simply live inside the anchor, where jsx-a11y wants it:

```tsx
<Button render={<a href="https://www.paypal.com/donate/...">Donate on PayPal!</a>} />
```

This PR restructures all 12 sites that way and deletes every suppression — no eslint config change, no shared wrapper component, and the JSX now reads the way the DOM comes out (a link with its content).

The one conditional site — `eventListTable`'s Watch button, which renders a link when the event is live/upcoming but a plain disabled button otherwise — shares its content between the anchor and the button children via a local `watchButtonContent` const, so nothing is duplicated and the non-link branch keeps its content.

`grep -rn 'anchor-has-content' app/` after this PR: **0 hits**.

## Why not the alternatives

- **eslint config** (`jsx-a11y` `components`/`polymorphicPropName` settings): those map custom components onto `<a>` semantics; they can't exempt literal empty `<a />` elements without disabling the rule.
- **A shared `RenderAnchor` wrapper carrying one suppression**: works (it was the first version of this PR), but it still suppresses a rule that this structure satisfies honestly, and adds a component whose only job is holding an eslint comment.

## Evidence

Verified against a local dev server ([`base-ui-fixes-evidence`](https://github.com/the-blue-alliance/the-blue-alliance/tree/base-ui-fixes-evidence/evidence/base-ui-fixes)):

- **/about** "Contribute on GitHub": rendered anchor identical before/after — `href=https://github.com/the-blue-alliance target=_blank rel=noreferrer`, same text.

  | main | This PR |
  | --- | --- |
  | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/about-button--2-main-broken.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/about-button--3-fixed.png" width="260"> |

- **Event page calendar dropdown** (the `DropdownMenuItem` path): all three items render as `<a role="menuitem">` with correct hrefs (Google/ICS/Outlook), their content, and the same merged class order (`cursor-pointer gap-2` + the item wrapper's classes) as the empty-anchor pattern produced — matching `mergeProps`' documented right-to-left `className` concatenation.

## Testing

- No behavior change intended; existing Playwright route coverage exercises the affected pages.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm test` (310 tests) all pass.

## Screenshot Pages

- /about About
- /contact Contact
- /donate Donate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
