### PR TITLE
Remove dead code left by the Base UI migration

### DIFF
--- a/pwa/app/components/tba/navigation/searchModal.tsx
+++ b/pwa/app/components/tba/navigation/searchModal.tsx
@@ -78,7 +78,6 @@ export function SearchModal() {
               pl-4 font-normal text-muted-foreground shadow-none hover:bg-white
               max-lg:hidden sm:pr-12 md:w-32 lg:w-56 xl:w-64 dark:bg-card`,
             )}
-            onClick={() => setOpen(true)}
           />
         }
       >

--- a/pwa/app/components/ui/popover.tsx
+++ b/pwa/app/components/ui/popover.tsx
@@ -54,10 +54,4 @@ function PopoverContent({
   );
 }
 
-function PopoverAnchor({ ...props }: ComponentProps<'div'>) {
-  // Base UI has no Popover.Anchor part (Positioner takes an `anchor` prop
-  // instead); kept as an inert passthrough since no consumer uses it.
-  return <div data-slot="popover-anchor" {...props} />;
-}
-
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+export { Popover, PopoverTrigger, PopoverContent };


### PR DESCRIPTION
## Description

Removes two pieces of dead code left behind by the Radix → Base UI migration (#10149). Found in a post-merge review of that PR.

### 1. `searchModal`: redundant `onClick={() => setOpen(true)}` on a `DialogTrigger` render prop

The desktop search Button used to be a plain `asChild` child that needed its own click handler. It now renders via `DialogTrigger`'s `render` prop, and Base UI merges the trigger's own open-toggle onto the rendered element — `DialogTrigger` wires `useClick`, and `useRenderElement` runs `mergeProps(props, render.props)`, where "event handlers are merged and called in right-to-left order". So the manual `onClick` set the same controlled state a second time on every click. The mobile trigger in the same file already omits it; now both do.

### 2. `ui/popover.tsx`: inert `PopoverAnchor` export

`PopoverAnchor` was kept as a `<div data-slot="popover-anchor">` passthrough with zero consumers (`git grep PopoverAnchor` matches only the definition and export). Base UI has no `Popover.Anchor` part — anchoring is the Positioner's `anchor` prop, which our `PopoverContent` doesn't forward — so any future use would compile fine and silently not anchor. Deleting the export means reaching for it fails loudly at the call site instead of shipping a positioning bug.

## Evidence

Search dialog opens normally after removing the redundant handler ([`base-ui-fixes-evidence`](https://github.com/the-blue-alliance/the-blue-alliance/tree/base-ui-fixes-evidence/evidence/base-ui-fixes)):

| Before #10149 (Radix) | main | This PR |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/search-modal--1-radix-baseline.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/search-modal--2-main-broken.png" width="260"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance/base-ui-fixes-evidence/evidence/base-ui-fixes/search-modal--3-fixed.png" width="260"> |

One dialog opens per click in all three states (measured `dialogCount: 1`).

## Testing

- Verified with Playwright that clicking the search button opens exactly one dialog on this branch (table above); existing specs cover the affected pages.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm test` all pass.

## Screenshot Pages

- / Homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
