### PR TITLE
[pwa] Fix dialog flicker

### DIFF
--- a/pwa/app/components/ui/dialog.tsx
+++ b/pwa/app/components/ui/dialog.tsx
@@ -38,7 +38,8 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         `fixed inset-0 z-50 bg-black/50 dark:bg-black/75 data-open:animate-in
-        data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
+        data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0
+        data-closed:fill-mode-forwards`,
         className,
       )}
       {...props}
@@ -87,7 +88,7 @@ function DialogContent({
           bg-background p-6 shadow-lg duration-200 sm:max-w-lg
           data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95
           data-closed:animate-out data-closed:fade-out-0
-          data-closed:zoom-out-95`,
+          data-closed:fill-mode-forwards data-closed:zoom-out-95`,
           className,
         )}
         {...props}


### PR DESCRIPTION
closing the match dialog results in a weird background flicker. this fixes it 

related:
https://github.com/shadcn-ui/ui/issues/1351
https://github.com/shadcn-ui/ui/issues/8951