### PR TITLE
[pwa] Add default staleTime to tanstack queries

### DIFF
--- a/pwa/README.md
+++ b/pwa/README.md
@@ -126,6 +126,48 @@ With all that said... There are various levels of caching available when making 
    - This is what the prod site does
    - But TanStack Router / React don't support this extremely well out of the box
 
+### `staleTime` policy
+
+TanStack Query is the cache that matters most for perceived freshness — the other
+layers above are transport optimizations underneath it. `staleTime` defaults to `0`
+in TanStack Query, which means data is considered stale the instant it arrives; left
+unset, this caused every `useSuspenseQuery` to refetch immediately on hydration, even
+though the server had just sent the same data moments earlier.
+
+The policy is centralized in `app/lib/queryClient.ts` and applied via `createQueryClient()`
+(wired into the router in `app/router.tsx`):
+
+- **Default: `staleTime: 60_000`** (~60s) on every query, anchored to the TBA API's own
+  `cache-control: max-age=61` header — this is the single default `defaultOptions.queries.staleTime`
+  set on the `QueryClient`.
+- **Historical data: `staleTimeForYear(year)`**, which returns a 1-hour `staleTime` for any past
+  calendar year (comparing against `Temporal.Now.plainDateISO().year`, deliberately not the
+  `/status` API's `current_season`, to avoid deepening that dependency) and falls back to the 60s
+  default for the current year. Applied today on the event page (`event.$eventKey.tsx`), the
+  team-year page (`team.$teamNumber.{-$year}.tsx`), and the districts list page
+  (`districts.{-$year}.tsx`); other year-scoped routes still inherit the 60s default.
+- **Live data keeps its own `staleTime`/`refetchInterval`** and is unaffected by the above — e.g.
+  the district champs page (`district.$districtAbbreviation.champs.$year.tsx`) polls on a
+  `refetchInterval` independent of `staleTime`, and Nexus/Firebase-backed queries
+  (`app/lib/nexus.ts`, `app/lib/gameday/useFirebaseWebcasts.ts`) keep their own shorter or
+  `Infinity` values.
+
+The generated `<name>Options()` helpers (from `hey-api`) return plain objects, so overrides
+compose by spreading:
+
+```ts
+useSuspenseQuery({
+  ...getEventOptions({ path: { event_key: eventKey } }),
+  staleTime: staleTimeForYear(year),
+});
+```
+
+A few routes still fetch data directly with the generated SDK functions instead of going through
+the `QueryClient` (e.g. `team.$teamNumber.stats.tsx`, `district.$districtAbbreviation.stats.tsx`,
+`district.$districtAbbreviation.{-$year}.tsx`, `district.$districtAbbreviation.insights.tsx`,
+`teams.{-$pgNum}.tsx`). Those routes get no benefit from `staleTime` until they're converted to use
+`ensureQueryData`/`useSuspenseQuery`; that conversion is tracked separately.
+
 ## Styling
 
 TBA Beta uses [TailwindCSS](https://tailwindcss.com/) and [ShadCN](https://ui.shadcn.com/) components.

--- a/pwa/app/lib/queryClient.test.ts
+++ b/pwa/app/lib/queryClient.test.ts
@@ -1,0 +1,70 @@
+import { dehydrate, hydrate } from '@tanstack/react-query';
+import { Temporal } from 'temporal-polyfill';
+import { describe, expect, test } from 'vitest';
+
+import { ApiError } from '~/lib/apiError';
+import {
+  STALE_TIME,
+  createQueryClient,
+  staleTimeForYear,
+} from '~/lib/queryClient';
+
+describe.concurrent('createQueryClient', () => {
+  test('defaults staleTime to STALE_TIME.DEFAULT', () => {
+    const queryClient = createQueryClient();
+    expect(queryClient.getDefaultOptions().queries?.staleTime).toEqual(
+      STALE_TIME.DEFAULT,
+    );
+  });
+
+  test('retry predicate skips 4xx ApiErrors', () => {
+    const queryClient = createQueryClient();
+    const retry = queryClient.getDefaultOptions().queries?.retry;
+    expect(typeof retry).toEqual('function');
+    if (typeof retry !== 'function') return;
+
+    expect(retry(0, new ApiError('not found', 404))).toEqual(false);
+    expect(retry(0, new ApiError('server error', 500))).toEqual(true);
+    expect(retry(2, new ApiError('server error', 500))).toEqual(true);
+    expect(retry(3, new ApiError('server error', 500))).toEqual(false);
+    expect(retry(0, new Error('network error'))).toEqual(true);
+  });
+
+  test('freshly hydrated data is not stale under the default staleTime', () => {
+    // Simulates the SSR -> hydration flow: a loader warms the cache on the
+    // server, the cache is dehydrated into the payload, and a fresh
+    // QueryClient hydrates it on the client. With staleTime: 0 (the old
+    // default), this data would be instantly stale and every
+    // useSuspenseQuery would refetch on mount. With STALE_TIME.DEFAULT set,
+    // it should not be stale immediately after hydration.
+    const serverQueryClient = createQueryClient();
+    const queryKey = ['test-query'];
+    serverQueryClient.setQueryData(queryKey, { hello: 'world' });
+
+    const dehydratedState = dehydrate(serverQueryClient);
+
+    const clientQueryClient = createQueryClient();
+    hydrate(clientQueryClient, dehydratedState);
+
+    const query = clientQueryClient.getQueryCache().find({ queryKey });
+    expect(query).toBeDefined();
+    expect(query?.isStaleByTime(STALE_TIME.DEFAULT)).toEqual(false);
+  });
+});
+
+describe.concurrent('staleTimeForYear', () => {
+  const currentYear = Temporal.Now.plainDateISO().year;
+
+  test('returns HISTORICAL for a past year', () => {
+    expect(staleTimeForYear(currentYear - 1)).toEqual(STALE_TIME.HISTORICAL);
+    expect(staleTimeForYear(2015)).toEqual(STALE_TIME.HISTORICAL);
+  });
+
+  test('returns DEFAULT for the current year', () => {
+    expect(staleTimeForYear(currentYear)).toEqual(STALE_TIME.DEFAULT);
+  });
+
+  test('returns DEFAULT for a future year', () => {
+    expect(staleTimeForYear(currentYear + 1)).toEqual(STALE_TIME.DEFAULT);
+  });
+});

--- a/pwa/app/lib/queryClient.ts
+++ b/pwa/app/lib/queryClient.ts
@@ -1,0 +1,65 @@
+import { QueryClient } from '@tanstack/react-query';
+import { Temporal } from 'temporal-polyfill';
+
+import { ApiError } from '~/lib/apiError';
+
+/**
+ * `staleTime` tiers for TanStack Query.
+ *
+ * `DEFAULT` is anchored to the TBA API's own `cache-control: max-age=61` header —
+ * telling Query what the API already tells every other cache in the chain. This
+ * alone prevents the hydration refetch storm: without it, `staleTime` defaults to
+ * `0`, so every `useSuspenseQuery` treats data the server just sent as instantly
+ * stale and refetches it on mount.
+ *
+ * `HISTORICAL` is for data that cannot change: a past season's events, team-years,
+ * districts, etc. are immutable, so they can hold far longer than the default.
+ *
+ * Live data (in-progress matches, rankings, `/status`) should NOT use either tier —
+ * it should keep a low `staleTime` (or the `DEFAULT`) alongside an explicit
+ * `refetchInterval`, which fires independent of `staleTime`.
+ */
+export const STALE_TIME = {
+  /** ~60s, matching the API's `max-age=61`. */
+  DEFAULT: 60_000,
+  /** 1h — for data that is known to be immutable (past seasons). */
+  HISTORICAL: 60 * 60 * 1000,
+} as const;
+
+/**
+ * Returns the appropriate `staleTime` for data scoped to a given (calendar) year.
+ *
+ * Past calendar years are immutable regardless of the current FRC season, so this
+ * is a pure calendar comparison — deliberately independent of the `/status` API's
+ * `current_season`, which is already a serialization bottleneck gating several
+ * routes. Reusing the same `Temporal.Now.plainDateISO().year` pattern already used
+ * elsewhere in the app (e.g. `app/routes/index.tsx`) as the current-year fallback.
+ */
+export function staleTimeForYear(year: number): number {
+  return year < Temporal.Now.plainDateISO().year
+    ? STALE_TIME.HISTORICAL
+    : STALE_TIME.DEFAULT;
+}
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: STALE_TIME.DEFAULT,
+        // Don't retry 4xx responses — they indicate a client or data error (e.g. 404
+        // "not found") that won't resolve on retry. Retrying them causes unnecessary
+        // background re-renders for the full exponential-backoff window (~10s).
+        retry: (failureCount, error) => {
+          if (
+            error instanceof ApiError &&
+            error.status >= 400 &&
+            error.status < 500
+          ) {
+            return false;
+          }
+          return failureCount < 3;
+        },
+      },
+    },
+  });
+}

--- a/pwa/app/router.tsx
+++ b/pwa/app/router.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/tanstackstart-react';
-import { QueryClient } from '@tanstack/react-query';
 import { ParsedLocation, createRouter } from '@tanstack/react-router';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
 import { logEvent } from 'firebase/analytics';
@@ -10,7 +9,7 @@ import ClipboardCopyIcon from '~icons/lucide/clipboard-copy';
 
 import { Button } from '~/components/ui/button';
 import { analytics } from '~/firebase/firebaseConfig';
-import { ApiError } from '~/lib/apiError';
+import { createQueryClient } from '~/lib/queryClient';
 import registerServiceWorker from '~/lib/serviceWorkerRegistration';
 import { createLogger } from '~/lib/utils';
 import { routeTree } from '~/routeTree.gen';
@@ -19,25 +18,7 @@ const queryCacheLogger = createLogger('queryCache');
 const routerLogger = createLogger('router');
 
 export function getRouter() {
-  // Don't retry 4xx responses — they indicate a client or data error (e.g. 404
-  // "not found") that won't resolve on retry. Retrying them causes unnecessary
-  // background re-renders for the full exponential-backoff window (~10s).
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: (failureCount, error) => {
-          if (
-            error instanceof ApiError &&
-            error.status >= 400 &&
-            error.status < 500
-          ) {
-            return false;
-          }
-          return failureCount < 3;
-        },
-      },
-    },
-  });
+  const queryClient = createQueryClient();
   queryClient.getQueryCache().subscribe((event) => {
     // Only log "added" events (new queries) and "updated" events when query completes successfully
     // This reduces noise from intermediate state transitions (loading states)

--- a/pwa/app/routes/districts.{-$year}.tsx
+++ b/pwa/app/routes/districts.{-$year}.tsx
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui/table';
+import { staleTimeForYear } from '~/lib/queryClient';
 import {
   parseParamsForYearElseDefault,
   publicCacheControlHeaders,
@@ -29,17 +30,21 @@ export const Route = createFileRoute('/districts/{-$year}')({
       throw notFound();
     }
 
-    const districts = await queryClient.ensureQueryData(
-      getDistrictsByYearOptions({ path: { year } }),
-    );
+    const yearStaleTime = staleTimeForYear(year);
+
+    const districts = await queryClient.ensureQueryData({
+      ...getDistrictsByYearOptions({ path: { year } }),
+      staleTime: yearStaleTime,
+    });
 
     await Promise.all(
       districts.map((district) =>
-        queryClient.ensureQueryData(
-          getDistrictTeamsKeysOptions({
+        queryClient.ensureQueryData({
+          ...getDistrictTeamsKeysOptions({
             path: { district_key: district.key },
           }),
-        ),
+          staleTime: yearStaleTime,
+        }),
       ),
     );
 
@@ -76,8 +81,10 @@ export const Route = createFileRoute('/districts/{-$year}')({
 
 function DistrictsPage() {
   const { year } = Route.useLoaderData();
+  const yearStaleTime = staleTimeForYear(year);
   const { data: districts } = useSuspenseQuery({
     ...getDistrictsByYearOptions({ path: { year } }),
+    staleTime: yearStaleTime,
   });
   const validYears = useValidYears();
   const sortedDistricts = useMemo(
@@ -89,9 +96,10 @@ function DistrictsPage() {
   );
 
   const teamKeyResults = useSuspenseQueries({
-    queries: districts.map((district) =>
-      getDistrictTeamsKeysOptions({ path: { district_key: district.key } }),
-    ),
+    queries: districts.map((district) => ({
+      ...getDistrictTeamsKeysOptions({ path: { district_key: district.key } }),
+      staleTime: yearStaleTime,
+    })),
   });
 
   const teamCountByDistrict = useMemo(() => {

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -162,6 +162,7 @@ import {
   getDefaultTeleopComponentName,
   getDefaultTotalComponentName,
 } from '~/lib/oprUtils';
+import { staleTimeForYear } from '~/lib/queryClient';
 import {
   RANKING_POINT_LABELS,
   getBonusRankingPoints,
@@ -182,42 +183,52 @@ export const Route = createFileRoute('/event/$eventKey')({
       throw notFound();
     }
 
+    // Event keys are prefixed with their 4-digit year (e.g. "2024mil"), so we
+    // can determine the staleTime tier without waiting on the event fetch.
+    const eventYear = Number(params.eventKey.slice(0, 4));
+    const eventStaleTime = staleTimeForYear(eventYear);
+
     // spawn these now, we don't need to await them yet though
     const matchesQuery = queryClient
-      .ensureQueryData(
-        getEventMatchesOptions({ path: { event_key: params.eventKey } }),
-      )
+      .ensureQueryData({
+        ...getEventMatchesOptions({ path: { event_key: params.eventKey } }),
+        staleTime: eventStaleTime,
+      })
       .catch(() => []);
     const alliancesQuery = queryClient
-      .ensureQueryData(
-        getEventAlliancesOptions({ path: { event_key: params.eventKey } }),
-      )
+      .ensureQueryData({
+        ...getEventAlliancesOptions({ path: { event_key: params.eventKey } }),
+        staleTime: eventStaleTime,
+      })
       .catch(() => []);
     const nexusQuery = queryClient
       .ensureQueryData(getNexusEventStatusOptions(params.eventKey))
       .catch(() => null);
 
     const event = await queryClient
-      .ensureQueryData(
-        getEventOptions({ path: { event_key: params.eventKey } }),
-      )
+      .ensureQueryData({
+        ...getEventOptions({ path: { event_key: params.eventKey } }),
+        staleTime: eventStaleTime,
+      })
       .catch(doThrowNotFound);
 
     // Greedily kick off parent/division event fetches so the dropdowns
     // render immediately and populate client-side as data arrives.
     if (event.parent_event_key) {
       void queryClient
-        .ensureQueryData(
-          getEventOptions({ path: { event_key: event.parent_event_key } }),
-        )
+        .ensureQueryData({
+          ...getEventOptions({ path: { event_key: event.parent_event_key } }),
+          staleTime: eventStaleTime,
+        })
         .then((parentEvent) => {
           // Also kick off sibling division fetches
           for (const key of parentEvent.division_keys) {
             if (key !== params.eventKey) {
               void queryClient
-                .ensureQueryData(
-                  getEventSimpleOptions({ path: { event_key: key } }),
-                )
+                .ensureQueryData({
+                  ...getEventSimpleOptions({ path: { event_key: key } }),
+                  staleTime: eventStaleTime,
+                })
                 .catch(() => undefined);
             }
           }
@@ -226,7 +237,10 @@ export const Route = createFileRoute('/event/$eventKey')({
     }
     for (const key of event.division_keys) {
       void queryClient
-        .ensureQueryData(getEventSimpleOptions({ path: { event_key: key } }))
+        .ensureQueryData({
+          ...getEventSimpleOptions({ path: { event_key: key } }),
+          staleTime: eventStaleTime,
+        })
         .catch(() => undefined);
     }
 
@@ -308,58 +322,74 @@ export const Route = createFileRoute('/event/$eventKey')({
 function EventPage() {
   const { eventKey } = Route.useLoaderData();
 
-  const { data: event } = useSuspenseQuery(
-    getEventOptions({ path: { event_key: eventKey } }),
-  );
+  // Event keys are prefixed with their 4-digit year (e.g. "2024mil").
+  const eventStaleTime = staleTimeForYear(Number(eventKey.slice(0, 4)));
 
-  const { data: matches } = useSuspenseQuery(
-    getEventMatchesOptions({ path: { event_key: eventKey } }),
-  );
+  const { data: event } = useSuspenseQuery({
+    ...getEventOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const { data: unsafeAlliances } = useSuspenseQuery(
-    getEventAlliancesOptions({ path: { event_key: eventKey } }),
-  );
+  const { data: matches } = useSuspenseQuery({
+    ...getEventMatchesOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
+
+  const { data: unsafeAlliances } = useSuspenseQuery({
+    ...getEventAlliancesOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
   const alliances = unsafeAlliances ?? [];
 
-  const awardsQuery = useQuery(
-    getEventAwardsOptions({ path: { event_key: eventKey } }),
-  );
+  const awardsQuery = useQuery({
+    ...getEventAwardsOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const coprsQuery = useQuery(
-    getEventCoprsOptions({ path: { event_key: eventKey } }),
-  );
+  const coprsQuery = useQuery({
+    ...getEventCoprsOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
   const colorsQuery = useQuery({
     queryKey: ['eventColors', eventKey],
     queryFn: () => getEventColors({ eventKey: eventKey }),
+    staleTime: eventStaleTime,
   });
 
-  const rankingsQuery = useQuery(
-    getEventRankingsOptions({ path: { event_key: eventKey } }),
-  );
+  const rankingsQuery = useQuery({
+    ...getEventRankingsOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const teamsQuery = useQuery(
-    getEventTeamsOptions({ path: { event_key: eventKey } }),
-  );
+  const teamsQuery = useQuery({
+    ...getEventTeamsOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const teamMediaQuery = useQuery(
-    getEventTeamMediaOptions({ path: { event_key: eventKey } }),
-  );
+  const teamMediaQuery = useQuery({
+    ...getEventTeamMediaOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const teamStatusesQuery = useQuery(
-    getEventTeamsStatusesOptions({ path: { event_key: eventKey } }),
-  );
+  const teamStatusesQuery = useQuery({
+    ...getEventTeamsStatusesOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const districtPointsQuery = useQuery(
-    getEventDistrictPointsOptions({ path: { event_key: eventKey } }),
-  );
+  const districtPointsQuery = useQuery({
+    ...getEventDistrictPointsOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
-  const regionalChampsPoolPointsQuery = useQuery(
-    getRegionalChampsPoolPointsOptions({ path: { event_key: eventKey } }),
-  );
+  const regionalChampsPoolPointsQuery = useQuery({
+    ...getRegionalChampsPoolPointsOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
 
   const regionalAdvancementQuery = useQuery({
     ...getRegionalAdvancementOptions({ path: { year: event.year } }),
+    staleTime: eventStaleTime,
     enabled: event.event_type === EventType.REGIONAL,
   });
 
@@ -368,6 +398,7 @@ function EventPage() {
     ...getEventOptions({
       path: { event_key: event.parent_event_key ?? '' },
     }),
+    staleTime: eventStaleTime,
     enabled: event.parent_event_key !== null,
   });
 
@@ -381,9 +412,10 @@ function EventPage() {
   );
 
   const siblingDivisionQueries = useQueries({
-    queries: siblingDivisionKeys.map((key) =>
-      getEventSimpleOptions({ path: { event_key: key } }),
-    ),
+    queries: siblingDivisionKeys.map((key) => ({
+      ...getEventSimpleOptions({ path: { event_key: key } }),
+      staleTime: eventStaleTime,
+    })),
   });
 
   const siblingEvents = siblingDivisionQueries
@@ -392,9 +424,10 @@ function EventPage() {
 
   // For parent events: fetch each division event
   const ownDivisionQueries = useQueries({
-    queries: event.division_keys.map((key) =>
-      getEventSimpleOptions({ path: { event_key: key } }),
-    ),
+    queries: event.division_keys.map((key) => ({
+      ...getEventSimpleOptions({ path: { event_key: key } }),
+      staleTime: eventStaleTime,
+    })),
   });
 
   const ownDivisionEvents = ownDivisionQueries

--- a/pwa/app/routes/team.$teamNumber.{-$year}.tsx
+++ b/pwa/app/routes/team.$teamNumber.{-$year}.tsx
@@ -76,6 +76,7 @@ import {
   getTeamsUnpenalizedHighScore,
 } from '~/lib/matchUtils';
 import { getEmbedMedia, getImageMedia } from '~/lib/mediaUtils';
+import { staleTimeForYear } from '~/lib/queryClient';
 import {
   MODEL_TYPE,
   addRecords,
@@ -102,11 +103,14 @@ export const Route = createFileRoute('/team/$teamNumber/{-$year}')({
       throw notFound();
     }
 
+    const yearStaleTime = staleTimeForYear(year);
+
     // spawn these now, we don't need to await them yet though
     const teamMediaQuery = queryClient
-      .ensureQueryData(
-        getTeamMediaByYearOptions({ path: { team_key: teamKey, year } }),
-      )
+      .ensureQueryData({
+        ...getTeamMediaByYearOptions({ path: { team_key: teamKey, year } }),
+        staleTime: yearStaleTime,
+      })
       .catch(() => []);
     const teamSocialsQuery = queryClient
       .ensureQueryData(
@@ -114,26 +118,30 @@ export const Route = createFileRoute('/team/$teamNumber/{-$year}')({
       )
       .catch(() => ({}));
     const teamMatchesQuery = queryClient
-      .ensureQueryData(
-        getTeamMatchesByYearOptions({ path: { team_key: teamKey, year } }),
-      )
+      .ensureQueryData({
+        ...getTeamMatchesByYearOptions({ path: { team_key: teamKey, year } }),
+        staleTime: yearStaleTime,
+      })
       .catch(() => []);
     const teamStatusesQuery = queryClient
-      .ensureQueryData(
-        getTeamEventsStatusesByYearOptions({
+      .ensureQueryData({
+        ...getTeamEventsStatusesByYearOptions({
           path: { team_key: teamKey, year },
         }),
-      )
+        staleTime: yearStaleTime,
+      })
       .catch(() => ({}));
     const teamAwardsQuery = queryClient
-      .ensureQueryData(
-        getTeamAwardsByYearOptions({ path: { team_key: teamKey, year } }),
-      )
+      .ensureQueryData({
+        ...getTeamAwardsByYearOptions({ path: { team_key: teamKey, year } }),
+        staleTime: yearStaleTime,
+      })
       .catch(() => []);
     const teamEventsQuery = queryClient
-      .ensureQueryData(
-        getTeamEventsByYearOptions({ path: { team_key: teamKey, year } }),
-      )
+      .ensureQueryData({
+        ...getTeamEventsByYearOptions({ path: { team_key: teamKey, year } }),
+        staleTime: yearStaleTime,
+      })
       .catch(() => []);
     const teamDistrictsQuery = queryClient
       .ensureQueryData(getTeamDistrictsOptions({ path: { team_key: teamKey } }))
@@ -247,31 +255,39 @@ export const Route = createFileRoute('/team/$teamNumber/{-$year}')({
 
 function TeamPage(): React.JSX.Element {
   const { teamKey, year } = Route.useLoaderData();
+  const yearStaleTime = staleTimeForYear(year);
 
   const { data: team } = useSuspenseQuery(
     getTeamOptions({ path: { team_key: teamKey } }),
   );
-  const { data: media } = useSuspenseQuery(
-    getTeamMediaByYearOptions({ path: { team_key: teamKey, year } }),
-  );
+  const { data: media } = useSuspenseQuery({
+    ...getTeamMediaByYearOptions({ path: { team_key: teamKey, year } }),
+    staleTime: yearStaleTime,
+  });
   const { data: socials } = useSuspenseQuery(
     getTeamSocialMediaOptions({ path: { team_key: teamKey } }),
   );
   const { data: yearsParticipated } = useSuspenseQuery(
     getTeamYearsParticipatedOptions({ path: { team_key: teamKey } }),
   );
-  const { data: events } = useSuspenseQuery(
-    getTeamEventsByYearOptions({ path: { team_key: teamKey, year } }),
-  );
-  const { data: matches } = useSuspenseQuery(
-    getTeamMatchesByYearOptions({ path: { team_key: teamKey, year } }),
-  );
-  const { data: statuses } = useSuspenseQuery(
-    getTeamEventsStatusesByYearOptions({ path: { team_key: teamKey, year } }),
-  );
-  const { data: awards } = useSuspenseQuery(
-    getTeamAwardsByYearOptions({ path: { team_key: teamKey, year } }),
-  );
+  const { data: events } = useSuspenseQuery({
+    ...getTeamEventsByYearOptions({ path: { team_key: teamKey, year } }),
+    staleTime: yearStaleTime,
+  });
+  const { data: matches } = useSuspenseQuery({
+    ...getTeamMatchesByYearOptions({ path: { team_key: teamKey, year } }),
+    staleTime: yearStaleTime,
+  });
+  const { data: statuses } = useSuspenseQuery({
+    ...getTeamEventsStatusesByYearOptions({
+      path: { team_key: teamKey, year },
+    }),
+    staleTime: yearStaleTime,
+  });
+  const { data: awards } = useSuspenseQuery({
+    ...getTeamAwardsByYearOptions({ path: { team_key: teamKey, year } }),
+    staleTime: yearStaleTime,
+  });
   const { data: districts } = useSuspenseQuery(
     getTeamDistrictsOptions({ path: { team_key: teamKey } }),
   );
@@ -282,6 +298,7 @@ function TeamPage(): React.JSX.Element {
     ...getDistrictRankingsOptions({
       path: { district_key: currentDistrict?.key ?? '' },
     }),
+    staleTime: yearStaleTime,
     enabled: !!currentDistrict,
   });
 
@@ -291,6 +308,7 @@ function TeamPage(): React.JSX.Element {
 
   const { data: regionalRankings } = useQuery({
     ...getRegionalRankingsOptions({ path: { year } }),
+    staleTime: yearStaleTime,
     enabled: !currentDistrict,
   });
 
@@ -304,6 +322,7 @@ function TeamPage(): React.JSX.Element {
 
   const { data: regionalAdvancement } = useQuery({
     ...getRegionalAdvancementOptions({ path: { year } }),
+    staleTime: yearStaleTime,
     enabled: hasRegionalEvents,
   });
 
@@ -319,6 +338,7 @@ function TeamPage(): React.JSX.Element {
   const eventDistrictPtsQueries = useQueries({
     queries: sortedEvents.map((e) => ({
       ...getEventDistrictPointsOptions({ path: { event_key: e.key } }),
+      staleTime: yearStaleTime,
       enabled: DISTRICT_EVENT_TYPES.has(e.event_type),
     })),
     combine: (results) =>
@@ -332,6 +352,7 @@ function TeamPage(): React.JSX.Element {
   const regionalPoolPtsQueries = useQueries({
     queries: sortedEvents.map((e) => ({
       ...getRegionalChampsPoolPointsOptions({ path: { event_key: e.key } }),
+      staleTime: yearStaleTime,
       enabled: e.event_type === EventType.REGIONAL,
     })),
     combine: (results) =>
@@ -343,9 +364,10 @@ function TeamPage(): React.JSX.Element {
       ),
   });
   const eventAlliancesQueries = useQueries({
-    queries: sortedEvents.map((e) =>
-      getEventAlliancesOptions({ path: { event_key: e.key } }),
-    ),
+    queries: sortedEvents.map((e) => ({
+      ...getEventAlliancesOptions({ path: { event_key: e.key } }),
+      staleTime: yearStaleTime,
+    })),
     combine: (results) =>
       Object.fromEntries(
         results.map((result, index) => [


### PR DESCRIPTION
TanStack Query had no default `staleTime`, so it defaulted to `0`. Every loader-warmed query was treated as instantly stale on hydration, causing pages like `/event/$eventKey` to immediately re-fetch ~15 requests for data the server had just sent.

- Added a global default `staleTime` of 60s (matching the API's `cache-control: max-age=61`), centralized in `app/lib/queryClient.ts`.
- Added a `staleTimeForYear()` helper that bumps historical (past-season) data to a 1h `staleTime`, since it's immutable. Applied to the event page, team-year page, and districts list page.
- Live-polling pages (e.g. district champs) are unaffected — `refetchInterval` runs independently of `staleTime`.
- Updated `pwa/README.md`'s caching section to document the actual policy.

Closes #10238.
