### PR TITLE
[pwa] Clean up lru cache logic + logging

### DIFF
--- a/pwa/README.md
+++ b/pwa/README.md
@@ -115,21 +115,26 @@ With all that said... There are various levels of caching available when making 
    - This is best done by utilizing a combination of `cache-control`, `etag`, or other headers (like [`Expires`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Expires), [`Last-Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Last-Modified), or [`If-Modified-Since`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Modified-Since)).
    - All major browsers will automatically & intelligently obey all of the caching-related headers I mentioned above (except the Cloudflare one, which is proprietary).
    - Most Node.js `fetch()` implementations don't automatically do this (some do, like [Undici](https://github.com/nodejs/undici))
-2. TanStack Query cache layer
+2. **SSR network LRU** (`app/lib/middleware/network-cache.ts`)
+   - Server-only transport cache under the hey-api TBA client (`client.setConfig` in `__root.tsx` installs it only when `typeof window === 'undefined'`).
+   - Reduces duplicate upstream API calls during SSR on a given Node process. TTL comes from the response `Cache-Control: max-age` (61s fallback).
+   - Shared across users on that process — safe because TBA read data is public and we use one shared `X-TBA-Auth-Key`. The browser must **not** get a second LRU underneath React Query.
+3. TanStack Query cache layer
    - This is a library that effectively wraps `fetch()` into a more state-management oriented philosophy
    - There are a [_lot_ of docs](https://tanstack.com/query/latest) on this
-3. TanStack Router cache layer
+   - Client freshness is owned here via `staleTime` (see below) — not by the SSR network LRU
+4. TanStack Router cache layer
    - Router caches `loader` data _per-route_ for us automatically
    - [Docs here](https://tanstack.com/router/v1/docs/framework/react/guide/data-loading)
    - Anything that is cached on the server is JSON-ified and sent to the client. So a larger server cache implies a slower first paint.
-4. Cache the entire html response
+5. Cache the entire html response
    - This is what the prod site does
    - But TanStack Router / React don't support this extremely well out of the box
 
 ### `staleTime` policy
 
-TanStack Query is the cache that matters most for perceived freshness — the other
-layers above are transport optimizations underneath it. `staleTime` defaults to `0`
+TanStack Query is the cache that matters most for perceived freshness on the client —
+the SSR network LRU above is a transport optimization for the Node process only. `staleTime` defaults to `0`
 in TanStack Query, which means data is considered stale the instant it arrives; left
 unset, this caused every `useSuspenseQuery` to refetch immediately on hydration, even
 though the server had just sent the same data moments earlier.

--- a/pwa/app/lib/middleware/network-cache.test.ts
+++ b/pwa/app/lib/middleware/network-cache.test.ts
@@ -1,16 +1,29 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   clearCache,
   createCachedFetch,
+  getCacheEntries,
   getCacheStats,
 } from '~/lib/middleware/network-cache';
 
 describe('Network Cache Middleware', () => {
+  let originalWindow: typeof globalThis.window;
+
   beforeEach(() => {
     clearCache();
     vi.clearAllMocks();
+    originalWindow = global.window;
   });
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  function mockServerEnvironment() {
+    // @ts-expect-error - mocking window
+    delete global.window;
+  }
 
   it('should create a cached fetch function', () => {
     const cachedFetch = createCachedFetch();
@@ -18,7 +31,6 @@ describe('Network Cache Middleware', () => {
   });
 
   it('should cache GET requests on server side', async () => {
-    // Mock fetch - return fresh Response on each call
     const mockFetch = vi.fn().mockImplementation(() =>
       Promise.resolve(
         new Response(JSON.stringify({ data: 'test' }), {
@@ -28,30 +40,20 @@ describe('Network Cache Middleware', () => {
       ),
     );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
-
     const url = 'https://api.example.com/data';
 
-    // First request - should hit network
     const response1 = await cachedFetch(url);
     const data1 = await response1.text();
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(data1).toBe('{"data":"test"}');
 
-    // Second request - should use cache
     const response2 = await cachedFetch(url);
     const data2 = await response2.text();
-    expect(mockFetch).toHaveBeenCalledTimes(1); // Still 1, not 2
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(data2).toBe('{"data":"test"}');
-
-    // Restore window
-    global.window = originalWindow;
   });
 
   it('should not cache non-GET requests', async () => {
@@ -64,27 +66,18 @@ describe('Network Cache Middleware', () => {
       ),
     );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
-
     const url = 'https://api.example.com/data';
 
-    // POST request - should not cache
     await cachedFetch(url, { method: 'POST' });
     await cachedFetch(url, { method: 'POST' });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // Restore window
-    global.window = originalWindow;
   });
 
-  it('should skip cache on client side', async () => {
+  it('should skip cache on client side and not grow the LRU', async () => {
     const mockFetch = vi
       .fn()
       .mockImplementation(() =>
@@ -92,58 +85,81 @@ describe('Network Cache Middleware', () => {
       );
     global.fetch = mockFetch;
 
-    // Ensure window is defined (client side)
-    const originalWindow = global.window;
     if (!global.window) {
       // @ts-expect-error - mocking window
       global.window = {};
     }
 
     const cachedFetch = createCachedFetch();
-
     const url = 'https://api.example.com/data';
 
     await cachedFetch(url);
     await cachedFetch(url);
 
-    // Should call fetch both times (no caching on client)
     expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // Restore window
-    global.window = originalWindow;
+    expect(getCacheStats().size).toBe(0);
   });
 
-  it('should respect global TTL and expire old entries', async () => {
-    const mockFetch = vi
-      .fn()
-      .mockImplementation(() =>
-        Promise.resolve(new Response('test', { status: 200 })),
-      );
+  it('should respect Cache-Control max-age for TTL', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response('cached-body', {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'public, max-age=1',
+          },
+        }),
+      ),
+    );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
+    const url = 'https://api.example.com/max-age-test';
 
-    const url = 'https://api.example.com/data-ttl-test';
-
-    // First request
     await cachedFetch(url);
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Second request immediately - should use cache
+    // Still within max-age — serve from cache
     await cachedFetch(url);
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Note: We can't easily test TTL expiration without mocking time
-    // The global TTL is 3 hours, which is too long for a unit test
-    // This test verifies caching works, TTL is configured at module level
+    const entries = getCacheEntries();
+    expect(entries).toHaveLength(1);
+    // max-age=1 → ~1000ms remaining (lru-cache may report slightly above)
+    expect(entries[0]?.remainingTTL).toBeGreaterThan(0);
+    expect(entries[0]?.remainingTTL).toBeLessThan(2000);
+  });
 
-    // Restore window
-    global.window = originalWindow;
+  it('should fall back to default TTL when Cache-Control is missing', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response('no-cc', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    global.fetch = mockFetch;
+    mockServerEnvironment();
+
+    const cachedFetch = createCachedFetch();
+    const url = 'https://api.example.com/no-cache-control';
+
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(getCacheStats().size).toBe(1);
+
+    // Within the default 61s TTL window — still cached
+    await cachedFetch(url);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const entries = getCacheEntries();
+    expect(entries).toHaveLength(1);
+    // Default fallback is 61s — longer than a 1s max-age entry
+    expect(entries[0]?.remainingTTL).toBeGreaterThan(1000);
+    expect(entries[0]?.remainingTTL).toBeLessThanOrEqual(62_000);
   });
 
   it('should respect maxEntries limit', async () => {
@@ -153,25 +169,16 @@ describe('Network Cache Middleware', () => {
         Promise.resolve(new Response(url, { status: 200 })),
       );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
 
-    // Make requests to different URLs - should respect default maxEntries
     for (let i = 0; i < 5; i++) {
       await cachedFetch(`https://api.example.com/data/${i}`);
     }
 
     const stats = getCacheStats();
-    // Should have cached all 5 entries (well under default of 500)
     expect(stats.size).toBe(5);
-
-    // Restore window
-    global.window = originalWindow;
   });
 
   it('should clear cache correctly', async () => {
@@ -181,29 +188,19 @@ describe('Network Cache Middleware', () => {
         Promise.resolve(new Response('test', { status: 200 })),
       );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
     const url = 'https://api.example.com/data';
 
-    // Add to cache
     await cachedFetch(url);
     expect(getCacheStats().size).toBe(1);
 
-    // Clear cache
     clearCache();
     expect(getCacheStats().size).toBe(0);
 
-    // Next request should hit network
     await cachedFetch(url);
     expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // Restore window
-    global.window = originalWindow;
   });
 
   it('should only cache successful responses (2xx)', async () => {
@@ -213,25 +210,16 @@ describe('Network Cache Middleware', () => {
         Promise.resolve(new Response('error', { status: 404 })),
       );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
     const url = 'https://api.example.com/not-found';
 
-    // First 404 request
     await cachedFetch(url);
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Second request - should not use cache (404 not cached)
     await cachedFetch(url);
     expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // Restore window
-    global.window = originalWindow;
   });
 
   it('should use same cache key regardless of headers', async () => {
@@ -241,32 +229,22 @@ describe('Network Cache Middleware', () => {
         Promise.resolve(new Response('test', { status: 200 })),
       );
     global.fetch = mockFetch;
-
-    // Mock server environment
-    const originalWindow = global.window;
-    // @ts-expect-error - mocking window
-    delete global.window;
+    mockServerEnvironment();
 
     const cachedFetch = createCachedFetch();
     const url = 'https://api.example.com/data';
 
-    // Request with header 1
     await cachedFetch(url, {
       headers: { 'Accept-Language': 'en' },
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Request with different header - should use cache (headers ignored)
     await cachedFetch(url, {
       headers: { 'Accept-Language': 'es' },
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Request without headers - should use cache
     await cachedFetch(url);
     expect(mockFetch).toHaveBeenCalledTimes(1);
-
-    // Restore window
-    global.window = originalWindow;
   });
 });

--- a/pwa/app/lib/middleware/network-cache.ts
+++ b/pwa/app/lib/middleware/network-cache.ts
@@ -1,28 +1,34 @@
 /**
- * Network cache middleware for API requests
+ * SSR-only network cache middleware for TBA API requests.
  *
- * Implements an in-memory LRU cache to cache JSON API responses across sessions.
- * Includes logging to track cache hits and outbound requests.
+ * Per-process in-memory LRU shared across users on a given SSR instance.
+ * Safe only because TBA read data is public and `X-TBA-Auth-Key` is a single
+ * shared read key — do not use this for user-private responses. If per-user
+ * auth keys ever land, cache keys must include the auth identity (or stop
+ * caching those requests).
+ *
+ * Installed only on the server via `client.setConfig` in `__root.tsx`. Client
+ * freshness is owned by React Query `staleTime`; this must not run in the
+ * browser as a second TTL under Query.
  */
 import ccParser from 'cache-control-parser';
 import { LRUCache } from 'lru-cache';
 
-import {
-  createLogger,
-  hoursToMilliseconds,
-  secondsToMilliseconds,
-} from '~/lib/utils';
+import { createLogger, secondsToMilliseconds } from '~/lib/utils';
 
 type CacheEntry = string;
 
 /**
- * Global cache configuration - applied to the singleton cache instance
+ * Cap kept deliberately modest: heavy pages (e.g. district stats) can fan out
+ * 20–40 entries and benefit from headroom, but each SSR instance holds the
+ * full LRU in memory — raising this fights F1 OOM pressure (see #9984).
  */
-const CACHE_MAX_ENTRIES = 500;
-const CACHE_TTL = hoursToMilliseconds(3);
+const CACHE_MAX_ENTRIES = 300;
+/** Fallback when the origin omits Cache-Control / max-age — matches TBA API max-age. */
+const CACHE_TTL = secondsToMilliseconds(61);
 
 /**
- * Global singleton LRU cache - shared across all sessions
+ * Global singleton LRU cache - shared across all SSR sessions on this process
  */
 const cache = new LRUCache<string, CacheEntry>({
   max: CACHE_MAX_ENTRIES,
@@ -40,7 +46,9 @@ interface NetworkCacheConfig {
 const logger = createLogger('network-cache');
 
 /**
- * Generate cache key from request
+ * Generate cache key from request.
+ * Keyed on METHOD:url only — fine today with one shared read key; not safe
+ * if responses ever vary by auth header.
  */
 function generateCacheKey(url: string, options: RequestInit = {}): string {
   const method = options.method?.toUpperCase() || 'GET';
@@ -48,7 +56,7 @@ function generateCacheKey(url: string, options: RequestInit = {}): string {
 }
 
 /**
- * Create a caching fetch function
+ * Create a caching fetch function (SSR-only; no-ops if invoked in the browser)
  */
 export function createCachedFetch(
   config: NetworkCacheConfig = {},
@@ -59,6 +67,11 @@ export function createCachedFetch(
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> {
+    // Defense in depth: never cache in the browser even if setConfig leaks.
+    if (typeof window !== 'undefined') {
+      return fetch(input, init);
+    }
+
     const url =
       typeof input === 'string'
         ? input
@@ -69,7 +82,7 @@ export function createCachedFetch(
 
     // Only cache specified methods (default: GET)
     if (!cacheableMethods.includes(method)) {
-      logger.info(
+      logger.debug(
         {
           method,
           url,
@@ -80,26 +93,12 @@ export function createCachedFetch(
       return fetch(input, init);
     }
 
-    // Check if running on server
-    const isServer = typeof window === 'undefined';
-    if (!isServer) {
-      // Don't cache on client - only server-side
-      logger.info(
-        {
-          method,
-          url,
-        },
-        'Client-side request, skipping cache',
-      );
-      return fetch(input, init);
-    }
-
     const cacheKey = generateCacheKey(url, init);
 
     // Check cache
     const cachedData = cache.get(cacheKey);
     if (cachedData) {
-      logger.info(
+      logger.debug(
         {
           method,
           url,
@@ -113,7 +112,7 @@ export function createCachedFetch(
     }
 
     // Cache miss or expired - fetch from network
-    logger.info(
+    logger.debug(
       {
         method,
         url,
@@ -154,7 +153,7 @@ export function createCachedFetch(
             cache.set(cacheKey, data, { ttl: CACHE_TTL });
           } else {
             const ttlMs = secondsToMilliseconds(ttl['max-age']);
-            logger.info(
+            logger.debug(
               {
                 method,
                 url,
@@ -193,7 +192,7 @@ export function createCachedFetch(
  */
 export function clearCache(): void {
   cache.clear();
-  logger.info('Cache cleared');
+  logger.debug('Cache cleared');
 }
 
 /**

--- a/pwa/app/routes/__root.tsx
+++ b/pwa/app/routes/__root.tsx
@@ -77,14 +77,15 @@ client.interceptors.error.use((_error, response) => {
   );
 });
 
-// Configure network cache middleware
-// Caches API responses in memory across sessions to reduce external API calls
-// Cache is a global singleton with 500 max entries and 3 hour TTL
-client.setConfig({
-  fetch: createCachedFetch({
-    cacheableMethods: ['GET'],
-  }),
-});
+// SSR-only network LRU under the API client. Client freshness is owned by
+// React Query staleTime — do not install a second TTL in the browser.
+if (typeof window === 'undefined') {
+  client.setConfig({
+    fetch: createCachedFetch({
+      cacheableMethods: ['GET'],
+    }),
+  });
+}
 
 // Point mobile API client at local backend when configured
 if (import.meta.env.VITE_TBA_MOBILE_API_BASE_URL) {


### PR DESCRIPTION
## Summary
- Install the TBA API LRU fetch wrapper only on the server so it no longer sits under React Query in the browser
- Document SSR/cross-user cache semantics; quiet routine cache logs; size the LRU for F1 (300 entries, 61s fallback TTL)

Closes #10244