### PR TITLE
Require start/end dates when accepting offseason event suggestions

### DIFF
--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -910,6 +910,48 @@ def test_accept_event_webcast_requires_fields(
     assert resp.json["result"] == "invalid"
 
 
+def test_accept_offseason_event_requires_dates(
+    api_client: Client, moderator, author: Account, taskqueue_stub
+) -> None:
+    # Dateless events violate the APIv3 contract and break strict clients
+    moderator([AccountPermission.REVIEW_OFFSEASON_EVENTS])
+    suggestion_id = create_suggestion(
+        author,
+        "offseason-event",
+        None,
+        {"name": "Dateless Offseason", "website": "https://example.com"},
+        suggestion_id="dateless_offseason",
+    )
+
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={"event_short": "dateless"},
+    )
+    assert resp.status_code == 400
+    assert resp.json["result"] == "invalid"
+    assert "start_date and end_date are required" in resp.json["message"]
+
+    suggestion = Suggestion.get_by_id("dateless_offseason")
+    assert suggestion is not None
+    assert suggestion.review_state == SuggestionState.REVIEW_PENDING
+    assert Event.query().count() == 0
+
+    # Reviewer-provided dates satisfy the requirement
+    resp = api_client.post(
+        f"{BASE_URL}/suggestions/{suggestion_id}/accept",
+        json={
+            "event_short": "dateless",
+            "start_date": "2016-10-01",
+            "end_date": "2016-10-02",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json["result"] == "accepted"
+    event = Event.get_by_id("2016dateless")
+    assert event is not None
+    assert event.start_date is not None
+
+
 def test_accept_offseason_event(
     api_client: Client, moderator, author: Account, taskqueue_stub
 ) -> None:

--- a/src/backend/common/suggestions/suggestion_reviewer.py
+++ b/src/backend/common/suggestions/suggestion_reviewer.py
@@ -375,8 +375,15 @@ class SuggestionReviewer:
             if end_date_str
             else None
         )
+        # Dateless events violate the APIv3 contract (start_date/end_date are
+        # non-nullable) and break strict API clients, so refuse to create one
+        if start_date is None or end_date is None:
+            return (
+                None,
+                "start_date and end_date are required to accept an offseason event",
+            )
 
-        year = int(overrides.get("year") or (start_date.year if start_date else 0))
+        year = int(overrides.get("year") or start_date.year)
         event_key = f"{year}{event_short}"
         if not Event.validate_key_name(event_key):
             return None, f"Bad event key {event_key}"


### PR DESCRIPTION
Fixes #10175. Stacked on #10150 (base branch is `moderation-api`; retarget to `main` if this should land after it merges instead).

`SuggestionReviewer._accept_offseason_event` could create an `Event` with `start_date=None`/`end_date=None` when the suggestion lacked dates and the reviewer supplied no overrides. Dateless events violate the APIv3 contract and break strict API clients — the PWA's generated zod validators reject `/api/v3/events/{year}` wholesale when one appears (this happened locally with a dateless test event and error-bounded the entire events page).

- Accept now returns `INVALID` ("start_date and end_date are required to accept an offseason event") unless dates come from the suggestion contents or reviewer overrides
- Removes the `year` fallback that silently produced `0`-prefixed event keys when `start_date` was missing
- Test covers both the rejection and reviewer-provided dates satisfying the requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)