### PR TITLE
Guard Twitch token fetch against None to avoid crash on auth failure

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_twitch.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_twitch.py
@@ -58,7 +58,7 @@ class TwitchGetAccessToken(DatafeedBase[Any, TwitchAccessToken]):
     @typed_tasklet
     def get_cached_token_async(
         cls,
-    ) -> Generator[Any, Any, TwitchAccessToken]:
+    ) -> Generator[Any, Any, Optional[TwitchAccessToken]]:
         """Get a Twitch access token, with automatic caching and refresh.
 
         Manages token lifecycle including cache checks, expiration checks,
@@ -82,6 +82,10 @@ class TwitchGetAccessToken(DatafeedBase[Any, TwitchAccessToken]):
         new_token = yield TwitchGetAccessToken(
             refresh_token=refresh_token
         ).fetch_async()
+
+        if new_token is None:
+            # Fetching a fresh token failed (e.g. Twitch auth outage)
+            return None
 
         # Cache the new token with expiration
         token_mc.expires(new_token["expires_in"])

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_twitch_get_access_token_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_twitch_get_access_token_test.py
@@ -80,3 +80,16 @@ def test_refresh_token(api_mock: mock.Mock, twitch_secrets) -> None:
     }
     expected.update(api_data)
     assert result == expected
+
+
+@mock.patch.object(TwitchGetAccessToken, "_fetch")
+def test_get_cached_token_returns_none_on_fetch_failure(
+    api_mock: mock.Mock, twitch_secrets
+) -> None:
+    api_response = URLFetchResult.mock_for_content(
+        "https://id.twitch.tv/oauth2/token", 503, ""
+    )
+    api_mock.return_value = InstantFuture(api_response)
+
+    result = TwitchGetAccessToken.get_cached_token_async().get_result()
+    assert result is None

--- a/src/backend/tasks_io/helpers/webcast_online_helper.py
+++ b/src/backend/tasks_io/helpers/webcast_online_helper.py
@@ -34,9 +34,12 @@ class WebcastOnlineHelper:
 
         Delegates token fetching, caching, and refresh to TwitchGetAccessToken.
         """
-        twitch_token: TwitchAccessToken = (
+        twitch_token: Optional[TwitchAccessToken] = (
             yield TwitchGetAccessToken.get_cached_token_async()
         )
+        if twitch_token is None:
+            # Token fetch failed (e.g. Twitch auth outage) - leave status as UNKNOWN
+            return
         yield TwitchWebcastStatus(twitch_token, webcast).fetch_async()
 
     @classmethod


### PR DESCRIPTION
## What

`TwitchGetAccessToken.get_cached_token_async` fetches a fresh Twitch access token via `fetch_async()`, then immediately does `new_token["expires_in"]` and caches `new_token`, with no `None` check.

`DatafeedBase._parse` (via `fetch_async`) returns `None` on any non-200 response or JSON-parse failure. So a transient Twitch auth outage (e.g. a 503 from `id.twitch.tv`) makes `new_token` `None`, and the code raises an opaque `TypeError: 'NoneType' object is not subscriptable` instead of failing gracefully. This takes down every caller of `get_cached_token_async`. Pyre didn't catch this because the declared return type was non-optional (`TwitchAccessToken`), masking the `None` possibility.

## Why

Twitch webcast status is best-effort, and the existing YouTube path in `WebcastOnlineHelper` already tolerates API errors gracefully (leaves status as `UNKNOWN` on failure). The Twitch path should behave the same way instead of raising and potentially crashing the whole batch of webcast status updates.

## Fix

- `datafeed_twitch.py`: change `get_cached_token_async`'s return type to `Generator[Any, Any, Optional[TwitchAccessToken]]`, and return `None` early if the fresh token fetch comes back `None`, before touching the memcache or subscripting the token.
- `webcast_online_helper.py`: `_add_twitch_status_async` now types `twitch_token` as `Optional[TwitchAccessToken]` and returns early (leaving the webcast status as `UNKNOWN`) if the token is `None`, instead of passing `None` into `TwitchWebcastStatus`.

## Testing

- Added `test_get_cached_token_returns_none_on_fetch_failure` to `datafeed_twitch_get_access_token_test.py`, mocking `TwitchGetAccessToken._fetch` to return a 503 and asserting `get_cached_token_async()` returns `None` without raising.
- Verified the new test fails with `TypeError: 'NoneType' object is not subscriptable` against the pre-fix code, and passes after the fix.
- `make test ARGS='src/backend/tasks_io/datafeeds/tests/datafeed_twitch_get_access_token_test.py'` — 4 passed.
- `make test ARGS='src/backend/tasks_io/helpers/tests/'` — 23 passed (no regression).
- `make typecheck` — no type errors found.
- `make lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)