### PR TITLE
Fixed incorrect response type in getTeamEventMatchesSimple endpoint

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -6341,7 +6341,7 @@ export type GetTeamEventMatchesSimpleResponses = {
   /**
    * Successful response
    */
-  200: Array<Match>;
+  200: Array<MatchSimple>;
 };
 
 export type GetTeamEventMatchesSimpleResponse =

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -2864,7 +2864,7 @@ export const zGetTeamEventMatchesSimplePath = z.object({
 /**
  * Successful response
  */
-export const zGetTeamEventMatchesSimpleResponse = z.array(zMatch);
+export const zGetTeamEventMatchesSimpleResponse = z.array(zMatchSimple);
 
 export const zGetTeamEventStatusHeaders = z.object({
   'If-None-Match': z.string().optional(),

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3723,7 +3723,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Match"
+                    "$ref": "#/components/schemas/Match_Simple"
                   }
                 }
               }


### PR DESCRIPTION
I identified an error in the [published TBA OpenAPI specification](https://www.thebluealliance.com/swagger/api_v3.json) on the `getTeamEventMatchesSimple` endpoint (i.e. `/team/{team_key}/event/{event_key}/matches/simple`).

The stated schema type for that endpoint was an array of `Match` objects, but I confirmed that the actual schema for that endpoint should be an array of `Match_Simple` objects.

You can see it for yourself [here](https://www.thebluealliance.com/apidocs/v3#operations-team-getTeamEventMatchesSimple) on the HTML version of the OpenAPI spec.

## Description

- Manually updated `src/backend/web/static/swagger/api_v3.json` to specify the correct schema on the `getTeamEventMatchesSimple` endpoint.

## Motivation and Context

Existing consumers of the old published spec must currently account for the erroneous variance between the models stated by the spec and the actual shape of the incoming data.

This change would resolve that variance.

## How Has This Been Tested?

I have a Rust-based TBA API client that I am working on that features models generated from the published TBA OpenAPI spec. When using the old published spec, I experienced deserialization errors caused by the parser receiving more fields than are expected on the generated models (fields which are present on `Match` but not on `Match_Simple`). Regenerating the models against this updated version of the spec fixes that deserialization issue.

(_Does that count?_ :grin:)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)