### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/pull_request_pwa.yml
+++ b/.github/workflows/pull_request_pwa.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-pwa-${{ github.head_ref }}
   cancel-in-progress: true
@@ -28,6 +31,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Check toolchain version consistency
         run: ./ops/pwa/check_node_versions.sh
@@ -54,6 +58,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up PWA toolchain
         uses: ./.github/actions/setup-pwa
@@ -74,6 +79,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up PWA toolchain
         uses: ./.github/actions/setup-pwa
@@ -100,6 +106,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up PWA toolchain
         uses: ./.github/actions/setup-pwa
@@ -120,6 +127,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up PWA toolchain
         uses: ./.github/actions/setup-pwa
@@ -158,6 +166,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up PWA toolchain
         uses: ./.github/actions/setup-pwa

--- a/.github/workflows/pwa_preview_build.yml
+++ b/.github/workflows/pwa_preview_build.yml
@@ -1,8 +1,11 @@
 name: PWA Preview Build
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize]
+
+permissions:
+  contents: read
 
 concurrency:
   group: pwa-preview-build-${{ github.event.pull_request.number }}
@@ -25,6 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up PWA toolchain
         uses: ./.github/actions/setup-pwa


### PR DESCRIPTION
`pull_request` CI jobs literally can't read any vars or secrets at all, so we have to use `pull_request_target`, which now requires an additional opt in