### PR TITLE
Use brand blue for default buttons

### DIFF
--- a/pwa/app/components/ui/button.tsx
+++ b/pwa/app/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default: 'bg-brand text-white hover:bg-brand/90',
         destructive:
           'text-destructive-foreground bg-destructive hover:bg-destructive/90',
         outline: `border border-input bg-background hover:bg-accent


### PR DESCRIPTION
Fixes #10166. Follow-up to #10148.

#10148 lightened `--primary` in dark mode so primary-colored *text* (links) meets WCAG AA against the dark background. Solid-fill buttons don't have that contrast problem — they render light text *on* the fill — so the default `Button` variant switches from `bg-primary text-primary-foreground` to `bg-brand text-white`, restoring TBA brand blue buttons in dark mode instead of the lightened indigo with dark text. White on brand blue is ~7.7:1, comfortably past AA.

Links and other primary-colored text keep the lightened dark-mode `--primary` — that's the part #10148 fixed and this doesn't touch. Other button variants (destructive/outline/secondary/ghost/link) unchanged.

## Screenshot Pages

- /account Account page

🤖 Generated with [Claude Code](https://claude.com/claude-code)