### PR TITLE
[pwa] Show DCMP/CMP slot counts on districts page

### DIFF
--- a/pwa/app/routes/districts.{-$year}.tsx
+++ b/pwa/app/routes/districts.{-$year}.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { useQueries, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import { useMemo } from 'react';
 
@@ -16,6 +16,11 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui/table';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '~/components/ui/tooltip';
 import { staleTimeForYear } from '~/lib/queryClient';
 import {
   parseParamsForYearElseDefault,
@@ -32,21 +37,10 @@ export const Route = createFileRoute('/districts/{-$year}')({
 
     const yearStaleTime = staleTimeForYear(year);
 
-    const districts = await queryClient.ensureQueryData({
+    await queryClient.ensureQueryData({
       ...getDistrictsByYearOptions({ path: { year } }),
       staleTime: yearStaleTime,
     });
-
-    await Promise.all(
-      districts.map((district) =>
-        queryClient.ensureQueryData({
-          ...getDistrictTeamsKeysOptions({
-            path: { district_key: district.key },
-          }),
-          staleTime: yearStaleTime,
-        }),
-      ),
-    );
 
     return { year };
   },
@@ -79,6 +73,29 @@ export const Route = createFileRoute('/districts/{-$year}')({
   component: DistrictsPage,
 });
 
+function AdvancementCountCell({
+  slots,
+  teamCount,
+}: {
+  slots: number;
+  teamCount: number | undefined;
+}) {
+  if (teamCount === undefined) {
+    return <TableCell className="text-right numeric-data">{slots}</TableCell>;
+  }
+
+  const percentage = Math.round((slots / teamCount) * 100);
+
+  return (
+    <TableCell className="text-right numeric-data">
+      <Tooltip>
+        <TooltipTrigger>{slots}</TooltipTrigger>
+        <TooltipContent>{percentage}% of teams</TooltipContent>
+      </Tooltip>
+    </TableCell>
+  );
+}
+
 function DistrictsPage() {
   const { year } = Route.useLoaderData();
   const yearStaleTime = staleTimeForYear(year);
@@ -95,17 +112,17 @@ function DistrictsPage() {
     [districts],
   );
 
-  const teamKeyResults = useSuspenseQueries({
+  const teamKeyResults = useQueries({
     queries: districts.map((district) => ({
       ...getDistrictTeamsKeysOptions({ path: { district_key: district.key } }),
       staleTime: yearStaleTime,
     })),
   });
 
-  const teamKeyCounts = teamKeyResults.map((result) => result.data.length);
+  const teamKeyCounts = teamKeyResults.map((result) => result.data?.length);
 
   const teamCountByDistrict = useMemo(() => {
-    const map = new Map<string, number>();
+    const map = new Map<string, number | undefined>();
     districts.forEach((district, i) => {
       map.set(district.key, teamKeyCounts[i]);
     });
@@ -138,6 +155,8 @@ function DistrictsPage() {
             <TableHead>District</TableHead>
             <TableHead>Key</TableHead>
             <TableHead className="text-right">Teams</TableHead>
+            <TableHead className="text-right">DCMP Slots</TableHead>
+            <TableHead className="text-right">CMP Slots</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -155,8 +174,16 @@ function DistrictsPage() {
                 {district.abbreviation}
               </TableCell>
               <TableCell className="text-right numeric-data">
-                {teamCountByDistrict.get(district.key)}
+                {teamCountByDistrict.get(district.key) ?? '-'}
               </TableCell>
+              <AdvancementCountCell
+                slots={district.official_advancement_counts.dcmp}
+                teamCount={teamCountByDistrict.get(district.key)}
+              />
+              <AdvancementCountCell
+                slots={district.official_advancement_counts.cmp}
+                teamCount={teamCountByDistrict.get(district.key)}
+              />
             </TableRow>
           ))}
         </TableBody>


### PR DESCRIPTION
## Description
Adds "DCMP Slots" and "CMP Slots" columns to the districts index page (`/districts/:year`). Each column shows the district's official advancement count. Hovering over a count shows what percentage of the district's teams it represents.

This also changes the per-district team-count query from `useSuspenseQueries` to `useQueries`. A slow or failed fetch for one district no longer blocks the whole table. Counts show as `-` until they load.

## Motivation and Context
Users could already see team counts per district. They could not see how many DCMP/CMP slots each district has. This column adds that context, and pairs with the advancement cutoff work later in this stack.

## How Has This Been Tested?
Manual verification in the dev server against `/districts/:year`.

## Screenshot Pages
- /districts/2026 Districts Page

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
