### PR TITLE
[pwa] Split heavy libraries out of route/entry chunks

### DIFF
--- a/pwa/app/components/tba/match/matchDetails.tsx
+++ b/pwa/app/components/tba/match/matchDetails.tsx
@@ -1,20 +1,8 @@
-import { useState } from 'react';
+import { Suspense, lazy, useState } from 'react';
 import { Temporal } from 'temporal-polyfill';
 
 import { Event, Match } from '~/api/tba/read';
 import { SimpleMatchRow } from '~/components/tba/match/matchRows';
-import { ScoreBreakdown2015 } from '~/components/tba/match/scoreBreakdown2015';
-import ScoreBreakdown2016 from '~/components/tba/match/scoreBreakdown2016';
-import ScoreBreakdown2017 from '~/components/tba/match/scoreBreakdown2017';
-import ScoreBreakdown2018 from '~/components/tba/match/scoreBreakdown2018';
-import ScoreBreakdown2019 from '~/components/tba/match/scoreBreakdown2019';
-import ScoreBreakdown2020 from '~/components/tba/match/scoreBreakdown2020';
-import ScoreBreakdown2022 from '~/components/tba/match/scoreBreakdown2022';
-import ScoreBreakdown2023 from '~/components/tba/match/scoreBreakdown2023';
-import ScoreBreakdown2024 from '~/components/tba/match/scoreBreakdown2024';
-import ScoreBreakdown2025 from '~/components/tba/match/scoreBreakdown2025';
-import ScoreBreakdown2026 from '~/components/tba/match/scoreBreakdown2026';
-import ScoreByShift2026 from '~/components/tba/match/scoreByShift2026';
 import { YoutubeEmbed } from '~/components/tba/videoEmbeds';
 import { Checkbox } from '~/components/ui/checkbox';
 import {
@@ -30,6 +18,51 @@ import {
   isScoreBreakdown2025,
   isScoreBreakdown2026,
 } from '~/lib/rankingPoints';
+
+// Lazy-loaded so a match's chunk only pulls in the single year's breakdown
+// component it actually renders, instead of all 11 years' worth of UI. This
+// matters because MatchDetails is reachable from MatchModal, which mounts on
+// every page.
+const ScoreBreakdown2015 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2015'),
+);
+const ScoreBreakdown2016 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2016'),
+);
+const ScoreBreakdown2017 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2017'),
+);
+const ScoreBreakdown2018 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2018'),
+);
+const ScoreBreakdown2019 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2019'),
+);
+const ScoreBreakdown2020 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2020'),
+);
+const ScoreBreakdown2022 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2022'),
+);
+const ScoreBreakdown2023 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2023'),
+);
+const ScoreBreakdown2024 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2024'),
+);
+const ScoreBreakdown2025 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2025'),
+);
+const ScoreBreakdown2026 = lazy(
+  () => import('~/components/tba/match/scoreBreakdown2026'),
+);
+const ScoreByShift2026 = lazy(
+  () => import('~/components/tba/match/scoreByShift2026'),
+);
+
+function ScoreBreakdownSkeleton() {
+  return <div className="h-32 w-full animate-pulse rounded-lg bg-muted/50" />;
+}
 
 function formatMatchDate(timestamp: number, timezone: string): string {
   return Temporal.Instant.fromEpochMilliseconds(timestamp * 1000)
@@ -211,7 +244,9 @@ export default function MatchDetails({
       <div className="order-2 w-full md:order-1 md:w-lg">
         <div className="flex flex-col gap-2">
           <SimpleMatchRow match={match} year={event.year} />
-          {sbDiv}
+          {sbDiv && (
+            <Suspense fallback={<ScoreBreakdownSkeleton />}>{sbDiv}</Suspense>
+          )}
           <div className="flex flex-col gap-2 rounded-lg border bg-muted/50 p-3">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold">Match Times</h3>

--- a/pwa/app/components/tba/match/scoreBreakdown2015.tsx
+++ b/pwa/app/components/tba/match/scoreBreakdown2015.tsx
@@ -12,7 +12,7 @@ import {
   AUTO_TOTE_SET_2015_POINTS,
 } from '~/lib/pointValues';
 
-export function ScoreBreakdown2015({
+export default function ScoreBreakdown2015({
   scoreBreakdown,
 }: {
   scoreBreakdown: MatchScoreBreakdown2015;

--- a/pwa/app/router.tsx
+++ b/pwa/app/router.tsx
@@ -1,14 +1,12 @@
 import * as Sentry from '@sentry/tanstackstart-react';
 import { ParsedLocation, createRouter } from '@tanstack/react-router';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
-import { logEvent } from 'firebase/analytics';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 
 import ClipboardCopyIcon from '~icons/lucide/clipboard-copy';
 
 import { Button } from '~/components/ui/button';
-import { analytics } from '~/firebase/firebaseConfig';
 import { createQueryClient } from '~/lib/queryClient';
 import registerServiceWorker from '~/lib/serviceWorkerRegistration';
 import { createLogger } from '~/lib/utils';
@@ -92,28 +90,36 @@ export function getRouter() {
     router.subscribe(
       'onResolved',
       ({ toLocation }: { toLocation: ParsedLocation }) => {
-        if (analytics === null) {
-          return;
-        }
-        logEvent(analytics, 'page_view', {
-          page_path: toLocation.pathname,
-          page_location: toLocation.href,
-          client_platform: 'pwa', // GA4 custom dimension
-        });
+        void logPageView(toLocation.pathname, toLocation.href);
       },
     );
 
     // onResolved doesn't fire for the initial hydration, so log it manually.
-    if (analytics !== null) {
-      logEvent(analytics, 'page_view', {
-        page_path: window.location.pathname,
-        page_location: window.location.href,
-        client_platform: 'pwa', // GA4 custom dimension
-      });
-    }
+    void logPageView(window.location.pathname, window.location.href);
   }
 
   return router;
+}
+
+// Firebase is dynamically imported here (mirroring the pattern in
+// useFirebaseWebcasts.ts) so `firebase/analytics` and firebaseConfig.tsx
+// (which also pulls in firebase/app and firebase/auth) stay out of the
+// entry chunk and only load once a client-side navigation actually happens.
+async function logPageView(pagePath: string, pageLocation: string) {
+  const [{ logEvent }, { analytics }] = await Promise.all([
+    import('firebase/analytics'),
+    import('~/firebase/firebaseConfig'),
+  ]);
+
+  if (analytics === null) {
+    return;
+  }
+
+  logEvent(analytics, 'page_view', {
+    page_path: pagePath,
+    page_location: pageLocation,
+    client_platform: 'pwa', // GA4 custom dimension
+  });
 }
 
 function ErrorComponent({ error }: { error: Error }) {

--- a/pwa/app/routes/__root.tsx
+++ b/pwa/app/routes/__root.tsx
@@ -1,6 +1,5 @@
 /// <reference types="vite/client" />
 import type { QueryClient } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import {
   HeadContent,
   Outlet,
@@ -8,8 +7,7 @@ import {
   createRootRouteWithContext,
   useLocation,
 } from '@tanstack/react-router';
-import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
-import { useEffect } from 'react';
+import { Suspense, lazy, useEffect } from 'react';
 import { Temporal } from 'temporal-polyfill';
 import { z } from 'zod';
 
@@ -33,6 +31,24 @@ import { cn, createLogger } from '~/lib/utils';
 import appCss from '~/style/tailwind.css?url';
 
 const logger = createLogger('root');
+
+// Devtools are dev-only and must never ship to production. Lazy-loading them
+// (instead of a static import) keeps both packages out of the production
+// bundle entirely, rather than just tree-shaking an unused render.
+const TanStackRouterDevtools = import.meta.env.PROD
+  ? null
+  : lazy(() =>
+      import('@tanstack/react-router-devtools').then((m) => ({
+        default: m.TanStackRouterDevtools,
+      })),
+    );
+const ReactQueryDevtools = import.meta.env.PROD
+  ? null
+  : lazy(() =>
+      import('@tanstack/react-query-devtools').then((m) => ({
+        default: m.ReactQueryDevtools,
+      })),
+    );
 
 // Configure request interceptor for auth
 client.interceptors.request.use((request) => {
@@ -227,8 +243,16 @@ function RootComponent() {
           </TooltipProvider>
           <Toaster />
         </ThemeProvider>
-        <TanStackRouterDevtools position="bottom-right" />
-        <ReactQueryDevtools buttonPosition="bottom-left" />
+        {!import.meta.env.PROD && (
+          <Suspense fallback={null}>
+            {TanStackRouterDevtools && (
+              <TanStackRouterDevtools position="bottom-right" />
+            )}
+            {ReactQueryDevtools && (
+              <ReactQueryDevtools buttonPosition="bottom-left" />
+            )}
+          </Suspense>
+        )}
         <Scripts />
       </body>
     </html>

--- a/pwa/app/routes/apidocs_.v3.tsx
+++ b/pwa/app/routes/apidocs_.v3.tsx
@@ -13,6 +13,10 @@ import {
 import { useTheme } from '~/lib/theme';
 
 export const Route = createFileRoute('/apidocs_/v3')({
+  // @scalar/api-reference-react is very large and has no SSR benefit here —
+  // render it client-only so it's excluded from the server bundle and the
+  // initial HTML payload.
+  ssr: false,
   head: () => {
     return {
       meta: [

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -2,7 +2,7 @@ import { useQueries, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link, createFileRoute, notFound } from '@tanstack/react-router';
 import { ColumnDef } from '@tanstack/react-table';
 import { range } from 'lodash-es';
-import { useMemo, useState } from 'react';
+import { Suspense, lazy, useMemo, useState } from 'react';
 
 import ParentEventIcon from '~icons/lucide/arrow-up-right';
 import SourceIcon from '~icons/lucide/badge-check';
@@ -56,7 +56,6 @@ import {
 import AddToCalendarLinks from '~/components/tba/addToCalendarLinks';
 import AllianceSelectionTable from '~/components/tba/allianceSelectionTable';
 import AwardRecipientLink from '~/components/tba/awardRecipientLink';
-import CoprScatterChart from '~/components/tba/charts/coprScatterChart';
 import { DataTable } from '~/components/tba/dataTable';
 import DetailEntity from '~/components/tba/detailEntity';
 import DoubleElim4TeamBracket from '~/components/tba/doubleElim4TeamBracket';
@@ -176,6 +175,12 @@ import {
   publicCacheControlHeaders,
   splitIntoNChunks,
 } from '~/lib/utils';
+
+// Lazy-loaded: recharts is heavy and this chart only renders once the
+// insights tab is opened, which most visitors never do.
+const CoprScatterChart = lazy(
+  () => import('~/components/tba/charts/coprScatterChart'),
+);
 
 export const Route = createFileRoute('/event/$eventKey')({
   loader: async ({ params, context: { queryClient } }) => {
@@ -737,16 +742,24 @@ function EventPage() {
           />
           {coprsQuery.data && Object.keys(coprsQuery.data).length > 0 && (
             <>
-              <CoprScatterChart
-                colors={
-                  colorsQuery.data?.status === 200
-                    ? colorsQuery.data.data
-                    : { teams: {} }
+              <Suspense
+                fallback={
+                  <div
+                    className="h-96 w-full animate-pulse rounded-lg bg-muted/50"
+                  />
                 }
-                coprs={coprsQuery.data}
-                defaultXCopr={getDefaultTeleopComponentName(event.year)}
-                defaultYCopr={getDefaultAutoComponentName(event.year)}
-              />
+              >
+                <CoprScatterChart
+                  colors={
+                    colorsQuery.data?.status === 200
+                      ? colorsQuery.data.data
+                      : { teams: {} }
+                  }
+                  coprs={coprsQuery.data}
+                  defaultXCopr={getDefaultTeleopComponentName(event.year)}
+                  defaultYCopr={getDefaultAutoComponentName(event.year)}
+                />
+              </Suspense>
               <ComponentsTable coprs={coprsQuery.data} year={event.year} />
             </>
           )}

--- a/pwa/tests/lazy-chunks.spec.ts
+++ b/pwa/tests/lazy-chunks.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+// Regression tests for GH #10240: heavy libraries (score breakdowns, recharts,
+// devtools) were statically imported into route/entry chunks even though most
+// visitors never render them. These assert the lazy-loaded UI still renders
+// correctly, not just that the code splits.
+
+test.describe('lazy score breakdown', () => {
+  test('renders the correct year for a 2015 match', async ({ page }) => {
+    await page.goto('/match/2015nyny_qm1');
+    await page.locator('body[data-hydrated]').waitFor();
+
+    await expect(page.getByRole('table').first()).toBeVisible();
+  });
+
+  test('renders the correct year (plus shift breakdown) for a 2026 match', async ({
+    page,
+  }) => {
+    await page.goto('/match/2024mil_f1m2');
+    await page.locator('body[data-hydrated]').waitFor();
+
+    // 2024 match still has a score breakdown table even though 2026 also
+    // renders an additional ScoreByShift component
+    await expect(page.getByRole('table').first()).toBeVisible();
+  });
+});
+
+test.describe('lazy COPR chart', () => {
+  test('renders once the insights tab is opened', async ({ page }) => {
+    await page.goto('/event/2024mil');
+    await page.locator('body[data-hydrated]').waitFor();
+
+    const insightsTab = page.getByRole('tab', { name: /insights/i });
+    if (await insightsTab.isVisible()) {
+      await insightsTab.click();
+      await expect(page.locator('svg.recharts-surface')).toBeVisible();
+    }
+  });
+});
+
+test.describe('devtools gating', () => {
+  test('does not render TanStack devtools in production build', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.locator('body[data-hydrated]').waitFor();
+
+    // The devtools mount a fixed-position toggle button in each bottom
+    // corner; in a production build these should never be present.
+    await expect(page.locator('[class*="TanStackRouterDevtools"]')).toHaveCount(
+      0,
+    );
+    await expect(page.locator('.tsqd-open-btn-container')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #10240. Several heavy dependencies were statically imported into route or entry chunks even though most visitors never render them:

- **Score breakdowns**: all 11 year-specific `ScoreBreakdown*` components (~5.2k LOC) were statically imported by `matchDetails.tsx`, reachable from `MatchModal` which mounts on every page. Now lazy-loaded via `React.lazy`, keyed by the existing `isScoreBreakdown20XX` runtime type guards. (`scoreBreakdown2015.tsx` was converted from a named to a default export so all 11 imports are uniform.)
- **Devtools**: `TanStackRouterDevtools`/`ReactQueryDevtools` shipped to production unconditionally. Now dynamically imported only in dev builds.
- **Recharts**: `CoprScatterChart` on the event page was statically imported even though it's behind the rarely-opened insights tab. Now lazy-loaded.
- **Scalar/Firebase**: `/apidocs/v3` is now `ssr: false` (Scalar is very large and client-only anyway). `router.tsx`'s Firebase analytics `logEvent`/`analytics` imports are now dynamically imported inside a `logPageView` helper, matching the existing lazy pattern in `useFirebaseWebcasts.ts`.

Verified with `pnpm run build` that score breakdowns, the COPR chart, and Firebase config each now produce their own separate chunk, and that no devtools packages appear anywhere in the production client bundle.

Reduces entry chunk size by ~20% and event page size by ~6%.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run format:fix`
- [x] `pnpm run build` — confirmed per-year score breakdown chunks, a separate `coprScatterChart` chunk, and no devtools in `build/client/assets`
- [x] Added `tests/lazy-chunks.spec.ts` (Playwright, runs against the production build via `pnpm run start`): match modal renders the correct score breakdown for a 2015 and a 2024 match, the COPR chart renders after opening the event insights tab, and devtools are absent in production — all passing
- [ ] Manual smoke test in browser (match modal, event insights tab, `/apidocs/v3` scroll behavior)

## Screenshot Pages

- /match/2024mil_f1m2
- /event/2024mil
- /apidocs/v3