### PR TITLE
Treat malformed Nexus 200 responses as fetch failures instead of crashing

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_nexus.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_nexus.py
@@ -55,7 +55,13 @@ class _DatafeedNexus(DatafeedBase[TAPIResponse, TReturn]):
                     EventSyncStatusMemcache(event_key).record_success(endpoint)
 
             return result
-        except (apiproxy_errors.ApplicationError, urlfetch_errors.Error) as e:
+        except (
+            apiproxy_errors.ApplicationError,
+            urlfetch_errors.Error,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as e:
             if event_key and endpoint:
                 EventSyncStatusMemcache(event_key).record_failure(endpoint)
             logging.warning(f"Nexus datafeed fetch failed: {e}")

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_nexus_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_nexus_test.py
@@ -396,3 +396,47 @@ def test_fetch_records_sync_status_failure(
     status = EventSyncStatusMemcache("2019casj").get()
     assert status is not None
     assert status["tasks.get.nexus_pit_locations"]["num_consecutive_failures"] == 1
+
+
+class DummyDatafeedNexusMalformedParser(_DatafeedNexus[PitAddresses, Any]):
+
+    def endpoint(self) -> str:
+        return "/"
+
+    def parser(self) -> ParserBase[PitAddresses, Any]:
+        class MalformedParser(ParserBase[PitAddresses, Any]):
+            def parse(self, response: PitAddresses) -> Any:
+                # Simulate a real parser (e.g. NexusAPIQueueStatusParser)
+                # direct-indexing a field that's missing/renamed on a
+                # malformed-but-200 response body.
+                raise KeyError("label")
+
+        return MalformedParser()
+
+    def event_key(self) -> Optional[str]:
+        return "2019casj"
+
+
+@mock.patch.object(_DatafeedNexus, "_fetch")
+def test_fetch_malformed_response_records_sync_status_failure(
+    fetch_mock: mock.Mock, ndb_stub, nexus_api_secrets
+) -> None:
+    response = URLFetchResult.mock_for_content(
+        "https://frc.nexus/api/v1/",
+        200,
+        json.dumps({"ok": True}),
+    )
+    fetch_mock.return_value = InstantFuture(response)
+
+    with mock.patch.object(
+        DummyDatafeedNexusMalformedParser,
+        "_request_endpoint",
+        return_value="tasks.get.nexus_event_queue_status",
+    ):
+        result = DummyDatafeedNexusMalformedParser().fetch_async().get_result()
+
+    assert result is None
+
+    status = EventSyncStatusMemcache("2019casj").get()
+    assert status is not None
+    assert status["tasks.get.nexus_event_queue_status"]["num_consecutive_failures"] == 1


### PR DESCRIPTION
## What
Broadens the except clause in `_DatafeedNexus._gen` (`src/backend/tasks_io/datafeeds/datafeed_nexus.py`) to also catch `KeyError`, `TypeError`, and `ValueError`, alongside the existing `apiproxy_errors.ApplicationError` / `urlfetch_errors.Error`.

## Why
The Nexus queue-status parser (`parsers/nexus_api/queue_status_parser.py`) direct-indexes fields like `api_match['label']`, `api_match['status']`, `api_match['times']`, and `response['dataAsOfTime']` after only verifying the top-level response is a dict. On live event days, third-party Nexus data can be missing a key or shaped unexpectedly (renamed/omitted field), which raises an uncaught `KeyError` (or `TypeError`/`ValueError` for other malformed shapes) that propagates straight out of the `_gen` tasklet.

Because the except clause didn't cover these exception types, a malformed-but-200 response would crash the tasklet outright **and** skip the `record_failure` sync-status bookkeeping in the except block — so on-call/monitoring wouldn't even see it as a recorded failure.

This change treats a malformed 200 body the same as any other fetch failure: record the sync-status failure, log a warning, and return `None`, instead of letting the exception propagate.

## Testing
- Added `test_fetch_malformed_response_records_sync_status_failure` to `src/backend/tasks_io/datafeeds/tests/datafeed_nexus_test.py`, mirroring the existing `test_fetch_records_sync_status_failure` / `test_fetch_exception_logs_warning` patterns. It uses a datafeed subclass whose parser raises `KeyError("label")` on a valid 200 response, and asserts `_gen` returns `None` without propagating and that `EventSyncStatusMemcache` records a failure.
- Verified the new test fails with an uncaught `KeyError` against the pre-fix code, and passes after the fix.
- `make test ARGS='src/backend/tasks_io/datafeeds/tests/datafeed_nexus_test.py'` — 24 passed.
- `make typecheck` — no type errors.
- `make lint` — clean (black + flake8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)