### PR TITLE
Fix duplicated 'Division' in 2002 CMP division blue banner names

### DIFF
--- a/src/backend/common/models/event.py
+++ b/src/backend/common/models/event.py
@@ -857,9 +857,14 @@ class Event(CachedModel):
             if self.event_type_enum == EventType.OFFSEASON:
                 return self.short_name
             else:
+                type_suffix = event_type.SHORT_TYPE_NAMES[
+                    EventType(self.event_type_enum)
+                ]
+                if self.short_name.strip().endswith(type_suffix):
+                    return self.short_name
                 return "{} {}".format(
                     self.short_name,
-                    event_type.SHORT_TYPE_NAMES[EventType(self.event_type_enum)],
+                    type_suffix,
                 )
         else:
             return self.name

--- a/src/backend/common/models/tests/event_test.py
+++ b/src/backend/common/models/tests/event_test.py
@@ -441,6 +441,39 @@ def test_details() -> None:
     assert event.details == d
 
 
+@pytest.mark.parametrize(
+    "short_name, event_type_enum, expected",
+    [
+        # Normal case - suffix should be appended
+        ("Archimedes", EventType.CMP_DIVISION, "Archimedes Division"),
+        # 2002-style data where short_name already contains the suffix -
+        # should not be duplicated. See #10206.
+        ("Archimedes Division", EventType.CMP_DIVISION, "Archimedes Division"),
+        (
+            "Newton",
+            EventType.DISTRICT_CMP_DIVISION,
+            "Newton District Championship Division",
+        ),
+        (
+            "Newton District Championship Division",
+            EventType.DISTRICT_CMP_DIVISION,
+            "Newton District Championship Division",
+        ),
+    ],
+)
+def test_normalized_name_division_suffix(
+    short_name: str, event_type_enum: EventType, expected: str
+) -> None:
+    event = Event(
+        id="2002cmp",
+        year=2002,
+        event_short="cmp",
+        short_name=short_name,
+        event_type_enum=event_type_enum,
+    )
+    assert event.normalized_name == expected
+
+
 def test_first_api_code() -> None:
     # Pre-2023 regular event
     event = Event(id="2019ingre", year=2019, event_short="ingre")


### PR DESCRIPTION
## Description
Event.normalized_name appends the SHORT_TYPE_NAMES suffix (e.g. 'Division') to short_name unconditionally. For 2002 Championship Division events, short_name was stored as '{Name} Division' instead of just '{Name}', so the result was doubled (e.g. 'Archimedes Division Division' on blue banners).

This checks whether short_name already ends with the suffix before appending it, so it works regardless of whether short_name includes the suffix or not.

## Motivation and Context
Fixes #10206

## How Has This Been Tested?
Added parametrized tests in event_test.py covering both the normal case and the 2002-style duplication case (where short_name already contains the suffix). Ran the full event_test.py suite locally: 104/104 passed.

## Screenshots (if appropriate):

## Screenshot Pages

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)