### PR TITLE
Default apistatus android/ios to placeholder versions

### DIFF
--- a/src/backend/common/sitevars/apistatus.py
+++ b/src/backend/common/sitevars/apistatus.py
@@ -43,13 +43,17 @@ class ApiStatus(Sitevar[ContentType]):
 
     @staticmethod
     def default_value() -> ContentType:
+        # The APIv3 spec declares android/ios as non-null objects (prod has
+        # always set them), so the default must satisfy the contract too —
+        # otherwise fresh dev datastores serve a /status that breaks strict
+        # API clients like the PWA's generated response validators.
         current_year = datetime.datetime.now().year
         return ContentType(
             current_season=current_year,
             max_season=current_year,
             web=None,
-            android=None,
-            ios=None,
+            android=AndroidConfig(min_app_version=-1, latest_app_version=-1),
+            ios=IOSConfig(min_app_version=-1, latest_app_version=-1),
             max_team_page=0,
         )
 

--- a/src/backend/common/sitevars/tests/apistatus_test.py
+++ b/src/backend/common/sitevars/tests/apistatus_test.py
@@ -22,10 +22,12 @@ def test_default_sitevar():
     assert default_sitevar is not None
 
     year = datetime.datetime.now().year
+    # android/ios placeholders keep the default consistent with the APIv3
+    # contract, which declares them as non-null objects
     default_json = {
-        "android": None,
+        "android": {"min_app_version": -1, "latest_app_version": -1},
         "current_season": year,
-        "ios": None,
+        "ios": {"min_app_version": -1, "latest_app_version": -1},
         "max_season": year,
         "web": None,
         "max_team_page": 0,
@@ -37,9 +39,9 @@ def test_default_sitevar():
 def test_status_empty():
     year = datetime.datetime.now().year
     assert ApiStatus.status() == {
-        "android": None,
+        "android": {"min_app_version": -1, "latest_app_version": -1},
         "current_season": year,
-        "ios": None,
+        "ios": {"min_app_version": -1, "latest_app_version": -1},
         "max_season": year,
         "web": None,
         "max_team_page": 0,


### PR DESCRIPTION
The APIv3 spec declares `status.android` / `status.ios` as non-null objects — true in prod since forever — but the `apistatus` sitevar *default* returned `null` for both. Any fresh dev datastore therefore serves a `/status` that violates the API contract.

This bit hard while testing the PWA's dev data-source toggle (#10164): the PWA's generated zod response validators reject the invalid payload, the status query errors after retries, and **every page that queries status shows the error boundary** — with a confusing `ApiError: OK` (the response was 200; validation failed). Placeholder `{min_app_version: -1, latest_app_version: -1}` objects keep the default inside the contract.

No prod impact: defaults only apply when the sitevar entity doesn't exist, and prod's has been set for years.

## Test plan
- Updated `apistatus_test.py` default/empty assertions
- Full sitevars suite (78), admin apistatus, status handler, tasks_io consumers all pass; pyre/black/flake8 clean
- Verified live: fresh-default local `/status` now passes the PWA's `zGetStatusResponse` validation and `/events` renders in local data mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)