### PR TITLE
Use the brand token for GameDay chrome

### DIFF
--- a/pwa/app/components/tba/gameday/ChatSidebar.tsx
+++ b/pwa/app/components/tba/gameday/ChatSidebar.tsx
@@ -70,8 +70,8 @@ export function ChatSidebar() {
       <button
         onClick={() => setSelectorOpen(true)}
         className="flex h-9 shrink-0 cursor-pointer items-center justify-between
-          border-t border-neutral-800 bg-primary px-3 text-white
-          transition-colors hover:bg-primary/90"
+          border-t border-neutral-800 bg-brand px-3 text-white transition-colors
+          hover:bg-brand/90"
       >
         <span className="truncate text-sm font-medium">
           {currentChatInfo?.name ?? 'Select a chat'}

--- a/pwa/app/components/tba/gameday/GamedayToolbar.tsx
+++ b/pwa/app/components/tba/gameday/GamedayToolbar.tsx
@@ -27,7 +27,7 @@ export function GamedayToolbar() {
     <>
       <header
         className="flex h-10 shrink-0 items-center gap-2 border-b
-          border-slate-700 bg-primary px-4"
+          border-slate-700 bg-brand px-4"
       >
         {/* TBA branding */}
         <a


### PR DESCRIPTION
Fixes #10165.

The GameDay toolbar and the chat selector bar are navbar-style chrome — white text on a solid brand fill — so they should sit on the pinned `--brand` token like the main navbar does. After #10148 lightened `--primary` in dark mode for text contrast, these two bars rendered as the lighter indigo instead of TBA brand blue.

`bg-primary` → `bg-brand` (and the hover variant) on `GamedayToolbar` and `ChatSidebar`'s selector bar. The layer-selection state in the toolbar (`border-primary bg-primary/10`) is intentionally untouched — that's a selection highlight, not chrome.

## Screenshot Pages

- /gameday GameDay

🤖 Generated with [Claude Code](https://claude.com/claude-code)