### PR TITLE
Remove dead admin Task Launcher buttons that 404

### DIFF
--- a/src/backend/web/templates/admin/tasks.html
+++ b/src/backend/web/templates/admin/tasks.html
@@ -356,35 +356,4 @@
     </div>
 </div>
 
-<hr>
-
-<h2>Special Tasks<h2>
-<h3>Special Registration Days</h3>
-<div class="row">
-    <div class="col-sm-6">
-        <form class="form-inline" action="/tasks/admin/enqueue/registration_day" method="post">
-            <div class="input-group">
-                <span class="help-block">Registration Date</span>
-                <input class="form-control" id="enqueue_registration_date" name="date_string" type="text" placeholder="2016-10-17">
-                <span class="help-block">Event Year to Enqueue</span>
-                <input class="form-control" id="enqueue_registration_year" name="event_year" type="text" placeholder="2017">
-                <span class="help-block">Scrape Interval (minutes)</span>
-                <input class="form-control" id="enqueue_registration_interval" name="interval" type="text" placeholder="30">
-            </div>
-            <span class="input-group-btn" id="enqueue_registration_submit">
-                  <button class="btn btn-warning" type="submit">Go <span class="glyphicon glyphicon-fast-forward"></span></button>
-            </span>
-        </form>
-    </div>
-</div>
-
-<h3>Run Post Update Hooks</h3>
-<div class="row">
-    <div class="col-sm-6">
-        <p>Manually runs post update hooks. WARNING: Don't use this unless you know what you're doing.</p>
-        <a class="btn btn-danger" href="/tasks/admin/enqueue/run_post_update_hooks/events">Events</a>
-        <a class="btn btn-danger" href="/tasks/admin/enqueue/run_post_update_hooks/teams">Teams</a>
-    </div>
-</div>
-
 {% endblock %}


### PR DESCRIPTION
## What

The **Special Tasks** section at the bottom of the admin Task Launcher (`/admin/tasks`) has two controls whose backend routes were never ported to Python 3, so clicking either one 404s today:

| Control | Posts/links to | Status |
|---|---|---|
| "Special Registration Days" form | `POST /tasks/admin/enqueue/registration_day` | route only exists in `old_py2/` |
| "Run Post Update Hooks" → Events / Teams | `/tasks/admin/enqueue/run_post_update_hooks/{events,teams}` | route only exists in `old_py2/` |

The Py2 handlers (`AdminRegistrationDayEnqueue`, `AdminRunPostUpdateHooks*` in `old_py2/controllers/admin/admin_cron_controller.py`) have no equivalent in `tasks_io`, so these buttons have been dead since the Py3 migration.

## Why remove rather than reimplement

Neither tool is in active use and both are niche admin power-tools (the registration-day scraper also depended on a `turbo_mode` sitevar that no longer exists). Removing the dead UI is the honest fix; the tools can be reintroduced deliberately if a need comes back.

Also drops a malformed unclosed `<h2>Special Tasks<h2>` tag that was in the removed block.

## Testing

Template-only change. The existing `/admin/tasks` render test (`admin_blueprint_test.py`) still passes, confirming the page loads after removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)