### PR TITLE
Improve "similar events" matching on the offseason suggestion review page

### DIFF
--- a/src/backend/common/helpers/similar_event_helper.py
+++ b/src/backend/common/helpers/similar_event_helper.py
@@ -61,6 +61,18 @@ MAX_SIMILAR_EVENTS = 8
 # that compare only the distinguishing words.
 RAW_NAME_WEIGHT = 0.85
 
+# Words an acronym may or may not pick up a letter from -- "South Carolina
+# Robotics & Practical Off-Season" is abbreviated SCRAP, but "Georgia Robotics
+# Invitational Tournament & Showcase" is GRITS
+CONNECTOR_WORDS: FrozenSet[str] = frozenset(
+    {"a", "an", "and", "at", "by", "for", "in", "of", "on", "the"}
+)
+
+# How much of an acronym has to be written out before a name that starts with
+# it counts as that acronym, since acronyms routinely drop the tail of a name
+# ("South Carolina Robotics And Practical" Off-Season -> SCRAP)
+MIN_ACRONYM_PREFIX = 4
+
 # Abbreviations that get written in caps but name a whole category of events
 # rather than one particular event
 AMBIGUOUS_ABBREVIATIONS: FrozenSet[str] = frozenset(
@@ -104,7 +116,8 @@ def _normalize(name: Optional[str]) -> str:
     """
     decomposed = unicodedata.normalize("NFKD", name or "")
     ascii_only = decomposed.encode("ascii", "ignore").decode()
-    return " ".join(_NON_ALPHANUMERIC.sub(" ", ascii_only.lower()).split())
+    spelled_out = ascii_only.lower().replace("&", " and ")
+    return " ".join(_NON_ALPHANUMERIC.sub(" ", spelled_out).split())
 
 
 def _tokens(name: Optional[str]) -> List[str]:
@@ -128,19 +141,31 @@ def _significant_tokens(name: Optional[str]) -> List[str]:
 
 def _acronyms(name: Optional[str]) -> Set[str]:
     """
-    Acronyms a name could plausibly be abbreviated to. Both the all-words form
-    ("Thundering Herd Of Robots" -> "thor") and the significant-words-only form
-    are included, since either may be the one that stuck.
+    Acronyms a name could plausibly be abbreviated to. Which words get a letter
+    varies -- every word ("Thundering Herd Of Robots" -> "thor"), every word
+    but the connectors ("Georgia Robotics Invitational Tournament & Showcase"
+    -> "grits"), or only the distinguishing ones -- so all three are included.
     """
     all_words = _tokens(name)
-    if len(all_words) < 2:
-        return set()
-
-    acronyms = {"".join(word[0] for word in all_words)}
-    significant = _significant_tokens(name)
-    if len(significant) > 1:
-        acronyms.add("".join(word[0] for word in significant))
+    without_connectors = [word for word in all_words if word not in CONNECTOR_WORDS]
+    acronyms = {
+        "".join(word[0] for word in words)
+        for words in (all_words, without_connectors, _significant_tokens(name))
+        if len(words) > 1
+    }
     return {acronym for acronym in acronyms if len(acronym) >= 3}
+
+
+def _is_acronym_of(word: str, acronyms: Set[str]) -> bool:
+    """
+    Whether a word abbreviates a name, either as the whole acronym or as enough
+    of the front of one to be unmistakable.
+    """
+    return any(
+        acronym == word
+        or (len(word) >= MIN_ACRONYM_PREFIX and acronym.startswith(word))
+        for acronym in acronyms
+    )
 
 
 def _acronym_like_words(name: Optional[str]) -> Set[str]:
@@ -226,7 +251,10 @@ def name_similarity(a: Optional[str], b: Optional[str]) -> float:
         # we have, so don't discount it.
         score = max(score, raw_similarity)
 
-    if _acronym_like_words(a) & _acronyms(b) or _acronym_like_words(b) & _acronyms(a):
+    acronyms_a, acronyms_b = _acronyms(a), _acronyms(b)
+    if any(_is_acronym_of(word, acronyms_b) for word in _acronym_like_words(a)) or any(
+        _is_acronym_of(word, acronyms_a) for word in _acronym_like_words(b)
+    ):
         score = max(score, ACRONYM_SCORE)
 
     if _abbreviations(a) & _abbreviations(b):

--- a/src/backend/common/helpers/similar_event_helper.py
+++ b/src/backend/common/helpers/similar_event_helper.py
@@ -1,0 +1,279 @@
+import re
+import unicodedata
+from difflib import SequenceMatcher
+from typing import FrozenSet, List, Optional, Set
+
+from backend.common.models.event import Event
+
+# Words that show up in so many FRC event names that sharing one tells us
+# nothing about two events being the same event in different years.
+GENERIC_NAME_WORDS: FrozenSet[str] = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "annual",
+        "at",
+        "by",
+        "challenge",
+        "champs",
+        "championship",
+        "championships",
+        "classic",
+        "competition",
+        "competitions",
+        "day",
+        "event",
+        "first",
+        "for",
+        "frc",
+        "ftc",
+        "in",
+        "invitational",
+        "of",
+        "off",
+        "offseason",
+        "on",
+        "presented",
+        "presents",
+        "robot",
+        "robotics",
+        "robots",
+        "season",
+        "state",
+        "the",
+        "tournament",
+        "vex",
+        "week",
+    }
+)
+
+# Similarity a candidate must reach to be shown to a reviewer at all
+SIMILARITY_THRESHOLD = 0.65
+
+# Most similar events to show for a single suggestion. Multi-day and
+# multi-stop offseason series (e.g. the Arizona Robotics League) can
+# legitimately have this many prior-year siblings.
+MAX_SIMILAR_EVENTS = 8
+
+# Full event names are mostly generic filler ("FRC Off-Season Robotics
+# Competition"), so raw name similarity is discounted relative to the signals
+# that compare only the distinguishing words.
+RAW_NAME_WEIGHT = 0.85
+
+# Abbreviations that get written in caps but name a whole category of events
+# rather than one particular event
+AMBIGUOUS_ABBREVIATIONS: FrozenSet[str] = frozenset(
+    {"frc", "ftc", "first", "stem", "tba", "usa", "vex"}
+)
+
+# Score given when one name is an acronym of the other ("GRITS" <->
+# "Georgia Robotics Invitational Tournament & Showcase"), or when both names
+# carry the same abbreviation ("THOR - Thundering Herd of Robots" <->
+# "THOR @ UNC Pembroke")
+ACRONYM_SCORE = 0.95
+SHARED_ABBREVIATION_SCORE = 0.9
+
+# How alike two words must look to count as the same word, which lets typos and
+# pluralization ("Invitations" vs "Invitational") still line up
+WORD_MATCH_THRESHOLD = 0.85
+
+# Every word of one name appearing in the other is slightly weaker evidence
+# when the other name has extra words in it, so a name that matches outright
+# still outranks a name that merely contains it.
+CONTAINMENT_WEIGHT = 0.9
+
+# Location agreement is a bonus on top of name similarity, never a match on
+# its own -- two unrelated events are often held in the same town.
+COUNTRY_BONUS = 0.05
+STATE_BONUS = 0.15
+CITY_BONUS = 0.15
+VENUE_BONUS = 0.2
+
+_NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
+_WORD = re.compile(r"[A-Za-z]+")
+_YEAR_TOKEN = re.compile(r"(19|20)\d\d")
+# Roman numerals up to XXXIX, which is as high as an offseason event's edition
+# number is going to get. Matching any run of i/v/x/l would swallow words.
+_ROMAN_NUMERAL_TOKEN = re.compile(r"(?=[ivx])x{0,3}(ix|iv|v?i{0,3})")
+
+
+def _normalize(name: Optional[str]) -> str:
+    """
+    Lowercases, strips accents, and collapses punctuation to single spaces.
+    """
+    decomposed = unicodedata.normalize("NFKD", name or "")
+    ascii_only = decomposed.encode("ascii", "ignore").decode()
+    return " ".join(_NON_ALPHANUMERIC.sub(" ", ascii_only.lower()).split())
+
+
+def _tokens(name: Optional[str]) -> List[str]:
+    """
+    Words of a name with edition markers (years, roman numerals) removed.
+    """
+    return [
+        token
+        for token in _normalize(name).split()
+        if not _YEAR_TOKEN.fullmatch(token)
+        and not _ROMAN_NUMERAL_TOKEN.fullmatch(token)
+    ]
+
+
+def _significant_tokens(name: Optional[str]) -> List[str]:
+    """
+    Words of a name that actually distinguish it from other event names.
+    """
+    return [token for token in _tokens(name) if token not in GENERIC_NAME_WORDS]
+
+
+def _acronyms(name: Optional[str]) -> Set[str]:
+    """
+    Acronyms a name could plausibly be abbreviated to. Both the all-words form
+    ("Thundering Herd Of Robots" -> "thor") and the significant-words-only form
+    are included, since either may be the one that stuck.
+    """
+    all_words = _tokens(name)
+    if len(all_words) < 2:
+        return set()
+
+    acronyms = {"".join(word[0] for word in all_words)}
+    significant = _significant_tokens(name)
+    if len(significant) > 1:
+        acronyms.add("".join(word[0] for word in significant))
+    return {acronym for acronym in acronyms if len(acronym) >= 3}
+
+
+def _acronym_like_words(name: Optional[str]) -> Set[str]:
+    """
+    Words in a name that could themselves be an acronym of another name.
+    """
+    return {
+        token
+        for token in _significant_tokens(name)
+        if len(token) >= 3 and token.isalpha()
+    }
+
+
+def _abbreviations(name: Optional[str]) -> Set[str]:
+    """
+    Words written in all caps, which offseason events use to carry their
+    identity across renames and rebrandings.
+    """
+    return {
+        word.lower()
+        for word in _WORD.findall(name or "")
+        if len(word) >= 3
+        and word.isupper()
+        and word.lower() not in GENERIC_NAME_WORDS
+        and word.lower() not in AMBIGUOUS_ABBREVIATIONS
+    }
+
+
+def _word_containment(a: List[str], b: List[str]) -> float:
+    """
+    Fraction of the shorter name's distinguishing words that also appear in the
+    longer one, in [0, 1]. Comparing word by word (rather than comparing the
+    names as a whole) means one long shared word doesn't make two events look
+    alike, while a subtitle or a reordering doesn't make them look different.
+    """
+    shorter, longer = (
+        (set(a), set(b)) if len(set(a)) <= len(set(b)) else (set(b), set(a))
+    )
+    matched = sum(
+        1
+        for word in shorter
+        if any(
+            SequenceMatcher(a=word, b=other).ratio() >= WORD_MATCH_THRESHOLD
+            for other in longer
+        )
+    )
+    length_agreement = len(shorter) / len(longer)
+    return (matched / len(shorter)) * (
+        CONTAINMENT_WEIGHT + (1 - CONTAINMENT_WEIGHT) * length_agreement
+    )
+
+
+def name_similarity(a: Optional[str], b: Optional[str]) -> float:
+    """
+    How likely two event names are to name the same event, in [0, 1].
+
+    Offseason events get renamed constantly between years, so this looks at a
+    few different kinds of agreement and takes the strongest one:
+      * the full names look alike (discounted, since the filler words match too)
+      * one name's distinguishing words are all present in the other, which
+        covers added subtitles ("GRITS" -> "GRITS - Deep Space") and
+        reorderings ("Tennessee Valley Fair Robo-Rodeo" -> "Robo-Rodeo at the
+        TN Valley Fair")
+      * one name is an acronym of the other
+      * both names carry the same abbreviation
+    """
+    normalized_a, normalized_b = _normalize(a), _normalize(b)
+    if not normalized_a or not normalized_b:
+        return 0.0
+
+    raw_similarity = SequenceMatcher(a=normalized_a, b=normalized_b).ratio()
+    # Names that match outright aren't discounted; partial matches are, since
+    # much of what they have in common is filler.
+    score = (
+        raw_similarity if raw_similarity == 1.0 else RAW_NAME_WEIGHT * raw_similarity
+    )
+
+    significant_a, significant_b = _significant_tokens(a), _significant_tokens(b)
+    if significant_a and significant_b:
+        score = max(score, _word_containment(significant_a, significant_b))
+    else:
+        # One of the names is entirely filler words; the raw comparison is all
+        # we have, so don't discount it.
+        score = max(score, raw_similarity)
+
+    if _acronym_like_words(a) & _acronyms(b) or _acronym_like_words(b) & _acronyms(a):
+        score = max(score, ACRONYM_SCORE)
+
+    if _abbreviations(a) & _abbreviations(b):
+        score = max(score, SHARED_ABBREVIATION_SCORE)
+
+    return score
+
+
+def location_similarity(a: Event, b: Event) -> float:
+    """
+    Bonus for two events being held in the same place, in [0, 0.55].
+    """
+    score = 0.0
+    if a.country and a.country == b.country:
+        score += COUNTRY_BONUS
+    if a.state_prov and a.state_prov == b.state_prov:
+        score += STATE_BONUS
+    if _normalize(a.city) and _normalize(a.city) == _normalize(b.city):
+        score += CITY_BONUS
+    if _normalize(a.venue) and _normalize(a.venue) == _normalize(b.venue):
+        score += VENUE_BONUS
+    return score
+
+
+def event_similarity(a: Event, b: Event) -> float:
+    """
+    How likely two events are to be the same event, name plus location.
+    """
+    return name_similarity(a.name, b.name) + location_similarity(a, b)
+
+
+class SimilarEventHelper:
+    @classmethod
+    def similar_events(
+        cls,
+        candidate_event: Event,
+        events: List[Event],
+        threshold: float = SIMILARITY_THRESHOLD,
+        limit: int = MAX_SIMILAR_EVENTS,
+    ) -> List[Event]:
+        """
+        Finds the events most likely to be the same event as the candidate,
+        best match first.
+        """
+        scored = [(event_similarity(candidate_event, event), event) for event in events]
+        matches = sorted(
+            (scored_event for scored_event in scored if scored_event[0] >= threshold),
+            key=lambda scored_event: (-scored_event[0], scored_event[1].key_name),
+        )
+        return [event for _, event in matches[:limit]]

--- a/src/backend/common/helpers/tests/similar_event_helper_test.py
+++ b/src/backend/common/helpers/tests/similar_event_helper_test.py
@@ -123,6 +123,26 @@ RENAMED_EVENTS = [
         id="boilerplate_dropped",
     ),
     pytest.param(
+        make_event(
+            "2021scsc",
+            "South Carolina Robotics & Practical Off-Season",
+            "Columbia",
+            "SC",
+        ),
+        make_event("2022scsc", "SCRAP - Friday", "Sumter", "SC"),
+        id="acronym_of_an_ampersand_and_a_shortened_name",
+    ),
+    pytest.param(
+        make_event(
+            "2024mncc",
+            "Central Minnesota Robotics Conference Championship",
+            "Becker",
+            "MN",
+        ),
+        make_event("2025cmrc", "CMRC Championship", "Becker", "MN"),
+        id="acronym_of_the_front_of_a_name",
+    ),
+    pytest.param(
         make_event("2024txri", "Texas Robotics Invitational", "Houston", "TX"),
         make_event("2025txhou1", "Texas Robotics Invitational", "Houston", "TX"),
         id="same_name_new_event_short",
@@ -255,6 +275,16 @@ def test_name_similarity_ignores_case_punctuation_and_accents() -> None:
     assert name_similarity("Beach Blitz", "beach-blitz!") == identical_names
     assert (
         name_similarity("Cezeri Robot Ligi Başakşehir", "Cezeri Robot Ligi Basaksehir")
+        == identical_names
+    )
+
+
+def test_name_similarity_spells_out_ampersands() -> None:
+    identical_names = name_similarity(
+        "Robotics and Practical", "Robotics and Practical"
+    )
+    assert (
+        name_similarity("Robotics & Practical", "Robotics and Practical")
         == identical_names
     )
 

--- a/src/backend/common/helpers/tests/similar_event_helper_test.py
+++ b/src/backend/common/helpers/tests/similar_event_helper_test.py
@@ -1,0 +1,280 @@
+from typing import Optional
+
+import pytest
+
+from backend.common.consts.event_type import EventType
+from backend.common.helpers.similar_event_helper import (
+    MAX_SIMILAR_EVENTS,
+    name_similarity,
+    SimilarEventHelper,
+    SIMILARITY_THRESHOLD,
+)
+from backend.common.models.event import Event
+
+
+@pytest.fixture(autouse=True)
+def auto_add_ndb_stub(ndb_stub):
+    yield
+
+
+def make_event(
+    key: str,
+    name: str,
+    city: str = "Anytown",
+    state_prov: str = "NY",
+    country: str = "USA",
+    venue: Optional[str] = None,
+) -> Event:
+    return Event(
+        id=key,
+        year=int(key[:4]),
+        event_short=key[4:],
+        event_type_enum=EventType.OFFSEASON,
+        name=name,
+        city=city,
+        state_prov=state_prov,
+        country=country,
+        venue=venue,
+    )
+
+
+# Real year-over-year renames pulled from TBA. Each entry is
+# (last year's event, this year's suggestion) for the same recurring event.
+RENAMED_EVENTS = [
+    pytest.param(
+        make_event("2024sccol", "SCRIW XIII", "Columbia", "SC"),
+        make_event(
+            "2025sccol",
+            "South Carolina Robotics Invitational & Workshops",
+            "Colunbia",
+            "SC",
+        ),
+        id="acronym_expanded",
+    ),
+    pytest.param(
+        make_event("2024wiwi", "Where is Wolcott Invitational", "Wolcott", "CT"),
+        make_event("2025wiwi", "WIWI", "Wolcott", "CT"),
+        id="acronym_abbreviated",
+    ),
+    pytest.param(
+        make_event(
+            "2017gagr",
+            "Georgia Robotics Invitational Tournament & Showcase",
+            "Gainesville",
+            "GA",
+        ),
+        make_event("2018gagr", "GRITS", "Roswell", "GA"),
+        id="acronym_across_cities",
+    ),
+    pytest.param(
+        make_event("2023ncrc", "NCRC", "Cranberry Township", "PA"),
+        make_event(
+            "2024ncrc", "North Catholic Robotics Competition", "Cranberry Twp", "PA"
+        ),
+        id="acronym_with_generic_words",
+    ),
+    pytest.param(
+        make_event(
+            "2016ncth", "THOR - Thundering Herd of Robots", "North Carolina", "NC"
+        ),
+        make_event("2017ncth", "THOR @ UNC Pembroke", "Pembroke", "NC"),
+        id="acronym_kept_subtitle_replaced",
+    ),
+    pytest.param(
+        make_event("2018gagr", "GRITS", "Roswell", "GA"),
+        make_event("2019gagr", "GRITS – Deep Space", "Marietta", "GA"),
+        id="game_name_appended",
+    ),
+    pytest.param(
+        make_event("2021cabl", "Beach Blitz", "Aliso Viejo", "CA"),
+        make_event(
+            "2022cabl",
+            "Beach Blitz presented by the Gene Haas Foundation",
+            "Mission Viejo",
+            "CA",
+        ),
+        id="sponsor_appended",
+    ),
+    pytest.param(
+        make_event("2024tnkno", "Tennessee Valley Fair Robo-Rodeo", "Knoxville", "TN"),
+        make_event("2025tnkno", "Robo-Rodeo at the TN Valley Fair", "Knoxville", "TN"),
+        id="words_reordered",
+    ),
+    pytest.param(
+        make_event("2022scriw", "SCRIW XI", "Columbia", "SC"),
+        make_event(
+            "2023scriw",
+            "SCRIW XII (South Carolina Robotics Invitational and Workshops)",
+            "Columbia",
+            "SC",
+        ),
+        id="roman_numeral_edition",
+    ),
+    pytest.param(
+        make_event(
+            "2016iroc", "IROC - ILITE Robotics Offseason Challenge", "Virginia", "VA"
+        ),
+        make_event("2017iroc", "IROC", "Haymarket", "VA"),
+        id="subtitle_dropped",
+    ),
+    pytest.param(
+        make_event("2018mirc", "ROBO-CON FRC Off Season Competition ", "Lapeer", "MI"),
+        make_event("2019mirc", "ROBO-CON", "Lapeer", "MI"),
+        id="boilerplate_dropped",
+    ),
+    pytest.param(
+        make_event("2024txri", "Texas Robotics Invitational", "Houston", "TX"),
+        make_event("2025txhou1", "Texas Robotics Invitational", "Houston", "TX"),
+        id="same_name_new_event_short",
+    ),
+]
+
+# Real pairs of *different* offseason events whose names collide on the generic
+# robotics vocabulary that shows up in nearly every FRC event name.
+UNRELATED_EVENTS = [
+    pytest.param(
+        make_event("2023txri", "Texas Robotics Invitational", "Houston", "TX"),
+        make_event("2024wiwi", "Where is Wolcott Invitational", "Wolcott", "CT"),
+        id="shared_invitational",
+    ),
+    pytest.param(
+        make_event(
+            "2018marc", "Michigan Advanced Robotics Competition", "Monroe", "MI"
+        ),
+        make_event("2019inirr", "Indiana Robotics Invitational", "Indianapolis", "IN"),
+        id="shared_robotics",
+    ),
+    pytest.param(
+        make_event("2019nhbb", "Battle of the Bay", "Alton", "NH"),
+        make_event("2024casd", "Battle at the Border", "San Diego", "CA"),
+        id="shared_battle",
+    ),
+    pytest.param(
+        make_event(
+            "2023aztem",
+            "Sanghi Foundation Arizona FRC State Championship",
+            "Tempe",
+            "AZ",
+        ),
+        make_event("2024ohna", "Ohio FRC State Championship", "New Albany", "OH"),
+        id="shared_state_championship",
+    ),
+    pytest.param(
+        make_event("2018ohsh", "Shawshank Showdown", "Mansfield", "OH"),
+        make_event("2019flsc", "Space Coast Showdown", "Rockledge", "FL"),
+        id="shared_showdown",
+    ),
+    pytest.param(
+        make_event("2024ndse", "STEM Expo", "West Fargo", "ND"),
+        make_event("2025txsg", "STEM Gals", "Rockwall", "TX"),
+        id="shared_stem",
+    ),
+    pytest.param(
+        make_event("2018mnwcw", "West Central Week 0", "Willmar", "MN"),
+        make_event("2019mibd", "Dickinson Center Week 0", "Livonia", "MI"),
+        id="shared_week_zero",
+    ),
+]
+
+
+@pytest.mark.parametrize("last_year_event, suggested_event", RENAMED_EVENTS)
+def test_renamed_event_is_surfaced(
+    last_year_event: Event, suggested_event: Event
+) -> None:
+    assert SimilarEventHelper.similar_events(suggested_event, [last_year_event]) == [
+        last_year_event
+    ]
+
+
+@pytest.mark.parametrize("existing_event, suggested_event", UNRELATED_EVENTS)
+def test_unrelated_event_is_not_surfaced(
+    existing_event: Event, suggested_event: Event
+) -> None:
+    assert SimilarEventHelper.similar_events(suggested_event, [existing_event]) == []
+
+
+def test_no_events_to_compare_against() -> None:
+    suggested = make_event("2025nyny", "Robot Rumble")
+    assert SimilarEventHelper.similar_events(suggested, []) == []
+
+
+def test_best_match_is_listed_first() -> None:
+    suggested = make_event("2025mibro", "Goonettes Invitational", "Brownstown", "MI")
+    exact = make_event("2024mibro", "Goonettes Invitational", "Brownstown", "MI")
+    renamed = make_event(
+        "2024mibr2", "Goonettes Invitational - Day 2", "Brownstown", "MI"
+    )
+    unrelated = make_event("2024miket", "Kettering Kickoff", "Flint", "MI")
+
+    assert SimilarEventHelper.similar_events(
+        suggested, [unrelated, renamed, exact]
+    ) == [exact, renamed]
+
+
+def test_same_name_in_another_state_ranks_below_local_match() -> None:
+    suggested = make_event("2025txri", "Texas Robotics Invitational", "Houston", "TX")
+    local = make_event("2024txri", "Texas Robotics Invitational", "Houston", "TX")
+    far_away = make_event(
+        "2024mnri", "Minnesota Robotics Invitational", "Minneapolis", "MN"
+    )
+
+    assert SimilarEventHelper.similar_events(suggested, [far_away, local])[0] == local
+
+
+def test_number_of_matches_is_capped() -> None:
+    # Multi-stop series (e.g. the Arizona Robotics League) all look alike, but a
+    # reviewer only needs to see a handful of them.
+    suggested = make_event(
+        "2025azrl", "Arizona Robotics League Championship", "Phoenix", "AZ"
+    )
+    league = [
+        make_event(
+            f"2024azrl{i}", f"Arizona Robotics League Qualifier {i}", "Phoenix", "AZ"
+        )
+        for i in range(MAX_SIMILAR_EVENTS + 3)
+    ]
+
+    assert len(SimilarEventHelper.similar_events(suggested, league)) == (
+        MAX_SIMILAR_EVENTS
+    )
+
+
+def test_limit_and_threshold_are_overridable() -> None:
+    suggested = make_event("2025nyny", "Robot Rumble", "Troy", "NY")
+    events = [
+        make_event("2024nyny", "Robot Rumble", "Troy", "NY"),
+        make_event("2024nyt2", "Robot Ruckus", "Troy", "NY"),
+    ]
+
+    assert len(SimilarEventHelper.similar_events(suggested, events, limit=1)) == 1
+    assert len(SimilarEventHelper.similar_events(suggested, events, threshold=2.0)) == 0
+
+
+def test_name_similarity_ignores_case_punctuation_and_accents() -> None:
+    identical_names = name_similarity("Beach Blitz", "Beach Blitz")
+    assert name_similarity("Beach Blitz", "beach-blitz!") == identical_names
+    assert (
+        name_similarity("Cezeri Robot Ligi Başakşehir", "Cezeri Robot Ligi Basaksehir")
+        == identical_names
+    )
+
+
+def test_name_similarity_ignores_edition_markers() -> None:
+    identical_names = name_similarity("SCRIW", "SCRIW")
+    assert name_similarity("SCRIW XI", "SCRIW XIII") == identical_names
+    assert (
+        name_similarity("Battle of the Bay 2024", "Battle of the Bay")
+        == identical_names
+    )
+
+
+def test_name_similarity_of_missing_names() -> None:
+    assert name_similarity(None, "Beach Blitz") == 0.0
+    assert name_similarity("Beach Blitz", "") == 0.0
+
+
+def test_name_similarity_of_only_generic_names() -> None:
+    # Nothing distinguishing to compare, so these fall back to comparing the
+    # names as written rather than comparing two empty strings.
+    assert name_similarity("Off-Season Event", "Offseason Event") > SIMILARITY_THRESHOLD
+    assert name_similarity("Robotics Competition", "Beach Blitz") < SIMILARITY_THRESHOLD

--- a/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from difflib import SequenceMatcher
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from flask import redirect, request
 from google.appengine.ext import ndb
@@ -11,9 +10,10 @@ from werkzeug.wrappers import Response
 from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.event_type import EventType
 from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.helpers.similar_event_helper import SimilarEventHelper
 from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.models.event import Event
-from backend.common.models.keys import EventKey
+from backend.common.models.keys import EventKey, Year
 from backend.common.models.suggestion import Suggestion
 from backend.common.queries.event_query import EventListQuery
 from backend.web.handlers.suggestions.suggestion_review_base import (
@@ -135,29 +135,27 @@ The Blue Alliance Admins\
             .filter(Suggestion.target_model == "offseason-event")
         )
 
-        year = datetime.now().year
-        year_events_future = EventListQuery(year).fetch_async()
-        last_year_events_future = EventListQuery(year - 1).fetch_async()
         events_and_ids = [
             self._create_candidate_event(suggestion) for suggestion in suggestions
         ]
 
-        year_events = year_events_future.get_result()
-        year_offseason_events = [
-            e for e in year_events if e.event_type_enum == EventType.OFFSEASON
-        ]
-        last_year_events = last_year_events_future.get_result()
-        last_year_offseason_events = [
-            e for e in last_year_events if e.event_type_enum == EventType.OFFSEASON
-        ]
+        # Compare each suggestion against the year it happens in, not against
+        # the year we happen to be reviewing it in -- suggestions for next
+        # year's preseason events show up before the new year starts.
+        default_year = datetime.now().year
+        similar_years = [event.year or default_year for _, event in events_and_ids]
+
+        offseasons_by_year = self._fetch_offseason_events(
+            {year for y in similar_years for year in (y, y - 1)}
+        )
 
         similar_events = [
-            self._get_similar_events(event[1], year_offseason_events)
-            for event in events_and_ids
+            self._get_similar_events(event, offseasons_by_year.get(year, []))
+            for (_, event), year in zip(events_and_ids, similar_years)
         ]
         similar_last_year = [
-            self._get_similar_events(event[1], last_year_offseason_events)
-            for event in events_and_ids
+            self._get_similar_events(event, offseasons_by_year.get(year - 1, []))
+            for (_, event), year in zip(events_and_ids, similar_years)
         ]
 
         template_values = {
@@ -166,6 +164,7 @@ The Blue Alliance Admins\
             "events_and_ids": events_and_ids,
             "similar_events": similar_events,
             "similar_last_year": similar_last_year,
+            "similar_years": similar_years,
         }
         return render_template(
             "suggestions/suggest_offseason_event_review_list.html", template_values
@@ -230,17 +229,28 @@ The Blue Alliance Admins\
         )
 
     @classmethod
+    def _fetch_offseason_events(cls, years: Set[Year]) -> Dict[Year, List[Event]]:
+        """
+        Fetches the non-official events for each year, keyed by year
+        """
+        futures = {year: EventListQuery(year).fetch_async() for year in years}
+        return {
+            year: [e for e in future.get_result() if e.is_offseason]
+            for year, future in futures.items()
+        }
+
+    @classmethod
     def _get_similar_events(
         cls, candidate_event: Event, offseason_events: List[Event]
     ) -> List[Tuple[str, str]]:
         """
-        Finds events this year with a similar name
-        Returns a tuple of (event key, event name)
+        Finds the events most likely to be the same event as the suggestion,
+        best match first.
+        Returns a list of (event key, event name)
         """
-        similar_events = []
-        for event in offseason_events:
-            similarity = SequenceMatcher(a=candidate_event.name, b=event.name).ratio()
-            if similarity > 0.5:
-                # Somewhat arbitrary cutoff
-                similar_events.append((event.key_name, event.name))
-        return similar_events
+        return [
+            (event.key_name, event.name)
+            for event in SimilarEventHelper.similar_events(
+                candidate_event, offseason_events
+            )
+        ]

--- a/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_review_controller_test.py
+++ b/src/backend/web/handlers/suggestions/tests/suggest_offseason_event_review_controller_test.py
@@ -1,9 +1,11 @@
+import datetime
 import re
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import pytest
 from bs4 import BeautifulSoup
+from freezegun import freeze_time
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 from werkzeug.test import Client
@@ -49,21 +51,70 @@ def get_suggestion_queue_and_fields(
     return queue, (inputs or {})
 
 
-def createSuggestion(logged_in_user) -> int:
+def createSuggestion(
+    logged_in_user,
+    name: str = "Test Event",
+    city: str = "New York",
+    state: str = "NY",
+) -> int:
     status = SuggestionCreator.createOffseasonEventSuggestion(
         logged_in_user.account_key,
-        "Test Event",
+        name,
         "2016-10-12",
         "2016-10-13",
         "http://foo.bar.com",
         "Venue Name",
         "123 Fake St",
-        "New York",
-        "NY",
+        city,
+        state,
         "USA",
     )
     assert status[0] == SuggestionCreationStatus.SUCCESS
     return none_throws(Suggestion.query().fetch(keys_only=True)[0].integer_id())
+
+
+def createEvent(
+    event_key: str,
+    name: str,
+    city: str = "New York",
+    state: str = "NY",
+    event_type: EventType = EventType.OFFSEASON,
+) -> Event:
+    year = int(event_key[:4])
+    event = Event(
+        id=event_key,
+        event_short=event_key[4:],
+        year=year,
+        name=name,
+        event_type_enum=event_type,
+        city=city,
+        state_prov=state,
+        country="USA",
+        start_date=datetime.datetime(year, 10, 12),
+        end_date=datetime.datetime(year, 10, 13),
+    )
+    event.put()
+    return event
+
+
+def get_similar_events(web_client: Client) -> Dict[str, List[str]]:
+    """
+    Returns the event keys the review page suggests as prior instances of each
+    pending suggestion, keyed by the heading they are listed under.
+    """
+    response = web_client.get("/suggest/offseason/review")
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.data, "html.parser")
+    review_form = soup.find(id="review_offseasons")
+    assert review_form is not None
+
+    similar_events = {}
+    for heading in review_form.find_all("h3", string=re.compile("^Similar Events")):
+        similar_events[heading.get_text(strip=True)] = [
+            link["href"].split("/event/")[1]
+            for link in heading.find_next_sibling("ul").find_all("a")
+        ]
+    return similar_events
 
 
 def test_login_redirect(web_client: Client) -> None:
@@ -368,3 +419,82 @@ def test_reject_does_not_create_audit_log(
     assert response.status_code == 302
 
     assert AuditLogEntry.query().count() == 0
+
+
+def test_similar_event_from_last_year_is_surfaced_despite_rename(
+    login_user_with_permission, web_client: Client, ndb_stub
+) -> None:
+    """Offseason events get renamed year to year, often to or from an acronym"""
+    createSuggestion(
+        login_user_with_permission,
+        name="South Carolina Robotics Invitational & Workshops",
+        city="Columbia",
+        state="SC",
+    )
+    createEvent("2015scriw", "SCRIW XII", city="Columbia", state="SC")
+
+    assert get_similar_events(web_client)["Similar Events in 2015"] == ["2015scriw"]
+
+
+def test_similar_preseason_event_is_surfaced(
+    login_user_with_permission, web_client: Client, ndb_stub
+) -> None:
+    """Prior instances of an event may have been categorized as preseason"""
+    createSuggestion(login_user_with_permission, name="Blue Twilight Week Zero")
+    createEvent(
+        "2015mnbt",
+        "Blue Twilight Week Zero Invitational",
+        event_type=EventType.PRESEASON,
+    )
+
+    assert get_similar_events(web_client)["Similar Events in 2015"] == ["2015mnbt"]
+
+
+def test_similar_event_from_the_suggested_year_is_surfaced(
+    login_user_with_permission, web_client: Client, ndb_stub
+) -> None:
+    """The event short of a recurring event changes year to year, so an event
+    that already exists this year won't be caught by the duplicate key check"""
+    createSuggestion(login_user_with_permission, name="Texas Robotics Invitational")
+    createEvent("2016txhou1", "Texas Robotics Invitational")
+
+    assert get_similar_events(web_client)["Similar Events in 2016"] == ["2016txhou1"]
+
+
+def test_unrelated_event_is_not_surfaced(
+    login_user_with_permission, web_client: Client, ndb_stub
+) -> None:
+    """Nearly every FRC event name shares words with every other one"""
+    createSuggestion(
+        login_user_with_permission,
+        name="Where is Wolcott Invitational",
+        city="Wolcott",
+        state="CT",
+    )
+    createEvent("2015txri", "Texas Robotics Invitational", city="Houston", state="TX")
+
+    assert get_similar_events(web_client)["Similar Events in 2015"] == []
+
+
+def test_official_events_are_not_surfaced(
+    login_user_with_permission, web_client: Client, ndb_stub
+) -> None:
+    createSuggestion(login_user_with_permission, name="Rocket City Regional")
+    createEvent("2015alhu", "Rocket City Regional", event_type=EventType.REGIONAL)
+
+    assert get_similar_events(web_client)["Similar Events in 2015"] == []
+
+
+@freeze_time("2020-06-01")
+def test_similar_events_are_compared_against_the_suggested_year(
+    login_user_with_permission, web_client: Client, ndb_stub
+) -> None:
+    """Suggestions are reviewed whenever a reviewer gets to them, which may be
+    a different year than the one the suggested event happens in"""
+    createSuggestion(login_user_with_permission, name="Beach Blitz")
+    createEvent("2015cabl", "Beach Blitz")
+    createEvent("2019cabl", "Beach Blitz")
+
+    similar_events = get_similar_events(web_client)
+    assert similar_events["Similar Events in 2015"] == ["2015cabl"]
+    assert "Similar Events in 2019" not in similar_events

--- a/src/backend/web/templates/suggestions/suggest_offseason_event_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_offseason_event_review_list.html
@@ -73,7 +73,7 @@
     <div class="col-xs-12">
       {% for suggestion_id, event in events_and_ids %}
         <div class="well">
-          <h3>Similar Events This Year</h3>
+          <h3>Similar Events in {{similar_years[loop.index0]}}</h3>
           <ul>
           {% for similar_key, similar_name in similar_events[loop.index0] %}
             <li><a href="/event/{{similar_key}}">{{similar_name}} ({{similar_key}})</a></li>
@@ -82,7 +82,7 @@
           {% endfor %}
           </ul>
 
-          <h3>Similar Events Last Year</h3>
+          <h3>Similar Events in {{similar_years[loop.index0] - 1}}</h3>
           <ul>
           {% for similar_key, similar_name in similar_last_year[loop.index0] %}
             <li><a href="/event/{{similar_key}}">{{similar_name}} ({{similar_key}})</a></li>


### PR DESCRIPTION
> Originally posted as an RFC; landing as-is after sitting for comment. The thresholds and the generic-word list remain judgment calls — if reviewing offseason suggestions surfaces the wrong things, they're the knobs to turn.

## Problem

When a reviewer looks at `/suggest/offseason/review`, the page lists similar existing events so they can tell a new event from a returning one and reuse a sensible event short. Today that list comes from `SequenceMatcher(candidate.name, event.name).ratio() > 0.5`, which fails in both directions because offseason events are renamed constantly.

I pulled every event from 2016–2025 with the `tba` CLI and built a ground-truth set of **571 real year-over-year offseason pairs** (same event code, identical normalized name, or same venue + city in consecutive years). Against that set the current rule gets **90.0% recall while showing 3.00 matches per suggestion**, and the failures are systematic:

**Renames it can't see**

| Last year | This year | Score |
| --- | --- | --- |
| `SCRIW XIII` | `South Carolina Robotics Invitational & Workshops` | 0.10 |
| `Where is Wolcott Invitational` | `WIWI` | 0.12 |
| `GRITS` | `Georgia Robotics Invitational Tournament & Showcase` | 0.16 |
| `NCRC` | `North Catholic Robotics Competition` | 0.21 |
| `Tennessee Valley Fair Robo-Rodeo` | `Robo-Rodeo at the TN Valley Fair` | 0.44 |

**Noise it does show** — 1,661 pairs land in the 0.50–0.72 band, nearly all of it from vocabulary that appears in every FRC event name (*Robotics*, *Invitational*, *Championship*, *Week 0*): `Texas Robotics Invitational` vs. `Where is Wolcott Invitational` scores 0.73 across different states.

Two related gaps:

- **Preseason and unlabeled events were filtered out** (`event_type_enum == OFFSEASON` only), hiding 37 prior-year instances in the corpus, 16 of which cross the offseason/preseason boundary.
- **Comparisons used `datetime.now().year`**, not the year the suggested event happens in — so a suggestion for next January's preseason event was compared against the wrong two years.

Worth noting for context: offseason event codes are *not* stable year to year (`2024txri` → `2025txhou1` is the same event), which is exactly why this list matters — the duplicate-key check can't catch a returning event.

## Approach

New `SimilarEventHelper` scores each pair as the strongest of:

- whole-name similarity, discounted — much of what two event names share is filler
- **word containment** over only the distinguishing words, fuzzy-matched so typos and pluralization still line up. Comparing word by word means one shared long word doesn't make two events look alike, while an added subtitle or a reordering doesn't make them look different
- **acronym vs. expansion** — `GRITS` ↔ `Georgia Robotics Invitational Tournament & Showcase`. Which words contribute a letter varies, so an ampersand counts as a word in one variant and is skipped in another (`SCRAP` ↔ `South Carolina Robotics & Practical Off-Season` needs it; `GRITS` skips it), and an acronym may stop partway through a name (`CMRC` ↔ `Central Minnesota Robotics Conference Championship`)
- **shared abbreviation** — `THOR - Thundering Herd of Robots` ↔ `THOR @ UNC Pembroke`

plus a location bonus (country / state / city / venue) that boosts a match but never makes one on its own. Results are ranked best-first and capped at 8, which is enough for multi-stop series like the Arizona Robotics League.

## Results

On the same 571 pairs:

| | Recall | Avg. matches shown |
| --- | --- | --- |
| Before | 90.0% (514/571) | 3.00 |
| After | **99.5%** (568/571) | **1.49** |

Better recall and half the noise. Of the three remaining misses, two are ground-truth artifacts (different events sharing a Hamilton, ON venue) and one is a complete rebranding with no shared words (`Lapeer Robotics ROBOCON Competition 1` → `RoboCat-astrophe`).

## Tests

30 helper tests built from the real renames and the real near-miss collisions in the pull, plus 6 handler tests covering rename surfacing, preseason inclusion, key drift within a year, generic-name rejection, official-event exclusion, and the year-window fix.

## Open questions

- **Threshold (0.65) and cap (8).** Tuned for recall on the assumption that a reviewer would rather glance past one extra event than miss a returning one. Happy to trade the other way.
- **The generic-word list is hand-built.** `state` and `championship` are in it, which means `Ohio State Championship` and `Ohio Robotics Invitational` in the same city score as a strong match. Deriving word weights from the year's event list (IDF-style) would be principled but is more machinery than this page probably warrants.
- **Only the event's own year and the year before are searched.** Some events skip a year. Worth widening to two years back?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


