### PR TITLE
[pwa] Resolve /status once in root beforeLoad, not per-route

### DIFF
--- a/pwa/README.md
+++ b/pwa/README.md
@@ -146,6 +146,11 @@ The policy is centralized in `app/lib/queryClient.ts` and applied via `createQue
   default for the current year. Applied today on the event page (`event.$eventKey.tsx`), the
   team-year page (`team.$teamNumber.{-$year}.tsx`), and the districts list page
   (`districts.{-$year}.tsx`); other year-scoped routes still inherit the 60s default.
+- **`/status`: `staleTime: STALE_TIME.STATUS`** (6h) — `/status` gates the default year/page-size
+  params for most of the site (`current_season`, `max_season`, `max_team_page`), so instead of
+  every route independently awaiting it, the root route's `beforeLoad` (`app/routes/__root.tsx`)
+  resolves it once per navigation and exposes `status`/`currentSeason` on router context for every
+  child loader to read. The long `staleTime` means this is a cache read after the first hit.
 - **Live data keeps its own `staleTime`/`refetchInterval`** and is unaffected by the above — e.g.
   the district champs page (`district.$districtAbbreviation.champs.$year.tsx`) polls on a
   `refetchInterval` independent of `staleTime`, and Nexus/Firebase-backed queries

--- a/pwa/app/lib/queryClient.test.ts
+++ b/pwa/app/lib/queryClient.test.ts
@@ -17,6 +17,12 @@ describe.concurrent('createQueryClient', () => {
     );
   });
 
+  test('STALE_TIME.STATUS is longer than STALE_TIME.HISTORICAL', () => {
+    // /status changes at most a few times a year, so it should be held even
+    // longer than "historical" (immutable past season) data.
+    expect(STALE_TIME.STATUS).toBeGreaterThan(STALE_TIME.HISTORICAL);
+  });
+
   test('retry predicate skips 4xx ApiErrors', () => {
     const queryClient = createQueryClient();
     const retry = queryClient.getDefaultOptions().queries?.retry;

--- a/pwa/app/lib/queryClient.ts
+++ b/pwa/app/lib/queryClient.ts
@@ -15,8 +15,15 @@ import { ApiError } from '~/lib/apiError';
  * `HISTORICAL` is for data that cannot change: a past season's events, team-years,
  * districts, etc. are immutable, so they can hold far longer than the default.
  *
- * Live data (in-progress matches, rankings, `/status`) should NOT use either tier —
- * it should keep a low `staleTime` (or the `DEFAULT`) alongside an explicit
+ * `STATUS` is for `/status`, specifically the `current_season` / `max_season` /
+ * `max_team_page` fields the PWA reads from it to pick default years and page bounds.
+ * Those flip only a handful of times a year, so `/status` is fetched once (see the
+ * root route's `beforeLoad`) and held for hours rather than re-awaited by every
+ * route. `is_datafeed_down` / `down_events` are not consumed by these call sites, so
+ * a long `staleTime` here doesn't risk showing stale outage banners.
+ *
+ * Live data (in-progress matches, rankings) should NOT use any of the above — it
+ * should keep a low `staleTime` (or the `DEFAULT`) alongside an explicit
  * `refetchInterval`, which fires independent of `staleTime`.
  */
 export const STALE_TIME = {
@@ -24,6 +31,8 @@ export const STALE_TIME = {
   DEFAULT: 60_000,
   /** 1h — for data that is known to be immutable (past seasons). */
   HISTORICAL: 60 * 60 * 1000,
+  /** 6h — for `/status`, which changes at most a few times a year. */
+  STATUS: 6 * 60 * 60 * 1000,
 } as const;
 
 /**
@@ -31,9 +40,9 @@ export const STALE_TIME = {
  *
  * Past calendar years are immutable regardless of the current FRC season, so this
  * is a pure calendar comparison — deliberately independent of the `/status` API's
- * `current_season`, which is already a serialization bottleneck gating several
- * routes. Reusing the same `Temporal.Now.plainDateISO().year` pattern already used
- * elsewhere in the app (e.g. `app/routes/index.tsx`) as the current-year fallback.
+ * `current_season` (resolved once in the root route's `beforeLoad`, see
+ * `app/routes/__root.tsx`). Reusing the same `Temporal.Now.plainDateISO().year`
+ * pattern already used elsewhere in the app as the current-year fallback.
  */
 export function staleTimeForYear(year: number): number {
   return year < Temporal.Now.plainDateISO().year

--- a/pwa/app/lib/utils.test.ts
+++ b/pwa/app/lib/utils.test.ts
@@ -4,10 +4,42 @@ import {
   camelCaseToHumanReadable,
   hasAnyMatches,
   median,
+  parseParamsForYearElseDefault,
   removeNonNumeric,
   slugify,
   splitIntoNChunks,
 } from '~/lib/utils';
+
+describe.concurrent('parseParamsForYearElseDefault', () => {
+  const currentSeason = 2026;
+
+  test('returns currentSeason when no year param is given', () => {
+    expect(parseParamsForYearElseDefault(currentSeason, {})).toEqual(
+      currentSeason,
+    );
+  });
+
+  test('parses a valid year param', () => {
+    expect(
+      parseParamsForYearElseDefault(currentSeason, { year: '2015' }),
+    ).toEqual(2015);
+  });
+
+  test('returns undefined for a non-numeric year param', () => {
+    expect(
+      parseParamsForYearElseDefault(currentSeason, { year: 'not-a-year' }),
+    ).toBeUndefined();
+  });
+
+  test('returns undefined for a non-positive year param', () => {
+    expect(
+      parseParamsForYearElseDefault(currentSeason, { year: '0' }),
+    ).toBeUndefined();
+    expect(
+      parseParamsForYearElseDefault(currentSeason, { year: '-5' }),
+    ).toBeUndefined();
+  });
+});
 
 describe.concurrent('removeNonNumeric', () => {
   test('basic', () => {

--- a/pwa/app/lib/utils.tsx
+++ b/pwa/app/lib/utils.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import { type ClassValue, clsx } from 'clsx';
 import pino from 'pino';
@@ -9,9 +9,13 @@ import { Temporal } from 'temporal-polyfill';
 import { WltRecord } from '~/api/tba/read';
 import { getStatusOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import { RequestResult } from '~/api/tba/read/client';
+import { STALE_TIME } from '~/lib/queryClient';
 
 export function useValidYears() {
-  const { data: status } = useSuspenseQuery(getStatusOptions({}));
+  const { data: status } = useSuspenseQuery({
+    ...getStatusOptions({}),
+    staleTime: STALE_TIME.STATUS,
+  });
   return Array.from(
     { length: status.max_season - 1992 + 1 },
     (_, i) => status.max_season - i,
@@ -45,15 +49,14 @@ export function slugify(str: string): string {
     .replace(/-+$/, '');
 }
 
-export async function parseParamsForYearElseDefault(
-  queryClient: QueryClient,
+export function parseParamsForYearElseDefault(
+  currentSeason: number,
   params: {
     year?: string | undefined;
   },
-): Promise<number | undefined> {
+): number | undefined {
   if (params.year === undefined) {
-    const status = await queryClient.ensureQueryData(getStatusOptions({}));
-    return status.current_season;
+    return currentSeason;
   }
 
   const year = Number(params.year);

--- a/pwa/app/routes/__root.tsx
+++ b/pwa/app/routes/__root.tsx
@@ -14,6 +14,7 @@ import { Temporal } from 'temporal-polyfill';
 import { z } from 'zod';
 
 import { client as mobileClient } from '~/api/tba/mobile/client.gen';
+import { getStatusOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import { client } from '~/api/tba/read/client.gen';
 import { AuthContextProvider } from '~/components/tba/auth/auth';
 import { MatchModal } from '~/components/tba/match/matchModal';
@@ -26,6 +27,7 @@ import appleTouchIcon180 from '~/images/apple-splash/apple-touch-icon-180.png?ur
 import { ApiError } from '~/lib/apiError';
 import { APPLE_SPLASH_STARTUP_LINKS } from '~/lib/appleSplashLinks';
 import { createCachedFetch } from '~/lib/middleware/network-cache';
+import { STALE_TIME } from '~/lib/queryClient';
 import { ThemeProvider } from '~/lib/theme';
 import { cn, createLogger } from '~/lib/utils';
 import appCss from '~/style/tailwind.css?url';
@@ -83,6 +85,20 @@ export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
 }>()({
   validateSearch: rootSearchSchema,
+  // `/status` gates the default year/page-size params for most of the site
+  // (see app/lib/queryClient.ts's STALE_TIME.STATUS doc comment), so it's
+  // resolved once here rather than independently by every route loader. With
+  // STALE_TIME.STATUS this is a cache read after the first navigation.
+  beforeLoad: async ({ context: { queryClient } }) => {
+    const status = await queryClient.ensureQueryData({
+      ...getStatusOptions({}),
+      staleTime: STALE_TIME.STATUS,
+    });
+    return {
+      status,
+      currentSeason: status.current_season ?? Temporal.Now.plainDateISO().year,
+    };
+  },
   loader: () => ({
     renderTime: Temporal.Now.zonedDateTimeISO().toLocaleString('en-US', {
       month: 'short',

--- a/pwa/app/routes/district.$districtAbbreviation.champs.$year.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.champs.$year.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Temporal } from 'temporal-polyfill';
 
 import { type EventColors, getEventColors } from '~/api/colors';
 import {
@@ -24,7 +23,6 @@ import {
   getEventMatchesOptions,
   getEventRankingsOptions,
   getEventsByYearOptions,
-  getStatusOptions,
 } from '~/api/tba/read/@tanstack/react-query.gen';
 import { EventLink, MatchLink, TeamLink } from '~/components/tba/links';
 import { YearSelector } from '~/components/tba/yearSelector';
@@ -46,7 +44,7 @@ const REFETCH_INTERVAL = 60_000;
 export const Route = createFileRoute(
   '/district/$districtAbbreviation/champs/$year',
 )({
-  loader: async ({ params, context: { queryClient } }) => {
+  loader: async ({ params, context: { queryClient, currentSeason } }) => {
     const history = await queryClient.ensureQueryData(
       getDistrictHistoryOptions({
         path: { district_abbreviation: params.districtAbbreviation },
@@ -63,9 +61,6 @@ export const Route = createFileRoute(
     }
 
     const displayName = history[history.length - 1].display_name;
-    const status = await queryClient.ensureQueryData(getStatusOptions({}));
-    const currentSeason =
-      status?.current_season ?? Temporal.Now.plainDateISO().year;
 
     return {
       abbreviation: params.districtAbbreviation,

--- a/pwa/app/routes/district.$districtAbbreviation.{-$year}.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.{-$year}.tsx
@@ -52,8 +52,8 @@ import {
 export const Route = createFileRoute(
   '/district/$districtAbbreviation/{-$year}',
 )({
-  loader: async ({ params, context: { queryClient } }) => {
-    const year = await parseParamsForYearElseDefault(queryClient, params);
+  loader: async ({ params, context: { currentSeason } }) => {
+    const year = parseParamsForYearElseDefault(currentSeason, params);
     if (year === undefined) {
       throw notFound();
     }

--- a/pwa/app/routes/districts.{-$year}.tsx
+++ b/pwa/app/routes/districts.{-$year}.tsx
@@ -24,8 +24,8 @@ import {
 } from '~/lib/utils';
 
 export const Route = createFileRoute('/districts/{-$year}')({
-  loader: async ({ params, context: { queryClient } }) => {
-    const year = await parseParamsForYearElseDefault(queryClient, params);
+  loader: async ({ params, context: { queryClient, currentSeason } }) => {
+    const year = parseParamsForYearElseDefault(currentSeason, params);
     if (year === undefined) {
       throw notFound();
     }

--- a/pwa/app/routes/events.{-$year}.tsx
+++ b/pwa/app/routes/events.{-$year}.tsx
@@ -46,8 +46,8 @@ export const Route = createFileRoute('/events/{-$year}')({
       });
     }
   },
-  loader: async ({ params, context: { queryClient } }) => {
-    const year = await parseParamsForYearElseDefault(queryClient, params);
+  loader: async ({ params, context: { queryClient, currentSeason } }) => {
+    const year = parseParamsForYearElseDefault(currentSeason, params);
     if (year === undefined) {
       throw notFound();
     }

--- a/pwa/app/routes/index.tsx
+++ b/pwa/app/routes/index.tsx
@@ -1,24 +1,15 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Temporal } from 'temporal-polyfill';
 
-import {
-  getEventsByYearOptions,
-  getStatusOptions,
-} from '~/api/tba/read/@tanstack/react-query.gen';
+import { getEventsByYearOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import EventListTable from '~/components/tba/eventListTable';
 import { getCurrentWeekEvents } from '~/lib/eventUtils';
 import { publicCacheControlHeaders } from '~/lib/utils';
 
 export const Route = createFileRoute('/')({
-  loader: async ({ context: { queryClient } }) => {
-    const status = await queryClient.ensureQueryData(getStatusOptions({}));
+  loader: async ({ context: { queryClient, currentSeason } }) => {
     await queryClient.ensureQueryData(
-      getEventsByYearOptions({
-        path: {
-          year: status?.current_season ?? Temporal.Now.plainDateISO().year,
-        },
-      }),
+      getEventsByYearOptions({ path: { year: currentSeason } }),
     );
   },
   headers: publicCacheControlHeaders(),
@@ -26,13 +17,9 @@ export const Route = createFileRoute('/')({
 });
 
 function Home() {
-  const { data: status } = useSuspenseQuery(getStatusOptions({}));
+  const { currentSeason } = Route.useRouteContext();
   const { data: events } = useSuspenseQuery(
-    getEventsByYearOptions({
-      path: {
-        year: status?.current_season ?? Temporal.Now.plainDateISO().year,
-      },
-    }),
+    getEventsByYearOptions({ path: { year: currentSeason } }),
   );
   const weekEvents = getCurrentWeekEvents(events);
 

--- a/pwa/app/routes/team.$teamNumber.{-$year}.tsx
+++ b/pwa/app/routes/team.$teamNumber.{-$year}.tsx
@@ -90,10 +90,10 @@ import {
 } from '~/lib/utils';
 
 export const Route = createFileRoute('/team/$teamNumber/{-$year}')({
-  loader: async ({ params, context: { queryClient } }) => {
+  loader: async ({ params, context: { queryClient, currentSeason } }) => {
     const startTime = Temporal.Now.instant().epochMilliseconds;
     const teamKey = `frc${params.teamNumber}`;
-    const year = await parseParamsForYearElseDefault(queryClient, params);
+    const year = parseParamsForYearElseDefault(currentSeason, params);
 
     Sentry.metrics.count('team.page.view', 1, {
       attributes: { team_number: params.teamNumber, year },

--- a/pwa/app/routes/teams.{-$pgNum}.tsx
+++ b/pwa/app/routes/teams.{-$pgNum}.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router';
 
 import { getTeamsSimple } from '~/api/tba/read';
-import { getStatusOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import FavoriteTeamsSection from '~/components/tba/favoriteTeamsSection';
 import TeamListTable from '~/components/tba/teamListTable';
 import {
@@ -17,9 +16,7 @@ import {
 } from '~/lib/utils';
 
 export const Route = createFileRoute('/teams/{-$pgNum}')({
-  loader: async ({ params, context: { queryClient } }) => {
-    const status = await queryClient.ensureQueryData(getStatusOptions({}));
-
+  loader: async ({ params, context: { status } }) => {
     const maxPageNum = Math.floor(status.max_team_page / 2) + 1;
     const pageNum = parseParamsForTeamPgNumElseDefault(params, maxPageNum);
 

--- a/pwa/app/routes/webcasts.tsx
+++ b/pwa/app/routes/webcasts.tsx
@@ -4,10 +4,7 @@ import { useMemo } from 'react';
 import { Temporal } from 'temporal-polyfill';
 
 import { Event } from '~/api/tba/read';
-import {
-  getEventsByYearOptions,
-  getStatusOptions,
-} from '~/api/tba/read/@tanstack/react-query.gen';
+import { getEventsByYearOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import { EventLink, EventLocationLink } from '~/components/tba/links';
 import { WebcastIcon } from '~/components/tba/socialBadges';
 import { Badge } from '~/components/ui/badge';
@@ -22,15 +19,12 @@ import { getEventDateString, getEventWeekString } from '~/lib/eventUtils';
 import { publicCacheControlHeaders } from '~/lib/utils';
 
 export const Route = createFileRoute('/webcasts')({
-  loader: async ({ context: { queryClient } }) => {
-    const status = await queryClient.ensureQueryData(getStatusOptions());
-    const year = status.current_season;
-
+  loader: async ({ context: { queryClient, currentSeason } }) => {
     await queryClient.ensureQueryData(
-      getEventsByYearOptions({ path: { year } }),
+      getEventsByYearOptions({ path: { year: currentSeason } }),
     );
 
-    return { year };
+    return { year: currentSeason };
   },
   headers: publicCacheControlHeaders(),
   head: () => ({


### PR DESCRIPTION
## Summary
- \`/status\` gates the default year/page-size params for most of the site (\`current_season\`, \`max_season\`, \`max_team_page\`), but was independently awaited by ~4 route loaders plus two shared helpers, each blocking its own round trip — so it sat on the critical path of nearly every navigation.
- Hoist \`/status\` into the root route's \`beforeLoad\` so it resolves once per navigation and is exposed via router context (\`status\`, \`currentSeason\`) for every child loader to read synchronously, instead of re-fetching.
- Add a dedicated \`STALE_TIME.STATUS\` tier (6h) since \`current_season\`/\`max_season\`/\`max_team_page\` change only a handful of times a year, so the \`beforeLoad\` await is a cache read after the first hit.
- \`parseParamsForYearElseDefault\` becomes a synchronous function of \`currentSeason\` instead of an async \`QueryClient\`-fetching helper, cutting its own redundant \`/status\` await from 6 route loaders (\`index\`, \`webcasts\`, \`teams\`, \`district…champs\`, \`events\`, \`districts\`, \`district.$abbr\`, \`team.$teamNumber\`). The district-champs \`Promise.all\` fix suggested in the issue is superseded — that loader now has only one await left.

Fixes #10242.

## Test plan
- [x] \`pnpm run typecheck\`, \`pnpm run lint\`, \`pnpm run format\` all pass
- [x] Unit tests pass (321 tests, incl. 2 new tests for \`STALE_TIME.STATUS\` and \`parseParamsForYearElseDefault\`)
- [x] Verified live via dev server + Playwright: \`/\`, \`/webcasts\`, \`/teams\`, \`/events\`, \`/team/254/2024\`, \`/district/fim/champs/2024\` all render correctly with real data
- [x] Confirmed via server logs that \`/status\` is fetched exactly once per navigation (root \`beforeLoad\`) rather than redundantly per route/helper

## Screenshot Pages

- /
- /webcasts
- /teams
- /events
- /team/254/2024
- /district/fim/champs/2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)