### PR TITLE
[pwa] fix pnpm version desync

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pull_request_pwa.yml
+++ b/.github/workflows/pull_request_pwa.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -64,7 +64,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -93,7 +93,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -128,7 +128,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -157,7 +157,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -204,7 +204,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -150,7 +150,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -173,7 +173,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -203,7 +203,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -239,7 +239,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pwa_preview_build.yml
+++ b/.github/workflows/pwa_preview_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pwa_screenshots.yml
+++ b/.github/workflows/pwa_screenshots.yml
@@ -89,7 +89,7 @@ jobs:
         if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'
         uses: pnpm/action-setup@v5
         with:
-          version: "10.24.0"
+          version: "11.13.0"
 
       - name: Set up Node
         if: steps.check-key.outputs.skip != 'true' && steps.pages.outputs.json != '[]'

--- a/copilot-setup-steps.yml
+++ b/copilot-setup-steps.yml
@@ -22,7 +22,7 @@ steps:
 
   # PWA environment setup
   - name: Install pnpm
-    run: npm install -g pnpm@10.24.0
+    run: npm install -g pnpm@11.13.0
 
   - name: Create PWA environment file
     run: ./ops/pwa/create_dotenv.sh --env

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "sideEffects": false,
   "type": "module",
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
     "build": "pnpm run build:app && pnpm run build:server && pnpm run build:sw",
     "build:app": "vite build",
@@ -119,7 +120,8 @@
     "workbox-build": "7.4.1"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22",
+    "pnpm": "11.13.0"
   },
   "overrides": {
     "react-is": "19.1.0"

--- a/pwa/pnpm-workspace.yaml
+++ b/pwa/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# Dependabot regenerates this lockfile with transitive deps published minutes earlier, which pnpm 11's
+# lockfile verification pass rejects (ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION) and breaks GAE deploys.
+# Resolution-time minimumReleaseAge (pnpm 11 default, 1440) still applies when resolving new versions.
+trustLockfile: true
+
 allowBuilds:
   '@firebase/util': true
   '@sentry/cli': true


### PR DESCRIPTION
some instances were using pnpm 10 while others defaulted to latest (pnpm 11). pnpm 11 adds minimum release age which then fails to install and breaks CI.