### PR TITLE
Add sort order arrows for user account review Write API Keys list

### DIFF
--- a/src/backend/web/handlers/account.py
+++ b/src/backend/web/handlers/account.py
@@ -36,6 +36,7 @@ from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.match_helper import MatchHelper
 from backend.common.helpers.mytba_helper import MyTBAHelper
 from backend.common.helpers.season_helper import SeasonHelper
+from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.event import Event
 from backend.common.models.favorite import Favorite
 from backend.common.models.keys import EventKey, TeamNumber
@@ -49,9 +50,35 @@ from backend.web.redirect import is_safe_url, safe_next_redirect
 blueprint = Blueprint("account", __name__, url_prefix="/account")
 
 
+def _api_write_key_sort_key(api_key: ApiAuthAccess) -> tuple[bool, str, str]:
+    event_keys = sorted(str(event_key.id()) for event_key in api_key.event_list)
+    return (
+        not event_keys,
+        event_keys[0] if event_keys else "",
+        str(api_key.key.id()),
+    )
+
+
+def _sorted_api_write_keys(
+    api_write_keys: list[ApiAuthAccess], descending: bool
+) -> list[ApiAuthAccess]:
+    keys_with_events = [key for key in api_write_keys if key.event_list]
+    keys_without_events = [key for key in api_write_keys if not key.event_list]
+    return sorted(
+        keys_with_events,
+        key=_api_write_key_sort_key,
+        reverse=descending,
+    ) + sorted(keys_without_events, key=_api_write_key_sort_key)
+
+
 @blueprint.route("")
 @require_login
 def overview() -> str:
+    user = none_throws(current_user())
+    api_write_keys_sort_direction = request.args.get("api_write_keys_sort", "asc")
+    if api_write_keys_sort_direction not in {"asc", "desc"}:
+        api_write_keys_sort_direction = "asc"
+
     template_values = {
         "status": session.pop("account_status", None),
         "webhook_verification_success": request.args.get(
@@ -60,6 +87,11 @@ def overview() -> str:
         "ping_sent": session.pop("ping_sent", None),
         "ping_enabled": NotificationsEnable.notifications_enabled(),
         "auth_write_type_names": AUTH_TYPE_WRITE_TYPE_NAMES,
+        "api_write_keys": _sorted_api_write_keys(
+            user.api_write_keys,
+            descending=api_write_keys_sort_direction == "desc",
+        ),
+        "api_write_keys_sort_direction": api_write_keys_sort_direction,
     }
     return render_template("account_overview.html", **template_values)
 

--- a/src/backend/web/handlers/tests/account_overview_test.py
+++ b/src/backend/web/handlers/tests/account_overview_test.py
@@ -608,6 +608,78 @@ def test_api_write_keys(
         assert len(api_write) == 0
 
 
+@pytest.mark.parametrize(
+    "path, expected_key_ids",
+    [
+        (
+            "/account",
+            [
+                "key-multiple-events",
+                "key-2025",
+                "key-2026",
+                "key-no-event",
+            ],
+        ),
+        (
+            "/account?api_write_keys_sort=desc",
+            [
+                "key-2026",
+                "key-2025",
+                "key-multiple-events",
+                "key-no-event",
+            ],
+        ),
+    ],
+)
+def test_api_write_keys_sorted_by_event_key(
+    login_user,
+    web_client: FlaskClient,
+    path: str,
+    expected_key_ids: List[str],
+) -> None:
+    def api_write_key(key_id: str, event_ids: List[str]) -> Mock:
+        events = []
+        for event_id in event_ids:
+            event = Mock()
+            event.configure_mock(**{"id.return_value": event_id})
+            events.append(event)
+
+        key = Mock(event_list=events, auth_types_enum=[])
+        key.expiration = None
+        key.secret = "secret"
+        key.key.configure_mock(**{"id.return_value": key_id})
+        return key
+
+    login_user.api_write_keys = [
+        api_write_key("key-2026", ["2026nmrc"]),
+        api_write_key("key-no-event", []),
+        api_write_key("key-multiple-events", ["2025mrcmp", "2024nmrc"]),
+        api_write_key("key-2025", ["2025nmrc"]),
+    ]
+
+    response = web_client.get(path)
+
+    assert response.status_code == 200
+    soup = bs4.BeautifulSoup(response.data, "html.parser")
+    api_write_rows = soup.find_all("tr", attrs={"class": "api-write-key"})
+    assert [
+        row.find_all("td")[3].text.strip() for row in api_write_rows
+    ] == expected_key_ids
+
+    ascending_sort = soup.find(id="api-write-keys-sort-asc")
+    descending_sort = soup.find(id="api-write-keys-sort-desc")
+    assert ascending_sort.get("href") == "/account?api_write_keys_sort=asc"
+    assert descending_sort.get("href") == "/account?api_write_keys_sort=desc"
+    assert ascending_sort.get("aria-label") == "Sort ascending"
+    assert descending_sort.get("aria-label") == "Sort descending"
+    assert ascending_sort.find("span", class_="glyphicon-arrow-up") is not None
+    assert descending_sort.find("span", class_="glyphicon-arrow-down") is not None
+
+    descending = path.endswith("desc")
+    assert ("btn-primary" in ascending_sort.get("class")) is not descending
+    assert ("btn-primary" in descending_sort.get("class")) is descending
+
+
 def test_auth_write_type_names(
     login_user,
     captured_templates: List[CapturedTemplate],

--- a/src/backend/web/templates/account_overview.html
+++ b/src/backend/web/templates/account_overview.html
@@ -216,14 +216,20 @@
     <div class="col-md-10 col-md-offset-1">
       <table id="api-write-keys" class="table table-striped">
         <tr>
-          <th>Event</th>
+          <th>
+            Event
+            <span class="btn-group btn-group-xs" role="group" aria-label="Sort write API keys by event">
+              <a id="api-write-keys-sort-asc" href="{{ url_for('account.overview', api_write_keys_sort='asc') }}" class="btn btn-{% if api_write_keys_sort_direction == 'asc' %}primary{% else %}default{% endif %}" aria-label="Sort ascending" title="Sort ascending" aria-pressed="{{ 'true' if api_write_keys_sort_direction == 'asc' else 'false' }}"><span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span></a>
+              <a id="api-write-keys-sort-desc" href="{{ url_for('account.overview', api_write_keys_sort='desc') }}" class="btn btn-{% if api_write_keys_sort_direction == 'desc' %}primary{% else %}default{% endif %}" aria-label="Sort descending" title="Sort descending" aria-pressed="{{ 'true' if api_write_keys_sort_direction == 'desc' else 'false' }}"><span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span></a>
+            </span>
+          </th>
           <th>Permissions</th>
           <th>Expires</th>
           <th>Auth ID</th>
           <th>Auth Secret</th>
         </tr>
         <tbody>
-          {% for key in user.api_write_keys %}
+          {% for key in api_write_keys %}
             <tr class="api-write-key">
               <td>
               {% for event in key.event_list %}


### PR DESCRIPTION
## Description
Add a sorting function to the Write API Keys listed on a users account overview page

## Motivation and Context
- Currently, the Write API Keys seem to have no logical order. Every year I add several events that I need to search the list to find the entry. This sort enables the user to sort in ascending or descending order. 
- No open issues found



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I bootstrapped a few events I have hosted the past few years into a locally running instance of TBA, I then added these events to the local account using the /admin/api_auth/add interface
<!--- Include details of your testing environment, and the tests you ran too -->
Windows 11
VSCODE with CODEX Pro add-on installed
Docker Desktop

compose exec tba make test  
    ==== short test summary info ====
    FAILED src/backend/common/environment/tests/environment_test.py::test_auth_emulator_host_none - AssertionError: assert 'firebase:9099' is None
    ==== 1 failed, 4490 passed, 38 skipped in 764.83s (0:12:44) ====
compose exec tba make lint  
   All done!
compose exec tba make typecheck
   no errors

## Screenshots (if appropriate):
<img width="1339" height="570" alt="image" src="https://github.com/user-attachments/assets/9ae80fcd-893a-4ffb-bbad-596d88e7a697" />

## Screenshot Pages
<!--- For PRs that touch pwa/ files, list additional pages to screenshot. -->
<!--- Each line: - /path Optional Display Name -->
<!--- Example: - /match/2024mil_f1m2 Match Page -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
