### PR TITLE
Fall back to non-preferred team images

### DIFF
--- a/src/backend/common/helpers/media_helper.py
+++ b/src/backend/common/helpers/media_helper.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Optional
 
+from google.appengine.ext import ndb
+
 from backend.common.consts.media_type import (
     IMAGE_TYPES,
     MediaType,
@@ -29,6 +31,18 @@ class MediaHelper(object):
     @classmethod
     def get_images(cls, medias: List[Media]) -> List[Media]:
         return list(filter(lambda m: m.media_type_enum in IMAGE_TYPES, medias))
+
+    @classmethod
+    def get_preferred_or_fallback_images(
+        cls, medias: List[Media], reference: ndb.Key
+    ) -> List[Media]:
+        images = [
+            media for media in cls.get_images(medias) if reference in media.references
+        ]
+        preferred_images = [
+            media for media in images if reference in media.preferred_references
+        ]
+        return preferred_images or images
 
     @classmethod
     def get_socials(cls, medias: List[Media]) -> List[Media]:

--- a/src/backend/common/helpers/tests/media_helper_test.py
+++ b/src/backend/common/helpers/tests/media_helper_test.py
@@ -1,5 +1,9 @@
+from google.appengine.ext import ndb
+
 from backend.common.consts.media_type import MediaType, SLUG_NAMES
 from backend.common.helpers.media_helper import MediaHelper
+from backend.common.models.media import Media
+from backend.common.models.team import Team
 
 
 def test_organize_media(test_data_importer) -> None:
@@ -36,6 +40,54 @@ def test_get_images(test_data_importer) -> None:
     )
     images = MediaHelper.get_images(medias)
     assert len(images) == 1
+
+
+def test_get_preferred_or_fallback_images_prefers_preferred() -> None:
+    team_key = ndb.Key(Team, "frc148")
+    fallback = Media(
+        id="imgur_fallback",
+        media_type_enum=MediaType.IMGUR,
+        foreign_key="fallback",
+        references=[team_key],
+        year=2025,
+    )
+    preferred = Media(
+        id="imgur_preferred",
+        media_type_enum=MediaType.IMGUR,
+        foreign_key="preferred",
+        references=[team_key],
+        preferred_references=[team_key],
+        year=2025,
+    )
+
+    images = MediaHelper.get_preferred_or_fallback_images(
+        [fallback, preferred], team_key
+    )
+
+    assert images == [preferred]
+
+
+def test_get_preferred_or_fallback_images_uses_fallback() -> None:
+    team_key = ndb.Key(Team, "frc148")
+    fallback = Media(
+        id="imgur_fallback",
+        media_type_enum=MediaType.IMGUR,
+        foreign_key="fallback",
+        references=[team_key],
+        year=2025,
+    )
+
+    images = MediaHelper.get_preferred_or_fallback_images([fallback], team_key)
+
+    assert images == [fallback]
+
+
+def test_get_preferred_or_fallback_images_without_media() -> None:
+    team_key = ndb.Key(Team, "frc148")
+
+    images = MediaHelper.get_preferred_or_fallback_images([], team_key)
+
+    assert images == []
 
 
 def test_get_socials(test_data_importer) -> None:

--- a/src/backend/web/handlers/event.py
+++ b/src/backend/web/handlers/event.py
@@ -1,4 +1,3 @@
-import collections
 import csv
 import io
 import json
@@ -141,7 +140,7 @@ def event_detail(event_key: EventKey) -> Response:
     event.prep_matches()
     event.prep_teams()
     event.prep_details()
-    medias_future = media_query.EventTeamsPreferredMediasQuery(event_key).fetch_async()
+    medias_future = media_query.EventTeamsMediasQuery(event_key).fetch_async()
     district_future = (
         district_query.DistrictQuery(
             none_throws(none_throws(event.district_key).string_id())
@@ -170,17 +169,14 @@ def event_detail(event_key: EventKey) -> Response:
     match_count, matches = MatchHelper.organized_matches(cleaned_matches)
     teams = TeamHelper.sort_teams(event.teams)  # pyre-ignore[6]
 
-    # Organize medias by team
-    image_medias = MediaHelper.get_images(
-        [media for media in medias_future.get_result()]
-    )
-    team_medias = collections.defaultdict(list)
-    for image_media in image_medias:
-        for reference in image_media.references:
-            team_medias[reference].append(image_media)
-    team_and_medias = []
-    for team in teams:
-        team_and_medias.append((team, team_medias.get(team.key, [])))
+    medias = medias_future.get_result()
+    team_and_medias = [
+        (
+            team,
+            MediaHelper.get_preferred_or_fallback_images(medias, team.key),
+        )
+        for team in teams
+    ]
 
     num_teams = len(team_and_medias)
     middle_value = num_teams // 2
@@ -201,10 +197,7 @@ def event_detail(event_key: EventKey) -> Response:
     # Build Team List CSV
     team_rows = []
     for team, medias in team_and_medias:
-        preferred_media = next(
-            (m for m in medias if m.is_image and team.key in m.preferred_references),
-            None,
-        )
+        selected_media = next(iter(medias), None)
         team_rows.append(
             OrderedDict(
                 [
@@ -215,7 +208,7 @@ def event_detail(event_key: EventKey) -> Response:
                     ("country", (team.country or "").replace(",", ";")),
                     (
                         "robot_image_url",
-                        preferred_media.image_direct_url_med if preferred_media else "",
+                        selected_media.image_direct_url_med if selected_media else "",
                     ),
                 ]
             )

--- a/src/backend/web/handlers/tests/event_detail_test.py
+++ b/src/backend/web/handlers/tests/event_detail_test.py
@@ -9,6 +9,7 @@ from werkzeug.test import Client
 from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import MediaType
 from backend.common.consts.webcast_status import WebcastStatus
 from backend.common.consts.webcast_type import WebcastType
 from backend.common.memcache_models.webcast_online_status_memcache import (
@@ -18,7 +19,9 @@ from backend.common.models.alliance import MatchAlliance
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.match import Match
+from backend.common.models.media import Media
 from backend.common.models.regional_champs_pool import RegionalChampsPool
+from backend.common.models.team import Team
 from backend.common.models.webcast import Webcast
 from backend.web.handlers.tests import helpers
 
@@ -37,6 +40,30 @@ def test_render_event(ndb_stub, web_client: Client) -> None:
 
     soup = BeautifulSoup(resp.data, "html.parser")
     assert soup.find(id="event-name").string == "Test Event 2020"
+
+
+def test_render_event_uses_team_image_fallback(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_team(148)
+    helpers.preseed_event_for_team(148, "2020test")
+    team_key = ndb.Key(Team, "frc148")
+    Media(
+        id="imgur_fallback",
+        media_type_enum=MediaType.IMGUR,
+        foreign_key="fallback",
+        references=[team_key],
+        year=2020,
+    ).put()
+
+    resp = web_client.get("/event/2020test")
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+    carousel = soup.find(id="team-carousel-frc148")
+    assert carousel is not None
+    assert carousel.find(attrs={"data-foreign-key": "fallback"}) is not None
+    team_list_csv = soup.find(id="team-list-csv")
+    assert team_list_csv is not None
+    assert "https://i.imgur.com/fallbackm.jpg" in team_list_csv.get_text()
 
 
 def test_render_2026_event_with_legacy_insight_data(


### PR DESCRIPTION
## Description
Uses preferred team images in event team lists when available, then falls back to that year's other images. The same selection is used for the team CSV image URL.

## Motivation and Context
Teams with submitted images currently show the add-media button until a moderator marks an image preferred.

Fixes #5159.

## How Has This Been Tested?
- `uv run --group dev pytest src/backend/common/helpers/tests/media_helper_test.py src/backend/common/queries/tests/event_teams_medias_query_test.py src/backend/common/queries/tests/event_teams_preferred_medias_query_test.py src/backend/web/handlers/tests/event_detail_test.py -q` (36 passed)
- `uv run --group lint flake8 src/backend/common/helpers/media_helper.py src/backend/common/helpers/tests/media_helper_test.py src/backend/web/handlers/event.py src/backend/web/handlers/tests/event_detail_test.py`
- `uv run --group dev black --check --fast src/backend/common/helpers/media_helper.py src/backend/common/helpers/tests/media_helper_test.py src/backend/web/handlers/event.py src/backend/web/handlers/tests/event_detail_test.py`

## Screenshots (if appropriate):
N/A

## Screenshot Pages
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)