### PR TITLE
Add DCMP advancement cutoff calculations

### DIFF
--- a/src/backend/common/helpers/district_advancement_helper.py
+++ b/src/backend/common/helpers/district_advancement_helper.py
@@ -1,0 +1,203 @@
+import heapq
+from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
+
+from backend.common.consts.award_type import AwardType
+from backend.common.consts.event_type import EventType
+from backend.common.helpers.district_helper import (
+    DistrictHelper,
+    DistrictRankingTiebreakers,
+)
+from backend.common.models.district import District
+from backend.common.models.district_advancement import DistrictAdvancementCutoffs
+from backend.common.models.district_ranking import DistrictRanking
+from backend.common.models.event import Event
+from backend.common.models.event_district_points import TeamAtEventDistrictPoints
+from backend.common.models.keys import EventKey, TeamKey
+from backend.common.queries.award_query import EventAwardsQuery
+
+
+class DcmpCutoffs(NamedTuple):
+    original: int
+    effective: int
+    declined: List[TeamKey]
+
+
+class DistrictAdvancementHelper:
+    @classmethod
+    def _competed_at_dcmp(cls, ranking: DistrictRanking) -> bool:
+        return any(
+            event_points.get("district_cmp")
+            and (
+                event_points["qual_points"]
+                or event_points["elim_points"]
+                or event_points["alliance_points"]
+            )
+            for event_points in ranking["event_points"]
+        )
+
+    @classmethod
+    def dcmp_attendance(cls, rankings: Sequence[DistrictRanking]) -> Set[TeamKey]:
+        return {r["team_key"] for r in rankings if cls._competed_at_dcmp(r)}
+
+    @classmethod
+    def match_scores_by_event(
+        cls, events: Sequence[Event]
+    ) -> Dict[EventKey, Dict[TeamKey, List[int]]]:
+        return {
+            event.key_name: {
+                team_key: tiebreakers.get("highest_match_scores", [])
+                for team_key, tiebreakers in event.district_points.get(
+                    "tiebreakers", {}
+                ).items()
+            }
+            for event in events
+            if event.district_points
+        }
+
+    @classmethod
+    def pre_dcmp_rankings(
+        cls,
+        rankings: Sequence[DistrictRanking],
+        match_scores: Optional[Dict[EventKey, Dict[TeamKey, List[int]]]] = None,
+    ) -> List[DistrictRanking]:
+        match_scores = match_scores or {}
+        adjusted: List[Tuple[Tuple[int, ...], DistrictRanking]] = []
+        for ranking in rankings:
+            kept: List[TeamAtEventDistrictPoints] = [
+                ep for ep in ranking["event_points"] if not ep.get("district_cmp")
+            ]
+            dcmp_total = sum(
+                ep["total"] for ep in ranking["event_points"] if ep.get("district_cmp")
+            )
+            elim = [ep["elim_points"] for ep in kept]
+            alliance = [ep["alliance_points"] for ep in kept]
+
+            pre_dcmp = DistrictRanking(
+                rank=ranking["rank"],
+                team_key=ranking["team_key"],
+                point_total=ranking["point_total"] - dcmp_total,
+                rookie_bonus=ranking["rookie_bonus"],
+                event_points=kept,
+            )
+            if "other_bonus" in ranking:
+                pre_dcmp["other_bonus"] = ranking["other_bonus"]
+            if "adjustments" in ranking:
+                pre_dcmp["adjustments"] = ranking["adjustments"]
+
+            top_match_scores = heapq.nlargest(
+                3,
+                [
+                    score
+                    for ep in kept
+                    for score in match_scores.get(ep["event_key"], {}).get(
+                        ranking["team_key"], []
+                    )
+                ],
+            )
+            top_match_scores += [0] * (3 - len(top_match_scores))
+
+            tiebreakers = DistrictRankingTiebreakers(
+                total_playoff_points=sum(elim),
+                best_playoff_points=max(elim, default=0),
+                total_alliance_points=sum(alliance),
+                best_alliance_points=max(alliance, default=0),
+                total_qual_points=sum(ep["qual_points"] for ep in kept),
+            )
+            sort_key = tuple(
+                DistrictHelper.ranking_sort_key(
+                    pre_dcmp["point_total"], tiebreakers, top_match_scores
+                )
+            ) + (ranking["rank"],)
+            adjusted.append((sort_key, pre_dcmp))
+
+        adjusted.sort(key=lambda item: item[0])
+
+        ordered = [ranking for _, ranking in adjusted]
+        for rank, ranking in enumerate(ordered, start=1):
+            ranking["rank"] = rank
+        return ordered
+
+    @classmethod
+    def calculate_dcmp_cutoffs(
+        cls,
+        pre_dcmp_rankings: Sequence[DistrictRanking],
+        slots: int,
+        auto_qualified: Set[TeamKey],
+        attendance: Set[TeamKey],
+    ) -> DcmpCutoffs:
+        ranked_teams = {r["team_key"] for r in pre_dcmp_rankings}
+        invited = auto_qualified & ranked_teams
+
+        remaining = slots - len(invited)
+        original = 0
+        for ranking in pre_dcmp_rankings:
+            if remaining <= 0:
+                break
+            if ranking["team_key"] in invited:
+                continue
+            original = ranking["point_total"]
+            remaining -= 1
+
+        points_attendees = [
+            r
+            for r in pre_dcmp_rankings
+            if r["team_key"] in attendance and r["team_key"] not in auto_qualified
+        ]
+        if not points_attendees:
+            return DcmpCutoffs(original=original, effective=0, declined=[])
+
+        lowest = points_attendees[-1]
+        declined = [
+            r["team_key"]
+            for r in pre_dcmp_rankings
+            if r["rank"] < lowest["rank"]
+            and r["team_key"] not in auto_qualified
+            and r["team_key"] not in attendance
+        ]
+        return DcmpCutoffs(
+            original=original,
+            effective=lowest["point_total"],
+            declined=declined,
+        )
+
+    @classmethod
+    def impact_award_winners(cls, events: Sequence[Event]) -> Set[TeamKey]:
+        winners: Set[TeamKey] = set()
+        award_futures = [
+            EventAwardsQuery(event_key=event.key_name).fetch_async()
+            for event in events
+            if event.event_type_enum == EventType.DISTRICT
+        ]
+        for future in award_futures:
+            for award in future.get_result():
+                if award.award_type_enum != AwardType.CHAIRMANS:
+                    continue
+                winners.update(team.id() for team in award.team_list)
+        return winners
+
+    @classmethod
+    def calculate_for_district(
+        cls, district: District, events: Sequence[Event]
+    ) -> Optional[DistrictAdvancementCutoffs]:
+        rankings = district.rankings
+        if not rankings:
+            return None
+
+        attendance = cls.dcmp_attendance(rankings)
+        if not attendance:
+            return None
+
+        dcmp = cls.calculate_dcmp_cutoffs(
+            cls.pre_dcmp_rankings(rankings, cls.match_scores_by_event(events)),
+            district.official_advancement_counts["dcmp"],
+            cls.impact_award_winners(events),
+            attendance,
+        )
+        return DistrictAdvancementCutoffs(
+            dcmp_original=dcmp.original,
+            dcmp_effective=dcmp.effective,
+            dcmp_declines=dcmp.declined,
+            cmp_original=0,
+            cmp_effective=0,
+            cmp_declines=[],
+        )

--- a/src/backend/common/helpers/district_helper.py
+++ b/src/backend/common/helpers/district_helper.py
@@ -211,6 +211,19 @@ class DistrictHelper:
         return district_points
 
     @classmethod
+    def ranking_sort_key(
+        cls,
+        point_total: int,
+        tiebreakers: Sequence[int],
+        match_scores: Sequence[int],
+    ) -> List[int]:
+        return (
+            [-point_total]
+            + [-t for t in tiebreakers]
+            + [-score for score in match_scores]
+        )
+
+    @classmethod
     def calculate_rankings(
         cls,
         events: List[Event],
@@ -352,11 +365,11 @@ class DistrictHelper:
         team_totals = dict(
             sorted(
                 team_totals.items(),
-                key=lambda item: [
-                    -item[1]["point_total"],
-                ]
-                + [-t for t in item[1]["tiebreakers"]]
-                + [-score for score in item[1]["match_scores"]],
+                key=lambda item: cls.ranking_sort_key(
+                    item[1]["point_total"],
+                    item[1]["tiebreakers"],
+                    item[1]["match_scores"],
+                ),
             )
         )
 

--- a/src/backend/common/helpers/tests/data/2026fim_awards.json
+++ b/src/backend/common/helpers/tests/data/2026fim_awards.json
@@ -1,0 +1,7118 @@
+[
+  {
+    "award_type": 0,
+    "event_key": "2026mibat",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4810"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mibat",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4237"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2767"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5538"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11511"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mibat",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11511"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mibat",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9215"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mibat",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9758"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mibat",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5675"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mibat",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mibat",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5675"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9776"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mibat",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5462"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mibat",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mibat",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11431"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mibat",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5248"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mibat",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5577"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mibat",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Tyler W",
+        "team_key": "frc1502"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mibat",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4237"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mibat",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8126"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mibat",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9776"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mibat",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1502"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mibel",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1188"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mibel",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6615"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4391"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6538"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mibel",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6615"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mibel",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4405"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mibel",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6120"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mibel",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1701"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mibel",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1188"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1701"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5067"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9455"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mibel",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8373"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mibel",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3656"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mibel",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9455"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mibel",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3641"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mibel",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6528"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mibel",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Aarya Y",
+        "team_key": "frc245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mibel",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4391"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mibel",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mibel",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9751"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mibel",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10656"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026miber",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc302"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026miber",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4237"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9758"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6588"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026miber",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11431"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026miber",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3452"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026miber",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4237"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026miber",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2959"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026miber",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9758"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026miber",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5535"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc302"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9182"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026miber",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5227"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026miber",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5462"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026miber",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4855"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026miber",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026miber",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5927"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026miber",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Vrishab M",
+        "team_key": "frc503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026miber",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3620"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026miber",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2604"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026miber",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10633"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026miber",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mibig",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1718"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mibig",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1918"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7160"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5213"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mibig",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11435"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mibig",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9176"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mibig",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7160"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mibig",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5535"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mibig",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5982"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mibig",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc244"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6100"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8286"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mibig",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3618"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mibig",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9673"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mibig",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6642"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mibig",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4004"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mibig",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5704"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mibig",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Arianna M",
+        "team_key": "frc3618"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mibig",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1918"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mibig",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc244"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mibig",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10421"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mibig",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc288"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mibkn",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mibkn",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9210"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3414"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3773"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mibkn",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11444"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mibkn",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2611"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mibkn",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4381"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mibkn",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4003"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mibkn",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3668"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mibkn",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5676"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1481"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mibkn",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9210"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mibkn",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1025"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mibkn",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4216"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mibkn",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7501"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mibkn",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4422"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mibkn",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Sayan S",
+        "team_key": "frc9312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mibkn",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc862"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mibkn",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1481"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mibkn",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5205"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mibkn",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mibro",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3604"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mibro",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc469"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8179"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mibro",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8179"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mibro",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6152"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mibro",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2620"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mibro",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3322"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mibro",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc247"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6528"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2832"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mibro",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1189"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mibro",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mibro",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6528"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mibro",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc469"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mibro",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc217"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mibro",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Gus S",
+        "team_key": "frc1189"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mibro",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5907"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mibro",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2832"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mibro",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc247"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mibro",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2834"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026miche",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1502"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026miche",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5460"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5567"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026miche",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11387"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026miche",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc302"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026miche",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3656"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026miche",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026miche",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2611"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026miche",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3656"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc302"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7056"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026miche",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7501"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026miche",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3641"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026miche",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7197"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026miche",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1076"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026miche",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6570"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026miche",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Sawyer B",
+        "team_key": "frc27"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026miche",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026miche",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5530"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026miche",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10285"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026miche",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5708"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026micmp",
+    "name": "District Championship FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5577"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3620"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3604"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc245"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026micmp",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3668"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026micmp",
+    "name": "District Championship Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11387"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11493"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026micmp",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5460"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7197"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4327"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 3,
+    "event_key": "2026micmp",
+    "name": "Woodie Flowers Finalist Award",
+    "recipient_list": [
+      {
+        "awardee": "Darren Losey",
+        "team_key": "frc226"
+      },
+      {
+        "awardee": "Julie Kausch",
+        "team_key": "frc217"
+      },
+      {
+        "awardee": "Jason Markesino",
+        "team_key": "frc27"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026micmp",
+    "name": "FIRST Leadership Award Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Sawyer B",
+        "team_key": "frc27"
+      },
+      {
+        "awardee": "Brett D",
+        "team_key": "frc2851"
+      },
+      {
+        "awardee": "Julia F",
+        "team_key": "frc6753"
+      },
+      {
+        "awardee": "Varun G",
+        "team_key": "frc548"
+      },
+      {
+        "awardee": "Emily L",
+        "team_key": "frc4422"
+      },
+      {
+        "awardee": "Vrishab M",
+        "team_key": "frc503"
+      },
+      {
+        "awardee": "Arianna M",
+        "team_key": "frc3618"
+      },
+      {
+        "awardee": "Samantha M",
+        "team_key": "frc3604"
+      },
+      {
+        "awardee": "Caiden N",
+        "team_key": "frc4967"
+      },
+      {
+        "awardee": "Logan P",
+        "team_key": "frc4810"
+      },
+      {
+        "awardee": "Soph R",
+        "team_key": "frc247"
+      },
+      {
+        "awardee": "Sayan S",
+        "team_key": "frc9312"
+      },
+      {
+        "awardee": "Casper S",
+        "team_key": "frc201"
+      },
+      {
+        "awardee": "Aarya Y",
+        "team_key": "frc245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026micmp",
+    "name": "District Championship Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026micmp1",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3668"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026micmp1",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1189"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026micmp1",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026micmp1",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8517"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026micmp1",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1502"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026micmp1",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5907"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026micmp1",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4362"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026micmp1",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc67"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026micmp1",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4680"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026micmp1",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8126"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026micmp1",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc85"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026micmp1",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026micmp1",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3357"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026micmp1",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026micmp2",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6090"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2767"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2586"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026micmp2",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2611"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026micmp2",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026micmp2",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1023"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026micmp2",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026micmp2",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3414"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc469"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc862"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026micmp2",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026micmp2",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026micmp2",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6528"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026micmp2",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc469"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026micmp2",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7598"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026micmp2",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6090"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026micmp2",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026micmp2",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4398"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026micmp3",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7166"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2337"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8280"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026micmp3",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8280"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026micmp3",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1711"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026micmp3",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026micmp3",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc818"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026micmp3",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5066"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc548"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4967"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026micmp3",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7056"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026micmp3",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2960"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026micmp3",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc70"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026micmp3",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5066"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026micmp3",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1481"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026micmp3",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4391"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026micmp3",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4956"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026micmp3",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5229"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026micmp4",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5460"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7197"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026micmp4",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2619"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026micmp4",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026micmp4",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1918"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026micmp4",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5534"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026micmp4",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1701"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3641"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5216"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026micmp4",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5460"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026micmp4",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc573"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026micmp4",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7197"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026micmp4",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3536"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026micmp4",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8873"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026micmp4",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026micmp4",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3707"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026micmp4",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11386"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026midtr",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5577"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026midtr",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3175"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc123"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5478"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026midtr",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11490"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026midtr",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2224"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026midtr",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2048"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026midtr",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7196"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026midtr",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4838"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026midtr",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8352"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9255"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3632"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026midtr",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026midtr",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc123"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026midtr",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7692"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026midtr",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8352"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026midtr",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4680"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026midtr",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Katia C",
+        "team_key": "frc5577"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026midtr",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9255"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026midtr",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10577"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026midtr",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10607"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026midtr",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3175"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026miesc",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5193"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026miesc",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4391"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5193"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6079"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026miesc",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4835"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026miesc",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5086"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026miesc",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3602"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026miesc",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10589"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026miesc",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5505"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2586"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10622"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026miesc",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10595"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026miesc",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6637"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026miesc",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6079"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026miesc",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4392"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026miesc",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4377"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026miesc",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Brooke R",
+        "team_key": "frc3770"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026miesc",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4391"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026miesc",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6088"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026miesc",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10605"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026miesc",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3770"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mifen",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc862"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mifen",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5114"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5660"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8193"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mifen",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10978"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mifen",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9207"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mifen",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6073"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mifen",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc494"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mifen",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc70"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mifen",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc494"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc68"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7598"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mifen",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6548"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mifen",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mifen",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7598"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mifen",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7202"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mifen",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3098"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mifen",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Logan P",
+        "team_key": "frc4810"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mifen",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc68"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mifen",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3568"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mifen",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7772"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mifen",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4810"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mifli",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2337"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mifli",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2337"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc68"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6085"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mifli",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11527"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mifli",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mifli",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5612"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mifli",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9757"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mifli",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5660"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mifli",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9757"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5660"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9648"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mifli",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6085"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mifli",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc68"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mifli",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4998"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mifli",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5046"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mifli",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5167"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mifli",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc894"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mifli",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5561"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mifli",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5282"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mifli",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5235"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026miken",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3620"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026miken",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7220"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10633"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10642"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026miken",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11399"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026miken",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9638"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026miken",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9549"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026miken",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1023"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026miken",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9208"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026miken",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5166"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc858"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026miken",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3234"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026miken",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6081"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026miken",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5980"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026miken",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026miken",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4967"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026miken",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Caiden N",
+        "team_key": "frc4967"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026miken",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10633"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026miken",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026miken",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7656"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026miken",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026milac",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc226"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026milac",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3603"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2054"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9650"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026milac",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11437"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026milac",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8041"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026milac",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2586"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026milac",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5534"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026milac",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7790"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026milac",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc226"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3536"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4983"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7855"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026milac",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7768"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026milac",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1684"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026milac",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6121"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026milac",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3603"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026milac",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7250"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026milac",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Finnegan E",
+        "team_key": "frc3536"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026milac",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2054"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026milac",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc141"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026milac",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3537"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026milac",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3536"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026milak",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026milak",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2767"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8608"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8397"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026milak",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11386"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026milak",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5248"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026milak",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3875"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026milak",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026milak",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5675"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026milak",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4237"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10473"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026milak",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4237"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026milak",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8608"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026milak",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7226"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026milak",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6002"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026milak",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9566"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026milak",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Niyati P",
+        "team_key": "frc4237"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026milak",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5152"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026milak",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4327"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026milak",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11407"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026milak",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1188"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026miliv",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026miliv",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc27"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8115"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026miliv",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11361"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026miliv",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026miliv",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1481"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026miliv",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2832"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026miliv",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026miliv",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1189"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3414"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5050"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026miliv",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc123"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026miliv",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026miliv",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5843"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026miliv",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1189"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026miliv",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5533"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026miliv",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Charles G",
+        "team_key": "frc3414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026miliv",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6152"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026miliv",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5907"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026miliv",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8297"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026miliv",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2604"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026milsu",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3452"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026milsu",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6121"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4779"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6088"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026milsu",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7768"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026milsu",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9249"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026milsu",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5424"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026milsu",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4398"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026milsu",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10666"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8517"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4375"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026milsu",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9548"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026milsu",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4967"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026milsu",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4779"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026milsu",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3536"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026milsu",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10605"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026milsu",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Robert P",
+        "team_key": "frc6121"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026milsu",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6121"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026milsu",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10666"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026milsu",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8517"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026milsu",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5216"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mimar",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1506"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mimar",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc33"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3539"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1718"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mimar",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11493"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mimar",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7211"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mimar",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7247"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mimar",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6120"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mimar",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5843"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mimar",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9245"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2851"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4130"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mimar",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8728"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mimar",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc818"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mimar",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5926"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mimar",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mimar",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3539"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mimar",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "John T",
+        "team_key": "frc1506"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mimar",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc33"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mimar",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1718"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mimar",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4130"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mimar",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8280"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mimas",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4327"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mimas",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5712"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8608"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9251"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mimas",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3655"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mimas",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8424"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mimas",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mimas",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3707"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mimas",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2137"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7166"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8374"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mimas",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8608"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mimas",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mimas",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9255"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mimas",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6078"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mimas",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5926"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mimas",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Leo R",
+        "team_key": "frc3655"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mimas",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2137"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mimas",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc910"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mimas",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11490"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mimas",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mimid",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc201"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mimid",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5166"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5712"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5603"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mimid",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11458"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mimid",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mimid",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6073"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mimid",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8517"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mimid",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8873"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mimid",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8873"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5216"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5424"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mimid",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9685"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mimid",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3770"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mimid",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2619"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mimid",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3357"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mimid",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5216"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mimid",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Casper S",
+        "team_key": "frc201"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mimid",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5533"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mimid",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6753"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mimid",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10629"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mimid",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mimil",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mimil",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4362"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3538"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8424"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mimil",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11457"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mimil",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1023"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mimil",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5066"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mimil",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc67"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mimil",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4362"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mimil",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2137"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc67"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc308"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mimil",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2145"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mimil",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3707"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mimil",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7660"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mimil",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6615"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mimil",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8424"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mimil",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Varun G",
+        "team_key": "frc548"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mimil",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2137"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mimil",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc548"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mimil",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10285"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mimil",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mimtp",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mimtp",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7166"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2337"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5234"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mimtp",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6642"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mimtp",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5110"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mimtp",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8873"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mimtp",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3688"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mimtp",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4381"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc573"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9673"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mimtp",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3655"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mimtp",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2337"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mimtp",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5982"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mimtp",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc573"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mimtp",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4422"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mimtp",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Emily L",
+        "team_key": "frc4422"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mimtp",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4381"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mimtp",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5436"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mimtp",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9568"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mimtp",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1711"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mimus",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4967"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mimus",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8612"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4967"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9106"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mimus",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mimus",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc107"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mimus",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7160"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mimus",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6090"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mimus",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mimus",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2075"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6090"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mimus",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3458"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mimus",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8612"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mimus",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7248"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mimus",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5505"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mimus",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6428"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mimus",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "McKenna B",
+        "team_key": "frc2405"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mimus",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2075"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mimus",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mimus",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6079"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mimus",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2405"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026misal",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc548"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026misal",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5460"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc67"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3568"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026misal",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11455"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026misal",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4395"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026misal",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5066"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026misal",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5460"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026misal",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc66"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026misal",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5066"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc548"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3632"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026misal",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc67"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026misal",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2834"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026misal",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10656"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026misal",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1076"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026misal",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc308"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026misal",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Samantha M",
+        "team_key": "frc3604"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026misal",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3322"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026misal",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3604"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026misal",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6057"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026misal",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1506"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mitr2",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc217"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mitr2",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1701"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc503"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2224"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mitr2",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11461"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mitr2",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8352"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mitr2",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc818"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mitr2",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc51"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mitr2",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8280"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mitr2",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7188"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc51"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2591"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mitr2",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3667"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mitr2",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1025"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mitr2",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2048"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mitr2",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1701"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mitr2",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5756"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mitr2",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Soph R",
+        "team_key": "frc247"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mitr2",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5531"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mitr2",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mitr2",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6616"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mitr2",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2960"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mitry",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc573"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mitry",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4362"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9679"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mitry",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11486"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mitry",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8728"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mitry",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5436"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mitry",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9245"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mitry",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc226"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mitry",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc201"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc33"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10612"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mitry",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc33"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mitry",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4362"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mitry",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4998"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mitry",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc469"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mitry",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7762"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mitry",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Brett D",
+        "team_key": "frc2851"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mitry",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7769"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mitry",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc201"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mitry",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1498"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mitry",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2851"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mitvc",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7598"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mitvc",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5534"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4398"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mitvc",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11466"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mitvc",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3618"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mitvc",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mitvc",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5193"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mitvc",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5534"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mitvc",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5193"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5086"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10614"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mitvc",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6569"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mitvc",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5086"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mitvc",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5110"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mitvc",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7782"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mitvc",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mitvc",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Cole H",
+        "team_key": "frc3767"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mitvc",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7790"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mitvc",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1711"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mitvc",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4398"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mitvc",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5509"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026miwmi",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2619"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026miwmi",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6090"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3539"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5623"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026miwmi",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11522"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026miwmi",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc85"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026miwmi",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6753"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026miwmi",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026miwmi",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3357"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026miwmi",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1918"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3572"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8397"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026miwmi",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3539"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026miwmi",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1918"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026miwmi",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7248"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026miwmi",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7054"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026miwmi",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4680"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026miwmi",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Julia F",
+        "team_key": "frc6753"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026miwmi",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6090"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026miwmi",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7195"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026miwmi",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9542"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026miwmi",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3572"
+      }
+    ],
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026fim_district_points.json
+++ b/src/backend/common/helpers/tests/data/2026fim_district_points.json
@@ -1,0 +1,18735 @@
+{
+ "2026mibat": {
+  "points": {
+   "frc10651": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc10654": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 7,
+    "total": 24
+   },
+   "frc11407": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc11423": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc11431": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc11460": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc11496": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc11511": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc1502": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 34
+   },
+   "frc2767": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc3234": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc3658": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc4237": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc4453": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc4568": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4810": {
+    "alliance_points": 5,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc4855": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc5150": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 18
+   },
+   "frc5152": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 43
+   },
+   "frc5227": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc5248": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc5462": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc5538": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 24,
+    "qual_points": 4,
+    "total": 29
+   },
+   "frc5577": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 28
+   },
+   "frc5675": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc6002": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc6556": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc6588": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7211": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 40
+   },
+   "frc7865": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc8126": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 31
+   },
+   "frc9205": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc9215": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 49
+   },
+   "frc9239": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9672": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9703": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc9743": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc9758": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   },
+   "frc9776": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 9,
+    "total": 36
+   }
+  },
+  "tiebreakers": {
+   "frc10651": {
+    "highest_match_scores": [
+     293,
+     250,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc10654": {
+    "highest_match_scores": [
+     355,
+     264,
+     246
+    ],
+    "qual_wins": 0
+   },
+   "frc11407": {
+    "highest_match_scores": [
+     340,
+     225,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc11423": {
+    "highest_match_scores": [
+     307,
+     192,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc11431": {
+    "highest_match_scores": [
+     406,
+     282,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc11460": {
+    "highest_match_scores": [
+     377,
+     359,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc11496": {
+    "highest_match_scores": [
+     306,
+     254,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc11511": {
+    "highest_match_scores": [
+     410,
+     354,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc1502": {
+    "highest_match_scores": [
+     314,
+     277,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc2767": {
+    "highest_match_scores": [
+     595,
+     513,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc3234": {
+    "highest_match_scores": [
+     357,
+     282,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc3658": {
+    "highest_match_scores": [
+     368,
+     306,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc4237": {
+    "highest_match_scores": [
+     513,
+     496,
+     489
+    ],
+    "qual_wins": 0
+   },
+   "frc4453": {
+    "highest_match_scores": [
+     340,
+     272,
+     270
+    ],
+    "qual_wins": 0
+   },
+   "frc4568": {
+    "highest_match_scores": [
+     304,
+     197,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc4810": {
+    "highest_match_scores": [
+     489,
+     359,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc4855": {
+    "highest_match_scores": [
+     258,
+     229,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc5150": {
+    "highest_match_scores": [
+     322,
+     307,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc5152": {
+    "highest_match_scores": [
+     377,
+     354,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc5227": {
+    "highest_match_scores": [
+     252,
+     248,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc5248": {
+    "highest_match_scores": [
+     319,
+     245,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc5462": {
+    "highest_match_scores": [
+     381,
+     359,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc5538": {
+    "highest_match_scores": [
+     496,
+     487,
+     466
+    ],
+    "qual_wins": 0
+   },
+   "frc5577": {
+    "highest_match_scores": [
+     473,
+     240,
+     211
+    ],
+    "qual_wins": 0
+   },
+   "frc5675": {
+    "highest_match_scores": [
+     473,
+     380,
+     380
+    ],
+    "qual_wins": 0
+   },
+   "frc6002": {
+    "highest_match_scores": [
+     595,
+     489,
+     381
+    ],
+    "qual_wins": 0
+   },
+   "frc6556": {
+    "highest_match_scores": [
+     270,
+     225,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc6588": {
+    "highest_match_scores": [
+     595,
+     293,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc7211": {
+    "highest_match_scores": [
+     406,
+     355,
+     277
+    ],
+    "qual_wins": 0
+   },
+   "frc7865": {
+    "highest_match_scores": [
+     240,
+     196,
+     129
+    ],
+    "qual_wins": 0
+   },
+   "frc8126": {
+    "highest_match_scores": [
+     359,
+     357,
+     319
+    ],
+    "qual_wins": 0
+   },
+   "frc9205": {
+    "highest_match_scores": [
+     381,
+     289,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc9215": {
+    "highest_match_scores": [
+     358,
+     304,
+     301
+    ],
+    "qual_wins": 0
+   },
+   "frc9239": {
+    "highest_match_scores": [
+     513,
+     196,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc9672": {
+    "highest_match_scores": [
+     197,
+     183,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc9703": {
+    "highest_match_scores": [
+     314,
+     254,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc9743": {
+    "highest_match_scores": [
+     368,
+     322,
+     277
+    ],
+    "qual_wins": 0
+   },
+   "frc9758": {
+    "highest_match_scores": [
+     358,
+     272,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc9776": {
+    "highest_match_scores": [
+     380,
+     380,
+     336
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mibel": {
+  "points": {
+   "frc10656": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 16
+   },
+   "frc10672": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc11505": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc1188": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 63
+   },
+   "frc1250": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 18
+   },
+   "frc1528": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc1701": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 56
+   },
+   "frc245": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 41
+   },
+   "frc3098": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc3641": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 22,
+    "total": 56
+   },
+   "frc3656": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 21,
+    "total": 55
+   },
+   "frc4391": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 69
+   },
+   "frc4395": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc4405": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc4737": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 20
+   },
+   "frc5053": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc5067": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 30
+   },
+   "frc5263": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5498": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc5708": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 34
+   },
+   "frc6029": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 19
+   },
+   "frc6120": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc6190": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6344": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc6528": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 30
+   },
+   "frc6538": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 44
+   },
+   "frc66": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc6615": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 70
+   },
+   "frc6618": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 7,
+    "total": 21
+   },
+   "frc7220": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 31
+   },
+   "frc7247": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc8373": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc8623": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc8832": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc9204": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc94": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9455": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc9735": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9751": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   }
+  },
+  "tiebreakers": {
+   "frc10656": {
+    "highest_match_scores": [
+     211,
+     141,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc10672": {
+    "highest_match_scores": [
+     226,
+     168,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc11505": {
+    "highest_match_scores": [
+     227,
+     178,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc1188": {
+    "highest_match_scores": [
+     281,
+     276,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc1250": {
+    "highest_match_scores": [
+     302,
+     222,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc1528": {
+    "highest_match_scores": [
+     199,
+     161,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc1701": {
+    "highest_match_scores": [
+     298,
+     283,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc245": {
+    "highest_match_scores": [
+     276,
+     254,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc3098": {
+    "highest_match_scores": [
+     257,
+     245,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc3641": {
+    "highest_match_scores": [
+     400,
+     382,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc3656": {
+    "highest_match_scores": [
+     400,
+     382,
+     322
+    ],
+    "qual_wins": 0
+   },
+   "frc4391": {
+    "highest_match_scores": [
+     333,
+     328,
+     316
+    ],
+    "qual_wins": 0
+   },
+   "frc4395": {
+    "highest_match_scores": [
+     322,
+     193,
+     173
+    ],
+    "qual_wins": 0
+   },
+   "frc4405": {
+    "highest_match_scores": [
+     298,
+     259,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc4737": {
+    "highest_match_scores": [
+     281,
+     269,
+     218
+    ],
+    "qual_wins": 0
+   },
+   "frc5053": {
+    "highest_match_scores": [
+     322,
+     281,
+     281
+    ],
+    "qual_wins": 0
+   },
+   "frc5067": {
+    "highest_match_scores": [
+     298,
+     276,
+     251
+    ],
+    "qual_wins": 0
+   },
+   "frc5263": {
+    "highest_match_scores": [
+     348,
+     333,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc5498": {
+    "highest_match_scores": [
+     245,
+     245,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc5708": {
+    "highest_match_scores": [
+     373,
+     281,
+     254
+    ],
+    "qual_wins": 0
+   },
+   "frc6029": {
+    "highest_match_scores": [
+     203,
+     199,
+     142
+    ],
+    "qual_wins": 0
+   },
+   "frc6120": {
+    "highest_match_scores": [
+     298,
+     213,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc6190": {
+    "highest_match_scores": [
+     180,
+     161,
+     128
+    ],
+    "qual_wins": 0
+   },
+   "frc6344": {
+    "highest_match_scores": [
+     295,
+     283,
+     218
+    ],
+    "qual_wins": 0
+   },
+   "frc6528": {
+    "highest_match_scores": [
+     314,
+     173,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc6538": {
+    "highest_match_scores": [
+     328,
+     316,
+     287
+    ],
+    "qual_wins": 0
+   },
+   "frc66": {
+    "highest_match_scores": [
+     257,
+     222,
+     184
+    ],
+    "qual_wins": 0
+   },
+   "frc6615": {
+    "highest_match_scores": [
+     373,
+     328,
+     316
+    ],
+    "qual_wins": 0
+   },
+   "frc6618": {
+    "highest_match_scores": [
+     400,
+     382,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc7220": {
+    "highest_match_scores": [
+     348,
+     302,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc7247": {
+    "highest_match_scores": [
+     269,
+     211,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc8373": {
+    "highest_match_scores": [
+     333,
+     295,
+     254
+    ],
+    "qual_wins": 0
+   },
+   "frc8623": {
+    "highest_match_scores": [
+     314,
+     142,
+     133
+    ],
+    "qual_wins": 0
+   },
+   "frc8832": {
+    "highest_match_scores": [
+     254,
+     203,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc9204": {
+    "highest_match_scores": [
+     245,
+     156,
+     142
+    ],
+    "qual_wins": 0
+   },
+   "frc94": {
+    "highest_match_scores": [
+     225,
+     180,
+     133
+    ],
+    "qual_wins": 0
+   },
+   "frc9455": {
+    "highest_match_scores": [
+     254,
+     252,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc9735": {
+    "highest_match_scores": [
+     235,
+     211,
+     133
+    ],
+    "qual_wins": 0
+   },
+   "frc9751": {
+    "highest_match_scores": [
+     228,
+     209,
+     198
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026miber": {
+  "points": {
+   "frc10473": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 16
+   },
+   "frc10633": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 21,
+    "total": 54
+   },
+   "frc10642": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc10666": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 15
+   },
+   "frc11399": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc11431": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc11491": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc11511": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc1504": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc1940": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc2604": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc2959": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 39
+   },
+   "frc2960": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc302": {
+    "alliance_points": 13,
+    "award_points": 10,
+    "elim_points": 20,
+    "qual_points": 14,
+    "total": 57
+   },
+   "frc3452": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc3620": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 49
+   },
+   "frc4237": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc4325": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 17
+   },
+   "frc4855": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 42
+   },
+   "frc503": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 39
+   },
+   "frc5182": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc5227": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc5462": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc5535": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 51
+   },
+   "frc5927": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 23
+   },
+   "frc6002": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc6548": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 26
+   },
+   "frc6588": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 10,
+    "qual_points": 13,
+    "total": 23
+   },
+   "frc7203": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc74": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc7809": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc7814": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 19
+   },
+   "frc9182": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 4,
+    "total": 28
+   },
+   "frc9208": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 26
+   },
+   "frc9549": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9758": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 14,
+    "total": 40
+   }
+  },
+  "tiebreakers": {
+   "frc10473": {
+    "highest_match_scores": [
+     292,
+     256,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc10633": {
+    "highest_match_scores": [
+     412,
+     339,
+     328
+    ],
+    "qual_wins": 0
+   },
+   "frc10642": {
+    "highest_match_scores": [
+     227,
+     204,
+     166
+    ],
+    "qual_wins": 0
+   },
+   "frc10666": {
+    "highest_match_scores": [
+     223,
+     192,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc11399": {
+    "highest_match_scores": [
+     215,
+     192,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc11431": {
+    "highest_match_scores": [
+     412,
+     233,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc11491": {
+    "highest_match_scores": [
+     254,
+     178,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc11511": {
+    "highest_match_scores": [
+     255,
+     178,
+     173
+    ],
+    "qual_wins": 0
+   },
+   "frc1504": {
+    "highest_match_scores": [
+     320,
+     281,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc1940": {
+    "highest_match_scores": [
+     181,
+     166,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc2604": {
+    "highest_match_scores": [
+     272,
+     170,
+     98
+    ],
+    "qual_wins": 0
+   },
+   "frc2959": {
+    "highest_match_scores": [
+     405,
+     296,
+     294
+    ],
+    "qual_wins": 0
+   },
+   "frc2960": {
+    "highest_match_scores": [
+     313,
+     219,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc302": {
+    "highest_match_scores": [
+     320,
+     292,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc3452": {
+    "highest_match_scores": [
+     281,
+     269,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc3620": {
+    "highest_match_scores": [
+     339,
+     328,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc4237": {
+    "highest_match_scores": [
+     442,
+     435,
+     434
+    ],
+    "qual_wins": 0
+   },
+   "frc4325": {
+    "highest_match_scores": [
+     256,
+     239,
+     119
+    ],
+    "qual_wins": 0
+   },
+   "frc4855": {
+    "highest_match_scores": [
+     296,
+     269,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc503": {
+    "highest_match_scores": [
+     294,
+     239,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc5182": {
+    "highest_match_scores": [
+     288,
+     189,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc5227": {
+    "highest_match_scores": [
+     435,
+     193,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc5462": {
+    "highest_match_scores": [
+     294,
+     254,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc5535": {
+    "highest_match_scores": [
+     405,
+     233,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc5927": {
+    "highest_match_scores": [
+     304,
+     223,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc6002": {
+    "highest_match_scores": [
+     442,
+     435,
+     434
+    ],
+    "qual_wins": 0
+   },
+   "frc6548": {
+    "highest_match_scores": [
+     339,
+     328,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc6588": {
+    "highest_match_scores": [
+     434,
+     335,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc7203": {
+    "highest_match_scores": [
+     171,
+     170,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc74": {
+    "highest_match_scores": [
+     188,
+     172,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc7809": {
+    "highest_match_scores": [
+     288,
+     227,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc7814": {
+    "highest_match_scores": [
+     233,
+     210,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc9182": {
+    "highest_match_scores": [
+     233,
+     227,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc9208": {
+    "highest_match_scores": [
+     313,
+     296,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc9549": {
+    "highest_match_scores": [
+     304,
+     225,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc9758": {
+    "highest_match_scores": [
+     442,
+     407,
+     343
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mibig": {
+  "points": {
+   "frc10421": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 29
+   },
+   "frc11435": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 16
+   },
+   "frc1718": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 21,
+    "total": 59
+   },
+   "frc1918": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc244": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 52
+   },
+   "frc288": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 55
+   },
+   "frc3603": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc3618": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc4004": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc5162": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5182": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5183": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5213": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 7,
+    "total": 38
+   },
+   "frc5247": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5525": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5535": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc5704": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc5878": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5982": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 37
+   },
+   "frc6005": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 23
+   },
+   "frc6077": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 32
+   },
+   "frc6091": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6098": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc6100": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 14,
+    "total": 45
+   },
+   "frc6122": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 19
+   },
+   "frc6642": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 30
+   },
+   "frc6963": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 25
+   },
+   "frc7109": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 18
+   },
+   "frc7160": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc7203": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7794": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc7810": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7911": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc8286": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 5,
+    "total": 31
+   },
+   "frc8611": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc9176": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc9673": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc9721": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9731": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9736": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9771": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   }
+  },
+  "tiebreakers": {
+   "frc10421": {
+    "highest_match_scores": [
+     406,
+     248,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc11435": {
+    "highest_match_scores": [
+     207,
+     165,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc1718": {
+    "highest_match_scores": [
+     404,
+     283,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc1918": {
+    "highest_match_scores": [
+     458,
+     407,
+     406
+    ],
+    "qual_wins": 0
+   },
+   "frc244": {
+    "highest_match_scores": [
+     294,
+     197,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc288": {
+    "highest_match_scores": [
+     353,
+     261,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc3603": {
+    "highest_match_scores": [
+     407,
+     248,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc3618": {
+    "highest_match_scores": [
+     317,
+     199,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc4004": {
+    "highest_match_scores": [
+     283,
+     221,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc5162": {
+    "highest_match_scores": [
+     294,
+     150,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc5182": {
+    "highest_match_scores": [
+     170,
+     110,
+     99
+    ],
+    "qual_wins": 0
+   },
+   "frc5183": {
+    "highest_match_scores": [
+     317,
+     221,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc5213": {
+    "highest_match_scores": [
+     345,
+     319,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc5247": {
+    "highest_match_scores": [
+     289,
+     168,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc5525": {
+    "highest_match_scores": [
+     243,
+     199,
+     136
+    ],
+    "qual_wins": 0
+   },
+   "frc5535": {
+    "highest_match_scores": [
+     406,
+     294,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc5704": {
+    "highest_match_scores": [
+     243,
+     163,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc5878": {
+    "highest_match_scores": [
+     404,
+     118,
+     106
+    ],
+    "qual_wins": 0
+   },
+   "frc5982": {
+    "highest_match_scores": [
+     458,
+     294,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc6005": {
+    "highest_match_scores": [
+     352,
+     261,
+     152
+    ],
+    "qual_wins": 0
+   },
+   "frc6077": {
+    "highest_match_scores": [
+     283,
+     248,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc6091": {
+    "highest_match_scores": [
+     155,
+     153,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc6098": {
+    "highest_match_scores": [
+     223,
+     148,
+     83
+    ],
+    "qual_wins": 0
+   },
+   "frc6100": {
+    "highest_match_scores": [
+     294,
+     254,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc6122": {
+    "highest_match_scores": [
+     367,
+     199,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc6642": {
+    "highest_match_scores": [
+     182,
+     169,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc6963": {
+    "highest_match_scores": [
+     238,
+     185,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc7109": {
+    "highest_match_scores": [
+     289,
+     187,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc7160": {
+    "highest_match_scores": [
+     345,
+     319,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc7203": {
+    "highest_match_scores": [
+     238,
+     197,
+     155
+    ],
+    "qual_wins": 0
+   },
+   "frc7794": {
+    "highest_match_scores": [
+     407,
+     184,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc7810": {
+    "highest_match_scores": [
+     367,
+     175,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc7911": {
+    "highest_match_scores": [
+     353,
+     285,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc8286": {
+    "highest_match_scores": [
+     177,
+     170,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc8611": {
+    "highest_match_scores": [
+     352,
+     207,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc9176": {
+    "highest_match_scores": [
+     285,
+     180,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc9673": {
+    "highest_match_scores": [
+     458,
+     199,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc9721": {
+    "highest_match_scores": [
+     119,
+     83,
+     76
+    ],
+    "qual_wins": 0
+   },
+   "frc9731": {
+    "highest_match_scores": [
+     143,
+     124,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc9736": {
+    "highest_match_scores": [
+     199,
+     124,
+     115
+    ],
+    "qual_wins": 0
+   },
+   "frc9771": {
+    "highest_match_scores": [
+     185,
+     184,
+     173
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mibkn": {
+  "points": {
+   "frc1025": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 33
+   },
+   "frc11386": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 33
+   },
+   "frc11387": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc11444": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 16
+   },
+   "frc11460": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc11462": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 25
+   },
+   "frc11496": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc1481": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 51
+   },
+   "frc2611": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc3414": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 74
+   },
+   "frc3668": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 52
+   },
+   "frc3773": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 5,
+    "total": 36
+   },
+   "frc4003": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 34
+   },
+   "frc4216": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc4381": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 27
+   },
+   "frc4422": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc4568": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5144": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 21,
+    "total": 49
+   },
+   "frc5205": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc5239": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5530": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 15
+   },
+   "frc5641": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 15
+   },
+   "frc5676": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 47
+   },
+   "frc6556": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7197": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 33
+   },
+   "frc7221": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7225": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc7501": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 35
+   },
+   "frc7656": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc8300": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 25
+   },
+   "frc862": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 33
+   },
+   "frc9183": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9210": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc9212": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9312": {
+    "alliance_points": 6,
+    "award_points": 10,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 49
+   },
+   "frc9594": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9753": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   }
+  },
+  "tiebreakers": {
+   "frc1025": {
+    "highest_match_scores": [
+     338,
+     303,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc11386": {
+    "highest_match_scores": [
+     266,
+     264,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc11387": {
+    "highest_match_scores": [
+     220,
+     208,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc11444": {
+    "highest_match_scores": [
+     279,
+     236,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc11460": {
+    "highest_match_scores": [
+     224,
+     215,
+     161
+    ],
+    "qual_wins": 0
+   },
+   "frc11462": {
+    "highest_match_scores": [
+     246,
+     240,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc11496": {
+    "highest_match_scores": [
+     338,
+     209,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc1481": {
+    "highest_match_scores": [
+     393,
+     276,
+     267
+    ],
+    "qual_wins": 0
+   },
+   "frc2611": {
+    "highest_match_scores": [
+     425,
+     281,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc3414": {
+    "highest_match_scores": [
+     425,
+     393,
+     353
+    ],
+    "qual_wins": 0
+   },
+   "frc3668": {
+    "highest_match_scores": [
+     353,
+     338,
+     299
+    ],
+    "qual_wins": 0
+   },
+   "frc3773": {
+    "highest_match_scores": [
+     349,
+     347,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc4003": {
+    "highest_match_scores": [
+     353,
+     302,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc4216": {
+    "highest_match_scores": [
+     260,
+     242,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc4381": {
+    "highest_match_scores": [
+     312,
+     266,
+     246
+    ],
+    "qual_wins": 0
+   },
+   "frc4422": {
+    "highest_match_scores": [
+     280,
+     225,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc4568": {
+    "highest_match_scores": [
+     323,
+     221,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc5144": {
+    "highest_match_scores": [
+     299,
+     299,
+     280
+    ],
+    "qual_wins": 0
+   },
+   "frc5205": {
+    "highest_match_scores": [
+     273,
+     254,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc5239": {
+    "highest_match_scores": [
+     303,
+     242,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc5530": {
+    "highest_match_scores": [
+     267,
+     212,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc5641": {
+    "highest_match_scores": [
+     425,
+     270,
+     231
+    ],
+    "qual_wins": 0
+   },
+   "frc5676": {
+    "highest_match_scores": [
+     281,
+     276,
+     251
+    ],
+    "qual_wins": 0
+   },
+   "frc6556": {
+    "highest_match_scores": [
+     267,
+     202,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc7197": {
+    "highest_match_scores": [
+     273,
+     245,
+     236
+    ],
+    "qual_wins": 0
+   },
+   "frc7221": {
+    "highest_match_scores": [
+     248,
+     215,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc7225": {
+    "highest_match_scores": [
+     257,
+     246,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc7501": {
+    "highest_match_scores": [
+     279,
+     264,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc7656": {
+    "highest_match_scores": [
+     312,
+     267,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc8300": {
+    "highest_match_scores": [
+     299,
+     299,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc862": {
+    "highest_match_scores": [
+     302,
+     270,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc9183": {
+    "highest_match_scores": [
+     257,
+     210,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc9210": {
+    "highest_match_scores": [
+     349,
+     347,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc9212": {
+    "highest_match_scores": [
+     206,
+     182,
+     161
+    ],
+    "qual_wins": 0
+   },
+   "frc9312": {
+    "highest_match_scores": [
+     276,
+     251,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc9594": {
+    "highest_match_scores": [
+     280,
+     260,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc9753": {
+    "highest_match_scores": [
+     214,
+     169,
+     161
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mibro": {
+  "points": {
+   "frc10606": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc1189": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc1528": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc217": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 33
+   },
+   "frc240": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc247": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 53
+   },
+   "frc2620": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc2832": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 38
+   },
+   "frc2834": {
+    "alliance_points": 8,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 27
+   },
+   "frc3322": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 42
+   },
+   "frc3604": {
+    "alliance_points": 7,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 29
+   },
+   "frc4390": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc469": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc5050": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 10
+   },
+   "frc5090": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5263": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5498": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5901": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5907": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc6029": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc6057": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6101": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6152": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 50
+   },
+   "frc6528": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 52
+   },
+   "frc6570": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc6618": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc6861": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc6914": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc7174": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 32
+   },
+   "frc7769": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc8124": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc815": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc8179": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 14,
+    "total": 50
+   },
+   "frc8362": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc8427": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc910": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 44
+   },
+   "frc9148": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9182": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9226": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 6,
+    "total": 23
+   },
+   "frc9572": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 36
+   }
+  },
+  "tiebreakers": {
+   "frc10606": {
+    "highest_match_scores": [
+     421,
+     174,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc1189": {
+    "highest_match_scores": [
+     298,
+     220,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc1528": {
+    "highest_match_scores": [
+     197,
+     165,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc217": {
+    "highest_match_scores": [
+     305,
+     231,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc240": {
+    "highest_match_scores": [
+     220,
+     201,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc247": {
+    "highest_match_scores": [
+     400,
+     262,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc2620": {
+    "highest_match_scores": [
+     305,
+     250,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc2832": {
+    "highest_match_scores": [
+     384,
+     262,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc2834": {
+    "highest_match_scores": [
+     257,
+     200,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc3322": {
+    "highest_match_scores": [
+     421,
+     298,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc3604": {
+    "highest_match_scores": [
+     363,
+     231,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc4390": {
+    "highest_match_scores": [
+     326,
+     182,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc469": {
+    "highest_match_scores": [
+     457,
+     435,
+     400
+    ],
+    "qual_wins": 0
+   },
+   "frc5050": {
+    "highest_match_scores": [
+     366,
+     206,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc5090": {
+    "highest_match_scores": [
+     293,
+     232,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc5263": {
+    "highest_match_scores": [
+     340,
+     179,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc5498": {
+    "highest_match_scores": [
+     340,
+     272,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc5901": {
+    "highest_match_scores": [
+     314,
+     225,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc5907": {
+    "highest_match_scores": [
+     314,
+     264,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc6029": {
+    "highest_match_scores": [
+     165,
+     164,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc6057": {
+    "highest_match_scores": [
+     177,
+     114,
+     104
+    ],
+    "qual_wins": 0
+   },
+   "frc6101": {
+    "highest_match_scores": [
+     326,
+     185,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc6152": {
+    "highest_match_scores": [
+     314,
+     299,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc6528": {
+    "highest_match_scores": [
+     262,
+     259,
+     243
+    ],
+    "qual_wins": 0
+   },
+   "frc6570": {
+    "highest_match_scores": [
+     293,
+     272,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc6618": {
+    "highest_match_scores": [
+     250,
+     237,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc6861": {
+    "highest_match_scores": [
+     215,
+     200,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc6914": {
+    "highest_match_scores": [
+     323,
+     197,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc7174": {
+    "highest_match_scores": [
+     293,
+     232,
+     231
+    ],
+    "qual_wins": 0
+   },
+   "frc7769": {
+    "highest_match_scores": [
+     457,
+     435,
+     421
+    ],
+    "qual_wins": 0
+   },
+   "frc8124": {
+    "highest_match_scores": [
+     363,
+     214,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc815": {
+    "highest_match_scores": [
+     207,
+     157,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc8179": {
+    "highest_match_scores": [
+     457,
+     435,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc8362": {
+    "highest_match_scores": [
+     233,
+     112,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc8427": {
+    "highest_match_scores": [
+     384,
+     237,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc910": {
+    "highest_match_scores": [
+     314,
+     299,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc9148": {
+    "highest_match_scores": [
+     207,
+     179,
+     112
+    ],
+    "qual_wins": 0
+   },
+   "frc9182": {
+    "highest_match_scores": [
+     293,
+     264,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc9226": {
+    "highest_match_scores": [
+     314,
+     299,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc9572": {
+    "highest_match_scores": [
+     257,
+     233,
+     232
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026miche": {
+  "points": {
+   "frc10285": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc10607": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc1076": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 32
+   },
+   "frc11387": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 23
+   },
+   "frc11437": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc11505": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc1502": {
+    "alliance_points": 0,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc240": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 17
+   },
+   "frc2611": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc27": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc302": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc3641": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 47
+   },
+   "frc3656": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc3668": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 28
+   },
+   "frc4216": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 25
+   },
+   "frc503": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 36
+   },
+   "frc5046": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc5144": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc5205": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5260": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5314": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5460": {
+    "alliance_points": 16,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 67
+   },
+   "frc5530": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 6,
+    "total": 29
+   },
+   "frc5567": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 43
+   },
+   "frc5708": {
+    "alliance_points": 4,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 24
+   },
+   "frc6081": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 21
+   },
+   "frc6570": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 31
+   },
+   "frc6591": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc7056": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 9,
+    "total": 31
+   },
+   "frc7197": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 48
+   },
+   "frc7501": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 26
+   },
+   "frc8124": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 19
+   },
+   "frc8300": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc8373": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc8374": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc8832": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9204": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9210": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 32
+   },
+   "frc9618": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   }
+  },
+  "tiebreakers": {
+   "frc10285": {
+    "highest_match_scores": [
+     205,
+     198,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc10607": {
+    "highest_match_scores": [
+     257,
+     229,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc1076": {
+    "highest_match_scores": [
+     354,
+     198,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc11387": {
+    "highest_match_scores": [
+     317,
+     159,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc11437": {
+    "highest_match_scores": [
+     344,
+     236,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc11505": {
+    "highest_match_scores": [
+     220,
+     172,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc1502": {
+    "highest_match_scores": [
+     210,
+     208,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc240": {
+    "highest_match_scores": [
+     220,
+     219,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc2611": {
+    "highest_match_scores": [
+     352,
+     267,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc27": {
+    "highest_match_scores": [
+     531,
+     491,
+     454
+    ],
+    "qual_wins": 0
+   },
+   "frc302": {
+    "highest_match_scores": [
+     344,
+     272,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc3641": {
+    "highest_match_scores": [
+     290,
+     269,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc3656": {
+    "highest_match_scores": [
+     357,
+     272,
+     262
+    ],
+    "qual_wins": 0
+   },
+   "frc3668": {
+    "highest_match_scores": [
+     337,
+     239,
+     237
+    ],
+    "qual_wins": 0
+   },
+   "frc4216": {
+    "highest_match_scores": [
+     357,
+     262,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc503": {
+    "highest_match_scores": [
+     316,
+     262,
+     236
+    ],
+    "qual_wins": 0
+   },
+   "frc5046": {
+    "highest_match_scores": [
+     267,
+     232,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc5144": {
+    "highest_match_scores": [
+     357,
+     290,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc5205": {
+    "highest_match_scores": [
+     223,
+     144,
+     112
+    ],
+    "qual_wins": 0
+   },
+   "frc5260": {
+    "highest_match_scores": [
+     227,
+     180,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc5314": {
+    "highest_match_scores": [
+     339,
+     228,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc5460": {
+    "highest_match_scores": [
+     531,
+     491,
+     454
+    ],
+    "qual_wins": 0
+   },
+   "frc5530": {
+    "highest_match_scores": [
+     337,
+     269,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc5567": {
+    "highest_match_scores": [
+     531,
+     491,
+     454
+    ],
+    "qual_wins": 0
+   },
+   "frc5708": {
+    "highest_match_scores": [
+     352,
+     237,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc6081": {
+    "highest_match_scores": [
+     290,
+     232,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc6570": {
+    "highest_match_scores": [
+     316,
+     270,
+     232
+    ],
+    "qual_wins": 0
+   },
+   "frc6591": {
+    "highest_match_scores": [
+     262,
+     214,
+     173
+    ],
+    "qual_wins": 0
+   },
+   "frc7056": {
+    "highest_match_scores": [
+     272,
+     270,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc7197": {
+    "highest_match_scores": [
+     307,
+     269,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc7501": {
+    "highest_match_scores": [
+     357,
+     180,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc8124": {
+    "highest_match_scores": [
+     172,
+     158,
+     155
+    ],
+    "qual_wins": 0
+   },
+   "frc8300": {
+    "highest_match_scores": [
+     308,
+     307,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc8373": {
+    "highest_match_scores": [
+     339,
+     258,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc8374": {
+    "highest_match_scores": [
+     317,
+     236,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc8832": {
+    "highest_match_scores": [
+     143,
+     130,
+     118
+    ],
+    "qual_wins": 0
+   },
+   "frc9204": {
+    "highest_match_scores": [
+     239,
+     223,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc9210": {
+    "highest_match_scores": [
+     308,
+     267,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc9618": {
+    "highest_match_scores": [
+     262,
+     165,
+     161
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026micmp": {
+  "points": {
+   "frc11387": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc11493": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc2337": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 0
+   },
+   "frc245": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc27": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 60,
+    "qual_points": 0,
+    "total": 90
+   },
+   "frc3538": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc3604": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc3620": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc3668": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 0,
+    "total": 60
+   },
+   "frc5460": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc5577": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc5712": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc7166": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 0
+   },
+   "frc7197": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc7769": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 0,
+    "total": 60
+   },
+   "frc8280": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 0
+   }
+  },
+  "tiebreakers": {
+   "frc2337": {
+    "highest_match_scores": [
+     552,
+     528,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc2586": {
+    "highest_match_scores": [
+     511,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc27": {
+    "highest_match_scores": [
+     774,
+     670,
+     635
+    ],
+    "qual_wins": 0
+   },
+   "frc2767": {
+    "highest_match_scores": [
+     511,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc3538": {
+    "highest_match_scores": [
+     543,
+     532,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc3668": {
+    "highest_match_scores": [
+     774,
+     670,
+     635
+    ],
+    "qual_wins": 0
+   },
+   "frc4327": {
+    "highest_match_scores": [
+     427
+    ],
+    "qual_wins": 0
+   },
+   "frc5460": {
+    "highest_match_scores": [
+     543,
+     532,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc6090": {
+    "highest_match_scores": [
+     511,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc7166": {
+    "highest_match_scores": [
+     552,
+     528,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc7197": {
+    "highest_match_scores": [
+     543,
+     532,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc7769": {
+    "highest_match_scores": [
+     774,
+     670,
+     635
+    ],
+    "qual_wins": 0
+   },
+   "frc8280": {
+    "highest_match_scores": [
+     552,
+     528,
+     456
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026micmp1": {
+  "points": {
+   "frc1025": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc10633": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 72
+   },
+   "frc10666": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc10978": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc11493": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc1189": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 114
+   },
+   "frc1502": {
+    "alliance_points": 12,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 69
+   },
+   "frc1506": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 39,
+    "total": 78
+   },
+   "frc2054": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 81
+   },
+   "frc2075": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 51,
+    "total": 105
+   },
+   "frc217": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc245": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc27": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 204
+   },
+   "frc3357": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc3620": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 90
+   },
+   "frc3668": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 36,
+    "total": 129
+   },
+   "frc3875": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 48
+   },
+   "frc4362": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 33,
+    "total": 117
+   },
+   "frc4381": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc4680": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc51": {
+    "alliance_points": 24,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 69
+   },
+   "frc5144": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc5505": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 27
+   },
+   "frc5567": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc5660": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 78
+   },
+   "frc5676": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc5907": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 60,
+    "total": 165
+   },
+   "frc6002": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 57,
+    "total": 177
+   },
+   "frc6088": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 30
+   },
+   "frc6121": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 90
+   },
+   "frc67": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 48,
+    "total": 132
+   },
+   "frc7160": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 75
+   },
+   "frc7220": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 42,
+    "total": 96
+   },
+   "frc7769": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 216
+   },
+   "frc8126": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 39
+   },
+   "frc8352": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc85": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 42
+   },
+   "frc8517": {
+    "alliance_points": 39,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 108
+   },
+   "frc9572": {
+    "alliance_points": 21,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 39,
+    "total": 99
+   },
+   "frc9771": {
+    "alliance_points": 6,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 27,
+    "total": 108
+   }
+  },
+  "tiebreakers": {
+   "frc1025": {
+    "highest_match_scores": [
+     753,
+     548,
+     525
+    ],
+    "qual_wins": 0
+   },
+   "frc10633": {
+    "highest_match_scores": [
+     501,
+     442,
+     425
+    ],
+    "qual_wins": 0
+   },
+   "frc10666": {
+    "highest_match_scores": [
+     580,
+     504,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc10978": {
+    "highest_match_scores": [
+     554,
+     514,
+     358
+    ],
+    "qual_wins": 0
+   },
+   "frc11493": {
+    "highest_match_scores": [
+     729,
+     402,
+     374
+    ],
+    "qual_wins": 0
+   },
+   "frc1189": {
+    "highest_match_scores": [
+     663,
+     525,
+     501
+    ],
+    "qual_wins": 0
+   },
+   "frc1502": {
+    "highest_match_scores": [
+     536,
+     449,
+     446
+    ],
+    "qual_wins": 0
+   },
+   "frc1506": {
+    "highest_match_scores": [
+     767,
+     580,
+     557
+    ],
+    "qual_wins": 0
+   },
+   "frc2054": {
+    "highest_match_scores": [
+     641,
+     618,
+     568
+    ],
+    "qual_wins": 0
+   },
+   "frc2075": {
+    "highest_match_scores": [
+     557,
+     513,
+     495
+    ],
+    "qual_wins": 0
+   },
+   "frc217": {
+    "highest_match_scores": [
+     464,
+     371,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc245": {
+    "highest_match_scores": [
+     637,
+     409,
+     371
+    ],
+    "qual_wins": 0
+   },
+   "frc27": {
+    "highest_match_scores": [
+     841,
+     796,
+     753
+    ],
+    "qual_wins": 0
+   },
+   "frc3357": {
+    "highest_match_scores": [
+     497,
+     483,
+     425
+    ],
+    "qual_wins": 0
+   },
+   "frc3620": {
+    "highest_match_scores": [
+     582,
+     568,
+     472
+    ],
+    "qual_wins": 0
+   },
+   "frc3668": {
+    "highest_match_scores": [
+     841,
+     796,
+     706
+    ],
+    "qual_wins": 0
+   },
+   "frc3875": {
+    "highest_match_scores": [
+     541,
+     536,
+     484
+    ],
+    "qual_wins": 0
+   },
+   "frc4362": {
+    "highest_match_scores": [
+     654,
+     583,
+     582
+    ],
+    "qual_wins": 0
+   },
+   "frc4381": {
+    "highest_match_scores": [
+     513,
+     469,
+     409
+    ],
+    "qual_wins": 0
+   },
+   "frc4680": {
+    "highest_match_scores": [
+     541,
+     407,
+     381
+    ],
+    "qual_wins": 0
+   },
+   "frc51": {
+    "highest_match_scores": [
+     528,
+     501,
+     472
+    ],
+    "qual_wins": 0
+   },
+   "frc5144": {
+    "highest_match_scores": [
+     753,
+     651,
+     442
+    ],
+    "qual_wins": 0
+   },
+   "frc5505": {
+    "highest_match_scores": [
+     663,
+     421,
+     374
+    ],
+    "qual_wins": 0
+   },
+   "frc5567": {
+    "highest_match_scores": [
+     458,
+     374,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc5660": {
+    "highest_match_scores": [
+     637,
+     501,
+     497
+    ],
+    "qual_wins": 0
+   },
+   "frc5676": {
+    "highest_match_scores": [
+     553,
+     421,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc5907": {
+    "highest_match_scores": [
+     640,
+     611,
+     536
+    ],
+    "qual_wins": 0
+   },
+   "frc6002": {
+    "highest_match_scores": [
+     611,
+     536,
+     528
+    ],
+    "qual_wins": 0
+   },
+   "frc6088": {
+    "highest_match_scores": [
+     437,
+     405,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc6121": {
+    "highest_match_scores": [
+     572,
+     558,
+     467
+    ],
+    "qual_wins": 0
+   },
+   "frc67": {
+    "highest_match_scores": [
+     654,
+     583,
+     571
+    ],
+    "qual_wins": 0
+   },
+   "frc7160": {
+    "highest_match_scores": [
+     767,
+     618,
+     469
+    ],
+    "qual_wins": 0
+   },
+   "frc7220": {
+    "highest_match_scores": [
+     729,
+     557,
+     553
+    ],
+    "qual_wins": 0
+   },
+   "frc7769": {
+    "highest_match_scores": [
+     841,
+     796,
+     767
+    ],
+    "qual_wins": 0
+   },
+   "frc8126": {
+    "highest_match_scores": [
+     436,
+     425,
+     405
+    ],
+    "qual_wins": 0
+   },
+   "frc8352": {
+    "highest_match_scores": [
+     480,
+     429,
+     392
+    ],
+    "qual_wins": 0
+   },
+   "frc85": {
+    "highest_match_scores": [
+     436,
+     373,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc8517": {
+    "highest_match_scores": [
+     651,
+     548,
+     446
+    ],
+    "qual_wins": 0
+   },
+   "frc9572": {
+    "highest_match_scores": [
+     654,
+     640,
+     583
+    ],
+    "qual_wins": 0
+   },
+   "frc9771": {
+    "highest_match_scores": [
+     611,
+     536,
+     506
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026micmp2": {
+  "points": {
+   "frc1023": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 84
+   },
+   "frc10349": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 75
+   },
+   "frc1076": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 33,
+    "total": 72
+   },
+   "frc1498": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 96
+   },
+   "frc1684": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 81
+   },
+   "frc201": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 24,
+    "total": 78
+   },
+   "frc226": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc244": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc247": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc2586": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 36,
+    "total": 129
+   },
+   "frc2611": {
+    "alliance_points": 33,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 117
+   },
+   "frc2767": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 216
+   },
+   "frc302": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc3414": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 60,
+    "total": 180
+   },
+   "frc3572": {
+    "alliance_points": 15,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 66
+   },
+   "frc3602": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 45
+   },
+   "frc3656": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 69
+   },
+   "frc3767": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 39
+   },
+   "frc4398": {
+    "alliance_points": 21,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 72
+   },
+   "frc469": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 54,
+    "total": 174
+   },
+   "frc4855": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc5046": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc5114": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 51,
+    "total": 132
+   },
+   "frc5193": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 57,
+    "total": 138
+   },
+   "frc5462": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 39,
+    "total": 87
+   },
+   "frc5535": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc5577": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc5982": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6090": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 219
+   },
+   "frc6528": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 57
+   },
+   "frc7250": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 87
+   },
+   "frc7598": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 45
+   },
+   "frc8424": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc8608": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 93
+   },
+   "frc862": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 18,
+    "total": 84
+   },
+   "frc8767": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc9210": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc9215": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 78
+   },
+   "frc9245": {
+    "alliance_points": 24,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 84
+   },
+   "frc9255": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   }
+  },
+  "tiebreakers": {
+   "frc1023": {
+    "highest_match_scores": [
+     486,
+     452,
+     411
+    ],
+    "qual_wins": 0
+   },
+   "frc10349": {
+    "highest_match_scores": [
+     557,
+     521,
+     499
+    ],
+    "qual_wins": 0
+   },
+   "frc1076": {
+    "highest_match_scores": [
+     491,
+     419,
+     377
+    ],
+    "qual_wins": 0
+   },
+   "frc1498": {
+    "highest_match_scores": [
+     508,
+     497,
+     423
+    ],
+    "qual_wins": 0
+   },
+   "frc1684": {
+    "highest_match_scores": [
+     572,
+     428,
+     386
+    ],
+    "qual_wins": 0
+   },
+   "frc201": {
+    "highest_match_scores": [
+     503,
+     471,
+     383
+    ],
+    "qual_wins": 0
+   },
+   "frc226": {
+    "highest_match_scores": [
+     536,
+     500,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc244": {
+    "highest_match_scores": [
+     464,
+     452,
+     432
+    ],
+    "qual_wins": 0
+   },
+   "frc247": {
+    "highest_match_scores": [
+     572,
+     419,
+     360
+    ],
+    "qual_wins": 0
+   },
+   "frc2586": {
+    "highest_match_scores": [
+     551,
+     546,
+     539
+    ],
+    "qual_wins": 0
+   },
+   "frc2611": {
+    "highest_match_scores": [
+     538,
+     491,
+     484
+    ],
+    "qual_wins": 0
+   },
+   "frc2767": {
+    "highest_match_scores": [
+     551,
+     546,
+     539
+    ],
+    "qual_wins": 0
+   },
+   "frc302": {
+    "highest_match_scores": [
+     449,
+     425,
+     374
+    ],
+    "qual_wins": 0
+   },
+   "frc3414": {
+    "highest_match_scores": [
+     595,
+     466,
+     444
+    ],
+    "qual_wins": 0
+   },
+   "frc3572": {
+    "highest_match_scores": [
+     499,
+     452,
+     374
+    ],
+    "qual_wins": 0
+   },
+   "frc3602": {
+    "highest_match_scores": [
+     503,
+     449,
+     400
+    ],
+    "qual_wins": 0
+   },
+   "frc3656": {
+    "highest_match_scores": [
+     595,
+     557,
+     521
+    ],
+    "qual_wins": 0
+   },
+   "frc3767": {
+    "highest_match_scores": [
+     538,
+     413,
+     380
+    ],
+    "qual_wins": 0
+   },
+   "frc4398": {
+    "highest_match_scores": [
+     452,
+     424,
+     413
+    ],
+    "qual_wins": 0
+   },
+   "frc469": {
+    "highest_match_scores": [
+     595,
+     536,
+     499
+    ],
+    "qual_wins": 0
+   },
+   "frc4855": {
+    "highest_match_scores": [
+     493,
+     400,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc5046": {
+    "highest_match_scores": [
+     462,
+     379,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc5114": {
+    "highest_match_scores": [
+     497,
+     462,
+     444
+    ],
+    "qual_wins": 0
+   },
+   "frc5193": {
+    "highest_match_scores": [
+     503,
+     491,
+     452
+    ],
+    "qual_wins": 0
+   },
+   "frc5462": {
+    "highest_match_scores": [
+     500,
+     497,
+     437
+    ],
+    "qual_wins": 0
+   },
+   "frc5535": {
+    "highest_match_scores": [
+     522,
+     425,
+     423
+    ],
+    "qual_wins": 0
+   },
+   "frc5577": {
+    "highest_match_scores": [
+     467,
+     403,
+     386
+    ],
+    "qual_wins": 0
+   },
+   "frc5982": {
+    "highest_match_scores": [
+     326,
+     313,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc6090": {
+    "highest_match_scores": [
+     572,
+     557,
+     551
+    ],
+    "qual_wins": 0
+   },
+   "frc6528": {
+    "highest_match_scores": [
+     462,
+     424,
+     424
+    ],
+    "qual_wins": 0
+   },
+   "frc7250": {
+    "highest_match_scores": [
+     493,
+     467,
+     464
+    ],
+    "qual_wins": 0
+   },
+   "frc7598": {
+    "highest_match_scores": [
+     441,
+     369,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc8424": {
+    "highest_match_scores": [
+     424,
+     338,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc8608": {
+    "highest_match_scores": [
+     538,
+     486,
+     471
+    ],
+    "qual_wins": 0
+   },
+   "frc862": {
+    "highest_match_scores": [
+     484,
+     466,
+     429
+    ],
+    "qual_wins": 0
+   },
+   "frc8767": {
+    "highest_match_scores": [
+     357,
+     321,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc9210": {
+    "highest_match_scores": [
+     522,
+     362,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc9215": {
+    "highest_match_scores": [
+     428,
+     394,
+     383
+    ],
+    "qual_wins": 0
+   },
+   "frc9245": {
+    "highest_match_scores": [
+     521,
+     508,
+     423
+    ],
+    "qual_wins": 0
+   },
+   "frc9255": {
+    "highest_match_scores": [
+     471,
+     444,
+     277
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026micmp3": {
+  "points": {
+   "frc123": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 21,
+    "total": 45
+   },
+   "frc1481": {
+    "alliance_points": 21,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 72
+   },
+   "frc1711": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc1718": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc2137": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 60,
+    "total": 141
+   },
+   "frc2337": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 57,
+    "total": 192
+   },
+   "frc2851": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 66,
+    "total": 135
+   },
+   "frc288": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc2960": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 48,
+    "total": 144
+   },
+   "frc33": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 75
+   },
+   "frc3322": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc3452": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc3618": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc4391": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 51,
+    "total": 135
+   },
+   "frc4392": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc4779": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc4810": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc4956": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 42
+   },
+   "frc4967": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 24,
+    "total": 99
+   },
+   "frc5066": {
+    "alliance_points": 36,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 54,
+    "total": 165
+   },
+   "frc5086": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 96
+   },
+   "frc5229": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 54
+   },
+   "frc548": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 45,
+    "total": 141
+   },
+   "frc5675": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 33,
+    "total": 81
+   },
+   "frc5712": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 84
+   },
+   "frc5843": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 87
+   },
+   "frc6152": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 81
+   },
+   "frc6637": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc68": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 63
+   },
+   "frc70": {
+    "alliance_points": 27,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 90
+   },
+   "frc7054": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc7056": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 54
+   },
+   "frc7166": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 213
+   },
+   "frc7188": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc818": {
+    "alliance_points": 24,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 69
+   },
+   "frc8280": {
+    "alliance_points": 6,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 36,
+    "total": 147
+   },
+   "frc8373": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 81
+   },
+   "frc8397": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc8612": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 54
+   },
+   "frc894": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc910": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 60
+   }
+  },
+  "tiebreakers": {
+   "frc123": {
+    "highest_match_scores": [
+     466,
+     464,
+     431
+    ],
+    "qual_wins": 0
+   },
+   "frc1481": {
+    "highest_match_scores": [
+     540,
+     532,
+     509
+    ],
+    "qual_wins": 0
+   },
+   "frc1711": {
+    "highest_match_scores": [
+     423,
+     390,
+     363
+    ],
+    "qual_wins": 0
+   },
+   "frc1718": {
+    "highest_match_scores": [
+     437,
+     349,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc2137": {
+    "highest_match_scores": [
+     497,
+     496,
+     488
+    ],
+    "qual_wins": 0
+   },
+   "frc2337": {
+    "highest_match_scores": [
+     538,
+     518,
+     488
+    ],
+    "qual_wins": 0
+   },
+   "frc2851": {
+    "highest_match_scores": [
+     532,
+     466,
+     464
+    ],
+    "qual_wins": 0
+   },
+   "frc288": {
+    "highest_match_scores": [
+     447,
+     415,
+     393
+    ],
+    "qual_wins": 0
+   },
+   "frc2960": {
+    "highest_match_scores": [
+     544,
+     538,
+     523
+    ],
+    "qual_wins": 0
+   },
+   "frc33": {
+    "highest_match_scores": [
+     540,
+     523,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc3322": {
+    "highest_match_scores": [
+     501,
+     399,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc3452": {
+    "highest_match_scores": [
+     561,
+     420,
+     395
+    ],
+    "qual_wins": 0
+   },
+   "frc3618": {
+    "highest_match_scores": [
+     428,
+     391,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc4391": {
+    "highest_match_scores": [
+     532,
+     509,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc4392": {
+    "highest_match_scores": [
+     471,
+     464,
+     415
+    ],
+    "qual_wins": 0
+   },
+   "frc4779": {
+    "highest_match_scores": [
+     413,
+     394,
+     391
+    ],
+    "qual_wins": 0
+   },
+   "frc4810": {
+    "highest_match_scores": [
+     452,
+     446,
+     393
+    ],
+    "qual_wins": 0
+   },
+   "frc4956": {
+    "highest_match_scores": [
+     450,
+     360,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc4967": {
+    "highest_match_scores": [
+     486,
+     485,
+     462
+    ],
+    "qual_wins": 0
+   },
+   "frc5066": {
+    "highest_match_scores": [
+     561,
+     501,
+     486
+    ],
+    "qual_wins": 0
+   },
+   "frc5086": {
+    "highest_match_scores": [
+     508,
+     474,
+     467
+    ],
+    "qual_wins": 0
+   },
+   "frc5229": {
+    "highest_match_scores": [
+     523,
+     508,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc548": {
+    "highest_match_scores": [
+     493,
+     486,
+     485
+    ],
+    "qual_wins": 0
+   },
+   "frc5675": {
+    "highest_match_scores": [
+     544,
+     497,
+     451
+    ],
+    "qual_wins": 0
+   },
+   "frc5712": {
+    "highest_match_scores": [
+     538,
+     508,
+     501
+    ],
+    "qual_wins": 0
+   },
+   "frc5843": {
+    "highest_match_scores": [
+     502,
+     456,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc6152": {
+    "highest_match_scores": [
+     540,
+     467,
+     437
+    ],
+    "qual_wins": 0
+   },
+   "frc6637": {
+    "highest_match_scores": [
+     427,
+     391,
+     391
+    ],
+    "qual_wins": 0
+   },
+   "frc68": {
+    "highest_match_scores": [
+     543,
+     471,
+     434
+    ],
+    "qual_wins": 0
+   },
+   "frc70": {
+    "highest_match_scores": [
+     509,
+     509,
+     502
+    ],
+    "qual_wins": 0
+   },
+   "frc7054": {
+    "highest_match_scores": [
+     427,
+     370,
+     357
+    ],
+    "qual_wins": 0
+   },
+   "frc7056": {
+    "highest_match_scores": [
+     461,
+     427,
+     410
+    ],
+    "qual_wins": 0
+   },
+   "frc7166": {
+    "highest_match_scores": [
+     561,
+     544,
+     543
+    ],
+    "qual_wins": 0
+   },
+   "frc7188": {
+    "highest_match_scores": [
+     436,
+     398,
+     391
+    ],
+    "qual_wins": 0
+   },
+   "frc818": {
+    "highest_match_scores": [
+     427,
+     387,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc8280": {
+    "highest_match_scores": [
+     518,
+     480,
+     464
+    ],
+    "qual_wins": 0
+   },
+   "frc8373": {
+    "highest_match_scores": [
+     543,
+     502,
+     428
+    ],
+    "qual_wins": 0
+   },
+   "frc8397": {
+    "highest_match_scores": [
+     449,
+     406,
+     393
+    ],
+    "qual_wins": 0
+   },
+   "frc8612": {
+    "highest_match_scores": [
+     493,
+     456,
+     449
+    ],
+    "qual_wins": 0
+   },
+   "frc894": {
+    "highest_match_scores": [
+     474,
+     416,
+     371
+    ],
+    "qual_wins": 0
+   },
+   "frc910": {
+    "highest_match_scores": [
+     509,
+     431,
+     395
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026micmp4": {
+  "points": {
+   "frc11386": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 36
+   },
+   "frc11503": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 45
+   },
+   "frc1188": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 33,
+    "total": 84
+   },
+   "frc1701": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 60,
+    "total": 162
+   },
+   "frc1918": {
+    "alliance_points": 39,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 111
+   },
+   "frc2224": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc2619": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 114
+   },
+   "frc3175": {
+    "alliance_points": 24,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 54
+   },
+   "frc3536": {
+    "alliance_points": 33,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 87
+   },
+   "frc3538": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 51,
+    "total": 204
+   },
+   "frc3539": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 93
+   },
+   "frc3603": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc3604": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 93
+   },
+   "frc3632": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc3641": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 48,
+    "total": 150
+   },
+   "frc3688": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc3707": {
+    "alliance_points": 27,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 84
+   },
+   "frc3770": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 57
+   },
+   "frc4237": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 45,
+    "total": 129
+   },
+   "frc4327": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc4422": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc494": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 90
+   },
+   "frc503": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 63,
+    "total": 147
+   },
+   "frc5152": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc5166": {
+    "alliance_points": 21,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 24,
+    "total": 66
+   },
+   "frc5216": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 30,
+    "total": 99
+   },
+   "frc5460": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 219
+   },
+   "frc5533": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc5534": {
+    "alliance_points": 6,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 42,
+    "total": 102
+   },
+   "frc573": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc6085": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc6615": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 75
+   },
+   "frc6753": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc7197": {
+    "alliance_points": 3,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 42,
+    "total": 150
+   },
+   "frc7768": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 36
+   },
+   "frc8179": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc858": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc8873": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 42
+   },
+   "frc9312": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc9757": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 84
+   }
+  },
+  "tiebreakers": {
+   "frc11386": {
+    "highest_match_scores": [
+     527,
+     406,
+     372
+    ],
+    "qual_wins": 0
+   },
+   "frc11503": {
+    "highest_match_scores": [
+     481,
+     360,
+     329
+    ],
+    "qual_wins": 0
+   },
+   "frc1188": {
+    "highest_match_scores": [
+     650,
+     457,
+     397
+    ],
+    "qual_wins": 0
+   },
+   "frc1701": {
+    "highest_match_scores": [
+     543,
+     533,
+     518
+    ],
+    "qual_wins": 0
+   },
+   "frc1918": {
+    "highest_match_scores": [
+     581,
+     576,
+     533
+    ],
+    "qual_wins": 0
+   },
+   "frc2224": {
+    "highest_match_scores": [
+     627,
+     429,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc2619": {
+    "highest_match_scores": [
+     553,
+     533,
+     406
+    ],
+    "qual_wins": 0
+   },
+   "frc3175": {
+    "highest_match_scores": [
+     518,
+     479,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc3536": {
+    "highest_match_scores": [
+     380,
+     375,
+     372
+    ],
+    "qual_wins": 0
+   },
+   "frc3538": {
+    "highest_match_scores": [
+     631,
+     581,
+     533
+    ],
+    "qual_wins": 0
+   },
+   "frc3539": {
+    "highest_match_scores": [
+     650,
+     623,
+     551
+    ],
+    "qual_wins": 0
+   },
+   "frc3603": {
+    "highest_match_scores": [
+     481,
+     366,
+     364
+    ],
+    "qual_wins": 0
+   },
+   "frc3604": {
+    "highest_match_scores": [
+     527,
+     457,
+     449
+    ],
+    "qual_wins": 0
+   },
+   "frc3632": {
+    "highest_match_scores": [
+     339,
+     294,
+     280
+    ],
+    "qual_wins": 0
+   },
+   "frc3641": {
+    "highest_match_scores": [
+     625,
+     553,
+     551
+    ],
+    "qual_wins": 0
+   },
+   "frc3688": {
+    "highest_match_scores": [
+     407,
+     376,
+     343
+    ],
+    "qual_wins": 0
+   },
+   "frc3707": {
+    "highest_match_scores": [
+     551,
+     479,
+     382
+    ],
+    "qual_wins": 0
+   },
+   "frc3770": {
+    "highest_match_scores": [
+     372,
+     363,
+     361
+    ],
+    "qual_wins": 0
+   },
+   "frc4237": {
+    "highest_match_scores": [
+     718,
+     650,
+     563
+    ],
+    "qual_wins": 0
+   },
+   "frc4327": {
+    "highest_match_scores": [
+     567,
+     474,
+     406
+    ],
+    "qual_wins": 0
+   },
+   "frc4422": {
+    "highest_match_scores": [
+     527,
+     366,
+     348
+    ],
+    "qual_wins": 0
+   },
+   "frc494": {
+    "highest_match_scores": [
+     623,
+     553,
+     533
+    ],
+    "qual_wins": 0
+   },
+   "frc503": {
+    "highest_match_scores": [
+     627,
+     474,
+     449
+    ],
+    "qual_wins": 0
+   },
+   "frc5152": {
+    "highest_match_scores": [
+     563,
+     375,
+     339
+    ],
+    "qual_wins": 0
+   },
+   "frc5166": {
+    "highest_match_scores": [
+     429,
+     353,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc5216": {
+    "highest_match_scores": [
+     581,
+     543,
+     472
+    ],
+    "qual_wins": 0
+   },
+   "frc5460": {
+    "highest_match_scores": [
+     718,
+     631,
+     627
+    ],
+    "qual_wins": 0
+   },
+   "frc5533": {
+    "highest_match_scores": [
+     576,
+     337,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc5534": {
+    "highest_match_scores": [
+     420,
+     417,
+     414
+    ],
+    "qual_wins": 0
+   },
+   "frc573": {
+    "highest_match_scores": [
+     625,
+     397,
+     337
+    ],
+    "qual_wins": 0
+   },
+   "frc6085": {
+    "highest_match_scores": [
+     476,
+     360,
+     339
+    ],
+    "qual_wins": 0
+   },
+   "frc6615": {
+    "highest_match_scores": [
+     576,
+     479,
+     406
+    ],
+    "qual_wins": 0
+   },
+   "frc6753": {
+    "highest_match_scores": [
+     507,
+     420,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc7197": {
+    "highest_match_scores": [
+     718,
+     631,
+     522
+    ],
+    "qual_wins": 0
+   },
+   "frc7768": {
+    "highest_match_scores": [
+     380,
+     299,
+     279
+    ],
+    "qual_wins": 0
+   },
+   "frc8179": {
+    "highest_match_scores": [
+     330,
+     291,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc858": {
+    "highest_match_scores": [
+     397,
+     390,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc8873": {
+    "highest_match_scores": [
+     376,
+     353,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc9312": {
+    "highest_match_scores": [
+     377,
+     342,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc9757": {
+    "highest_match_scores": [
+     567,
+     563,
+     533
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026midtr": {
+  "points": {
+   "frc1": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc10577": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 38
+   },
+   "frc10607": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 18
+   },
+   "frc11423": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc11461": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc11490": {
+    "alliance_points": 11,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 37
+   },
+   "frc123": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc2048": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc2224": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 48
+   },
+   "frc2591": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc2673": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc3096": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 25
+   },
+   "frc3175": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 76
+   },
+   "frc3619": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   },
+   "frc3632": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 9,
+    "total": 31
+   },
+   "frc4680": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 34
+   },
+   "frc4758": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc4838": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc4851": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc4854": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5065": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5197": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc5225": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5478": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 5,
+    "total": 36
+   },
+   "frc5532": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5577": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 36
+   },
+   "frc5642": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc5756": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc6096": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 24
+   },
+   "frc6099": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6532": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc6616": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7145": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7196": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 39
+   },
+   "frc7692": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc7865": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   },
+   "frc8352": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc8899": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9255": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 56
+   },
+   "frc9651": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 25
+   }
+  },
+  "tiebreakers": {
+   "frc1": {
+    "highest_match_scores": [
+     149,
+     68,
+     58
+    ],
+    "qual_wins": 0
+   },
+   "frc10577": {
+    "highest_match_scores": [
+     113,
+     107,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc10607": {
+    "highest_match_scores": [
+     109,
+     90,
+     89
+    ],
+    "qual_wins": 0
+   },
+   "frc11423": {
+    "highest_match_scores": [
+     149,
+     112,
+     92
+    ],
+    "qual_wins": 0
+   },
+   "frc11461": {
+    "highest_match_scores": [
+     102,
+     92,
+     55
+    ],
+    "qual_wins": 0
+   },
+   "frc11490": {
+    "highest_match_scores": [
+     182,
+     107,
+     95
+    ],
+    "qual_wins": 0
+   },
+   "frc123": {
+    "highest_match_scores": [
+     232,
+     186,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc2048": {
+    "highest_match_scores": [
+     123,
+     100,
+     74
+    ],
+    "qual_wins": 0
+   },
+   "frc2224": {
+    "highest_match_scores": [
+     159,
+     102,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc2591": {
+    "highest_match_scores": [
+     139,
+     97,
+     90
+    ],
+    "qual_wins": 0
+   },
+   "frc2673": {
+    "highest_match_scores": [
+     144,
+     139,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc3096": {
+    "highest_match_scores": [
+     173,
+     85,
+     75
+    ],
+    "qual_wins": 0
+   },
+   "frc3175": {
+    "highest_match_scores": [
+     232,
+     186,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc3619": {
+    "highest_match_scores": [
+     101,
+     90,
+     85
+    ],
+    "qual_wins": 0
+   },
+   "frc3632": {
+    "highest_match_scores": [
+     142,
+     138,
+     111
+    ],
+    "qual_wins": 0
+   },
+   "frc4680": {
+    "highest_match_scores": [
+     90,
+     86,
+     84
+    ],
+    "qual_wins": 0
+   },
+   "frc4758": {
+    "highest_match_scores": [
+     94,
+     71,
+     60
+    ],
+    "qual_wins": 0
+   },
+   "frc4838": {
+    "highest_match_scores": [
+     143,
+     109,
+     106
+    ],
+    "qual_wins": 0
+   },
+   "frc4851": {
+    "highest_match_scores": [
+     159,
+     103,
+     47
+    ],
+    "qual_wins": 0
+   },
+   "frc4854": {
+    "highest_match_scores": [
+     173,
+     97,
+     45
+    ],
+    "qual_wins": 0
+   },
+   "frc5065": {
+    "highest_match_scores": [
+     161,
+     66,
+     47
+    ],
+    "qual_wins": 0
+   },
+   "frc5197": {
+    "highest_match_scores": [
+     132,
+     100,
+     92
+    ],
+    "qual_wins": 0
+   },
+   "frc5225": {
+    "highest_match_scores": [
+     95,
+     55,
+     52
+    ],
+    "qual_wins": 0
+   },
+   "frc5478": {
+    "highest_match_scores": [
+     232,
+     186,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc5532": {
+    "highest_match_scores": [
+     176,
+     64,
+     50
+    ],
+    "qual_wins": 0
+   },
+   "frc5577": {
+    "highest_match_scores": [
+     109,
+     107,
+     92
+    ],
+    "qual_wins": 0
+   },
+   "frc5642": {
+    "highest_match_scores": [
+     107,
+     103,
+     64
+    ],
+    "qual_wins": 0
+   },
+   "frc5756": {
+    "highest_match_scores": [
+     107,
+     106,
+     94
+    ],
+    "qual_wins": 0
+   },
+   "frc6096": {
+    "highest_match_scores": [
+     165,
+     112,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc6099": {
+    "highest_match_scores": [
+     48,
+     47,
+     42
+    ],
+    "qual_wins": 0
+   },
+   "frc6532": {
+    "highest_match_scores": [
+     72,
+     70,
+     63
+    ],
+    "qual_wins": 0
+   },
+   "frc6616": {
+    "highest_match_scores": [
+     102,
+     70,
+     57
+    ],
+    "qual_wins": 0
+   },
+   "frc7145": {
+    "highest_match_scores": [
+     74,
+     68,
+     51
+    ],
+    "qual_wins": 0
+   },
+   "frc7196": {
+    "highest_match_scores": [
+     176,
+     94,
+     90
+    ],
+    "qual_wins": 0
+   },
+   "frc7692": {
+    "highest_match_scores": [
+     113,
+     106,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc7865": {
+    "highest_match_scores": [
+     123,
+     68,
+     63
+    ],
+    "qual_wins": 0
+   },
+   "frc8352": {
+    "highest_match_scores": [
+     182,
+     144,
+     142
+    ],
+    "qual_wins": 0
+   },
+   "frc8899": {
+    "highest_match_scores": [
+     60,
+     49,
+     44
+    ],
+    "qual_wins": 0
+   },
+   "frc9255": {
+    "highest_match_scores": [
+     165,
+     161,
+     142
+    ],
+    "qual_wins": 0
+   },
+   "frc9651": {
+    "highest_match_scores": [
+     132,
+     97,
+     90
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026miesc": {
+  "points": {
+   "frc10589": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 38
+   },
+   "frc10595": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   },
+   "frc10605": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc10622": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 39
+   },
+   "frc11466": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc2586": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 51
+   },
+   "frc3602": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 41
+   },
+   "frc3770": {
+    "alliance_points": 9,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc4375": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 17
+   },
+   "frc4377": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 16
+   },
+   "frc4391": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc4392": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc4827": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4835": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc5086": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc5193": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 77
+   },
+   "frc5486": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 26
+   },
+   "frc5505": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 52
+   },
+   "frc5702": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5706": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc6079": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 45
+   },
+   "frc6088": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 24
+   },
+   "frc6112": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6113": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc6558": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6569": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc6637": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 53
+   },
+   "frc7250": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc7713": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc7782": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc857": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc8612": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 46
+   },
+   "frc9249": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 24
+   },
+   "frc9548": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc9674": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc9682": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9722": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9733": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9755": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9773": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   }
+  },
+  "tiebreakers": {
+   "frc10589": {
+    "highest_match_scores": [
+     335,
+     303,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc10595": {
+    "highest_match_scores": [
+     292,
+     223,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc10605": {
+    "highest_match_scores": [
+     306,
+     257,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc10622": {
+    "highest_match_scores": [
+     294,
+     279,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc11466": {
+    "highest_match_scores": [
+     226,
+     210,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc2586": {
+    "highest_match_scores": [
+     294,
+     290,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc3602": {
+    "highest_match_scores": [
+     346,
+     306,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc3770": {
+    "highest_match_scores": [
+     335,
+     297,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc4375": {
+    "highest_match_scores": [
+     303,
+     273,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc4377": {
+    "highest_match_scores": [
+     305,
+     235,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc4391": {
+    "highest_match_scores": [
+     466,
+     413,
+     394
+    ],
+    "qual_wins": 0
+   },
+   "frc4392": {
+    "highest_match_scores": [
+     376,
+     305,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc4827": {
+    "highest_match_scores": [
+     378,
+     334,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc4835": {
+    "highest_match_scores": [
+     292,
+     235,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc5086": {
+    "highest_match_scores": [
+     365,
+     305,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc5193": {
+    "highest_match_scores": [
+     466,
+     413,
+     393
+    ],
+    "qual_wins": 0
+   },
+   "frc5486": {
+    "highest_match_scores": [
+     394,
+     280,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc5505": {
+    "highest_match_scores": [
+     393,
+     365,
+     315
+    ],
+    "qual_wins": 0
+   },
+   "frc5702": {
+    "highest_match_scores": [
+     265,
+     246,
+     167
+    ],
+    "qual_wins": 0
+   },
+   "frc5706": {
+    "highest_match_scores": [
+     224,
+     221,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc6079": {
+    "highest_match_scores": [
+     466,
+     413,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc6088": {
+    "highest_match_scores": [
+     303,
+     285,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc6112": {
+    "highest_match_scores": [
+     228,
+     169,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc6113": {
+    "highest_match_scores": [
+     268,
+     243,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc6558": {
+    "highest_match_scores": [
+     393,
+     192,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc6569": {
+    "highest_match_scores": [
+     279,
+     264,
+     218
+    ],
+    "qual_wins": 0
+   },
+   "frc6637": {
+    "highest_match_scores": [
+     394,
+     325,
+     291
+    ],
+    "qual_wins": 0
+   },
+   "frc7250": {
+    "highest_match_scores": [
+     351,
+     285,
+     273
+    ],
+    "qual_wins": 0
+   },
+   "frc7713": {
+    "highest_match_scores": [
+     325,
+     292,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc7782": {
+    "highest_match_scores": [
+     378,
+     254,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc857": {
+    "highest_match_scores": [
+     352,
+     334,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc8612": {
+    "highest_match_scores": [
+     352,
+     335,
+     325
+    ],
+    "qual_wins": 0
+   },
+   "frc9249": {
+    "highest_match_scores": [
+     351,
+     283,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc9548": {
+    "highest_match_scores": [
+     291,
+     252,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc9674": {
+    "highest_match_scores": [
+     352,
+     230,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc9682": {
+    "highest_match_scores": [
+     346,
+     196,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc9722": {
+    "highest_match_scores": [
+     297,
+     228,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc9733": {
+    "highest_match_scores": [
+     253,
+     191,
+     167
+    ],
+    "qual_wins": 0
+   },
+   "frc9755": {
+    "highest_match_scores": [
+     284,
+     228,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc9773": {
+    "highest_match_scores": [
+     315,
+     303,
+     230
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mifen": {
+  "points": {
+   "frc10667": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc10690": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc10978": {
+    "alliance_points": 13,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 46
+   },
+   "frc1322": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc2145": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc3098": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc3568": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc4130": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 15
+   },
+   "frc4810": {
+    "alliance_points": 10,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 33
+   },
+   "frc494": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc5084": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 29
+   },
+   "frc5114": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 71
+   },
+   "frc5229": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 38
+   },
+   "frc5234": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5260": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5282": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5517": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5532": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc5603": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc5641": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5660": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 65
+   },
+   "frc6067": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6071": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc6073": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   },
+   "frc6190": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6538": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc6548": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc68": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 58
+   },
+   "frc70": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc7202": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 34
+   },
+   "frc7598": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 12,
+    "total": 38
+   },
+   "frc7772": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc8193": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 15,
+    "total": 47
+   },
+   "frc8385": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc862": {
+    "alliance_points": 12,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 35
+   },
+   "frc9207": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 27
+   },
+   "frc9237": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 19
+   },
+   "frc9455": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9697": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc9757": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc9759": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9776": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   }
+  },
+  "tiebreakers": {
+   "frc10667": {
+    "highest_match_scores": [
+     352,
+     283,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc10690": {
+    "highest_match_scores": [
+     315,
+     225,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc10978": {
+    "highest_match_scores": [
+     331,
+     260,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc1322": {
+    "highest_match_scores": [
+     360,
+     191,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc2145": {
+    "highest_match_scores": [
+     391,
+     224,
+     166
+    ],
+    "qual_wins": 0
+   },
+   "frc3098": {
+    "highest_match_scores": [
+     341,
+     209,
+     123
+    ],
+    "qual_wins": 0
+   },
+   "frc3568": {
+    "highest_match_scores": [
+     315,
+     259,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc4130": {
+    "highest_match_scores": [
+     289,
+     275,
+     240
+    ],
+    "qual_wins": 0
+   },
+   "frc4810": {
+    "highest_match_scores": [
+     352,
+     226,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc494": {
+    "highest_match_scores": [
+     392,
+     391,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc5084": {
+    "highest_match_scores": [
+     303,
+     271,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc5114": {
+    "highest_match_scores": [
+     477,
+     392,
+     388
+    ],
+    "qual_wins": 0
+   },
+   "frc5229": {
+    "highest_match_scores": [
+     271,
+     244,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc5234": {
+    "highest_match_scores": [
+     214,
+     186,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc5260": {
+    "highest_match_scores": [
+     190,
+     185,
+     184
+    ],
+    "qual_wins": 0
+   },
+   "frc5282": {
+    "highest_match_scores": [
+     260,
+     201,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc5517": {
+    "highest_match_scores": [
+     224,
+     186,
+     125
+    ],
+    "qual_wins": 0
+   },
+   "frc5532": {
+    "highest_match_scores": [
+     186,
+     166,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc5603": {
+    "highest_match_scores": [
+     205,
+     203,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc5641": {
+    "highest_match_scores": [
+     289,
+     229,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc5660": {
+    "highest_match_scores": [
+     477,
+     388,
+     383
+    ],
+    "qual_wins": 0
+   },
+   "frc6067": {
+    "highest_match_scores": [
+     229,
+     226,
+     117
+    ],
+    "qual_wins": 0
+   },
+   "frc6071": {
+    "highest_match_scores": [
+     392,
+     185,
+     139
+    ],
+    "qual_wins": 0
+   },
+   "frc6073": {
+    "highest_match_scores": [
+     320,
+     252,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc6190": {
+    "highest_match_scores": [
+     200,
+     190,
+     142
+    ],
+    "qual_wins": 0
+   },
+   "frc6538": {
+    "highest_match_scores": [
+     348,
+     290,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc6548": {
+    "highest_match_scores": [
+     240,
+     199,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc68": {
+    "highest_match_scores": [
+     360,
+     341,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc70": {
+    "highest_match_scores": [
+     391,
+     360,
+     303
+    ],
+    "qual_wins": 0
+   },
+   "frc7202": {
+    "highest_match_scores": [
+     383,
+     280,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc7598": {
+    "highest_match_scores": [
+     328,
+     327,
+     318
+    ],
+    "qual_wins": 0
+   },
+   "frc7772": {
+    "highest_match_scores": [
+     328,
+     238,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc8193": {
+    "highest_match_scores": [
+     477,
+     388,
+     319
+    ],
+    "qual_wins": 0
+   },
+   "frc8385": {
+    "highest_match_scores": [
+     209,
+     207,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc862": {
+    "highest_match_scores": [
+     356,
+     290,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc9207": {
+    "highest_match_scores": [
+     341,
+     248,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc9237": {
+    "highest_match_scores": [
+     309,
+     248,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc9455": {
+    "highest_match_scores": [
+     197,
+     189,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc9697": {
+    "highest_match_scores": [
+     275,
+     233,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc9757": {
+    "highest_match_scores": [
+     356,
+     348,
+     341
+    ],
+    "qual_wins": 0
+   },
+   "frc9759": {
+    "highest_match_scores": [
+     341,
+     190,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc9776": {
+    "highest_match_scores": [
+     283,
+     280,
+     271
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mifli": {
+  "points": {
+   "frc10547": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   },
+   "frc10587": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc10659": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc10665": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc10667": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc11458": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc11527": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc1322": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc1684": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 36
+   },
+   "frc2337": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 78
+   },
+   "frc314": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc494": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc4998": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc5046": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 21,
+    "total": 54
+   },
+   "frc5150": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 17
+   },
+   "frc5167": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 27
+   },
+   "frc5214": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5235": {
+    "alliance_points": 2,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 7,
+    "total": 30
+   },
+   "frc5282": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc5517": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5527": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5561": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 43
+   },
+   "frc5612": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc5660": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 57
+   },
+   "frc5697": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc6085": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 48
+   },
+   "frc6610": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc68": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 70
+   },
+   "frc70": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc7597": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc7772": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 23
+   },
+   "frc7784": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc8193": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc8385": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc8767": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 25
+   },
+   "frc894": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 52
+   },
+   "frc9207": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc9242": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc9648": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 30
+   },
+   "frc9697": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9757": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 59
+   }
+  },
+  "tiebreakers": {
+   "frc10547": {
+    "highest_match_scores": [
+     279,
+     186,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc10587": {
+    "highest_match_scores": [
+     228,
+     182,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc10659": {
+    "highest_match_scores": [
+     165,
+     76,
+     74
+    ],
+    "qual_wins": 0
+   },
+   "frc10665": {
+    "highest_match_scores": [
+     234,
+     155,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc10667": {
+    "highest_match_scores": [
+     300,
+     168,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc11458": {
+    "highest_match_scores": [
+     147,
+     134,
+     133
+    ],
+    "qual_wins": 0
+   },
+   "frc11527": {
+    "highest_match_scores": [
+     311,
+     254,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc1322": {
+    "highest_match_scores": [
+     228,
+     221,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc1684": {
+    "highest_match_scores": [
+     311,
+     262,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc2337": {
+    "highest_match_scores": [
+     486,
+     409,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc314": {
+    "highest_match_scores": [
+     231,
+     228,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc494": {
+    "highest_match_scores": [
+     309,
+     258,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc4998": {
+    "highest_match_scores": [
+     333,
+     170,
+     161
+    ],
+    "qual_wins": 0
+   },
+   "frc5046": {
+    "highest_match_scores": [
+     326,
+     309,
+     299
+    ],
+    "qual_wins": 0
+   },
+   "frc5150": {
+    "highest_match_scores": [
+     269,
+     182,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc5167": {
+    "highest_match_scores": [
+     309,
+     262,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc5214": {
+    "highest_match_scores": [
+     198,
+     142,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc5235": {
+    "highest_match_scores": [
+     326,
+     299,
+     281
+    ],
+    "qual_wins": 0
+   },
+   "frc5282": {
+    "highest_match_scores": [
+     229,
+     171,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc5517": {
+    "highest_match_scores": [
+     221,
+     131,
+     129
+    ],
+    "qual_wins": 0
+   },
+   "frc5527": {
+    "highest_match_scores": [
+     221,
+     155,
+     152
+    ],
+    "qual_wins": 0
+   },
+   "frc5561": {
+    "highest_match_scores": [
+     308,
+     282,
+     262
+    ],
+    "qual_wins": 0
+   },
+   "frc5612": {
+    "highest_match_scores": [
+     254,
+     244,
+     234
+    ],
+    "qual_wins": 0
+   },
+   "frc5660": {
+    "highest_match_scores": [
+     399,
+     298,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc5697": {
+    "highest_match_scores": [
+     281,
+     151,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc6085": {
+    "highest_match_scores": [
+     486,
+     409,
+     387
+    ],
+    "qual_wins": 0
+   },
+   "frc6610": {
+    "highest_match_scores": [
+     199,
+     194,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc68": {
+    "highest_match_scores": [
+     486,
+     409,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc70": {
+    "highest_match_scores": [
+     333,
+     221,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc7597": {
+    "highest_match_scores": [
+     282,
+     146,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc7772": {
+    "highest_match_scores": [
+     204,
+     198,
+     174
+    ],
+    "qual_wins": 0
+   },
+   "frc7784": {
+    "highest_match_scores": [
+     269,
+     186,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc8193": {
+    "highest_match_scores": [
+     185,
+     168,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc8385": {
+    "highest_match_scores": [
+     281,
+     228,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc8767": {
+    "highest_match_scores": [
+     358,
+     308,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc894": {
+    "highest_match_scores": [
+     358,
+     326,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc9207": {
+    "highest_match_scores": [
+     301,
+     231,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc9242": {
+    "highest_match_scores": [
+     309,
+     281,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc9648": {
+    "highest_match_scores": [
+     300,
+     298,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc9697": {
+    "highest_match_scores": [
+     168,
+     157,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc9757": {
+    "highest_match_scores": [
+     301,
+     298,
+     284
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026miken": {
+  "points": {
+   "frc10181": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 24
+   },
+   "frc1023": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 52
+   },
+   "frc10633": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 70
+   },
+   "frc10642": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 13,
+    "total": 45
+   },
+   "frc10664": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc11399": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc2075": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 40
+   },
+   "frc2771": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc3234": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc3620": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 22,
+    "total": 61
+   },
+   "frc3875": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 32
+   },
+   "frc4325": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 14
+   },
+   "frc4967": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 43
+   },
+   "frc5166": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 55
+   },
+   "frc5256": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5980": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc6081": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc7220": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 66
+   },
+   "frc7221": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc7256": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc7289": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc7656": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc7658": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc7808": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc7809": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc7818": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc8285": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc8423": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc858": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 47
+   },
+   "frc8767": {
+    "alliance_points": 5,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 14,
+    "total": 47
+   },
+   "frc904": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc9206": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9208": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 31
+   },
+   "frc9549": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc9566": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 15
+   },
+   "frc9638": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 20
+   },
+   "frc9671": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 9,
+    "total": 19
+   },
+   "frc9685": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 21
+   },
+   "frc9756": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   }
+  },
+  "tiebreakers": {
+   "frc10181": {
+    "highest_match_scores": [
+     327,
+     317,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc1023": {
+    "highest_match_scores": [
+     385,
+     364,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc10633": {
+    "highest_match_scores": [
+     429,
+     398,
+     385
+    ],
+    "qual_wins": 0
+   },
+   "frc10642": {
+    "highest_match_scores": [
+     429,
+     341,
+     336
+    ],
+    "qual_wins": 0
+   },
+   "frc10664": {
+    "highest_match_scores": [
+     211,
+     176,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc11399": {
+    "highest_match_scores": [
+     306,
+     217,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc2075": {
+    "highest_match_scores": [
+     371,
+     364,
+     329
+    ],
+    "qual_wins": 0
+   },
+   "frc2771": {
+    "highest_match_scores": [
+     330,
+     305,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc3234": {
+    "highest_match_scores": [
+     306,
+     162,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc3620": {
+    "highest_match_scores": [
+     371,
+     347,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc3875": {
+    "highest_match_scores": [
+     419,
+     330,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc4325": {
+    "highest_match_scores": [
+     367,
+     282,
+     274
+    ],
+    "qual_wins": 0
+   },
+   "frc4967": {
+    "highest_match_scores": [
+     398,
+     386,
+     367
+    ],
+    "qual_wins": 0
+   },
+   "frc5166": {
+    "highest_match_scores": [
+     386,
+     385,
+     366
+    ],
+    "qual_wins": 0
+   },
+   "frc5256": {
+    "highest_match_scores": [
+     347,
+     288,
+     246
+    ],
+    "qual_wins": 0
+   },
+   "frc5980": {
+    "highest_match_scores": [
+     364,
+     259,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc6081": {
+    "highest_match_scores": [
+     365,
+     259,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc7220": {
+    "highest_match_scores": [
+     429,
+     419,
+     385
+    ],
+    "qual_wins": 0
+   },
+   "frc7221": {
+    "highest_match_scores": [
+     302,
+     259,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc7256": {
+    "highest_match_scores": [
+     305,
+     193,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc7289": {
+    "highest_match_scores": [
+     217,
+     216,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc7656": {
+    "highest_match_scores": [
+     385,
+     333,
+     274
+    ],
+    "qual_wins": 0
+   },
+   "frc7658": {
+    "highest_match_scores": [
+     255,
+     246,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc7808": {
+    "highest_match_scores": [
+     278,
+     145,
+     139
+    ],
+    "qual_wins": 0
+   },
+   "frc7809": {
+    "highest_match_scores": [
+     273,
+     243,
+     216
+    ],
+    "qual_wins": 0
+   },
+   "frc7818": {
+    "highest_match_scores": [
+     366,
+     230,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc8285": {
+    "highest_match_scores": [
+     346,
+     204,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc8423": {
+    "highest_match_scores": [
+     419,
+     290,
+     282
+    ],
+    "qual_wins": 0
+   },
+   "frc858": {
+    "highest_match_scores": [
+     386,
+     265,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc8767": {
+    "highest_match_scores": [
+     290,
+     278,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc904": {
+    "highest_match_scores": [
+     175,
+     153,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc9206": {
+    "highest_match_scores": [
+     217,
+     217,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc9208": {
+    "highest_match_scores": [
+     333,
+     204,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9549": {
+    "highest_match_scores": [
+     317,
+     243,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc9566": {
+    "highest_match_scores": [
+     266,
+     193,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc9638": {
+    "highest_match_scores": [
+     398,
+     333,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc9671": {
+    "highest_match_scores": [
+     285,
+     273,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc9685": {
+    "highest_match_scores": [
+     385,
+     259,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc9756": {
+    "highest_match_scores": [
+     365,
+     239,
+     217
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026milac": {
+  "points": {
+   "frc10421": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 8,
+    "total": 20
+   },
+   "frc11435": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc11437": {
+    "alliance_points": 7,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 26
+   },
+   "frc11440": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc141": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 38
+   },
+   "frc1684": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 41
+   },
+   "frc2054": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 70
+   },
+   "frc226": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 64
+   },
+   "frc2586": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 38
+   },
+   "frc3536": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 59
+   },
+   "frc3537": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc3603": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc4776": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 11
+   },
+   "frc4956": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 31
+   },
+   "frc4983": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 14,
+    "qual_points": 9,
+    "total": 26
+   },
+   "frc5534": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 41
+   },
+   "frc5547": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 14
+   },
+   "frc5560": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6087": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc6114": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc6121": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 30
+   },
+   "frc6963": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 17
+   },
+   "frc7155": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 17
+   },
+   "frc7202": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc7250": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 12,
+    "total": 38
+   },
+   "frc7768": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 14,
+    "total": 41
+   },
+   "frc7790": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc7794": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7855": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 7,
+    "total": 14
+   },
+   "frc8041": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc9106": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9541": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc9568": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc9650": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 40
+   }
+  },
+  "tiebreakers": {
+   "frc10421": {
+    "highest_match_scores": [
+     238,
+     176,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc11435": {
+    "highest_match_scores": [
+     153,
+     106,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc11437": {
+    "highest_match_scores": [
+     264,
+     156,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc11440": {
+    "highest_match_scores": [
+     136,
+     107,
+     100
+    ],
+    "qual_wins": 0
+   },
+   "frc141": {
+    "highest_match_scores": [
+     248,
+     246,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc1684": {
+    "highest_match_scores": [
+     245,
+     186,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc2054": {
+    "highest_match_scores": [
+     289,
+     275,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc226": {
+    "highest_match_scores": [
+     289,
+     265,
+     246
+    ],
+    "qual_wins": 0
+   },
+   "frc2586": {
+    "highest_match_scores": [
+     248,
+     169,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc3536": {
+    "highest_match_scores": [
+     265,
+     248,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc3537": {
+    "highest_match_scores": [
+     246,
+     187,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc3603": {
+    "highest_match_scores": [
+     275,
+     264,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc4776": {
+    "highest_match_scores": [
+     157,
+     97,
+     85
+    ],
+    "qual_wins": 0
+   },
+   "frc4956": {
+    "highest_match_scores": [
+     289,
+     152,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc4983": {
+    "highest_match_scores": [
+     265,
+     209,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc5534": {
+    "highest_match_scores": [
+     264,
+     176,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc5547": {
+    "highest_match_scores": [
+     245,
+     171,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc5560": {
+    "highest_match_scores": [
+     223,
+     83,
+     62
+    ],
+    "qual_wins": 0
+   },
+   "frc6087": {
+    "highest_match_scores": [
+     163,
+     153,
+     120
+    ],
+    "qual_wins": 0
+   },
+   "frc6114": {
+    "highest_match_scores": [
+     247,
+     207,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc6121": {
+    "highest_match_scores": [
+     179,
+     151,
+     149
+    ],
+    "qual_wins": 0
+   },
+   "frc6963": {
+    "highest_match_scores": [
+     199,
+     190,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc7155": {
+    "highest_match_scores": [
+     224,
+     151,
+     106
+    ],
+    "qual_wins": 0
+   },
+   "frc7202": {
+    "highest_match_scores": [
+     223,
+     187,
+     155
+    ],
+    "qual_wins": 0
+   },
+   "frc7250": {
+    "highest_match_scores": [
+     207,
+     186,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc7768": {
+    "highest_match_scores": [
+     207,
+     176,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc7790": {
+    "highest_match_scores": [
+     186,
+     183,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc7794": {
+    "highest_match_scores": [
+     109,
+     74,
+     69
+    ],
+    "qual_wins": 0
+   },
+   "frc7855": {
+    "highest_match_scores": [
+     173,
+     161,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc8041": {
+    "highest_match_scores": [
+     155,
+     152,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc9106": {
+    "highest_match_scores": [
+     238,
+     155,
+     123
+    ],
+    "qual_wins": 0
+   },
+   "frc9541": {
+    "highest_match_scores": [
+     247,
+     199,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc9568": {
+    "highest_match_scores": [
+     224,
+     157,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc9650": {
+    "highest_match_scores": [
+     275,
+     261,
+     250
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026milak": {
+  "points": {
+   "frc10473": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 9,
+    "total": 31
+   },
+   "frc10651": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc11386": {
+    "alliance_points": 5,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 32
+   },
+   "frc11407": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc1188": {
+    "alliance_points": 9,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc245": {
+    "alliance_points": 12,
+    "award_points": 10,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 45
+   },
+   "frc2767": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc2959": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc3658": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 20
+   },
+   "frc3875": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc4237": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc4327": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc4453": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5152": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc5248": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc5559": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc5610": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5623": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5675": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc5676": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc5980": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 26
+   },
+   "frc6002": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 59
+   },
+   "frc7226": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc7256": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc7658": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc7911": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc8041": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc8126": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc8397": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 10,
+    "total": 41
+   },
+   "frc858": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc8608": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc9203": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9215": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc9239": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9566": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 30
+   },
+   "frc9638": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9672": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc9703": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 12
+   }
+  },
+  "tiebreakers": {
+   "frc10473": {
+    "highest_match_scores": [
+     276,
+     238,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc10651": {
+    "highest_match_scores": [
+     235,
+     202,
+     107
+    ],
+    "qual_wins": 0
+   },
+   "frc11386": {
+    "highest_match_scores": [
+     285,
+     201,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc11407": {
+    "highest_match_scores": [
+     220,
+     196,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc1188": {
+    "highest_match_scores": [
+     227,
+     201,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc245": {
+    "highest_match_scores": [
+     201,
+     196,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc2767": {
+    "highest_match_scores": [
+     389,
+     385,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc2959": {
+    "highest_match_scores": [
+     243,
+     160,
+     117
+    ],
+    "qual_wins": 0
+   },
+   "frc3658": {
+    "highest_match_scores": [
+     234,
+     221,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc3875": {
+    "highest_match_scores": [
+     382,
+     243,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc4237": {
+    "highest_match_scores": [
+     389,
+     283,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc4327": {
+    "highest_match_scores": [
+     193,
+     161,
+     140
+    ],
+    "qual_wins": 0
+   },
+   "frc4453": {
+    "highest_match_scores": [
+     198,
+     168,
+     117
+    ],
+    "qual_wins": 0
+   },
+   "frc5152": {
+    "highest_match_scores": [
+     244,
+     205,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc5248": {
+    "highest_match_scores": [
+     221,
+     202,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc5559": {
+    "highest_match_scores": [
+     187,
+     186,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc5610": {
+    "highest_match_scores": [
+     193,
+     191,
+     107
+    ],
+    "qual_wins": 0
+   },
+   "frc5623": {
+    "highest_match_scores": [
+     285,
+     194,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc5675": {
+    "highest_match_scores": [
+     310,
+     297,
+     243
+    ],
+    "qual_wins": 0
+   },
+   "frc5676": {
+    "highest_match_scores": [
+     235,
+     235,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc5980": {
+    "highest_match_scores": [
+     201,
+     156,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc6002": {
+    "highest_match_scores": [
+     382,
+     297,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc7226": {
+    "highest_match_scores": [
+     202,
+     146,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc7256": {
+    "highest_match_scores": [
+     235,
+     183,
+     79
+    ],
+    "qual_wins": 0
+   },
+   "frc7658": {
+    "highest_match_scores": [
+     260,
+     121,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc7911": {
+    "highest_match_scores": [
+     220,
+     202,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc8041": {
+    "highest_match_scores": [
+     297,
+     131,
+     122
+    ],
+    "qual_wins": 0
+   },
+   "frc8126": {
+    "highest_match_scores": [
+     389,
+     243,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc8397": {
+    "highest_match_scores": [
+     385,
+     350,
+     345
+    ],
+    "qual_wins": 0
+   },
+   "frc858": {
+    "highest_match_scores": [
+     244,
+     198,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc8608": {
+    "highest_match_scores": [
+     385,
+     382,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc9203": {
+    "highest_match_scores": [
+     218,
+     103,
+     83
+    ],
+    "qual_wins": 0
+   },
+   "frc9215": {
+    "highest_match_scores": [
+     202,
+     201,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc9239": {
+    "highest_match_scores": [
+     318,
+     227,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc9566": {
+    "highest_match_scores": [
+     234,
+     202,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc9638": {
+    "highest_match_scores": [
+     283,
+     218,
+     104
+    ],
+    "qual_wins": 0
+   },
+   "frc9672": {
+    "highest_match_scores": [
+     222,
+     161,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc9703": {
+    "highest_match_scores": [
+     243,
+     205,
+     159
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026miliv": {
+  "points": {
+   "frc10590": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc10659": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc10664": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc10672": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc11361": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 17
+   },
+   "frc11455": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc1189": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc123": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 36
+   },
+   "frc1250": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 26
+   },
+   "frc1481": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc2604": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 15
+   },
+   "frc27": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 78
+   },
+   "frc2832": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc3414": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 59
+   },
+   "frc3538": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc4405": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 17
+   },
+   "frc4768": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5050": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 12,
+    "total": 34
+   },
+   "frc5467": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5533": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 38
+   },
+   "frc5559": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc5843": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc5907": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc6099": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc6152": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 50
+   },
+   "frc6861": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc6914": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc7145": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc7147": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 25
+   },
+   "frc7174": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 31
+   },
+   "frc7553": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 23
+   },
+   "frc8115": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 10,
+    "total": 41
+   },
+   "frc8297": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 19
+   },
+   "frc830": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 9,
+    "total": 25
+   },
+   "frc8426": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   },
+   "frc8427": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc8623": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9205": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9572": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc9735": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9751": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   }
+  },
+  "tiebreakers": {
+   "frc10590": {
+    "highest_match_scores": [
+     242,
+     169,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc10659": {
+    "highest_match_scores": [
+     404,
+     196,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc10664": {
+    "highest_match_scores": [
+     467,
+     302,
+     301
+    ],
+    "qual_wins": 0
+   },
+   "frc10672": {
+    "highest_match_scores": [
+     501,
+     324,
+     251
+    ],
+    "qual_wins": 0
+   },
+   "frc11361": {
+    "highest_match_scores": [
+     224,
+     219,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc11455": {
+    "highest_match_scores": [
+     345,
+     235,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc1189": {
+    "highest_match_scores": [
+     533,
+     519,
+     408
+    ],
+    "qual_wins": 0
+   },
+   "frc123": {
+    "highest_match_scores": [
+     408,
+     340,
+     301
+    ],
+    "qual_wins": 0
+   },
+   "frc1250": {
+    "highest_match_scores": [
+     553,
+     379,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc1481": {
+    "highest_match_scores": [
+     366,
+     319,
+     282
+    ],
+    "qual_wins": 0
+   },
+   "frc2604": {
+    "highest_match_scores": [
+     286,
+     219,
+     202
+    ],
+    "qual_wins": 0
+   },
+   "frc27": {
+    "highest_match_scores": [
+     723,
+     645,
+     563
+    ],
+    "qual_wins": 0
+   },
+   "frc2832": {
+    "highest_match_scores": [
+     533,
+     349,
+     289
+    ],
+    "qual_wins": 0
+   },
+   "frc3414": {
+    "highest_match_scores": [
+     408,
+     395,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc3538": {
+    "highest_match_scores": [
+     723,
+     563,
+     519
+    ],
+    "qual_wins": 0
+   },
+   "frc4405": {
+    "highest_match_scores": [
+     645,
+     385,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc4768": {
+    "highest_match_scores": [
+     438,
+     408,
+     366
+    ],
+    "qual_wins": 0
+   },
+   "frc5050": {
+    "highest_match_scores": [
+     395,
+     354,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc5467": {
+    "highest_match_scores": [
+     266,
+     201,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc5533": {
+    "highest_match_scores": [
+     535,
+     408,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc5559": {
+    "highest_match_scores": [
+     468,
+     304,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc5843": {
+    "highest_match_scores": [
+     553,
+     403,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc5907": {
+    "highest_match_scores": [
+     645,
+     414,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc6099": {
+    "highest_match_scores": [
+     349,
+     342,
+     202
+    ],
+    "qual_wins": 0
+   },
+   "frc6152": {
+    "highest_match_scores": [
+     723,
+     414,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc6861": {
+    "highest_match_scores": [
+     408,
+     330,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc6914": {
+    "highest_match_scores": [
+     342,
+     307,
+     297
+    ],
+    "qual_wins": 0
+   },
+   "frc7145": {
+    "highest_match_scores": [
+     467,
+     265,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc7147": {
+    "highest_match_scores": [
+     468,
+     414,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc7174": {
+    "highest_match_scores": [
+     535,
+     385,
+     345
+    ],
+    "qual_wins": 0
+   },
+   "frc7553": {
+    "highest_match_scores": [
+     309,
+     288,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc8115": {
+    "highest_match_scores": [
+     563,
+     500,
+     499
+    ],
+    "qual_wins": 0
+   },
+   "frc8297": {
+    "highest_match_scores": [
+     404,
+     275,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc830": {
+    "highest_match_scores": [
+     499,
+     350,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc8426": {
+    "highest_match_scores": [
+     298,
+     268,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc8427": {
+    "highest_match_scores": [
+     324,
+     215,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc8623": {
+    "highest_match_scores": [
+     211,
+     143,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc9205": {
+    "highest_match_scores": [
+     519,
+     278,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc9572": {
+    "highest_match_scores": [
+     501,
+     403,
+     385
+    ],
+    "qual_wins": 0
+   },
+   "frc9735": {
+    "highest_match_scores": [
+     235,
+     229,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc9751": {
+    "highest_match_scores": [
+     438,
+     297,
+     219
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026milsu": {
+  "points": {
+   "frc10589": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   },
+   "frc10595": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc10605": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc10622": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc10666": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc1596": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 22
+   },
+   "frc3452": {
+    "alliance_points": 9,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 32
+   },
+   "frc3536": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc4375": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc4377": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4392": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 39
+   },
+   "frc4398": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 22,
+    "total": 50
+   },
+   "frc4779": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 17,
+    "total": 64
+   },
+   "frc4967": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 49
+   },
+   "frc5213": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc5216": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 21,
+    "total": 52
+   },
+   "frc5314": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc5424": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 30
+   },
+   "frc5486": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 18
+   },
+   "frc5547": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5706": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5878": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6077": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 30
+   },
+   "frc6088": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 8,
+    "total": 43
+   },
+   "frc6098": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 12
+   },
+   "frc6112": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc6113": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6121": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 18,
+    "total": 65
+   },
+   "frc6558": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc6637": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc7713": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc7768": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 30
+   },
+   "frc7814": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc8517": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 59
+   },
+   "frc857": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 28
+   },
+   "frc9249": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc9548": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 20
+   },
+   "frc9674": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc9682": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9722": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9733": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   }
+  },
+  "tiebreakers": {
+   "frc10589": {
+    "highest_match_scores": [
+     276,
+     266,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc10595": {
+    "highest_match_scores": [
+     229,
+     209,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc10605": {
+    "highest_match_scores": [
+     319,
+     185,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc10622": {
+    "highest_match_scores": [
+     207,
+     172,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc10666": {
+    "highest_match_scores": [
+     287,
+     240,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc1596": {
+    "highest_match_scores": [
+     235,
+     229,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc3452": {
+    "highest_match_scores": [
+     284,
+     278,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc3536": {
+    "highest_match_scores": [
+     300,
+     284,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc4375": {
+    "highest_match_scores": [
+     240,
+     227,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc4377": {
+    "highest_match_scores": [
+     240,
+     234,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc4392": {
+    "highest_match_scores": [
+     278,
+     275,
+     269
+    ],
+    "qual_wins": 0
+   },
+   "frc4398": {
+    "highest_match_scores": [
+     319,
+     287,
+     282
+    ],
+    "qual_wins": 0
+   },
+   "frc4779": {
+    "highest_match_scores": [
+     319,
+     281,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc4967": {
+    "highest_match_scores": [
+     278,
+     269,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc5213": {
+    "highest_match_scores": [
+     207,
+     161,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc5216": {
+    "highest_match_scores": [
+     287,
+     276,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc5314": {
+    "highest_match_scores": [
+     234,
+     229,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc5424": {
+    "highest_match_scores": [
+     269,
+     198,
+     188
+    ],
+    "qual_wins": 0
+   },
+   "frc5486": {
+    "highest_match_scores": [
+     282,
+     271,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc5547": {
+    "highest_match_scores": [
+     216,
+     179,
+     173
+    ],
+    "qual_wins": 0
+   },
+   "frc5706": {
+    "highest_match_scores": [
+     202,
+     166,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc5878": {
+    "highest_match_scores": [
+     141,
+     130,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc6077": {
+    "highest_match_scores": [
+     318,
+     300,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc6088": {
+    "highest_match_scores": [
+     281,
+     245,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc6098": {
+    "highest_match_scores": [
+     226,
+     187,
+     184
+    ],
+    "qual_wins": 0
+   },
+   "frc6112": {
+    "highest_match_scores": [
+     213,
+     197,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc6113": {
+    "highest_match_scores": [
+     127,
+     102,
+     100
+    ],
+    "qual_wins": 0
+   },
+   "frc6121": {
+    "highest_match_scores": [
+     281,
+     278,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc6558": {
+    "highest_match_scores": [
+     198,
+     180,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc6637": {
+    "highest_match_scores": [
+     282,
+     228,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc7713": {
+    "highest_match_scores": [
+     300,
+     219,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc7768": {
+    "highest_match_scores": [
+     318,
+     227,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc7814": {
+    "highest_match_scores": [
+     262,
+     240,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc8517": {
+    "highest_match_scores": [
+     318,
+     250,
+     240
+    ],
+    "qual_wins": 0
+   },
+   "frc857": {
+    "highest_match_scores": [
+     262,
+     227,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc9249": {
+    "highest_match_scores": [
+     230,
+     200,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc9548": {
+    "highest_match_scores": [
+     248,
+     181,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc9674": {
+    "highest_match_scores": [
+     284,
+     228,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc9682": {
+    "highest_match_scores": [
+     208,
+     136,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc9722": {
+    "highest_match_scores": [
+     278,
+     250,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc9733": {
+    "highest_match_scores": [
+     157,
+     141,
+     136
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mimar": {
+  "points": {
+   "frc10349": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc11493": {
+    "alliance_points": 10,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 33
+   },
+   "frc1498": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc1506": {
+    "alliance_points": 5,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 23
+   },
+   "frc1718": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 45
+   },
+   "frc2851": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 55
+   },
+   "frc33": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc3539": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 18,
+    "total": 69
+   },
+   "frc3667": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc4130": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 38
+   },
+   "frc453": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc4779": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 31
+   },
+   "frc4961": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4994": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc51": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc5167": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc5214": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5612": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5843": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc5860": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 16
+   },
+   "frc5926": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 25
+   },
+   "frc6091": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6120": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 30
+   },
+   "frc6344": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc7211": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 24
+   },
+   "frc7247": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc7597": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc7813": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc818": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 31
+   },
+   "frc8280": {
+    "alliance_points": 11,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 41
+   },
+   "frc8364": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc8728": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 29
+   },
+   "frc894": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 32
+   },
+   "frc9183": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9245": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc9251": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9252": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9528": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9558": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 7,
+    "total": 23
+   },
+   "frc9747": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   }
+  },
+  "tiebreakers": {
+   "frc10349": {
+    "highest_match_scores": [
+     232,
+     214,
+     211
+    ],
+    "qual_wins": 0
+   },
+   "frc11493": {
+    "highest_match_scores": [
+     261,
+     250,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc1498": {
+    "highest_match_scores": [
+     345,
+     327,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc1506": {
+    "highest_match_scores": [
+     293,
+     183,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc1718": {
+    "highest_match_scores": [
+     417,
+     363,
+     337
+    ],
+    "qual_wins": 0
+   },
+   "frc2851": {
+    "highest_match_scores": [
+     377,
+     359,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc33": {
+    "highest_match_scores": [
+     417,
+     363,
+     337
+    ],
+    "qual_wins": 0
+   },
+   "frc3539": {
+    "highest_match_scores": [
+     417,
+     377,
+     377
+    ],
+    "qual_wins": 0
+   },
+   "frc3667": {
+    "highest_match_scores": [
+     250,
+     195,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc4130": {
+    "highest_match_scores": [
+     359,
+     268,
+     236
+    ],
+    "qual_wins": 0
+   },
+   "frc453": {
+    "highest_match_scores": [
+     280,
+     230,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc4779": {
+    "highest_match_scores": [
+     377,
+     228,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc4961": {
+    "highest_match_scores": [
+     267,
+     125,
+     121
+    ],
+    "qual_wins": 0
+   },
+   "frc4994": {
+    "highest_match_scores": [
+     293,
+     239,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc51": {
+    "highest_match_scores": [
+     311,
+     272,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc5167": {
+    "highest_match_scores": [
+     165,
+     160,
+     130
+    ],
+    "qual_wins": 0
+   },
+   "frc5214": {
+    "highest_match_scores": [
+     216,
+     192,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc5612": {
+    "highest_match_scores": [
+     311,
+     183,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc5843": {
+    "highest_match_scores": [
+     327,
+     288,
+     287
+    ],
+    "qual_wins": 0
+   },
+   "frc5860": {
+    "highest_match_scores": [
+     193,
+     191,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc5926": {
+    "highest_match_scores": [
+     280,
+     241,
+     188
+    ],
+    "qual_wins": 0
+   },
+   "frc6091": {
+    "highest_match_scores": [
+     377,
+     187,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc6120": {
+    "highest_match_scores": [
+     272,
+     242,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc6344": {
+    "highest_match_scores": [
+     327,
+     204,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc7211": {
+    "highest_match_scores": [
+     272,
+     261,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc7247": {
+    "highest_match_scores": [
+     323,
+     157,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc7597": {
+    "highest_match_scores": [
+     237,
+     167,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc7813": {
+    "highest_match_scores": [
+     172,
+     157,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc818": {
+    "highest_match_scores": [
+     377,
+     239,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc8280": {
+    "highest_match_scores": [
+     327,
+     287,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc8364": {
+    "highest_match_scores": [
+     187,
+     141,
+     126
+    ],
+    "qual_wins": 0
+   },
+   "frc8728": {
+    "highest_match_scores": [
+     267,
+     214,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc894": {
+    "highest_match_scores": [
+     345,
+     241,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc9183": {
+    "highest_match_scores": [
+     188,
+     164,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc9245": {
+    "highest_match_scores": [
+     359,
+     323,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc9251": {
+    "highest_match_scores": [
+     324,
+     211,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc9252": {
+    "highest_match_scores": [
+     236,
+     213,
+     119
+    ],
+    "qual_wins": 0
+   },
+   "frc9528": {
+    "highest_match_scores": [
+     227,
+     201,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc9558": {
+    "highest_match_scores": [
+     327,
+     288,
+     260
+    ],
+    "qual_wins": 0
+   },
+   "frc9747": {
+    "highest_match_scores": [
+     318,
+     160,
+     158
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mimas": {
+  "points": {
+   "frc10577": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc10606": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc10629": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc11444": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc11490": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc11503": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc1504": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc1940": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc2137": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc3655": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc3707": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 47
+   },
+   "frc4327": {
+    "alliance_points": 12,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 39
+   },
+   "frc4776": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 18
+   },
+   "frc5225": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5674": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc5704": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5712": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 74
+   },
+   "frc5926": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc6078": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc6085": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc6591": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc7056": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 40
+   },
+   "frc7166": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 61
+   },
+   "frc7226": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc7289": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc7491": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc7818": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc8179": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc8362": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc8374": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 8,
+    "total": 29
+   },
+   "frc8424": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 49
+   },
+   "frc8608": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 18,
+    "total": 68
+   },
+   "frc910": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc9203": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc9237": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9238": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9251": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 44
+   },
+   "frc9255": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 27
+   },
+   "frc9312": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 33
+   },
+   "frc9753": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   }
+  },
+  "tiebreakers": {
+   "frc10577": {
+    "highest_match_scores": [
+     357,
+     264,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc10606": {
+    "highest_match_scores": [
+     285,
+     275,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc10629": {
+    "highest_match_scores": [
+     329,
+     198,
+     132
+    ],
+    "qual_wins": 0
+   },
+   "frc11444": {
+    "highest_match_scores": [
+     245,
+     207,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc11490": {
+    "highest_match_scores": [
+     259,
+     221,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc11503": {
+    "highest_match_scores": [
+     329,
+     275,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc1504": {
+    "highest_match_scores": [
+     254,
+     164,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc1940": {
+    "highest_match_scores": [
+     311,
+     129,
+     115
+    ],
+    "qual_wins": 0
+   },
+   "frc2137": {
+    "highest_match_scores": [
+     485,
+     463,
+     439
+    ],
+    "qual_wins": 0
+   },
+   "frc3655": {
+    "highest_match_scores": [
+     215,
+     190,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc3707": {
+    "highest_match_scores": [
+     338,
+     311,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc4327": {
+    "highest_match_scores": [
+     309,
+     250,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc4776": {
+    "highest_match_scores": [
+     391,
+     254,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc5225": {
+    "highest_match_scores": [
+     463,
+     216,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc5674": {
+    "highest_match_scores": [
+     255,
+     190,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc5704": {
+    "highest_match_scores": [
+     181,
+     173,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc5712": {
+    "highest_match_scores": [
+     413,
+     391,
+     357
+    ],
+    "qual_wins": 0
+   },
+   "frc5926": {
+    "highest_match_scores": [
+     338,
+     302,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc6078": {
+    "highest_match_scores": [
+     396,
+     311,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc6085": {
+    "highest_match_scores": [
+     275,
+     266,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc6591": {
+    "highest_match_scores": [
+     279,
+     216,
+     149
+    ],
+    "qual_wins": 0
+   },
+   "frc7056": {
+    "highest_match_scores": [
+     386,
+     357,
+     279
+    ],
+    "qual_wins": 0
+   },
+   "frc7166": {
+    "highest_match_scores": [
+     485,
+     463,
+     439
+    ],
+    "qual_wins": 0
+   },
+   "frc7226": {
+    "highest_match_scores": [
+     396,
+     332,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc7289": {
+    "highest_match_scores": [
+     296,
+     289,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc7491": {
+    "highest_match_scores": [
+     223,
+     220,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc7818": {
+    "highest_match_scores": [
+     207,
+     198,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc8179": {
+    "highest_match_scores": [
+     386,
+     289,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc8362": {
+    "highest_match_scores": [
+     225,
+     217,
+     216
+    ],
+    "qual_wins": 0
+   },
+   "frc8374": {
+    "highest_match_scores": [
+     485,
+     439,
+     351
+    ],
+    "qual_wins": 0
+   },
+   "frc8424": {
+    "highest_match_scores": [
+     413,
+     223,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc8608": {
+    "highest_match_scores": [
+     391,
+     391,
+     353
+    ],
+    "qual_wins": 0
+   },
+   "frc910": {
+    "highest_match_scores": [
+     332,
+     309,
+     287
+    ],
+    "qual_wins": 0
+   },
+   "frc9203": {
+    "highest_match_scores": [
+     206,
+     190,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc9237": {
+    "highest_match_scores": [
+     226,
+     206,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc9238": {
+    "highest_match_scores": [
+     255,
+     221,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc9251": {
+    "highest_match_scores": [
+     391,
+     353,
+     287
+    ],
+    "qual_wins": 0
+   },
+   "frc9255": {
+    "highest_match_scores": [
+     296,
+     175,
+     149
+    ],
+    "qual_wins": 0
+   },
+   "frc9312": {
+    "highest_match_scores": [
+     309,
+     285,
+     166
+    ],
+    "qual_wins": 0
+   },
+   "frc9753": {
+    "highest_match_scores": [
+     216,
+     190,
+     147
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mimid": {
+  "points": {
+   "frc10547": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc10587": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc10629": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   },
+   "frc11458": {
+    "alliance_points": 10,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc11527": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc1596": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 23
+   },
+   "frc201": {
+    "alliance_points": 13,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 40
+   },
+   "frc2619": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 37
+   },
+   "frc3357": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 20,
+    "total": 46
+   },
+   "frc3425": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc3770": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc5166": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 76
+   },
+   "frc5216": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc5229": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc5231": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5424": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 32
+   },
+   "frc5504": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc5509": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc5525": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5533": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc5538": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 21
+   },
+   "frc5561": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   },
+   "frc5603": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 7,
+    "total": 38
+   },
+   "frc5712": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 16,
+    "total": 67
+   },
+   "frc6033": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc6067": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6073": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 19
+   },
+   "frc6533": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6753": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 45
+   },
+   "frc7784": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc8517": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 48
+   },
+   "frc8873": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc9238": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9648": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9661": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc9662": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9685": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 36
+   },
+   "frc9731": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9736": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   }
+  },
+  "tiebreakers": {
+   "frc10547": {
+    "highest_match_scores": [
+     243,
+     162,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc10587": {
+    "highest_match_scores": [
+     208,
+     166,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc10629": {
+    "highest_match_scores": [
+     130,
+     117,
+     112
+    ],
+    "qual_wins": 0
+   },
+   "frc11458": {
+    "highest_match_scores": [
+     176,
+     146,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc11527": {
+    "highest_match_scores": [
+     176,
+     170,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc1596": {
+    "highest_match_scores": [
+     178,
+     177,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc201": {
+    "highest_match_scores": [
+     283,
+     277,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc2619": {
+    "highest_match_scores": [
+     208,
+     204,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc3357": {
+    "highest_match_scores": [
+     208,
+     206,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc3425": {
+    "highest_match_scores": [
+     165,
+     152,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc3770": {
+    "highest_match_scores": [
+     233,
+     192,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc5166": {
+    "highest_match_scores": [
+     287,
+     277,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc5216": {
+    "highest_match_scores": [
+     304,
+     274,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc5229": {
+    "highest_match_scores": [
+     283,
+     204,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc5231": {
+    "highest_match_scores": [
+     169,
+     129,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc5424": {
+    "highest_match_scores": [
+     304,
+     274,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc5504": {
+    "highest_match_scores": [
+     238,
+     121,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc5509": {
+    "highest_match_scores": [
+     199,
+     143,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc5525": {
+    "highest_match_scores": [
+     177,
+     166,
+     136
+    ],
+    "qual_wins": 0
+   },
+   "frc5533": {
+    "highest_match_scores": [
+     243,
+     238,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc5538": {
+    "highest_match_scores": [
+     161,
+     160,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc5561": {
+    "highest_match_scores": [
+     192,
+     170,
+     166
+    ],
+    "qual_wins": 0
+   },
+   "frc5603": {
+    "highest_match_scores": [
+     287,
+     263,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc5712": {
+    "highest_match_scores": [
+     287,
+     263,
+     243
+    ],
+    "qual_wins": 0
+   },
+   "frc6033": {
+    "highest_match_scores": [
+     192,
+     178,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc6067": {
+    "highest_match_scores": [
+     140,
+     125,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc6073": {
+    "highest_match_scores": [
+     180,
+     169,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc6533": {
+    "highest_match_scores": [
+     137,
+     125,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc6753": {
+    "highest_match_scores": [
+     206,
+     200,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc7784": {
+    "highest_match_scores": [
+     208,
+     140,
+     140
+    ],
+    "qual_wins": 0
+   },
+   "frc8517": {
+    "highest_match_scores": [
+     283,
+     208,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc8873": {
+    "highest_match_scores": [
+     304,
+     274,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc9238": {
+    "highest_match_scores": [
+     177,
+     164,
+     130
+    ],
+    "qual_wins": 0
+   },
+   "frc9648": {
+    "highest_match_scores": [
+     179,
+     118,
+     99
+    ],
+    "qual_wins": 0
+   },
+   "frc9661": {
+    "highest_match_scores": [
+     238,
+     206,
+     172
+    ],
+    "qual_wins": 0
+   },
+   "frc9662": {
+    "highest_match_scores": [
+     194,
+     162,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc9685": {
+    "highest_match_scores": [
+     206,
+     200,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc9731": {
+    "highest_match_scores": [
+     165,
+     140,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc9736": {
+    "highest_match_scores": [
+     277,
+     164,
+     150
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mimil": {
+  "points": {
+   "frc1023": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 50
+   },
+   "frc10285": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc10612": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc10652": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc11457": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 18
+   },
+   "frc11462": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc11473": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc11486": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc2137": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc2145": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 19
+   },
+   "frc308": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 32
+   },
+   "frc314": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc3302": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc3538": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 75
+   },
+   "frc3707": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 42
+   },
+   "frc4362": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc4384": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc4737": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc5053": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc5066": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc5067": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 6,
+    "total": 22
+   },
+   "frc5114": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 55
+   },
+   "frc548": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc5674": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 18
+   },
+   "frc5695": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6078": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc6566": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc6610": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6615": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 44
+   },
+   "frc67": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc7178": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc7225": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc7491": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc7553": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc7660": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 29
+   },
+   "frc7762": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc830": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc8423": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 19
+   },
+   "frc8424": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 45
+   },
+   "frc8426": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   }
+  },
+  "tiebreakers": {
+   "frc1023": {
+    "highest_match_scores": [
+     441,
+     330,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc10285": {
+    "highest_match_scores": [
+     233,
+     200,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc10612": {
+    "highest_match_scores": [
+     241,
+     178,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc10652": {
+    "highest_match_scores": [
+     289,
+     241,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc11457": {
+    "highest_match_scores": [
+     304,
+     158,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc11462": {
+    "highest_match_scores": [
+     190,
+     171,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc11473": {
+    "highest_match_scores": [
+     234,
+     199,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc11486": {
+    "highest_match_scores": [
+     306,
+     270,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc2137": {
+    "highest_match_scores": [
+     359,
+     322,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc2145": {
+    "highest_match_scores": [
+     292,
+     289,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc308": {
+    "highest_match_scores": [
+     322,
+     292,
+     287
+    ],
+    "qual_wins": 0
+   },
+   "frc314": {
+    "highest_match_scores": [
+     264,
+     236,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc3302": {
+    "highest_match_scores": [
+     180,
+     145,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc3538": {
+    "highest_match_scores": [
+     449,
+     441,
+     411
+    ],
+    "qual_wins": 0
+   },
+   "frc3707": {
+    "highest_match_scores": [
+     359,
+     233,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc4362": {
+    "highest_match_scores": [
+     449,
+     441,
+     411
+    ],
+    "qual_wins": 0
+   },
+   "frc4384": {
+    "highest_match_scores": [
+     270,
+     254,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc4737": {
+    "highest_match_scores": [
+     271,
+     200,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc5053": {
+    "highest_match_scores": [
+     222,
+     191,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc5066": {
+    "highest_match_scores": [
+     304,
+     270,
+     254
+    ],
+    "qual_wins": 0
+   },
+   "frc5067": {
+    "highest_match_scores": [
+     330,
+     254,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc5114": {
+    "highest_match_scores": [
+     334,
+     330,
+     254
+    ],
+    "qual_wins": 0
+   },
+   "frc548": {
+    "highest_match_scores": [
+     254,
+     234,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc5674": {
+    "highest_match_scores": [
+     207,
+     178,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc5695": {
+    "highest_match_scores": [
+     332,
+     332,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc6078": {
+    "highest_match_scores": [
+     233,
+     207,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc6566": {
+    "highest_match_scores": [
+     233,
+     222,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc6610": {
+    "highest_match_scores": [
+     233,
+     198,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc6615": {
+    "highest_match_scores": [
+     332,
+     254,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc67": {
+    "highest_match_scores": [
+     334,
+     332,
+     322
+    ],
+    "qual_wins": 0
+   },
+   "frc7178": {
+    "highest_match_scores": [
+     270,
+     250,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc7225": {
+    "highest_match_scores": [
+     198,
+     187,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc7491": {
+    "highest_match_scores": [
+     273,
+     171,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc7553": {
+    "highest_match_scores": [
+     233,
+     203,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc7660": {
+    "highest_match_scores": [
+     334,
+     264,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc7762": {
+    "highest_match_scores": [
+     252,
+     191,
+     184
+    ],
+    "qual_wins": 0
+   },
+   "frc830": {
+    "highest_match_scores": [
+     193,
+     184,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc8423": {
+    "highest_match_scores": [
+     306,
+     273,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc8424": {
+    "highest_match_scores": [
+     449,
+     411,
+     395
+    ],
+    "qual_wins": 0
+   },
+   "frc8426": {
+    "highest_match_scores": [
+     271,
+     254,
+     238
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mimtp": {
+  "points": {
+   "frc10613": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc10614": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc10978": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 19
+   },
+   "frc1711": {
+    "alliance_points": 6,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc2337": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc2405": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 29
+   },
+   "frc3655": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 32
+   },
+   "frc3688": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc3767": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 14,
+    "total": 40
+   },
+   "frc4381": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc4422": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 50
+   },
+   "frc5084": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc5110": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 30
+   },
+   "frc5162": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5231": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5234": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 40
+   },
+   "frc5235": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5436": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc5697": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 28
+   },
+   "frc573": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 56
+   },
+   "frc5982": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc6033": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc6071": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc6100": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 16
+   },
+   "frc6533": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6642": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc7109": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc7166": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 78
+   },
+   "frc7195": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc7210": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 21
+   },
+   "frc8286": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 16
+   },
+   "frc8873": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 38
+   },
+   "frc9568": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc9594": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9650": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9661": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 24
+   },
+   "frc9662": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9673": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc9755": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9773": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 34
+   }
+  },
+  "tiebreakers": {
+   "frc10613": {
+    "highest_match_scores": [
+     129,
+     91,
+     69
+    ],
+    "qual_wins": 0
+   },
+   "frc10614": {
+    "highest_match_scores": [
+     220,
+     182,
+     123
+    ],
+    "qual_wins": 0
+   },
+   "frc10978": {
+    "highest_match_scores": [
+     178,
+     176,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc1711": {
+    "highest_match_scores": [
+     131,
+     117,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc2337": {
+    "highest_match_scores": [
+     371,
+     349,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc2405": {
+    "highest_match_scores": [
+     145,
+     128,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc3655": {
+    "highest_match_scores": [
+     223,
+     170,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc3688": {
+    "highest_match_scores": [
+     217,
+     178,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc3767": {
+    "highest_match_scores": [
+     270,
+     191,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc4381": {
+    "highest_match_scores": [
+     270,
+     241,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc4422": {
+    "highest_match_scores": [
+     276,
+     206,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc5084": {
+    "highest_match_scores": [
+     143,
+     138,
+     123
+    ],
+    "qual_wins": 0
+   },
+   "frc5110": {
+    "highest_match_scores": [
+     241,
+     217,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc5162": {
+    "highest_match_scores": [
+     164,
+     122,
+     94
+    ],
+    "qual_wins": 0
+   },
+   "frc5231": {
+    "highest_match_scores": [
+     241,
+     104,
+     85
+    ],
+    "qual_wins": 0
+   },
+   "frc5234": {
+    "highest_match_scores": [
+     371,
+     349,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc5235": {
+    "highest_match_scores": [
+     182,
+     148,
+     104
+    ],
+    "qual_wins": 0
+   },
+   "frc5436": {
+    "highest_match_scores": [
+     287,
+     242,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc5697": {
+    "highest_match_scores": [
+     241,
+     156,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc573": {
+    "highest_match_scores": [
+     210,
+     201,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc5982": {
+    "highest_match_scores": [
+     237,
+     223,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc6033": {
+    "highest_match_scores": [
+     217,
+     176,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc6071": {
+    "highest_match_scores": [
+     242,
+     135,
+     104
+    ],
+    "qual_wins": 0
+   },
+   "frc6100": {
+    "highest_match_scores": [
+     222,
+     197,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc6533": {
+    "highest_match_scores": [
+     193,
+     156,
+     99
+    ],
+    "qual_wins": 0
+   },
+   "frc6642": {
+    "highest_match_scores": [
+     206,
+     201,
+     140
+    ],
+    "qual_wins": 0
+   },
+   "frc7109": {
+    "highest_match_scores": [
+     164,
+     148,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc7166": {
+    "highest_match_scores": [
+     371,
+     349,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc7195": {
+    "highest_match_scores": [
+     217,
+     209,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc7210": {
+    "highest_match_scores": [
+     270,
+     147,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc8286": {
+    "highest_match_scores": [
+     237,
+     195,
+     123
+    ],
+    "qual_wins": 0
+   },
+   "frc8873": {
+    "highest_match_scores": [
+     217,
+     197,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc9568": {
+    "highest_match_scores": [
+     191,
+     88,
+     81
+    ],
+    "qual_wins": 0
+   },
+   "frc9594": {
+    "highest_match_scores": [
+     193,
+     141,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc9650": {
+    "highest_match_scores": [
+     222,
+     166,
+     98
+    ],
+    "qual_wins": 0
+   },
+   "frc9661": {
+    "highest_match_scores": [
+     287,
+     276,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc9662": {
+    "highest_match_scores": [
+     134,
+     123,
+     99
+    ],
+    "qual_wins": 0
+   },
+   "frc9673": {
+    "highest_match_scores": [
+     210,
+     209,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc9755": {
+    "highest_match_scores": [
+     195,
+     150,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc9773": {
+    "highest_match_scores": [
+     220,
+     166,
+     146
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mimus": {
+  "points": {
+   "frc10607": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc10654": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 11
+   },
+   "frc107": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 4,
+    "total": 26
+   },
+   "frc11503": {
+    "alliance_points": 1,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 36
+   },
+   "frc11522": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc2075": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc2405": {
+    "alliance_points": 8,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 30
+   },
+   "frc2771": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc3458": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   },
+   "frc3572": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 38
+   },
+   "frc4004": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 24
+   },
+   "frc4827": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc4956": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 36
+   },
+   "frc4967": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 16,
+    "total": 70
+   },
+   "frc5470": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5505": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 38
+   },
+   "frc6005": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc6079": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc6090": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 61
+   },
+   "frc6094": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc6128": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 28
+   },
+   "frc6428": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc6877": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc7054": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc7160": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 49
+   },
+   "frc7248": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 22
+   },
+   "frc7810": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc8285": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc85": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 41
+   },
+   "frc8612": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 68
+   },
+   "frc9106": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 10,
+    "total": 43
+   },
+   "frc9541": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc9743": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc9754": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9756": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 8,
+    "total": 22
+   }
+  },
+  "tiebreakers": {
+   "frc10607": {
+    "highest_match_scores": [
+     199,
+     166,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc10654": {
+    "highest_match_scores": [
+     208,
+     194,
+     188
+    ],
+    "qual_wins": 0
+   },
+   "frc107": {
+    "highest_match_scores": [
+     197,
+     178,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc11503": {
+    "highest_match_scores": [
+     301,
+     301,
+     291
+    ],
+    "qual_wins": 0
+   },
+   "frc11522": {
+    "highest_match_scores": [
+     220,
+     173,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc2075": {
+    "highest_match_scores": [
+     302,
+     301,
+     301
+    ],
+    "qual_wins": 0
+   },
+   "frc2405": {
+    "highest_match_scores": [
+     272,
+     253,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc2771": {
+    "highest_match_scores": [
+     244,
+     228,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc3458": {
+    "highest_match_scores": [
+     241,
+     182,
+     121
+    ],
+    "qual_wins": 0
+   },
+   "frc3572": {
+    "highest_match_scores": [
+     277,
+     276,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc4004": {
+    "highest_match_scores": [
+     267,
+     228,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc4827": {
+    "highest_match_scores": [
+     142,
+     138,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc4956": {
+    "highest_match_scores": [
+     314,
+     275,
+     267
+    ],
+    "qual_wins": 0
+   },
+   "frc4967": {
+    "highest_match_scores": [
+     306,
+     282,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc5470": {
+    "highest_match_scores": [
+     251,
+     202,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc5505": {
+    "highest_match_scores": [
+     251,
+     228,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc6005": {
+    "highest_match_scores": [
+     209,
+     166,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc6079": {
+    "highest_match_scores": [
+     209,
+     172,
+     122
+    ],
+    "qual_wins": 0
+   },
+   "frc6090": {
+    "highest_match_scores": [
+     314,
+     314,
+     301
+    ],
+    "qual_wins": 0
+   },
+   "frc6094": {
+    "highest_match_scores": [
+     314,
+     175,
+     139
+    ],
+    "qual_wins": 0
+   },
+   "frc6128": {
+    "highest_match_scores": [
+     257,
+     163,
+     152
+    ],
+    "qual_wins": 0
+   },
+   "frc6428": {
+    "highest_match_scores": [
+     202,
+     195,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc6877": {
+    "highest_match_scores": [
+     214,
+     199,
+     188
+    ],
+    "qual_wins": 0
+   },
+   "frc7054": {
+    "highest_match_scores": [
+     314,
+     228,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc7160": {
+    "highest_match_scores": [
+     275,
+     272,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc7248": {
+    "highest_match_scores": [
+     222,
+     161,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc7810": {
+    "highest_match_scores": [
+     214,
+     126,
+     125
+    ],
+    "qual_wins": 0
+   },
+   "frc8285": {
+    "highest_match_scores": [
+     178,
+     159,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc85": {
+    "highest_match_scores": [
+     282,
+     248,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc8612": {
+    "highest_match_scores": [
+     306,
+     302,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc9106": {
+    "highest_match_scores": [
+     314,
+     306,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc9541": {
+    "highest_match_scores": [
+     242,
+     182,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc9743": {
+    "highest_match_scores": [
+     276,
+     242,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc9754": {
+    "highest_match_scores": [
+     151,
+     142,
+     139
+    ],
+    "qual_wins": 0
+   },
+   "frc9756": {
+    "highest_match_scores": [
+     302,
+     282,
+     228
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026misal": {
+  "points": {
+   "frc1": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc10590": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc10656": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc1076": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 4,
+    "qual_points": 18,
+    "total": 40
+   },
+   "frc11455": {
+    "alliance_points": 9,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc1506": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 54
+   },
+   "frc2620": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc2834": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc308": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 19
+   },
+   "frc3322": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 53
+   },
+   "frc3568": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 42
+   },
+   "frc3604": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 44
+   },
+   "frc3632": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 33
+   },
+   "frc3773": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4395": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc453": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4838": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc4994": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5066": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 58
+   },
+   "frc5090": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 23
+   },
+   "frc5460": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc548": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 61
+   },
+   "frc5567": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 26
+   },
+   "frc6057": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc6101": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc6532": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc66": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 27
+   },
+   "frc67": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc7147": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc7178": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc7660": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 22
+   },
+   "frc7692": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc815": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc8297": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 4,
+    "qual_points": 13,
+    "total": 17
+   },
+   "frc8899": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9148": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc9226": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc9242": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc9727": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   }
+  },
+  "tiebreakers": {
+   "frc1": {
+    "highest_match_scores": [
+     238,
+     139,
+     132
+    ],
+    "qual_wins": 0
+   },
+   "frc10590": {
+    "highest_match_scores": [
+     256,
+     156,
+     140
+    ],
+    "qual_wins": 0
+   },
+   "frc10656": {
+    "highest_match_scores": [
+     308,
+     181,
+     138
+    ],
+    "qual_wins": 0
+   },
+   "frc1076": {
+    "highest_match_scores": [
+     263,
+     251,
+     231
+    ],
+    "qual_wins": 0
+   },
+   "frc11455": {
+    "highest_match_scores": [
+     394,
+     237,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc1506": {
+    "highest_match_scores": [
+     595,
+     284,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc2620": {
+    "highest_match_scores": [
+     630,
+     254,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc2834": {
+    "highest_match_scores": [
+     298,
+     227,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc308": {
+    "highest_match_scores": [
+     188,
+     180,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc3322": {
+    "highest_match_scores": [
+     595,
+     303,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc3568": {
+    "highest_match_scores": [
+     422,
+     392,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc3604": {
+    "highest_match_scores": [
+     325,
+     322,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc3632": {
+    "highest_match_scores": [
+     286,
+     252,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc3773": {
+    "highest_match_scores": [
+     325,
+     231,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc4395": {
+    "highest_match_scores": [
+     257,
+     224,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc453": {
+    "highest_match_scores": [
+     254,
+     250,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc4838": {
+    "highest_match_scores": [
+     231,
+     172,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc4994": {
+    "highest_match_scores": [
+     231,
+     227,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc5066": {
+    "highest_match_scores": [
+     286,
+     259,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc5090": {
+    "highest_match_scores": [
+     315,
+     168,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc5460": {
+    "highest_match_scores": [
+     630,
+     595,
+     422
+    ],
+    "qual_wins": 0
+   },
+   "frc548": {
+    "highest_match_scores": [
+     306,
+     303,
+     286
+    ],
+    "qual_wins": 0
+   },
+   "frc5567": {
+    "highest_match_scores": [
+     251,
+     210,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc6057": {
+    "highest_match_scores": [
+     252,
+     205,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc6101": {
+    "highest_match_scores": [
+     204,
+     185,
+     167
+    ],
+    "qual_wins": 0
+   },
+   "frc6532": {
+    "highest_match_scores": [
+     197,
+     183,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc66": {
+    "highest_match_scores": [
+     263,
+     256,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc67": {
+    "highest_match_scores": [
+     630,
+     422,
+     392
+    ],
+    "qual_wins": 0
+   },
+   "frc7147": {
+    "highest_match_scores": [
+     322,
+     147,
+     123
+    ],
+    "qual_wins": 0
+   },
+   "frc7178": {
+    "highest_match_scores": [
+     284,
+     258,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc7660": {
+    "highest_match_scores": [
+     258,
+     188,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc7692": {
+    "highest_match_scores": [
+     308,
+     257,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc815": {
+    "highest_match_scores": [
+     298,
+     250,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc8297": {
+    "highest_match_scores": [
+     242,
+     237,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc8899": {
+    "highest_match_scores": [
+     278,
+     147,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc9148": {
+    "highest_match_scores": [
+     252,
+     219,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc9226": {
+    "highest_match_scores": [
+     394,
+     306,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9242": {
+    "highest_match_scores": [
+     259,
+     210,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc9727": {
+    "highest_match_scores": [
+     315,
+     303,
+     185
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mitr2": {
+  "points": {
+   "frc1025": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 45
+   },
+   "frc10349": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 43
+   },
+   "frc10690": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc11457": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc11461": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 16
+   },
+   "frc11473": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc1701": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc2048": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc217": {
+    "alliance_points": 11,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 36
+   },
+   "frc2224": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 4,
+    "total": 35
+   },
+   "frc247": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 29
+   },
+   "frc2591": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 36
+   },
+   "frc2673": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 16
+   },
+   "frc2960": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 49
+   },
+   "frc3096": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc3619": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc3667": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc4758": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc4851": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc503": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc51": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 56
+   },
+   "frc5239": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc5531": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc5642": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc5695": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc5756": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc5901": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6096": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc6566": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6616": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 7,
+    "total": 30
+   },
+   "frc7188": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 53
+   },
+   "frc7196": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc7716": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc818": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 37
+   },
+   "frc8280": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 21,
+    "total": 48
+   },
+   "frc8352": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 31
+   },
+   "frc9212": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9558": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 18
+   },
+   "frc9679": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 7,
+    "total": 16
+   },
+   "frc9727": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   }
+  },
+  "tiebreakers": {
+   "frc1025": {
+    "highest_match_scores": [
+     428,
+     315,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc10349": {
+    "highest_match_scores": [
+     310,
+     294,
+     280
+    ],
+    "qual_wins": 0
+   },
+   "frc10690": {
+    "highest_match_scores": [
+     254,
+     190,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc11457": {
+    "highest_match_scores": [
+     250,
+     201,
+     188
+    ],
+    "qual_wins": 0
+   },
+   "frc11461": {
+    "highest_match_scores": [
+     298,
+     296,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc11473": {
+    "highest_match_scores": [
+     407,
+     203,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc1701": {
+    "highest_match_scores": [
+     527,
+     428,
+     426
+    ],
+    "qual_wins": 0
+   },
+   "frc2048": {
+    "highest_match_scores": [
+     294,
+     250,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc217": {
+    "highest_match_scores": [
+     223,
+     217,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc2224": {
+    "highest_match_scores": [
+     527,
+     380,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc247": {
+    "highest_match_scores": [
+     353,
+     254,
+     234
+    ],
+    "qual_wins": 0
+   },
+   "frc2591": {
+    "highest_match_scores": [
+     344,
+     279,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc2673": {
+    "highest_match_scores": [
+     355,
+     290,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc2960": {
+    "highest_match_scores": [
+     426,
+     355,
+     310
+    ],
+    "qual_wins": 0
+   },
+   "frc3096": {
+    "highest_match_scores": [
+     220,
+     217,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc3619": {
+    "highest_match_scores": [
+     254,
+     190,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc3667": {
+    "highest_match_scores": [
+     258,
+     254,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc4758": {
+    "highest_match_scores": [
+     234,
+     225,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc4851": {
+    "highest_match_scores": [
+     238,
+     230,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc503": {
+    "highest_match_scores": [
+     527,
+     426,
+     380
+    ],
+    "qual_wins": 0
+   },
+   "frc51": {
+    "highest_match_scores": [
+     407,
+     344,
+     296
+    ],
+    "qual_wins": 0
+   },
+   "frc5239": {
+    "highest_match_scores": [
+     210,
+     191,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc5531": {
+    "highest_match_scores": [
+     277,
+     254,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc5642": {
+    "highest_match_scores": [
+     212,
+     211,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc5695": {
+    "highest_match_scores": [
+     235,
+     223,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc5756": {
+    "highest_match_scores": [
+     266,
+     266,
+     254
+    ],
+    "qual_wins": 0
+   },
+   "frc5901": {
+    "highest_match_scores": [
+     428,
+     207,
+     188
+    ],
+    "qual_wins": 0
+   },
+   "frc6096": {
+    "highest_match_scores": [
+     225,
+     191,
+     174
+    ],
+    "qual_wins": 0
+   },
+   "frc6566": {
+    "highest_match_scores": [
+     290,
+     188,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc6616": {
+    "highest_match_scores": [
+     310,
+     262,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc7188": {
+    "highest_match_scores": [
+     355,
+     344,
+     296
+    ],
+    "qual_wins": 0
+   },
+   "frc7196": {
+    "highest_match_scores": [
+     353,
+     238,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc7716": {
+    "highest_match_scores": [
+     288,
+     210,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc818": {
+    "highest_match_scores": [
+     290,
+     280,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc8280": {
+    "highest_match_scores": [
+     315,
+     290,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc8352": {
+    "highest_match_scores": [
+     298,
+     280,
+     277
+    ],
+    "qual_wins": 0
+   },
+   "frc9212": {
+    "highest_match_scores": [
+     279,
+     211,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc9558": {
+    "highest_match_scores": [
+     290,
+     230,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc9679": {
+    "highest_match_scores": [
+     315,
+     256,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc9727": {
+    "highest_match_scores": [
+     203,
+     165,
+     155
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mitry": {
+  "points": {
+   "frc10612": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 14,
+    "total": 36
+   },
+   "frc10652": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 22
+   },
+   "frc10665": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   },
+   "frc11361": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc11486": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc11493": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc1498": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 43
+   },
+   "frc201": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc226": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc2851": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 55
+   },
+   "frc3175": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc33": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 59
+   },
+   "frc3302": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4362": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc4384": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 26
+   },
+   "frc469": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc4768": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc4961": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4998": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc5065": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5197": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5436": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 20
+   },
+   "frc5467": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5478": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5527": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 19
+   },
+   "frc5531": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc573": {
+    "alliance_points": 8,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 31
+   },
+   "frc5860": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc7188": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc7716": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc7762": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 20
+   },
+   "frc7769": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc7813": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc8115": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc8364": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc8728": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc9245": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 42
+   },
+   "frc9252": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9528": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc9618": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc9651": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9679": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 42
+   },
+   "frc9747": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   }
+  },
+  "tiebreakers": {
+   "frc10612": {
+    "highest_match_scores": [
+     474,
+     471,
+     466
+    ],
+    "qual_wins": 0
+   },
+   "frc10652": {
+    "highest_match_scores": [
+     546,
+     348,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc10665": {
+    "highest_match_scores": [
+     310,
+     215,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc11361": {
+    "highest_match_scores": [
+     328,
+     253,
+     251
+    ],
+    "qual_wins": 0
+   },
+   "frc11486": {
+    "highest_match_scores": [
+     342,
+     277,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc11493": {
+    "highest_match_scores": [
+     342,
+     290,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc1498": {
+    "highest_match_scores": [
+     474,
+     398,
+     386
+    ],
+    "qual_wins": 0
+   },
+   "frc201": {
+    "highest_match_scores": [
+     568,
+     554,
+     471
+    ],
+    "qual_wins": 0
+   },
+   "frc226": {
+    "highest_match_scores": [
+     568,
+     364,
+     310
+    ],
+    "qual_wins": 0
+   },
+   "frc2851": {
+    "highest_match_scores": [
+     483,
+     423,
+     398
+    ],
+    "qual_wins": 0
+   },
+   "frc3175": {
+    "highest_match_scores": [
+     418,
+     374,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc33": {
+    "highest_match_scores": [
+     555,
+     471,
+     466
+    ],
+    "qual_wins": 0
+   },
+   "frc3302": {
+    "highest_match_scores": [
+     398,
+     266,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc4362": {
+    "highest_match_scores": [
+     629,
+     615,
+     566
+    ],
+    "qual_wins": 0
+   },
+   "frc4384": {
+    "highest_match_scores": [
+     423,
+     404,
+     398
+    ],
+    "qual_wins": 0
+   },
+   "frc469": {
+    "highest_match_scores": [
+     474,
+     423,
+     398
+    ],
+    "qual_wins": 0
+   },
+   "frc4768": {
+    "highest_match_scores": [
+     400,
+     298,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc4961": {
+    "highest_match_scores": [
+     525,
+     327,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc4998": {
+    "highest_match_scores": [
+     274,
+     224,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc5065": {
+    "highest_match_scores": [
+     317,
+     248,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc5197": {
+    "highest_match_scores": [
+     255,
+     235,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc5436": {
+    "highest_match_scores": [
+     400,
+     274,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc5467": {
+    "highest_match_scores": [
+     277,
+     250,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc5478": {
+    "highest_match_scores": [
+     281,
+     268,
+     262
+    ],
+    "qual_wins": 0
+   },
+   "frc5527": {
+    "highest_match_scores": [
+     388,
+     327,
+     297
+    ],
+    "qual_wins": 0
+   },
+   "frc5531": {
+    "highest_match_scores": [
+     386,
+     290,
+     277
+    ],
+    "qual_wins": 0
+   },
+   "frc573": {
+    "highest_match_scores": [
+     360,
+     259,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc5860": {
+    "highest_match_scores": [
+     310,
+     298,
+     281
+    ],
+    "qual_wins": 0
+   },
+   "frc7188": {
+    "highest_match_scores": [
+     525,
+     350,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc7716": {
+    "highest_match_scores": [
+     301,
+     297,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc7762": {
+    "highest_match_scores": [
+     240,
+     194,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc7769": {
+    "highest_match_scores": [
+     629,
+     615,
+     568
+    ],
+    "qual_wins": 0
+   },
+   "frc7813": {
+    "highest_match_scores": [
+     328,
+     224,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc8115": {
+    "highest_match_scores": [
+     404,
+     346,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc8364": {
+    "highest_match_scores": [
+     555,
+     212,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc8728": {
+    "highest_match_scores": [
+     554,
+     478,
+     374
+    ],
+    "qual_wins": 0
+   },
+   "frc9245": {
+    "highest_match_scores": [
+     374,
+     364,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc9252": {
+    "highest_match_scores": [
+     220,
+     207,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc9528": {
+    "highest_match_scores": [
+     350,
+     317,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc9618": {
+    "highest_match_scores": [
+     478,
+     297,
+     262
+    ],
+    "qual_wins": 0
+   },
+   "frc9651": {
+    "highest_match_scores": [
+     483,
+     297,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc9679": {
+    "highest_match_scores": [
+     629,
+     615,
+     566
+    ],
+    "qual_wins": 0
+   },
+   "frc9747": {
+    "highest_match_scores": [
+     269,
+     265,
+     261
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mitvc": {
+  "points": {
+   "frc10181": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc10613": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc10614": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 34
+   },
+   "frc11440": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc11466": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 18
+   },
+   "frc1711": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 47
+   },
+   "frc3537": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc3602": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 30
+   },
+   "frc3618": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 37
+   },
+   "frc3688": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 41
+   },
+   "frc3767": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 45
+   },
+   "frc4398": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 17,
+    "total": 66
+   },
+   "frc4835": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc4983": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc5086": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 62
+   },
+   "frc5110": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc5183": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5193": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc5247": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5504": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5509": {
+    "alliance_points": 6,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 25
+   },
+   "frc5534": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 68
+   },
+   "frc5560": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc6087": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc6122": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 7,
+    "total": 16
+   },
+   "frc6569": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 20
+   },
+   "frc7155": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc7598": {
+    "alliance_points": 5,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 12,
+    "total": 40
+   },
+   "frc7782": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 29
+   },
+   "frc7790": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 20,
+    "total": 47
+   },
+   "frc7808": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc7855": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc8611": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc904": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9176": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9542": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9759": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9771": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 47
+   }
+  },
+  "tiebreakers": {
+   "frc10181": {
+    "highest_match_scores": [
+     184,
+     147,
+     120
+    ],
+    "qual_wins": 0
+   },
+   "frc10613": {
+    "highest_match_scores": [
+     236,
+     213,
+     107
+    ],
+    "qual_wins": 0
+   },
+   "frc10614": {
+    "highest_match_scores": [
+     314,
+     259,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc11440": {
+    "highest_match_scores": [
+     199,
+     187,
+     105
+    ],
+    "qual_wins": 0
+   },
+   "frc11466": {
+    "highest_match_scores": [
+     184,
+     171,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc1711": {
+    "highest_match_scores": [
+     215,
+     210,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc3537": {
+    "highest_match_scores": [
+     217,
+     124,
+     83
+    ],
+    "qual_wins": 0
+   },
+   "frc3602": {
+    "highest_match_scores": [
+     255,
+     170,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc3618": {
+    "highest_match_scores": [
+     177,
+     166,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc3688": {
+    "highest_match_scores": [
+     239,
+     236,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc3767": {
+    "highest_match_scores": [
+     288,
+     228,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc4398": {
+    "highest_match_scores": [
+     243,
+     242,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc4835": {
+    "highest_match_scores": [
+     148,
+     134,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc4983": {
+    "highest_match_scores": [
+     223,
+     160,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc5086": {
+    "highest_match_scores": [
+     316,
+     314,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc5110": {
+    "highest_match_scores": [
+     170,
+     134,
+     131
+    ],
+    "qual_wins": 0
+   },
+   "frc5183": {
+    "highest_match_scores": [
+     147,
+     128,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc5193": {
+    "highest_match_scores": [
+     316,
+     314,
+     295
+    ],
+    "qual_wins": 0
+   },
+   "frc5247": {
+    "highest_match_scores": [
+     192,
+     155,
+     131
+    ],
+    "qual_wins": 0
+   },
+   "frc5504": {
+    "highest_match_scores": [
+     196,
+     123,
+     119
+    ],
+    "qual_wins": 0
+   },
+   "frc5509": {
+    "highest_match_scores": [
+     178,
+     107,
+     101
+    ],
+    "qual_wins": 0
+   },
+   "frc5534": {
+    "highest_match_scores": [
+     295,
+     243,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc5560": {
+    "highest_match_scores": [
+     295,
+     118,
+     111
+    ],
+    "qual_wins": 0
+   },
+   "frc6087": {
+    "highest_match_scores": [
+     226,
+     210,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc6122": {
+    "highest_match_scores": [
+     228,
+     200,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc6569": {
+    "highest_match_scores": [
+     243,
+     166,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc7155": {
+    "highest_match_scores": [
+     187,
+     186,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc7598": {
+    "highest_match_scores": [
+     255,
+     241,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc7782": {
+    "highest_match_scores": [
+     228,
+     199,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc7790": {
+    "highest_match_scores": [
+     243,
+     241,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc7808": {
+    "highest_match_scores": [
+     316,
+     134,
+     118
+    ],
+    "qual_wins": 0
+   },
+   "frc7855": {
+    "highest_match_scores": [
+     223,
+     117,
+     105
+    ],
+    "qual_wins": 0
+   },
+   "frc8611": {
+    "highest_match_scores": [
+     288,
+     152,
+     105
+    ],
+    "qual_wins": 0
+   },
+   "frc904": {
+    "highest_match_scores": [
+     152,
+     87,
+     67
+    ],
+    "qual_wins": 0
+   },
+   "frc9176": {
+    "highest_match_scores": [
+     192,
+     170,
+     119
+    ],
+    "qual_wins": 0
+   },
+   "frc9542": {
+    "highest_match_scores": [
+     239,
+     159,
+     129
+    ],
+    "qual_wins": 0
+   },
+   "frc9759": {
+    "highest_match_scores": [
+     128,
+     123,
+     100
+    ],
+    "qual_wins": 0
+   },
+   "frc9771": {
+    "highest_match_scores": [
+     243,
+     242,
+     241
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026miwmi": {
+  "points": {
+   "frc107": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc11491": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc11522": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc141": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc1918": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc2054": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc244": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc2619": {
+    "alliance_points": 12,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 38
+   },
+   "frc288": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc3357": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc3425": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc3458": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc3539": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc3572": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 62
+   },
+   "frc4003": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 29
+   },
+   "frc4680": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 14,
+    "total": 35
+   },
+   "frc5256": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5470": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5610": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 12
+   },
+   "frc5623": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 10,
+    "total": 41
+   },
+   "frc5927": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc6090": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc6094": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc6114": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 26
+   },
+   "frc6128": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 27
+   },
+   "frc6428": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6753": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 40
+   },
+   "frc6877": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 24
+   },
+   "frc7054": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 39
+   },
+   "frc7195": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc7210": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc7248": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc74": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 31
+   },
+   "frc8397": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 37
+   },
+   "frc85": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 45
+   },
+   "frc9206": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc9542": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc9671": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc9721": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc9754": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   }
+  },
+  "tiebreakers": {
+   "frc107": {
+    "highest_match_scores": [
+     287,
+     283,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc11491": {
+    "highest_match_scores": [
+     339,
+     275,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc11522": {
+    "highest_match_scores": [
+     410,
+     311,
+     240
+    ],
+    "qual_wins": 0
+   },
+   "frc141": {
+    "highest_match_scores": [
+     313,
+     265,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc1918": {
+    "highest_match_scores": [
+     397,
+     397,
+     384
+    ],
+    "qual_wins": 0
+   },
+   "frc2054": {
+    "highest_match_scores": [
+     345,
+     341,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc244": {
+    "highest_match_scores": [
+     451,
+     264,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc2619": {
+    "highest_match_scores": [
+     410,
+     299,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc288": {
+    "highest_match_scores": [
+     287,
+     265,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc3357": {
+    "highest_match_scores": [
+     384,
+     240,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc3425": {
+    "highest_match_scores": [
+     345,
+     192,
+     172
+    ],
+    "qual_wins": 0
+   },
+   "frc3458": {
+    "highest_match_scores": [
+     264,
+     213,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc3539": {
+    "highest_match_scores": [
+     451,
+     410,
+     370
+    ],
+    "qual_wins": 0
+   },
+   "frc3572": {
+    "highest_match_scores": [
+     397,
+     370,
+     364
+    ],
+    "qual_wins": 0
+   },
+   "frc4003": {
+    "highest_match_scores": [
+     339,
+     265,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc4680": {
+    "highest_match_scores": [
+     341,
+     317,
+     295
+    ],
+    "qual_wins": 0
+   },
+   "frc5256": {
+    "highest_match_scores": [
+     248,
+     210,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc5470": {
+    "highest_match_scores": [
+     294,
+     240,
+     236
+    ],
+    "qual_wins": 0
+   },
+   "frc5610": {
+    "highest_match_scores": [
+     307,
+     199,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc5623": {
+    "highest_match_scores": [
+     370,
+     359,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc5927": {
+    "highest_match_scores": [
+     307,
+     266,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc6090": {
+    "highest_match_scores": [
+     451,
+     384,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc6094": {
+    "highest_match_scores": [
+     290,
+     287,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc6114": {
+    "highest_match_scores": [
+     397,
+     295,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc6128": {
+    "highest_match_scores": [
+     364,
+     303,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc6428": {
+    "highest_match_scores": [
+     220,
+     207,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc6753": {
+    "highest_match_scores": [
+     364,
+     309,
+     281
+    ],
+    "qual_wins": 0
+   },
+   "frc6877": {
+    "highest_match_scores": [
+     309,
+     303,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc7054": {
+    "highest_match_scores": [
+     353,
+     309,
+     299
+    ],
+    "qual_wins": 0
+   },
+   "frc7195": {
+    "highest_match_scores": [
+     356,
+     311,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc7210": {
+    "highest_match_scores": [
+     260,
+     251,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc7248": {
+    "highest_match_scores": [
+     283,
+     244,
+     241
+    ],
+    "qual_wins": 0
+   },
+   "frc74": {
+    "highest_match_scores": [
+     397,
+     376,
+     299
+    ],
+    "qual_wins": 0
+   },
+   "frc8397": {
+    "highest_match_scores": [
+     397,
+     376,
+     370
+    ],
+    "qual_wins": 0
+   },
+   "frc85": {
+    "highest_match_scores": [
+     345,
+     341,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc9206": {
+    "highest_match_scores": [
+     353,
+     260,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9542": {
+    "highest_match_scores": [
+     220,
+     210,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9671": {
+    "highest_match_scores": [
+     250,
+     235,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc9721": {
+    "highest_match_scores": [
+     266,
+     189,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc9754": {
+    "highest_match_scores": [
+     313,
+     287,
+     220
+    ],
+    "qual_wins": 0
+   }
+  }
+ }
+}

--- a/src/backend/common/helpers/tests/data/2026fim_events.json
+++ b/src/backend/common/helpers/tests/data/2026fim_events.json
@@ -1,0 +1,706 @@
+[
+  {
+    "city": "Battle Creek",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "mibat",
+    "event_type": 1,
+    "key": "2026mibat",
+    "name": "FIM District Battle Creek Event presented by BlueOval Battery Park Michigan",
+    "start_date": "2026-03-27",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Belleville",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "mibel",
+    "event_type": 1,
+    "key": "2026mibel",
+    "name": "FIM District Belleville Event presented by DTE",
+    "start_date": "2026-03-19",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Berrien Springs",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-22",
+    "event_code": "miber",
+    "event_type": 1,
+    "key": "2026miber",
+    "name": "FIM District Berrien Springs Event presented by Edgewater Automation",
+    "start_date": "2026-03-20",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Big Rapids",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-11",
+    "event_code": "mibig",
+    "event_type": 1,
+    "key": "2026mibig",
+    "name": "FIM District Ferris State Event presented by Ferris State University",
+    "start_date": "2026-04-09",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Brooklyn",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-22",
+    "event_code": "mibkn",
+    "event_type": 1,
+    "key": "2026mibkn",
+    "name": "FIM District Jackson at Columbia Event presented by Consumers Energy Foundation",
+    "start_date": "2026-03-20",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Brownstown Charter Twp",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "mibro",
+    "event_type": 1,
+    "key": "2026mibro",
+    "name": "FIM District Woodhaven Event",
+    "start_date": "2026-03-13",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Chelsea",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-08",
+    "event_code": "miche",
+    "event_type": 1,
+    "key": "2026miche",
+    "name": "FIM District Chelsea Event presented by DTE",
+    "start_date": "2026-03-06",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "University Center",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "micmp",
+    "event_type": 2,
+    "key": "2026micmp",
+    "name": "FIRST in Michigan State Championship",
+    "start_date": "2026-04-18",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "University Center",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "micmp1",
+    "event_type": 5,
+    "key": "2026micmp1",
+    "name": "FIRST in Michigan State Championship - DTE Energy Foundation Division",
+    "start_date": "2026-04-16",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "University Center",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "micmp2",
+    "event_type": 5,
+    "key": "2026micmp2",
+    "name": "FIRST in Michigan State Championship - Consumers Energy Foundation Division",
+    "start_date": "2026-04-16",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "University Center",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "micmp3",
+    "event_type": 5,
+    "key": "2026micmp3",
+    "name": "FIRST in Michigan State Championship - Hemlock Semiconductor Division",
+    "start_date": "2026-04-16",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "University Center",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "micmp4",
+    "event_type": 5,
+    "key": "2026micmp4",
+    "name": "FIRST in Michigan State Championship - Aptiv Foundation Division",
+    "start_date": "2026-04-16",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Detroit",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-14",
+    "event_code": "midtr",
+    "event_type": 1,
+    "key": "2026midtr",
+    "name": "FIM District Wayne State Event presented by Magna",
+    "start_date": "2026-03-12",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Escanaba",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-11",
+    "event_code": "miesc",
+    "event_type": 1,
+    "key": "2026miesc",
+    "name": "FIM District Escanaba Event",
+    "start_date": "2026-04-09",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Fenton",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-12",
+    "event_code": "mifen",
+    "event_type": 1,
+    "key": "2026mifen",
+    "name": "FIM District Fenton Event presented by Gene Haas Foundation",
+    "start_date": "2026-04-10",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Flint",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-22",
+    "event_code": "mifli",
+    "event_type": 1,
+    "key": "2026mifli",
+    "name": "FIM District Kearsley Event presented by BAE Systems",
+    "start_date": "2026-03-20",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Kentwood",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-11",
+    "event_code": "miken",
+    "event_type": 1,
+    "key": "2026miken",
+    "name": "FIM District Kentwood Event presented by Dematic",
+    "start_date": "2026-04-09",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Lake City",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "milac",
+    "event_type": 1,
+    "key": "2026milac",
+    "name": "FIM District Lake City Event presented by AT&T",
+    "start_date": "2026-03-13",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Battle Creek",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-07",
+    "event_code": "milak",
+    "event_type": 1,
+    "key": "2026milak",
+    "name": "FIM District Lakeview Event",
+    "start_date": "2026-03-05",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Livonia",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-04",
+    "event_code": "miliv",
+    "event_type": 1,
+    "key": "2026miliv",
+    "name": "FIM District Livonia Event presented by Aisin",
+    "start_date": "2026-04-02",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Sault Ste. Marie",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-28",
+    "event_code": "milsu",
+    "event_type": 1,
+    "key": "2026milsu",
+    "name": "FIM District LSSU Event presented by Lake Superior State University",
+    "start_date": "2026-03-26",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Marysville",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "mimar",
+    "event_type": 1,
+    "key": "2026mimar",
+    "name": "FIM District Marysville Event",
+    "start_date": "2026-03-13",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Mason",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "mimas",
+    "event_type": 1,
+    "key": "2026mimas",
+    "name": "FIM District Mason Event presented by Altair",
+    "start_date": "2026-03-27",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Midland",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-14",
+    "event_code": "mimid",
+    "event_type": 1,
+    "key": "2026mimid",
+    "name": "FIM District Midland Event presented by Dow",
+    "start_date": "2026-03-12",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Highland",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-14",
+    "event_code": "mimil",
+    "event_type": 1,
+    "key": "2026mimil",
+    "name": "FIM District Milford Event presented by GM Proving Grounds",
+    "start_date": "2026-03-12",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Mt Pleasant",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-08",
+    "event_code": "mimtp",
+    "event_type": 1,
+    "key": "2026mimtp",
+    "name": "FIM District Mt Pleasant Event presented by AT&T",
+    "start_date": "2026-03-06",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Muskegon",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "mimus",
+    "event_type": 1,
+    "key": "2026mimus",
+    "name": "FIM District Muskegon Event presented by RENK",
+    "start_date": "2026-03-19",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Saline",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "misal",
+    "event_type": 1,
+    "key": "2026misal",
+    "name": "FIM District Saline Event presented by Oracle",
+    "start_date": "2026-03-27",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Troy",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-04",
+    "event_code": "mitr2",
+    "event_type": 1,
+    "key": "2026mitr2",
+    "name": "FIM District Troy Event #2 presented by DTE Foundation",
+    "start_date": "2026-04-02",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Troy",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "mitry",
+    "event_type": 1,
+    "key": "2026mitry",
+    "name": "FIM District Troy Event presented by Aptiv Foundation",
+    "start_date": "2026-03-27",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Traverse City",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "mitvc",
+    "event_type": 1,
+    "key": "2026mitvc",
+    "name": "FIM District Traverse City Event presented by Cone Drive",
+    "start_date": "2026-03-19",
+    "state_prov": "MI",
+    "year": 2026
+  },
+  {
+    "city": "Allendale",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fim",
+      "display_name": "FIRST in Michigan",
+      "key": "2026fim",
+      "official_advancement_counts": {
+        "cmp": 83,
+        "dcmp": 160
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-28",
+    "event_code": "miwmi",
+    "event_type": 1,
+    "key": "2026miwmi",
+    "name": "FIM District West Michigan Event presented by Grand Valley State University",
+    "start_date": "2026-03-26",
+    "state_prov": "MI",
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026fim_rankings.json
+++ b/src/backend/common/helpers/tests/data/2026fim_rankings.json
@@ -1,0 +1,15877 @@
+[
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miche",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miliv",
+        "qual_points": 22,
+        "total": 78
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp1",
+        "qual_points": 66,
+        "total": 204
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 90
+      }
+    ],
+    "point_total": 445,
+    "rank": 1,
+    "rookie_bonus": 0,
+    "team_key": "frc27"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibro",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitry",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp1",
+        "qual_points": 63,
+        "total": 216
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 60
+      }
+    ],
+    "point_total": 422,
+    "rank": 2,
+    "rookie_bonus": 0,
+    "team_key": "frc7769"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miche",
+        "qual_points": 21,
+        "total": 67
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026misal",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp4",
+        "qual_points": 66,
+        "total": 219
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 389,
+    "rank": 3,
+    "rookie_bonus": 0,
+    "team_key": "frc5460"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimil",
+        "qual_points": 19,
+        "total": 75
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miliv",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp4",
+        "qual_points": 51,
+        "total": 204
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 380,
+    "rank": 4,
+    "rookie_bonus": 0,
+    "team_key": "frc3538"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milak",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibat",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp2",
+        "qual_points": 63,
+        "total": 216
+      }
+    ],
+    "point_total": 361,
+    "rank": 5,
+    "rookie_bonus": 0,
+    "team_key": "frc2767"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimus",
+        "qual_points": 20,
+        "total": 61
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miwmi",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp2",
+        "qual_points": 66,
+        "total": 219
+      }
+    ],
+    "point_total": 353,
+    "rank": 6,
+    "rookie_bonus": 0,
+    "team_key": "frc6090"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimtp",
+        "qual_points": 22,
+        "total": 78
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimas",
+        "qual_points": 20,
+        "total": 61
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp3",
+        "qual_points": 63,
+        "total": 213
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 0
+      }
+    ],
+    "point_total": 352,
+    "rank": 7,
+    "rookie_bonus": 0,
+    "team_key": "frc7166"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimtp",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mifli",
+        "qual_points": 22,
+        "total": 78
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp3",
+        "qual_points": 57,
+        "total": 192
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 0
+      }
+    ],
+    "point_total": 342,
+    "rank": 8,
+    "rookie_bonus": 0,
+    "team_key": "frc2337"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibkn",
+        "qual_points": 20,
+        "total": 74
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miliv",
+        "qual_points": 19,
+        "total": 59
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp2",
+        "qual_points": 60,
+        "total": 180
+      }
+    ],
+    "point_total": 313,
+    "rank": 9,
+    "rookie_bonus": 0,
+    "team_key": "frc3414"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milak",
+        "qual_points": 19,
+        "total": 59
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miber",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp1",
+        "qual_points": 57,
+        "total": 177
+      }
+    ],
+    "point_total": 309,
+    "rank": 10,
+    "rookie_bonus": 0,
+    "team_key": "frc6002"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibro",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitry",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp2",
+        "qual_points": 54,
+        "total": 174
+      }
+    ],
+    "point_total": 294,
+    "rank": 11,
+    "rookie_bonus": 0,
+    "team_key": "frc469"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibel",
+        "qual_points": 17,
+        "total": 56
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitr2",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp4",
+        "qual_points": 60,
+        "total": 162
+      }
+    ],
+    "point_total": 291,
+    "rank": 12,
+    "rookie_bonus": 0,
+    "team_key": "frc1701"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitvc",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miesc",
+        "qual_points": 21,
+        "total": 77
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp2",
+        "qual_points": 57,
+        "total": 138
+      }
+    ],
+    "point_total": 278,
+    "rank": 13,
+    "rookie_bonus": 0,
+    "team_key": "frc5193"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibel",
+        "qual_points": 19,
+        "total": 69
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miesc",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp3",
+        "qual_points": 51,
+        "total": 135
+      }
+    ],
+    "point_total": 277,
+    "rank": 14,
+    "rookie_bonus": 0,
+    "team_key": "frc4391"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 15,
+        "total": 28
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibkn",
+        "qual_points": 19,
+        "total": 52
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp1",
+        "qual_points": 36,
+        "total": 129
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 60
+      }
+    ],
+    "point_total": 269,
+    "rank": 15,
+    "rookie_bonus": 0,
+    "team_key": "frc3668"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimil",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimas",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp3",
+        "qual_points": 60,
+        "total": 141
+      }
+    ],
+    "point_total": 265,
+    "rank": 16,
+    "rookie_bonus": 0,
+    "team_key": "frc2137"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimil",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026misal",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp1",
+        "qual_points": 48,
+        "total": 132
+      }
+    ],
+    "point_total": 262,
+    "rank": 17,
+    "rookie_bonus": 0,
+    "team_key": "frc67"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miche",
+        "qual_points": 18,
+        "total": 48
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 19,
+        "total": 33
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp4",
+        "qual_points": 42,
+        "total": 150
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 261,
+    "rank": 18,
+    "rookie_bonus": 0,
+    "team_key": "frc7197"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimil",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitry",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp1",
+        "qual_points": 33,
+        "total": 117
+      }
+    ],
+    "point_total": 261,
+    "rank": 19,
+    "rookie_bonus": 0,
+    "team_key": "frc4362"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibro",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miliv",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp1",
+        "qual_points": 60,
+        "total": 165
+      }
+    ],
+    "point_total": 261,
+    "rank": 20,
+    "rookie_bonus": 0,
+    "team_key": "frc5907"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milak",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miber",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp4",
+        "qual_points": 45,
+        "total": 129
+      }
+    ],
+    "point_total": 260,
+    "rank": 21,
+    "rookie_bonus": 0,
+    "team_key": "frc4237"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimil",
+        "qual_points": 20,
+        "total": 55
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mifen",
+        "qual_points": 21,
+        "total": 71
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp2",
+        "qual_points": 51,
+        "total": 132
+      }
+    ],
+    "point_total": 258,
+    "rank": 22,
+    "rookie_bonus": 0,
+    "team_key": "frc5114"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miche",
+        "qual_points": 17,
+        "total": 47
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibel",
+        "qual_points": 22,
+        "total": 56
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp4",
+        "qual_points": 48,
+        "total": 150
+      }
+    ],
+    "point_total": 253,
+    "rank": 23,
+    "rookie_bonus": 0,
+    "team_key": "frc3641"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026misal",
+        "qual_points": 19,
+        "total": 58
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp3",
+        "qual_points": 54,
+        "total": 165
+      }
+    ],
+    "point_total": 251,
+    "rank": 24,
+    "rookie_bonus": 0,
+    "team_key": "frc5066"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimid",
+        "qual_points": 16,
+        "total": 67
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimas",
+        "qual_points": 21,
+        "total": 74
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 45,
+        "total": 84
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 249,
+    "rank": 25,
+    "rookie_bonus": 0,
+    "team_key": "frc5712"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimar",
+        "qual_points": 20,
+        "total": 55
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitry",
+        "qual_points": 20,
+        "total": 55
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp3",
+        "qual_points": 66,
+        "total": 135
+      }
+    ],
+    "point_total": 245,
+    "rank": 26,
+    "rookie_bonus": 0,
+    "team_key": "frc2851"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miwmi",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibig",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 57,
+        "total": 111
+      }
+    ],
+    "point_total": 244,
+    "rank": 27,
+    "rookie_bonus": 0,
+    "team_key": "frc1918"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimar",
+        "qual_points": 15,
+        "total": 41
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitr2",
+        "qual_points": 21,
+        "total": 48
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp3",
+        "qual_points": 36,
+        "total": 147
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 0
+      }
+    ],
+    "point_total": 236,
+    "rank": 28,
+    "rookie_bonus": 0,
+    "team_key": "frc8280"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimar",
+        "qual_points": 18,
+        "total": 69
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miwmi",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 54,
+        "total": 93
+      }
+    ],
+    "point_total": 234,
+    "rank": 29,
+    "rookie_bonus": 0,
+    "team_key": "frc3539"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026misal",
+        "qual_points": 17,
+        "total": 61
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp3",
+        "qual_points": 45,
+        "total": 141
+      }
+    ],
+    "point_total": 233,
+    "rank": 30,
+    "rookie_bonus": 0,
+    "team_key": "frc548"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milak",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimas",
+        "qual_points": 18,
+        "total": 68
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 54,
+        "total": 93
+      }
+    ],
+    "point_total": 233,
+    "rank": 31,
+    "rookie_bonus": 0,
+    "team_key": "frc8608"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miber",
+        "qual_points": 16,
+        "total": 49
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miken",
+        "qual_points": 22,
+        "total": 61
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 51,
+        "total": 90
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 230,
+    "rank": 32,
+    "rookie_bonus": 0,
+    "team_key": "frc3620"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miche",
+        "qual_points": 13,
+        "total": 36
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 17,
+        "total": 39
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp4",
+        "qual_points": 63,
+        "total": 147
+      }
+    ],
+    "point_total": 222,
+    "rank": 33,
+    "rookie_bonus": 0,
+    "team_key": "frc503"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitr2",
+        "qual_points": 16,
+        "total": 49
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp3",
+        "qual_points": 48,
+        "total": 144
+      }
+    ],
+    "point_total": 220,
+    "rank": 34,
+    "rookie_bonus": 0,
+    "team_key": "frc2960"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milac",
+        "qual_points": 14,
+        "total": 38
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miesc",
+        "qual_points": 18,
+        "total": 51
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026micmp2",
+        "qual_points": 36,
+        "total": 129
+      }
+    ],
+    "point_total": 218,
+    "rank": 35,
+    "rookie_bonus": 0,
+    "team_key": "frc2586"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimus",
+        "qual_points": 16,
+        "total": 70
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milsu",
+        "qual_points": 18,
+        "total": 49
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp3",
+        "qual_points": 24,
+        "total": 99
+      }
+    ],
+    "point_total": 218,
+    "rank": 36,
+    "rookie_bonus": 0,
+    "team_key": "frc4967"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimid",
+        "qual_points": 18,
+        "total": 48
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milsu",
+        "qual_points": 19,
+        "total": 59
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 54,
+        "total": 108
+      }
+    ],
+    "point_total": 215,
+    "rank": 37,
+    "rookie_bonus": 0,
+    "team_key": "frc8517"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milac",
+        "qual_points": 17,
+        "total": 41
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitvc",
+        "qual_points": 19,
+        "total": 68
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp4",
+        "qual_points": 42,
+        "total": 102
+      }
+    ],
+    "point_total": 211,
+    "rank": 38,
+    "rookie_bonus": 0,
+    "team_key": "frc5534"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 18,
+        "total": 35
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miliv",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 57,
+        "total": 114
+      }
+    ],
+    "point_total": 210,
+    "rank": 39,
+    "rookie_bonus": 0,
+    "team_key": "frc1189"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimid",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milsu",
+        "qual_points": 21,
+        "total": 52
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp4",
+        "qual_points": 30,
+        "total": 99
+      }
+    ],
+    "point_total": 209,
+    "rank": 40,
+    "rookie_bonus": 0,
+    "team_key": "frc5216"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimus",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miken",
+        "qual_points": 19,
+        "total": 40
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp1",
+        "qual_points": 51,
+        "total": 105
+      }
+    ],
+    "point_total": 208,
+    "rank": 41,
+    "rookie_bonus": 0,
+    "team_key": "frc2075"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimar",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitry",
+        "qual_points": 19,
+        "total": 59
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 45,
+        "total": 75
+      }
+    ],
+    "point_total": 207,
+    "rank": 42,
+    "rookie_bonus": 0,
+    "team_key": "frc33"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miber",
+        "qual_points": 21,
+        "total": 54
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miken",
+        "qual_points": 20,
+        "total": 70
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 45,
+        "total": 72
+      }
+    ],
+    "point_total": 201,
+    "rank": 43,
+    "rookie_bonus": 5,
+    "team_key": "frc10633"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mifli",
+        "qual_points": 18,
+        "total": 57
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mifen",
+        "qual_points": 20,
+        "total": 65
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 42,
+        "total": 78
+      }
+    ],
+    "point_total": 200,
+    "rank": 44,
+    "rookie_bonus": 0,
+    "team_key": "frc5660"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimid",
+        "qual_points": 22,
+        "total": 76
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miken",
+        "qual_points": 18,
+        "total": 55
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp4",
+        "qual_points": 24,
+        "total": 66
+      }
+    ],
+    "point_total": 197,
+    "rank": 45,
+    "rookie_bonus": 0,
+    "team_key": "frc5166"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milac",
+        "qual_points": 19,
+        "total": 70
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miwmi",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 39,
+        "total": 81
+      }
+    ],
+    "point_total": 197,
+    "rank": 46,
+    "rookie_bonus": 0,
+    "team_key": "frc2054"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 12,
+        "total": 29
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026misal",
+        "qual_points": 19,
+        "total": 44
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 57,
+        "total": 93
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 196,
+    "rank": 47,
+    "rookie_bonus": 0,
+    "team_key": "frc3604"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimus",
+        "qual_points": 18,
+        "total": 49
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibig",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 48,
+        "total": 75
+      }
+    ],
+    "point_total": 195,
+    "rank": 48,
+    "rookie_bonus": 0,
+    "team_key": "frc7160"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitvc",
+        "qual_points": 21,
+        "total": 62
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 57,
+        "total": 96
+      }
+    ],
+    "point_total": 194,
+    "rank": 49,
+    "rookie_bonus": 0,
+    "team_key": "frc5086"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 18,
+        "total": 31
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miken",
+        "qual_points": 21,
+        "total": 66
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp1",
+        "qual_points": 42,
+        "total": 96
+      }
+    ],
+    "point_total": 193,
+    "rank": 50,
+    "rookie_bonus": 0,
+    "team_key": "frc7220"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mifli",
+        "qual_points": 19,
+        "total": 70
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mifen",
+        "qual_points": 17,
+        "total": 58
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 36,
+        "total": 63
+      }
+    ],
+    "point_total": 191,
+    "rank": 51,
+    "rookie_bonus": 0,
+    "team_key": "frc68"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp2",
+        "qual_points": 48,
+        "total": 117
+      }
+    ],
+    "point_total": 191,
+    "rank": 52,
+    "rookie_bonus": 0,
+    "team_key": "frc2611"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimil",
+        "qual_points": 19,
+        "total": 44
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibel",
+        "qual_points": 20,
+        "total": 70
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 48,
+        "total": 75
+      }
+    ],
+    "point_total": 189,
+    "rank": 53,
+    "rookie_bonus": 0,
+    "team_key": "frc6615"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mifli",
+        "qual_points": 20,
+        "total": 59
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mifen",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 51,
+        "total": 84
+      }
+    ],
+    "point_total": 189,
+    "rank": 54,
+    "rookie_bonus": 0,
+    "team_key": "frc9757"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 19,
+        "total": 37
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 16,
+        "total": 38
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp4",
+        "qual_points": 48,
+        "total": 114
+      }
+    ],
+    "point_total": 189,
+    "rank": 55,
+    "rookie_bonus": 0,
+    "team_key": "frc2619"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitvc",
+        "qual_points": 17,
+        "total": 66
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milsu",
+        "qual_points": 22,
+        "total": 50
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 36,
+        "total": 72
+      }
+    ],
+    "point_total": 188,
+    "rank": 56,
+    "rookie_bonus": 0,
+    "team_key": "frc4398"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimar",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitry",
+        "qual_points": 17,
+        "total": 42
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 45,
+        "total": 84
+      }
+    ],
+    "point_total": 187,
+    "rank": 57,
+    "rookie_bonus": 0,
+    "team_key": "frc9245"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimil",
+        "qual_points": 18,
+        "total": 50
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miken",
+        "qual_points": 18,
+        "total": 52
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 39,
+        "total": 84
+      }
+    ],
+    "point_total": 186,
+    "rank": 58,
+    "rookie_bonus": 0,
+    "team_key": "frc1023"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 15,
+        "total": 30
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milsu",
+        "qual_points": 18,
+        "total": 65
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 54,
+        "total": 90
+      }
+    ],
+    "point_total": 185,
+    "rank": 59,
+    "rookie_bonus": 0,
+    "team_key": "frc6121"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimar",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitry",
+        "qual_points": 18,
+        "total": 43
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 57,
+        "total": 96
+      }
+    ],
+    "point_total": 185,
+    "rank": 60,
+    "rookie_bonus": 0,
+    "team_key": "frc1498"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miche",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibel",
+        "qual_points": 21,
+        "total": 55
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 42,
+        "total": 69
+      }
+    ],
+    "point_total": 184,
+    "rank": 61,
+    "rookie_bonus": 0,
+    "team_key": "frc3656"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milac",
+        "qual_points": 17,
+        "total": 59
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 39,
+        "total": 87
+      }
+    ],
+    "point_total": 184,
+    "rank": 62,
+    "rookie_bonus": 0,
+    "team_key": "frc3536"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitvc",
+        "qual_points": 9,
+        "total": 47
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp1",
+        "qual_points": 27,
+        "total": 108
+      }
+    ],
+    "point_total": 181,
+    "rank": 63,
+    "rookie_bonus": 0,
+    "team_key": "frc9771"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibro",
+        "qual_points": 19,
+        "total": 50
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miliv",
+        "qual_points": 18,
+        "total": 50
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 51,
+        "total": 81
+      }
+    ],
+    "point_total": 181,
+    "rank": 64,
+    "rookie_bonus": 0,
+    "team_key": "frc6152"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 17,
+        "total": 40
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitry",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp2",
+        "qual_points": 24,
+        "total": 78
+      }
+    ],
+    "point_total": 179,
+    "rank": 65,
+    "rookie_bonus": 0,
+    "team_key": "frc201"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 13,
+        "total": 30
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibel",
+        "qual_points": 19,
+        "total": 63
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp4",
+        "qual_points": 33,
+        "total": 84
+      }
+    ],
+    "point_total": 177,
+    "rank": 66,
+    "rookie_bonus": 0,
+    "team_key": "frc1188"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mifen",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 54,
+        "total": 90
+      }
+    ],
+    "point_total": 177,
+    "rank": 67,
+    "rookie_bonus": 0,
+    "team_key": "frc494"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibat",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp3",
+        "qual_points": 33,
+        "total": 81
+      }
+    ],
+    "point_total": 175,
+    "rank": 68,
+    "rookie_bonus": 0,
+    "team_key": "frc5675"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimil",
+        "qual_points": 17,
+        "total": 42
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimas",
+        "qual_points": 16,
+        "total": 47
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 42,
+        "total": 84
+      }
+    ],
+    "point_total": 173,
+    "rank": 69,
+    "rookie_bonus": 0,
+    "team_key": "frc3707"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibat",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp2",
+        "qual_points": 39,
+        "total": 87
+      }
+    ],
+    "point_total": 170,
+    "rank": 70,
+    "rookie_bonus": 0,
+    "team_key": "frc5462"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mifen",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 48,
+        "total": 90
+      }
+    ],
+    "point_total": 170,
+    "rank": 71,
+    "rookie_bonus": 0,
+    "team_key": "frc70"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 21,
+        "total": 36
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026micmp1",
+        "qual_points": 39,
+        "total": 99
+      }
+    ],
+    "point_total": 169,
+    "rank": 72,
+    "rookie_bonus": 0,
+    "team_key": "frc9572"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimar",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 17,
+        "total": 33
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 54,
+        "total": 87
+      }
+    ],
+    "point_total": 169,
+    "rank": 73,
+    "rookie_bonus": 0,
+    "team_key": "frc5843"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimus",
+        "qual_points": 19,
+        "total": 68
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miesc",
+        "qual_points": 18,
+        "total": 46
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 42,
+        "total": 54
+      }
+    ],
+    "point_total": 168,
+    "rank": 74,
+    "rookie_bonus": 0,
+    "team_key": "frc8612"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 18,
+        "total": 38
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miwmi",
+        "qual_points": 19,
+        "total": 62
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 36,
+        "total": 66
+      }
+    ],
+    "point_total": 166,
+    "rank": 75,
+    "rookie_bonus": 0,
+    "team_key": "frc3572"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milac",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibig",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 160,
+    "rank": 76,
+    "rookie_bonus": 0,
+    "team_key": "frc3603"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026midtr",
+        "qual_points": 22,
+        "total": 76
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 30,
+        "total": 54
+      }
+    ],
+    "point_total": 159,
+    "rank": 77,
+    "rookie_bonus": 0,
+    "team_key": "frc3175"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 21,
+        "total": 41
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mifli",
+        "qual_points": 16,
+        "total": 36
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 45,
+        "total": 81
+      }
+    ],
+    "point_total": 158,
+    "rank": 78,
+    "rookie_bonus": 0,
+    "team_key": "frc1684"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimar",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitr2",
+        "qual_points": 18,
+        "total": 43
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 48,
+        "total": 75
+      }
+    ],
+    "point_total": 157,
+    "rank": 79,
+    "rookie_bonus": 5,
+    "team_key": "frc10349"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 8,
+        "total": 23
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026misal",
+        "qual_points": 18,
+        "total": 54
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp1",
+        "qual_points": 39,
+        "total": 78
+      }
+    ],
+    "point_total": 155,
+    "rank": 80,
+    "rookie_bonus": 0,
+    "team_key": "frc1506"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibkn",
+        "qual_points": 15,
+        "total": 51
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 36,
+        "total": 72
+      }
+    ],
+    "point_total": 154,
+    "rank": 81,
+    "rookie_bonus": 0,
+    "team_key": "frc1481"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibkn",
+        "qual_points": 14,
+        "total": 33
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 13,
+        "total": 35
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026micmp2",
+        "qual_points": 18,
+        "total": 84
+      }
+    ],
+    "point_total": 152,
+    "rank": 82,
+    "rookie_bonus": 0,
+    "team_key": "frc862"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026midtr",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miliv",
+        "qual_points": 14,
+        "total": 36
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp3",
+        "qual_points": 21,
+        "total": 45
+      }
+    ],
+    "point_total": 152,
+    "rank": 83,
+    "rookie_bonus": 0,
+    "team_key": "frc123"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milak",
+        "qual_points": 16,
+        "total": 45
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibel",
+        "qual_points": 17,
+        "total": 41
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 36,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 152,
+    "rank": 84,
+    "rookie_bonus": 0,
+    "team_key": "frc245"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milac",
+        "qual_points": 12,
+        "total": 38
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 51,
+        "total": 87
+      }
+    ],
+    "point_total": 152,
+    "rank": 85,
+    "rookie_bonus": 0,
+    "team_key": "frc7250"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miche",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 48,
+        "total": 81
+      }
+    ],
+    "point_total": 152,
+    "rank": 86,
+    "rookie_bonus": 0,
+    "team_key": "frc8373"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibro",
+        "qual_points": 18,
+        "total": 44
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimas",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 42,
+        "total": 60
+      }
+    ],
+    "point_total": 149,
+    "rank": 87,
+    "rookie_bonus": 0,
+    "team_key": "frc910"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 14,
+        "total": 22
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibat",
+        "qual_points": 18,
+        "total": 49
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 48,
+        "total": 78
+      }
+    ],
+    "point_total": 149,
+    "rank": 88,
+    "rookie_bonus": 0,
+    "team_key": "frc9215"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miche",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miber",
+        "qual_points": 14,
+        "total": 57
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 148,
+    "rank": 89,
+    "rookie_bonus": 0,
+    "team_key": "frc302"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitr2",
+        "qual_points": 17,
+        "total": 56
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 45,
+        "total": 69
+      }
+    ],
+    "point_total": 148,
+    "rank": 90,
+    "rookie_bonus": 0,
+    "team_key": "frc51"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miche",
+        "qual_points": 14,
+        "total": 32
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 4,
+        "event_key": "2026misal",
+        "qual_points": 18,
+        "total": 40
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026micmp2",
+        "qual_points": 33,
+        "total": 72
+      }
+    ],
+    "point_total": 144,
+    "rank": 91,
+    "rookie_bonus": 0,
+    "team_key": "frc1076"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimid",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 27,
+        "total": 42
+      }
+    ],
+    "point_total": 141,
+    "rank": 92,
+    "rookie_bonus": 0,
+    "team_key": "frc8873"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibro",
+        "qual_points": 16,
+        "total": 52
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 15,
+        "total": 30
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 42,
+        "total": 57
+      }
+    ],
+    "point_total": 139,
+    "rank": 93,
+    "rookie_bonus": 0,
+    "team_key": "frc6528"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimtp",
+        "qual_points": 16,
+        "total": 56
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 13,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 138,
+    "rank": 94,
+    "rookie_bonus": 0,
+    "team_key": "frc573"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 14,
+        "total": 31
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 19,
+        "total": 37
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 30,
+        "total": 69
+      }
+    ],
+    "point_total": 137,
+    "rank": 95,
+    "rookie_bonus": 0,
+    "team_key": "frc818"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milac",
+        "qual_points": 20,
+        "total": 64
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 18,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 135,
+    "rank": 96,
+    "rookie_bonus": 0,
+    "team_key": "frc226"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibkn",
+        "qual_points": 13,
+        "total": 49
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 16,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 133,
+    "rank": 97,
+    "rookie_bonus": 0,
+    "team_key": "frc9312"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miber",
+        "qual_points": 18,
+        "total": 51
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 131,
+    "rank": 98,
+    "rookie_bonus": 0,
+    "team_key": "frc5535"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milak",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 19,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 48,
+        "total": 48
+      }
+    ],
+    "point_total": 129,
+    "rank": 99,
+    "rookie_bonus": 0,
+    "team_key": "frc3875"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimus",
+        "qual_points": 15,
+        "total": 41
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miwmi",
+        "qual_points": 13,
+        "total": 45
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 27,
+        "total": 42
+      }
+    ],
+    "point_total": 128,
+    "rank": 100,
+    "rookie_bonus": 0,
+    "team_key": "frc85"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 18,
+        "total": 31
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milsu",
+        "qual_points": 17,
+        "total": 64
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 125,
+    "rank": 101,
+    "rookie_bonus": 0,
+    "team_key": "frc4779"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miche",
+        "qual_points": 9,
+        "total": 31
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimas",
+        "qual_points": 19,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 39,
+        "total": 54
+      }
+    ],
+    "point_total": 125,
+    "rank": 102,
+    "rookie_bonus": 0,
+    "team_key": "frc7056"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026midtr",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 16,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 125,
+    "rank": 103,
+    "rookie_bonus": 0,
+    "team_key": "frc8352"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimtp",
+        "qual_points": 14,
+        "total": 40
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitvc",
+        "qual_points": 18,
+        "total": 45
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 24,
+        "total": 39
+      }
+    ],
+    "point_total": 124,
+    "rank": 104,
+    "rookie_bonus": 0,
+    "team_key": "frc3767"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 11,
+        "total": 21
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 14,
+        "total": 34
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 42,
+        "total": 69
+      }
+    ],
+    "point_total": 124,
+    "rank": 105,
+    "rookie_bonus": 0,
+    "team_key": "frc1502"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitvc",
+        "qual_points": 12,
+        "total": 40
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mifen",
+        "qual_points": 12,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 30,
+        "total": 45
+      }
+    ],
+    "point_total": 123,
+    "rank": 106,
+    "rookie_bonus": 0,
+    "team_key": "frc7598"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 19,
+        "total": 32
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibkn",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 123,
+    "rank": 107,
+    "rookie_bonus": 0,
+    "team_key": "frc9210"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimid",
+        "qual_points": 20,
+        "total": 46
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 122,
+    "rank": 108,
+    "rookie_bonus": 0,
+    "team_key": "frc3357"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 17,
+        "total": 33
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 39,
+        "total": 57
+      }
+    ],
+    "point_total": 122,
+    "rank": 109,
+    "rookie_bonus": 0,
+    "team_key": "frc3770"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimil",
+        "qual_points": 9,
+        "total": 45
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimas",
+        "qual_points": 18,
+        "total": 49
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 121,
+    "rank": 110,
+    "rookie_bonus": 0,
+    "team_key": "frc8424"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 12,
+        "total": 26
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitvc",
+        "qual_points": 17,
+        "total": 47
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 121,
+    "rank": 111,
+    "rookie_bonus": 0,
+    "team_key": "frc1711"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 12,
+        "total": 36
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 12,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 27,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 121,
+    "rank": 112,
+    "rookie_bonus": 0,
+    "team_key": "frc5577"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimtp",
+        "qual_points": 19,
+        "total": 50
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 119,
+    "rank": 113,
+    "rookie_bonus": 0,
+    "team_key": "frc4422"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mifen",
+        "qual_points": 18,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 39,
+        "total": 54
+      }
+    ],
+    "point_total": 118,
+    "rank": 114,
+    "rookie_bonus": 0,
+    "team_key": "frc5229"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 15,
+        "total": 33
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 27,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 118,
+    "rank": 115,
+    "rookie_bonus": 10,
+    "team_key": "frc11493"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milak",
+        "qual_points": 10,
+        "total": 41
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miwmi",
+        "qual_points": 15,
+        "total": 37
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 117,
+    "rank": 116,
+    "rookie_bonus": 0,
+    "team_key": "frc8397"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimus",
+        "qual_points": 16,
+        "total": 38
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miesc",
+        "qual_points": 19,
+        "total": 52
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 18,
+        "total": 27
+      }
+    ],
+    "point_total": 117,
+    "rank": 117,
+    "rookie_bonus": 0,
+    "team_key": "frc5505"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimtp",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 14,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 117,
+    "rank": 118,
+    "rookie_bonus": 0,
+    "team_key": "frc4381"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimus",
+        "qual_points": 7,
+        "total": 36
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 45,
+        "total": 45
+      }
+    ],
+    "point_total": 117,
+    "rank": 119,
+    "rookie_bonus": 10,
+    "team_key": "frc11503"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimar",
+        "qual_points": 9,
+        "total": 45
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibig",
+        "qual_points": 21,
+        "total": 59
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 116,
+    "rank": 120,
+    "rookie_bonus": 0,
+    "team_key": "frc1718"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026midtr",
+        "qual_points": 17,
+        "total": 48
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitr2",
+        "qual_points": 4,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 116,
+    "rank": 121,
+    "rookie_bonus": 0,
+    "team_key": "frc2224"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 17,
+        "total": 30
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miesc",
+        "qual_points": 17,
+        "total": 41
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 33,
+        "total": 45
+      }
+    ],
+    "point_total": 116,
+    "rank": 122,
+    "rookie_bonus": 0,
+    "team_key": "frc3602"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 12,
+        "total": 22
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mifli",
+        "qual_points": 21,
+        "total": 54
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 115,
+    "rank": 123,
+    "rookie_bonus": 0,
+    "team_key": "frc5046"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibkn",
+        "qual_points": 21,
+        "total": 49
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 114,
+    "rank": 124,
+    "rookie_bonus": 0,
+    "team_key": "frc5144"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 15,
+        "total": 33
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitr2",
+        "qual_points": 18,
+        "total": 45
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 114,
+    "rank": 125,
+    "rookie_bonus": 0,
+    "team_key": "frc1025"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimid",
+        "qual_points": 15,
+        "total": 45
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miwmi",
+        "qual_points": 17,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 112,
+    "rank": 126,
+    "rookie_bonus": 0,
+    "team_key": "frc6753"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milak",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibkn",
+        "qual_points": 16,
+        "total": 47
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 111,
+    "rank": 127,
+    "rookie_bonus": 0,
+    "team_key": "frc5676"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitr2",
+        "qual_points": 19,
+        "total": 53
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 111,
+    "rank": 128,
+    "rookie_bonus": 0,
+    "team_key": "frc7188"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milak",
+        "qual_points": 12,
+        "total": 32
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibkn",
+        "qual_points": 16,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 21,
+        "total": 36
+      }
+    ],
+    "point_total": 111,
+    "rank": 129,
+    "rookie_bonus": 10,
+    "team_key": "frc11386"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 9,
+        "total": 15
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milsu",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 110,
+    "rank": 130,
+    "rookie_bonus": 5,
+    "team_key": "frc10666"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibro",
+        "qual_points": 16,
+        "total": 42
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026misal",
+        "qual_points": 20,
+        "total": 53
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 110,
+    "rank": 131,
+    "rookie_bonus": 0,
+    "team_key": "frc3322"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibro",
+        "qual_points": 17,
+        "total": 53
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 16,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 109,
+    "rank": 132,
+    "rookie_bonus": 0,
+    "team_key": "frc247"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 18,
+        "total": 31
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 21,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 27,
+        "total": 42
+      }
+    ],
+    "point_total": 109,
+    "rank": 133,
+    "rookie_bonus": 0,
+    "team_key": "frc4956"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 14,
+        "total": 25
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miken",
+        "qual_points": 15,
+        "total": 47
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 108,
+    "rank": 134,
+    "rookie_bonus": 0,
+    "team_key": "frc858"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milac",
+        "qual_points": 14,
+        "total": 41
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 14,
+        "total": 30
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 24,
+        "total": 36
+      }
+    ],
+    "point_total": 107,
+    "rank": 135,
+    "rookie_bonus": 0,
+    "team_key": "frc7768"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milsu",
+        "qual_points": 13,
+        "total": 39
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 107,
+    "rank": 136,
+    "rookie_bonus": 0,
+    "team_key": "frc4392"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibig",
+        "qual_points": 16,
+        "total": 52
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 106,
+    "rank": 137,
+    "rookie_bonus": 0,
+    "team_key": "frc244"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milak",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 16,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 24,
+        "total": 39
+      }
+    ],
+    "point_total": 106,
+    "rank": 138,
+    "rookie_bonus": 0,
+    "team_key": "frc8126"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibat",
+        "qual_points": 17,
+        "total": 43
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 105,
+    "rank": 139,
+    "rookie_bonus": 0,
+    "team_key": "frc5152"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026midtr",
+        "qual_points": 16,
+        "total": 56
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 14,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 104,
+    "rank": 140,
+    "rookie_bonus": 0,
+    "team_key": "frc9255"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 13,
+        "total": 28
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 15,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 103,
+    "rank": 141,
+    "rookie_bonus": 0,
+    "team_key": "frc4810"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 19,
+        "total": 32
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mifli",
+        "qual_points": 19,
+        "total": 52
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 102,
+    "rank": 142,
+    "rookie_bonus": 0,
+    "team_key": "frc894"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimid",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miliv",
+        "qual_points": 16,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 101,
+    "rank": 143,
+    "rookie_bonus": 0,
+    "team_key": "frc5533"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milsu",
+        "qual_points": 8,
+        "total": 43
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 11,
+        "total": 24
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 15,
+        "total": 30
+      }
+    ],
+    "point_total": 97,
+    "rank": 144,
+    "rookie_bonus": 0,
+    "team_key": "frc6088"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026midtr",
+        "qual_points": 12,
+        "total": 34
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miwmi",
+        "qual_points": 14,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 12,
+        "total": 27
+      }
+    ],
+    "point_total": 96,
+    "rank": 145,
+    "rookie_bonus": 0,
+    "team_key": "frc4680"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimus",
+        "qual_points": 13,
+        "total": 30
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miwmi",
+        "qual_points": 16,
+        "total": 39
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 96,
+    "rank": 146,
+    "rookie_bonus": 0,
+    "team_key": "frc7054"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 14,
+        "total": 22
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miesc",
+        "qual_points": 20,
+        "total": 53
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 96,
+    "rank": 147,
+    "rookie_bonus": 0,
+    "team_key": "frc6637"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 14,
+        "total": 19
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mifen",
+        "qual_points": 18,
+        "total": 46
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 96,
+    "rank": 148,
+    "rookie_bonus": 10,
+    "team_key": "frc10978"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 17,
+        "total": 39
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 95,
+    "rank": 149,
+    "rookie_bonus": 0,
+    "team_key": "frc4327"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 16,
+        "total": 33
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 15,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 93,
+    "rank": 150,
+    "rookie_bonus": 0,
+    "team_key": "frc217"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibig",
+        "qual_points": 19,
+        "total": 55
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 92,
+    "rank": 151,
+    "rookie_bonus": 0,
+    "team_key": "frc288"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 17,
+        "total": 33
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 13,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 92,
+    "rank": 152,
+    "rookie_bonus": 0,
+    "team_key": "frc3452"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 19,
+        "total": 37
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp3",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 91,
+    "rank": 153,
+    "rookie_bonus": 0,
+    "team_key": "frc3618"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mifli",
+        "qual_points": 12,
+        "total": 48
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimas",
+        "qual_points": 11,
+        "total": 21
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 90,
+    "rank": 154,
+    "rookie_bonus": 0,
+    "team_key": "frc6085"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miche",
+        "qual_points": 12,
+        "total": 43
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 14,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 90,
+    "rank": 155,
+    "rookie_bonus": 0,
+    "team_key": "frc5567"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 13,
+        "total": 25
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miken",
+        "qual_points": 14,
+        "total": 47
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 87,
+    "rank": 156,
+    "rookie_bonus": 0,
+    "team_key": "frc8767"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miber",
+        "qual_points": 18,
+        "total": 42
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 87,
+    "rank": 157,
+    "rookie_bonus": 0,
+    "team_key": "frc4855"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibro",
+        "qual_points": 14,
+        "total": 50
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 85,
+    "rank": 158,
+    "rookie_bonus": 0,
+    "team_key": "frc8179"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 12,
+        "total": 26
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitvc",
+        "qual_points": 16,
+        "total": 41
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 85,
+    "rank": 159,
+    "rookie_bonus": 0,
+    "team_key": "frc3688"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 18,
+        "total": 35
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 18,
+        "total": 37
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp2",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 84,
+    "rank": 160,
+    "rookie_bonus": 0,
+    "team_key": "frc5982"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026midtr",
+        "qual_points": 9,
+        "total": 31
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026misal",
+        "qual_points": 10,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp4",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 79,
+    "rank": 161,
+    "rookie_bonus": 0,
+    "team_key": "frc3632"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 15,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026micmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 66,
+    "rank": 162,
+    "rookie_bonus": 10,
+    "team_key": "frc11387"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 11,
+        "total": 24
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibat",
+        "qual_points": 19,
+        "total": 40
+      }
+    ],
+    "point_total": 64,
+    "rank": 163,
+    "rookie_bonus": 0,
+    "team_key": "frc7211"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026midtr",
+        "qual_points": 17,
+        "total": 39
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 15,
+        "total": 25
+      }
+    ],
+    "point_total": 64,
+    "rank": 164,
+    "rookie_bonus": 0,
+    "team_key": "frc7196"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 18,
+        "total": 35
+      }
+    ],
+    "point_total": 64,
+    "rank": 165,
+    "rookie_bonus": 0,
+    "team_key": "frc7195"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 19,
+        "total": 38
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 15,
+        "total": 26
+      }
+    ],
+    "point_total": 64,
+    "rank": 166,
+    "rookie_bonus": 0,
+    "team_key": "frc4838"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 18,
+        "total": 37
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 12,
+        "total": 17
+      }
+    ],
+    "point_total": 64,
+    "rank": 167,
+    "rookie_bonus": 10,
+    "team_key": "frc11490"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 17,
+        "total": 32
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 18,
+        "total": 31
+      }
+    ],
+    "point_total": 63,
+    "rank": 168,
+    "rookie_bonus": 0,
+    "team_key": "frc7174"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 17,
+        "total": 34
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 16,
+        "total": 29
+      }
+    ],
+    "point_total": 63,
+    "rank": 169,
+    "rookie_bonus": 0,
+    "team_key": "frc4003"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimid",
+        "qual_points": 10,
+        "total": 32
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milsu",
+        "qual_points": 8,
+        "total": 30
+      }
+    ],
+    "point_total": 62,
+    "rank": 170,
+    "rookie_bonus": 0,
+    "team_key": "frc5424"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miken",
+        "qual_points": 13,
+        "total": 45
+      }
+    ],
+    "point_total": 62,
+    "rank": 171,
+    "rookie_bonus": 5,
+    "team_key": "frc10642"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miesc",
+        "qual_points": 9,
+        "total": 45
+      }
+    ],
+    "point_total": 62,
+    "rank": 172,
+    "rookie_bonus": 0,
+    "team_key": "frc6079"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibat",
+        "qual_points": 9,
+        "total": 36
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 62,
+    "rank": 173,
+    "rookie_bonus": 0,
+    "team_key": "frc9776"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimtp",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 15,
+        "total": 29
+      }
+    ],
+    "point_total": 62,
+    "rank": 174,
+    "rookie_bonus": 0,
+    "team_key": "frc9673"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 16,
+        "total": 30
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibig",
+        "qual_points": 13,
+        "total": 32
+      }
+    ],
+    "point_total": 62,
+    "rank": 175,
+    "rookie_bonus": 0,
+    "team_key": "frc6077"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 13,
+        "total": 19
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mifli",
+        "qual_points": 18,
+        "total": 43
+      }
+    ],
+    "point_total": 62,
+    "rank": 176,
+    "rookie_bonus": 0,
+    "team_key": "frc5561"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 13,
+        "total": 19
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miesc",
+        "qual_points": 14,
+        "total": 38
+      }
+    ],
+    "point_total": 62,
+    "rank": 177,
+    "rookie_bonus": 5,
+    "team_key": "frc10589"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitvc",
+        "qual_points": 20,
+        "total": 47
+      }
+    ],
+    "point_total": 62,
+    "rank": 178,
+    "rookie_bonus": 0,
+    "team_key": "frc7790"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 17,
+        "total": 33
+      }
+    ],
+    "point_total": 62,
+    "rank": 179,
+    "rookie_bonus": 0,
+    "team_key": "frc2771"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 13,
+        "total": 16
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibig",
+        "qual_points": 14,
+        "total": 45
+      }
+    ],
+    "point_total": 61,
+    "rank": 180,
+    "rookie_bonus": 0,
+    "team_key": "frc6100"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026midtr",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 12,
+        "total": 16
+      }
+    ],
+    "point_total": 61,
+    "rank": 181,
+    "rookie_bonus": 0,
+    "team_key": "frc2673"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 13,
+        "total": 26
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibkn",
+        "qual_points": 13,
+        "total": 35
+      }
+    ],
+    "point_total": 61,
+    "rank": 182,
+    "rookie_bonus": 0,
+    "team_key": "frc7501"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimar",
+        "qual_points": 11,
+        "total": 29
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 16,
+        "total": 32
+      }
+    ],
+    "point_total": 61,
+    "rank": 183,
+    "rookie_bonus": 0,
+    "team_key": "frc8728"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 18,
+        "total": 35
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 61,
+    "rank": 184,
+    "rookie_bonus": 0,
+    "team_key": "frc7692"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 18,
+        "total": 38
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 12,
+        "total": 22
+      }
+    ],
+    "point_total": 60,
+    "rank": 185,
+    "rookie_bonus": 0,
+    "team_key": "frc141"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026misal",
+        "qual_points": 11,
+        "total": 42
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 12,
+        "total": 17
+      }
+    ],
+    "point_total": 59,
+    "rank": 186,
+    "rookie_bonus": 0,
+    "team_key": "frc3568"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibro",
+        "qual_points": 7,
+        "total": 38
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 11,
+        "total": 21
+      }
+    ],
+    "point_total": 59,
+    "rank": 187,
+    "rookie_bonus": 0,
+    "team_key": "frc2832"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milac",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 14,
+        "total": 26
+      }
+    ],
+    "point_total": 59,
+    "rank": 188,
+    "rookie_bonus": 0,
+    "team_key": "frc6114"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 13,
+        "total": 20
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miber",
+        "qual_points": 15,
+        "total": 39
+      }
+    ],
+    "point_total": 59,
+    "rank": 189,
+    "rookie_bonus": 0,
+    "team_key": "frc2959"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimtp",
+        "qual_points": 12,
+        "total": 29
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 14,
+        "total": 30
+      }
+    ],
+    "point_total": 59,
+    "rank": 190,
+    "rookie_bonus": 0,
+    "team_key": "frc2405"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 12,
+        "total": 24
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 17,
+        "total": 35
+      }
+    ],
+    "point_total": 59,
+    "rank": 191,
+    "rookie_bonus": 0,
+    "team_key": "frc4004"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 17,
+        "total": 34
+      }
+    ],
+    "point_total": 59,
+    "rank": 192,
+    "rookie_bonus": 0,
+    "team_key": "frc7202"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 17,
+        "total": 33
+      }
+    ],
+    "point_total": 59,
+    "rank": 193,
+    "rookie_bonus": 0,
+    "team_key": "frc5531"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 11,
+        "total": 27
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 16,
+        "total": 32
+      }
+    ],
+    "point_total": 59,
+    "rank": 194,
+    "rookie_bonus": 0,
+    "team_key": "frc2834"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 16,
+        "total": 30
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 15,
+        "total": 29
+      }
+    ],
+    "point_total": 59,
+    "rank": 195,
+    "rookie_bonus": 0,
+    "team_key": "frc6120"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mitry",
+        "qual_points": 11,
+        "total": 42
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitr2",
+        "qual_points": 7,
+        "total": 16
+      }
+    ],
+    "point_total": 58,
+    "rank": 196,
+    "rookie_bonus": 0,
+    "team_key": "frc9679"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 12,
+        "total": 24
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibel",
+        "qual_points": 15,
+        "total": 34
+      }
+    ],
+    "point_total": 58,
+    "rank": 197,
+    "rookie_bonus": 0,
+    "team_key": "frc5708"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibat",
+        "qual_points": 14,
+        "total": 29
+      }
+    ],
+    "point_total": 58,
+    "rank": 198,
+    "rookie_bonus": 0,
+    "team_key": "frc5248"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 13,
+        "total": 25
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 17,
+        "total": 33
+      }
+    ],
+    "point_total": 58,
+    "rank": 199,
+    "rookie_bonus": 0,
+    "team_key": "frc5926"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mifen",
+        "qual_points": 15,
+        "total": 47
+      }
+    ],
+    "point_total": 57,
+    "rank": 200,
+    "rookie_bonus": 0,
+    "team_key": "frc8193"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibel",
+        "qual_points": 12,
+        "total": 44
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 57,
+    "rank": 201,
+    "rookie_bonus": 0,
+    "team_key": "frc6538"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimid",
+        "qual_points": 13,
+        "total": 36
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 13,
+        "total": 21
+      }
+    ],
+    "point_total": 57,
+    "rank": 202,
+    "rookie_bonus": 0,
+    "team_key": "frc9685"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miber",
+        "qual_points": 14,
+        "total": 26
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 16,
+        "total": 31
+      }
+    ],
+    "point_total": 57,
+    "rank": 203,
+    "rookie_bonus": 0,
+    "team_key": "frc9208"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 11,
+        "total": 23
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 16,
+        "total": 34
+      }
+    ],
+    "point_total": 57,
+    "rank": 204,
+    "rookie_bonus": 0,
+    "team_key": "frc7656"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimas",
+        "qual_points": 12,
+        "total": 44
+      }
+    ],
+    "point_total": 56,
+    "rank": 205,
+    "rookie_bonus": 0,
+    "team_key": "frc9251"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miesc",
+        "qual_points": 15,
+        "total": 39
+      }
+    ],
+    "point_total": 56,
+    "rank": 206,
+    "rookie_bonus": 5,
+    "team_key": "frc10622"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026midtr",
+        "qual_points": 16,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 56,
+    "rank": 207,
+    "rookie_bonus": 5,
+    "team_key": "frc10577"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 56,
+    "rank": 208,
+    "rookie_bonus": 0,
+    "team_key": "frc5559"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 56,
+    "rank": 209,
+    "rookie_bonus": 0,
+    "team_key": "frc9541"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimus",
+        "qual_points": 10,
+        "total": 43
+      }
+    ],
+    "point_total": 55,
+    "rank": 210,
+    "rookie_bonus": 0,
+    "team_key": "frc9106"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026misal",
+        "qual_points": 13,
+        "total": 28
+      }
+    ],
+    "point_total": 55,
+    "rank": 211,
+    "rookie_bonus": 0,
+    "team_key": "frc9242"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimtp",
+        "qual_points": 10,
+        "total": 32
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 11,
+        "total": 23
+      }
+    ],
+    "point_total": 55,
+    "rank": 212,
+    "rookie_bonus": 0,
+    "team_key": "frc3655"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 16,
+        "total": 27
+      }
+    ],
+    "point_total": 55,
+    "rank": 213,
+    "rookie_bonus": 0,
+    "team_key": "frc1322"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 17,
+        "total": 28
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 16,
+        "total": 27
+      }
+    ],
+    "point_total": 55,
+    "rank": 214,
+    "rookie_bonus": 0,
+    "team_key": "frc857"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 12,
+        "total": 26
+      }
+    ],
+    "point_total": 55,
+    "rank": 215,
+    "rookie_bonus": 0,
+    "team_key": "frc3667"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 17,
+        "total": 28
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 17,
+        "total": 27
+      }
+    ],
+    "point_total": 55,
+    "rank": 216,
+    "rookie_bonus": 0,
+    "team_key": "frc6128"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 13,
+        "total": 29
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 55,
+    "rank": 217,
+    "rookie_bonus": 0,
+    "team_key": "frc7782"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 16,
+        "total": 31
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 14,
+        "total": 24
+      }
+    ],
+    "point_total": 55,
+    "rank": 218,
+    "rookie_bonus": 0,
+    "team_key": "frc6570"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 18,
+        "total": 35
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 8,
+        "total": 20
+      }
+    ],
+    "point_total": 55,
+    "rank": 219,
+    "rookie_bonus": 0,
+    "team_key": "frc5436"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimid",
+        "qual_points": 7,
+        "total": 38
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 54,
+    "rank": 220,
+    "rookie_bonus": 0,
+    "team_key": "frc5603"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milac",
+        "qual_points": 8,
+        "total": 20
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibig",
+        "qual_points": 12,
+        "total": 29
+      }
+    ],
+    "point_total": 54,
+    "rank": 221,
+    "rookie_bonus": 5,
+    "team_key": "frc10421"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026milak",
+        "qual_points": 10,
+        "total": 26
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 13,
+        "total": 28
+      }
+    ],
+    "point_total": 54,
+    "rank": 222,
+    "rookie_bonus": 0,
+    "team_key": "frc5980"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 14,
+        "total": 28
+      }
+    ],
+    "point_total": 54,
+    "rank": 223,
+    "rookie_bonus": 0,
+    "team_key": "frc5756"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 54,
+    "rank": 224,
+    "rookie_bonus": 5,
+    "team_key": "frc10651"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimar",
+        "qual_points": 11,
+        "total": 38
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 8,
+        "total": 15
+      }
+    ],
+    "point_total": 53,
+    "rank": 225,
+    "rookie_bonus": 0,
+    "team_key": "frc4130"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitry",
+        "qual_points": 14,
+        "total": 36
+      }
+    ],
+    "point_total": 53,
+    "rank": 226,
+    "rookie_bonus": 5,
+    "team_key": "frc10612"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026milac",
+        "qual_points": 9,
+        "total": 26
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 16,
+        "total": 27
+      }
+    ],
+    "point_total": 53,
+    "rank": 227,
+    "rookie_bonus": 0,
+    "team_key": "frc4983"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimas",
+        "qual_points": 13,
+        "total": 30
+      }
+    ],
+    "point_total": 53,
+    "rank": 228,
+    "rookie_bonus": 0,
+    "team_key": "frc7491"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miken",
+        "qual_points": 10,
+        "total": 24
+      }
+    ],
+    "point_total": 53,
+    "rank": 229,
+    "rookie_bonus": 5,
+    "team_key": "frc10181"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 16,
+        "total": 30
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 11,
+        "total": 23
+      }
+    ],
+    "point_total": 53,
+    "rank": 230,
+    "rookie_bonus": 0,
+    "team_key": "frc5110"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 53,
+    "rank": 231,
+    "rookie_bonus": 10,
+    "team_key": "frc11458"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimil",
+        "qual_points": 6,
+        "total": 22
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibel",
+        "qual_points": 7,
+        "total": 30
+      }
+    ],
+    "point_total": 52,
+    "rank": 232,
+    "rookie_bonus": 0,
+    "team_key": "frc5067"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milak",
+        "qual_points": 9,
+        "total": 31
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 13,
+        "total": 16
+      }
+    ],
+    "point_total": 52,
+    "rank": 233,
+    "rookie_bonus": 5,
+    "team_key": "frc10473"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitry",
+        "qual_points": 10,
+        "total": 26
+      }
+    ],
+    "point_total": 52,
+    "rank": 234,
+    "rookie_bonus": 0,
+    "team_key": "frc4384"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 11,
+        "total": 21
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 18,
+        "total": 31
+      }
+    ],
+    "point_total": 52,
+    "rank": 235,
+    "rookie_bonus": 0,
+    "team_key": "frc74"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 14,
+        "total": 24
+      }
+    ],
+    "point_total": 52,
+    "rank": 236,
+    "rookie_bonus": 0,
+    "team_key": "frc2620"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 14,
+        "total": 21
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 15,
+        "total": 31
+      }
+    ],
+    "point_total": 52,
+    "rank": 237,
+    "rookie_bonus": 0,
+    "team_key": "frc6081"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimil",
+        "qual_points": 10,
+        "total": 32
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 9,
+        "total": 19
+      }
+    ],
+    "point_total": 51,
+    "rank": 238,
+    "rookie_bonus": 0,
+    "team_key": "frc308"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miber",
+        "qual_points": 11,
+        "total": 26
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 14,
+        "total": 25
+      }
+    ],
+    "point_total": 51,
+    "rank": 239,
+    "rookie_bonus": 0,
+    "team_key": "frc6548"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimil",
+        "qual_points": 13,
+        "total": 29
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 15,
+        "total": 22
+      }
+    ],
+    "point_total": 51,
+    "rank": 240,
+    "rookie_bonus": 0,
+    "team_key": "frc7660"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 15,
+        "total": 23
+      }
+    ],
+    "point_total": 51,
+    "rank": 241,
+    "rookie_bonus": 0,
+    "team_key": "frc7553"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 14,
+        "total": 22
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 51,
+    "rank": 242,
+    "rookie_bonus": 0,
+    "team_key": "frc7178"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miliv",
+        "qual_points": 10,
+        "total": 41
+      }
+    ],
+    "point_total": 50,
+    "rank": 243,
+    "rookie_bonus": 0,
+    "team_key": "frc8115"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026miwmi",
+        "qual_points": 10,
+        "total": 41
+      }
+    ],
+    "point_total": 50,
+    "rank": 244,
+    "rookie_bonus": 0,
+    "team_key": "frc5623"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 14,
+        "total": 21
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 24,
+        "event_key": "2026mibat",
+        "qual_points": 4,
+        "total": 29
+      }
+    ],
+    "point_total": 50,
+    "rank": 245,
+    "rookie_bonus": 0,
+    "team_key": "frc5538"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026milsu",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 11,
+        "total": 17
+      }
+    ],
+    "point_total": 50,
+    "rank": 246,
+    "rookie_bonus": 0,
+    "team_key": "frc4375"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitvc",
+        "qual_points": 13,
+        "total": 34
+      }
+    ],
+    "point_total": 50,
+    "rank": 247,
+    "rookie_bonus": 5,
+    "team_key": "frc10614"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miber",
+        "qual_points": 14,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 5,
+        "total": 10
+      }
+    ],
+    "point_total": 50,
+    "rank": 248,
+    "rookie_bonus": 0,
+    "team_key": "frc9758"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 50,
+    "rank": 249,
+    "rookie_bonus": 0,
+    "team_key": "frc6033"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 50,
+    "rank": 250,
+    "rookie_bonus": 10,
+    "team_key": "frc11460"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 50,
+    "rank": 251,
+    "rookie_bonus": 10,
+    "team_key": "frc11455"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 6,
+        "total": 20
+      }
+    ],
+    "point_total": 49,
+    "rank": 252,
+    "rookie_bonus": 0,
+    "team_key": "frc7762"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 49,
+    "rank": 253,
+    "rookie_bonus": 0,
+    "team_key": "frc6861"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 13,
+        "total": 20
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 49,
+    "rank": 254,
+    "rookie_bonus": 5,
+    "team_key": "frc10690"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 11,
+        "total": 26
+      }
+    ],
+    "point_total": 49,
+    "rank": 255,
+    "rookie_bonus": 10,
+    "team_key": "frc11437"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mimtp",
+        "qual_points": 9,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 48,
+    "rank": 256,
+    "rookie_bonus": 0,
+    "team_key": "frc5234"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibkn",
+        "qual_points": 5,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 48,
+    "rank": 257,
+    "rookie_bonus": 0,
+    "team_key": "frc3773"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026milac",
+        "qual_points": 9,
+        "total": 40
+      }
+    ],
+    "point_total": 48,
+    "rank": 258,
+    "rookie_bonus": 0,
+    "team_key": "frc9650"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibro",
+        "qual_points": 12,
+        "total": 22
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miliv",
+        "qual_points": 12,
+        "total": 26
+      }
+    ],
+    "point_total": 48,
+    "rank": 259,
+    "rookie_bonus": 0,
+    "team_key": "frc6914"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimtp",
+        "qual_points": 10,
+        "total": 24
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimid",
+        "qual_points": 14,
+        "total": 24
+      }
+    ],
+    "point_total": 48,
+    "rank": 260,
+    "rookie_bonus": 0,
+    "team_key": "frc9661"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimtp",
+        "qual_points": 17,
+        "total": 34
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 48,
+    "rank": 261,
+    "rookie_bonus": 0,
+    "team_key": "frc9773"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 11,
+        "total": 25
+      }
+    ],
+    "point_total": 48,
+    "rank": 262,
+    "rookie_bonus": 0,
+    "team_key": "frc5509"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 15,
+        "total": 25
+      }
+    ],
+    "point_total": 48,
+    "rank": 263,
+    "rookie_bonus": 10,
+    "team_key": "frc11496"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 16,
+        "total": 16
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mibig",
+        "qual_points": 5,
+        "total": 31
+      }
+    ],
+    "point_total": 47,
+    "rank": 264,
+    "rookie_bonus": 0,
+    "team_key": "frc8286"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mitr2",
+        "qual_points": 13,
+        "total": 36
+      }
+    ],
+    "point_total": 47,
+    "rank": 265,
+    "rookie_bonus": 0,
+    "team_key": "frc2591"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026midtr",
+        "qual_points": 5,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 46,
+    "rank": 266,
+    "rookie_bonus": 0,
+    "team_key": "frc5478"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimus",
+        "qual_points": 4,
+        "total": 26
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 12,
+        "total": 20
+      }
+    ],
+    "point_total": 46,
+    "rank": 267,
+    "rookie_bonus": 0,
+    "team_key": "frc107"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 11,
+        "total": 16
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibig",
+        "qual_points": 10,
+        "total": 30
+      }
+    ],
+    "point_total": 46,
+    "rank": 268,
+    "rookie_bonus": 0,
+    "team_key": "frc6642"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mimus",
+        "qual_points": 8,
+        "total": 22
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 46,
+    "rank": 269,
+    "rookie_bonus": 0,
+    "team_key": "frc9756"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miwmi",
+        "qual_points": 11,
+        "total": 24
+      }
+    ],
+    "point_total": 46,
+    "rank": 270,
+    "rookie_bonus": 0,
+    "team_key": "frc6877"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 12,
+        "total": 22
+      }
+    ],
+    "point_total": 46,
+    "rank": 271,
+    "rookie_bonus": 0,
+    "team_key": "frc9674"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 13,
+        "total": 19
+      }
+    ],
+    "point_total": 46,
+    "rank": 272,
+    "rookie_bonus": 0,
+    "team_key": "frc8426"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 16,
+        "total": 27
+      }
+    ],
+    "point_total": 46,
+    "rank": 273,
+    "rookie_bonus": 5,
+    "team_key": "frc10667"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 17,
+        "total": 33
+      }
+    ],
+    "point_total": 46,
+    "rank": 274,
+    "rookie_bonus": 0,
+    "team_key": "frc5612"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 12,
+        "total": 19
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 45,
+    "rank": 275,
+    "rookie_bonus": 0,
+    "team_key": "frc7814"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 13,
+        "total": 23
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 15,
+        "total": 22
+      }
+    ],
+    "point_total": 45,
+    "rank": 276,
+    "rookie_bonus": 0,
+    "team_key": "frc1596"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 15,
+        "total": 30
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 8,
+        "total": 15
+      }
+    ],
+    "point_total": 45,
+    "rank": 277,
+    "rookie_bonus": 0,
+    "team_key": "frc9566"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 11,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 45,
+    "rank": 278,
+    "rookie_bonus": 10,
+    "team_key": "frc11431"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 8,
+        "total": 10
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miliv",
+        "qual_points": 12,
+        "total": 34
+      }
+    ],
+    "point_total": 44,
+    "rank": 279,
+    "rookie_bonus": 0,
+    "team_key": "frc5050"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milsu",
+        "qual_points": 10,
+        "total": 18
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miesc",
+        "qual_points": 11,
+        "total": 26
+      }
+    ],
+    "point_total": 44,
+    "rank": 280,
+    "rookie_bonus": 0,
+    "team_key": "frc5486"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miche",
+        "qual_points": 6,
+        "total": 29
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 11,
+        "total": 15
+      }
+    ],
+    "point_total": 44,
+    "rank": 281,
+    "rookie_bonus": 0,
+    "team_key": "frc5530"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 9,
+        "total": 18
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 14,
+        "total": 26
+      }
+    ],
+    "point_total": 44,
+    "rank": 282,
+    "rookie_bonus": 0,
+    "team_key": "frc1250"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 44,
+    "rank": 283,
+    "rookie_bonus": 10,
+    "team_key": "frc11399"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mibig",
+        "qual_points": 7,
+        "total": 38
+      }
+    ],
+    "point_total": 43,
+    "rank": 284,
+    "rookie_bonus": 0,
+    "team_key": "frc5213"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibat",
+        "qual_points": 13,
+        "total": 28
+      }
+    ],
+    "point_total": 43,
+    "rank": 285,
+    "rookie_bonus": 10,
+    "team_key": "frc11511"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 12,
+        "total": 18
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 15,
+        "total": 25
+      }
+    ],
+    "point_total": 43,
+    "rank": 286,
+    "rookie_bonus": 0,
+    "team_key": "frc5674"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 15,
+        "total": 20
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 43,
+    "rank": 287,
+    "rookie_bonus": 0,
+    "team_key": "frc9548"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 12,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 12,
+        "total": 17
+      }
+    ],
+    "point_total": 43,
+    "rank": 288,
+    "rookie_bonus": 0,
+    "team_key": "frc2048"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 6,
+        "total": 17
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 15,
+        "total": 25
+      }
+    ],
+    "point_total": 42,
+    "rank": 289,
+    "rookie_bonus": 0,
+    "team_key": "frc7155"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 12,
+        "total": 19
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 42,
+    "rank": 290,
+    "rookie_bonus": 0,
+    "team_key": "frc8423"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 12,
+        "total": 16
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 15,
+        "total": 26
+      }
+    ],
+    "point_total": 42,
+    "rank": 291,
+    "rookie_bonus": 0,
+    "team_key": "frc5860"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 13,
+        "total": 17
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 16,
+        "total": 25
+      }
+    ],
+    "point_total": 42,
+    "rank": 292,
+    "rookie_bonus": 0,
+    "team_key": "frc6963"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 16,
+        "total": 25
+      }
+    ],
+    "point_total": 42,
+    "rank": 293,
+    "rookie_bonus": 10,
+    "team_key": "frc11462"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 14,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 42,
+    "rank": 294,
+    "rookie_bonus": 10,
+    "team_key": "frc11423"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 11,
+        "total": 19
+      }
+    ],
+    "point_total": 42,
+    "rank": 295,
+    "rookie_bonus": 10,
+    "team_key": "frc11486"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mimar",
+        "qual_points": 7,
+        "total": 23
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 12,
+        "total": 18
+      }
+    ],
+    "point_total": 41,
+    "rank": 296,
+    "rookie_bonus": 0,
+    "team_key": "frc9558"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mifen",
+        "qual_points": 13,
+        "total": 29
+      }
+    ],
+    "point_total": 41,
+    "rank": 297,
+    "rookie_bonus": 0,
+    "team_key": "frc5084"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miesc",
+        "qual_points": 12,
+        "total": 24
+      }
+    ],
+    "point_total": 41,
+    "rank": 298,
+    "rookie_bonus": 0,
+    "team_key": "frc9249"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 9,
+        "total": 19
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 41,
+    "rank": 299,
+    "rookie_bonus": 0,
+    "team_key": "frc2145"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 11,
+        "total": 16
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 14,
+        "total": 25
+      }
+    ],
+    "point_total": 41,
+    "rank": 300,
+    "rookie_bonus": 0,
+    "team_key": "frc7226"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 10,
+        "total": 18
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 41,
+    "rank": 301,
+    "rookie_bonus": 10,
+    "team_key": "frc11466"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 9,
+        "total": 11
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibat",
+        "qual_points": 7,
+        "total": 24
+      }
+    ],
+    "point_total": 40,
+    "rank": 302,
+    "rookie_bonus": 5,
+    "team_key": "frc10654"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mifen",
+        "qual_points": 11,
+        "total": 27
+      }
+    ],
+    "point_total": 40,
+    "rank": 303,
+    "rookie_bonus": 0,
+    "team_key": "frc9207"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 14,
+        "total": 20
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 12,
+        "total": 20
+      }
+    ],
+    "point_total": 40,
+    "rank": 304,
+    "rookie_bonus": 0,
+    "team_key": "frc3658"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 16,
+        "total": 34
+      }
+    ],
+    "point_total": 40,
+    "rank": 305,
+    "rookie_bonus": 0,
+    "team_key": "frc8041"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 10,
+        "total": 23
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 12,
+        "total": 17
+      }
+    ],
+    "point_total": 40,
+    "rank": 306,
+    "rookie_bonus": 0,
+    "team_key": "frc5927"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 11,
+        "total": 20
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 13,
+        "total": 20
+      }
+    ],
+    "point_total": 40,
+    "rank": 307,
+    "rookie_bonus": 0,
+    "team_key": "frc6569"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 15,
+        "total": 29
+      }
+    ],
+    "point_total": 40,
+    "rank": 308,
+    "rookie_bonus": 0,
+    "team_key": "frc6078"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 14,
+        "total": 27
+      }
+    ],
+    "point_total": 40,
+    "rank": 309,
+    "rookie_bonus": 0,
+    "team_key": "frc66"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 12,
+        "total": 20
+      }
+    ],
+    "point_total": 40,
+    "rank": 310,
+    "rookie_bonus": 10,
+    "team_key": "frc11522"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibro",
+        "qual_points": 6,
+        "total": 23
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 10,
+        "total": 16
+      }
+    ],
+    "point_total": 39,
+    "rank": 311,
+    "rookie_bonus": 0,
+    "team_key": "frc9226"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mitr2",
+        "qual_points": 7,
+        "total": 30
+      }
+    ],
+    "point_total": 39,
+    "rank": 312,
+    "rookie_bonus": 0,
+    "team_key": "frc6616"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 39,
+    "rank": 313,
+    "rookie_bonus": 0,
+    "team_key": "frc9743"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 16,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 9,
+        "total": 14
+      }
+    ],
+    "point_total": 39,
+    "rank": 314,
+    "rookie_bonus": 0,
+    "team_key": "frc4216"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 9,
+        "total": 17
+      }
+    ],
+    "point_total": 39,
+    "rank": 315,
+    "rookie_bonus": 10,
+    "team_key": "frc11361"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mifli",
+        "qual_points": 7,
+        "total": 30
+      }
+    ],
+    "point_total": 38,
+    "rank": 316,
+    "rookie_bonus": 0,
+    "team_key": "frc9648"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026miliv",
+        "qual_points": 9,
+        "total": 25
+      }
+    ],
+    "point_total": 38,
+    "rank": 317,
+    "rookie_bonus": 0,
+    "team_key": "frc830"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026milac",
+        "qual_points": 7,
+        "total": 14
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 38,
+    "rank": 318,
+    "rookie_bonus": 0,
+    "team_key": "frc7855"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitry",
+        "qual_points": 11,
+        "total": 22
+      }
+    ],
+    "point_total": 38,
+    "rank": 319,
+    "rookie_bonus": 5,
+    "team_key": "frc10652"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 17,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 38,
+    "rank": 320,
+    "rookie_bonus": 0,
+    "team_key": "frc5697"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 38,
+    "rank": 321,
+    "rookie_bonus": 0,
+    "team_key": "frc453"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 14,
+        "total": 24
+      }
+    ],
+    "point_total": 38,
+    "rank": 322,
+    "rookie_bonus": 0,
+    "team_key": "frc6087"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 11,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 38,
+    "rank": 323,
+    "rookie_bonus": 0,
+    "team_key": "frc7248"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 10,
+        "total": 18
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 38,
+    "rank": 324,
+    "rookie_bonus": 10,
+    "team_key": "frc11457"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 8,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 38,
+    "rank": 325,
+    "rookie_bonus": 10,
+    "team_key": "frc11444"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mifli",
+        "qual_points": 7,
+        "total": 30
+      }
+    ],
+    "point_total": 37,
+    "rank": 326,
+    "rookie_bonus": 0,
+    "team_key": "frc5235"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 37,
+    "rank": 327,
+    "rookie_bonus": 0,
+    "team_key": "frc5314"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 11,
+        "total": 19
+      }
+    ],
+    "point_total": 37,
+    "rank": 328,
+    "rookie_bonus": 10,
+    "team_key": "frc11527"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 8,
+        "total": 16
+      }
+    ],
+    "point_total": 37,
+    "rank": 329,
+    "rookie_bonus": 10,
+    "team_key": "frc11435"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mibel",
+        "qual_points": 11,
+        "total": 23
+      }
+    ],
+    "point_total": 36,
+    "rank": 330,
+    "rookie_bonus": 0,
+    "team_key": "frc5498"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026misal",
+        "qual_points": 12,
+        "total": 23
+      }
+    ],
+    "point_total": 36,
+    "rank": 331,
+    "rookie_bonus": 0,
+    "team_key": "frc5090"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 4,
+        "event_key": "2026misal",
+        "qual_points": 13,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 14,
+        "total": 19
+      }
+    ],
+    "point_total": 36,
+    "rank": 332,
+    "rookie_bonus": 0,
+    "team_key": "frc8297"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 13,
+        "total": 19
+      }
+    ],
+    "point_total": 36,
+    "rank": 333,
+    "rookie_bonus": 5,
+    "team_key": "frc10547"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mitvc",
+        "qual_points": 7,
+        "total": 16
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 12,
+        "total": 19
+      }
+    ],
+    "point_total": 35,
+    "rank": 334,
+    "rookie_bonus": 0,
+    "team_key": "frc6122"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 8,
+        "total": 17
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 11,
+        "total": 18
+      }
+    ],
+    "point_total": 35,
+    "rank": 335,
+    "rookie_bonus": 0,
+    "team_key": "frc5150"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 12,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 35,
+    "rank": 336,
+    "rookie_bonus": 0,
+    "team_key": "frc6096"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 35,
+    "rank": 337,
+    "rookie_bonus": 0,
+    "team_key": "frc8385"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 35,
+    "rank": 338,
+    "rookie_bonus": 0,
+    "team_key": "frc7784"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 14,
+        "total": 28
+      }
+    ],
+    "point_total": 35,
+    "rank": 339,
+    "rookie_bonus": 0,
+    "team_key": "frc5205"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 15,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 7,
+        "total": 12
+      }
+    ],
+    "point_total": 35,
+    "rank": 340,
+    "rookie_bonus": 0,
+    "team_key": "frc7772"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 13,
+        "total": 19
+      }
+    ],
+    "point_total": 35,
+    "rank": 341,
+    "rookie_bonus": 5,
+    "team_key": "frc10665"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 12,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 8,
+        "total": 13
+      }
+    ],
+    "point_total": 35,
+    "rank": 342,
+    "rookie_bonus": 0,
+    "team_key": "frc4998"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026miber",
+        "qual_points": 4,
+        "total": 28
+      }
+    ],
+    "point_total": 34,
+    "rank": 343,
+    "rookie_bonus": 0,
+    "team_key": "frc9182"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mimas",
+        "qual_points": 8,
+        "total": 29
+      }
+    ],
+    "point_total": 34,
+    "rank": 344,
+    "rookie_bonus": 0,
+    "team_key": "frc8374"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibkn",
+        "qual_points": 10,
+        "total": 25
+      }
+    ],
+    "point_total": 34,
+    "rank": 345,
+    "rookie_bonus": 0,
+    "team_key": "frc8300"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 34,
+    "rank": 346,
+    "rookie_bonus": 0,
+    "team_key": "frc6566"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 34,
+    "rank": 347,
+    "rookie_bonus": 0,
+    "team_key": "frc9204"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 34,
+    "rank": 348,
+    "rookie_bonus": 0,
+    "team_key": "frc9751"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 33,
+    "rank": 349,
+    "rookie_bonus": 0,
+    "team_key": "frc9205"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 33,
+    "rank": 350,
+    "rookie_bonus": 0,
+    "team_key": "frc5182"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 14,
+        "total": 17
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 33,
+    "rank": 351,
+    "rookie_bonus": 0,
+    "team_key": "frc240"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 33,
+    "rank": 352,
+    "rookie_bonus": 10,
+    "team_key": "frc11505"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 8,
+        "total": 13
+      }
+    ],
+    "point_total": 33,
+    "rank": 353,
+    "rookie_bonus": 5,
+    "team_key": "frc10605"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 10,
+        "event_key": "2026miber",
+        "qual_points": 13,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 32,
+    "rank": 354,
+    "rookie_bonus": 0,
+    "team_key": "frc6588"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026midtr",
+        "qual_points": 11,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 32,
+    "rank": 355,
+    "rookie_bonus": 0,
+    "team_key": "frc9651"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mifli",
+        "qual_points": 11,
+        "total": 27
+      }
+    ],
+    "point_total": 32,
+    "rank": 356,
+    "rookie_bonus": 0,
+    "team_key": "frc5167"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 14,
+        "total": 24
+      }
+    ],
+    "point_total": 32,
+    "rank": 357,
+    "rookie_bonus": 0,
+    "team_key": "frc8611"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 8,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 6,
+        "total": 11
+      }
+    ],
+    "point_total": 32,
+    "rank": 358,
+    "rookie_bonus": 5,
+    "team_key": "frc10656"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 8,
+        "total": 16
+      }
+    ],
+    "point_total": 32,
+    "rank": 359,
+    "rookie_bonus": 10,
+    "team_key": "frc11461"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mibel",
+        "qual_points": 7,
+        "total": 21
+      }
+    ],
+    "point_total": 31,
+    "rank": 360,
+    "rookie_bonus": 0,
+    "team_key": "frc6618"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 8,
+        "total": 17
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 10,
+        "total": 14
+      }
+    ],
+    "point_total": 31,
+    "rank": 361,
+    "rookie_bonus": 0,
+    "team_key": "frc4325"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 16,
+        "total": 27
+      }
+    ],
+    "point_total": 31,
+    "rank": 362,
+    "rookie_bonus": 0,
+    "team_key": "frc8832"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 13,
+        "total": 22
+      }
+    ],
+    "point_total": 31,
+    "rank": 363,
+    "rookie_bonus": 0,
+    "team_key": "frc815"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 16,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 31,
+    "rank": 364,
+    "rookie_bonus": 0,
+    "team_key": "frc3096"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 15,
+        "total": 23
+      }
+    ],
+    "point_total": 31,
+    "rank": 365,
+    "rookie_bonus": 0,
+    "team_key": "frc6005"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 31,
+    "rank": 366,
+    "rookie_bonus": 0,
+    "team_key": "frc5695"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 9,
+        "total": 14
+      }
+    ],
+    "point_total": 31,
+    "rank": 367,
+    "rookie_bonus": 5,
+    "team_key": "frc10606"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 15,
+        "total": 18
+      }
+    ],
+    "point_total": 31,
+    "rank": 368,
+    "rookie_bonus": 0,
+    "team_key": "frc7109"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 10,
+        "total": 18
+      }
+    ],
+    "point_total": 31,
+    "rank": 369,
+    "rookie_bonus": 5,
+    "team_key": "frc10607"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 8,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 31,
+    "rank": 370,
+    "rookie_bonus": 10,
+    "team_key": "frc11407"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026miken",
+        "qual_points": 9,
+        "total": 19
+      }
+    ],
+    "point_total": 30,
+    "rank": 371,
+    "rookie_bonus": 0,
+    "team_key": "frc9671"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 10,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 30,
+    "rank": 372,
+    "rookie_bonus": 0,
+    "team_key": "frc8124"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 30,
+    "rank": 373,
+    "rookie_bonus": 0,
+    "team_key": "frc6344"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 30,
+    "rank": 374,
+    "rookie_bonus": 10,
+    "team_key": "frc11473"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 7,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 8,
+        "total": 13
+      }
+    ],
+    "point_total": 30,
+    "rank": 375,
+    "rookie_bonus": 5,
+    "team_key": "frc10285"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 5,
+        "total": 11
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 12,
+        "total": 18
+      }
+    ],
+    "point_total": 29,
+    "rank": 376,
+    "rookie_bonus": 0,
+    "team_key": "frc4776"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 14,
+        "total": 25
+      }
+    ],
+    "point_total": 29,
+    "rank": 377,
+    "rookie_bonus": 0,
+    "team_key": "frc5053"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 29,
+    "rank": 378,
+    "rookie_bonus": 0,
+    "team_key": "frc7809"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 16,
+        "total": 25
+      }
+    ],
+    "point_total": 29,
+    "rank": 379,
+    "rookie_bonus": 0,
+    "team_key": "frc7147"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 10,
+        "total": 19
+      }
+    ],
+    "point_total": 29,
+    "rank": 380,
+    "rookie_bonus": 0,
+    "team_key": "frc9237"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 12,
+        "total": 19
+      }
+    ],
+    "point_total": 29,
+    "rank": 381,
+    "rookie_bonus": 0,
+    "team_key": "frc6029"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 14,
+        "total": 19
+      }
+    ],
+    "point_total": 29,
+    "rank": 382,
+    "rookie_bonus": 0,
+    "team_key": "frc5527"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 10,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 5,
+        "total": 10
+      }
+    ],
+    "point_total": 29,
+    "rank": 383,
+    "rookie_bonus": 0,
+    "team_key": "frc6073"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 29,
+    "rank": 384,
+    "rookie_bonus": 10,
+    "team_key": "frc11491"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 13,
+        "total": 18
+      }
+    ],
+    "point_total": 29,
+    "rank": 385,
+    "rookie_bonus": 5,
+    "team_key": "frc10595"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 7,
+        "total": 12
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 10,
+        "total": 16
+      }
+    ],
+    "point_total": 28,
+    "rank": 386,
+    "rookie_bonus": 0,
+    "team_key": "frc5227"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 6,
+        "total": 11
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 13,
+        "total": 17
+      }
+    ],
+    "point_total": 28,
+    "rank": 387,
+    "rookie_bonus": 0,
+    "team_key": "frc4405"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 13,
+        "total": 22
+      }
+    ],
+    "point_total": 28,
+    "rank": 388,
+    "rookie_bonus": 0,
+    "team_key": "frc9176"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 8,
+        "total": 16
+      }
+    ],
+    "point_total": 28,
+    "rank": 389,
+    "rookie_bonus": 0,
+    "team_key": "frc4377"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 9,
+        "total": 14
+      }
+    ],
+    "point_total": 28,
+    "rank": 390,
+    "rookie_bonus": 0,
+    "team_key": "frc4835"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 28,
+    "rank": 391,
+    "rookie_bonus": 10,
+    "team_key": "frc11440"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 13,
+        "total": 21
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 27,
+    "rank": 392,
+    "rookie_bonus": 0,
+    "team_key": "frc7210"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 13,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 27,
+    "rank": 393,
+    "rookie_bonus": 0,
+    "team_key": "frc7865"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 13,
+        "total": 18
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 27,
+    "rank": 394,
+    "rookie_bonus": 0,
+    "team_key": "frc3619"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 10,
+        "total": 15
+      }
+    ],
+    "point_total": 27,
+    "rank": 395,
+    "rookie_bonus": 0,
+    "team_key": "frc9542"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 7,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 7,
+        "total": 15
+      }
+    ],
+    "point_total": 27,
+    "rank": 396,
+    "rookie_bonus": 0,
+    "team_key": "frc2604"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 26,
+    "rank": 397,
+    "rookie_bonus": 0,
+    "team_key": "frc5560"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 9,
+        "total": 20
+      }
+    ],
+    "point_total": 26,
+    "rank": 398,
+    "rookie_bonus": 0,
+    "team_key": "frc9638"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 26,
+    "rank": 399,
+    "rookie_bonus": 0,
+    "team_key": "frc9183"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 26,
+    "rank": 400,
+    "rookie_bonus": 5,
+    "team_key": "frc10672"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 26,
+    "rank": 401,
+    "rookie_bonus": 0,
+    "team_key": "frc7247"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 26,
+    "rank": 402,
+    "rookie_bonus": 5,
+    "team_key": "frc10587"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 11,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 25,
+    "rank": 403,
+    "rookie_bonus": 0,
+    "team_key": "frc3425"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 14,
+        "total": 20
+      }
+    ],
+    "point_total": 25,
+    "rank": 404,
+    "rookie_bonus": 0,
+    "team_key": "frc4737"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 12,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 25,
+    "rank": 405,
+    "rookie_bonus": 0,
+    "team_key": "frc5641"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 25,
+    "rank": 406,
+    "rookie_bonus": 0,
+    "team_key": "frc7289"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 25,
+    "rank": 407,
+    "rookie_bonus": 0,
+    "team_key": "frc9697"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 9,
+        "total": 14
+      }
+    ],
+    "point_total": 25,
+    "rank": 408,
+    "rookie_bonus": 0,
+    "team_key": "frc3098"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 24,
+    "rank": 409,
+    "rookie_bonus": 0,
+    "team_key": "frc4390"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 8,
+        "total": 12
+      }
+    ],
+    "point_total": 24,
+    "rank": 410,
+    "rookie_bonus": 0,
+    "team_key": "frc5610"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 12,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 24,
+    "rank": 411,
+    "rookie_bonus": 0,
+    "team_key": "frc5547"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 24,
+    "rank": 412,
+    "rookie_bonus": 0,
+    "team_key": "frc4961"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 24,
+    "rank": 413,
+    "rookie_bonus": 0,
+    "team_key": "frc7713"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 24,
+    "rank": 414,
+    "rookie_bonus": 0,
+    "team_key": "frc9747"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 24,
+    "rank": 415,
+    "rookie_bonus": 0,
+    "team_key": "frc9594"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 24,
+    "rank": 416,
+    "rookie_bonus": 0,
+    "team_key": "frc5197"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 24,
+    "rank": 417,
+    "rookie_bonus": 0,
+    "team_key": "frc4851"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 24,
+    "rank": 418,
+    "rookie_bonus": 0,
+    "team_key": "frc6610"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 6,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 24,
+    "rank": 419,
+    "rookie_bonus": 0,
+    "team_key": "frc9568"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 8,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 23,
+    "rank": 420,
+    "rookie_bonus": 0,
+    "team_key": "frc9703"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 23,
+    "rank": 421,
+    "rookie_bonus": 0,
+    "team_key": "frc7808"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 15,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 23,
+    "rank": 422,
+    "rookie_bonus": 0,
+    "team_key": "frc6532"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 23,
+    "rank": 423,
+    "rookie_bonus": 0,
+    "team_key": "frc9455"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 22,
+    "rank": 424,
+    "rookie_bonus": 0,
+    "team_key": "frc8427"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 22,
+    "rank": 425,
+    "rookie_bonus": 0,
+    "team_key": "frc5263"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 22,
+    "rank": 426,
+    "rookie_bonus": 0,
+    "team_key": "frc8285"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 22,
+    "rank": 427,
+    "rookie_bonus": 5,
+    "team_key": "frc10664"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 22,
+    "rank": 428,
+    "rookie_bonus": 0,
+    "team_key": "frc3234"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 11,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 22,
+    "rank": 429,
+    "rookie_bonus": 0,
+    "team_key": "frc1"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 8,
+        "total": 13
+      }
+    ],
+    "point_total": 21,
+    "rank": 430,
+    "rookie_bonus": 0,
+    "team_key": "frc7225"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 21,
+    "rank": 431,
+    "rookie_bonus": 0,
+    "team_key": "frc9239"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 21,
+    "rank": 432,
+    "rookie_bonus": 0,
+    "team_key": "frc7794"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 21,
+    "rank": 433,
+    "rookie_bonus": 0,
+    "team_key": "frc6091"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 21,
+    "rank": 434,
+    "rookie_bonus": 0,
+    "team_key": "frc7810"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 21,
+    "rank": 435,
+    "rookie_bonus": 0,
+    "team_key": "frc5256"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 21,
+    "rank": 436,
+    "rookie_bonus": 0,
+    "team_key": "frc5247"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 10,
+        "total": 15
+      }
+    ],
+    "point_total": 21,
+    "rank": 437,
+    "rookie_bonus": 0,
+    "team_key": "frc5704"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 9,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 21,
+    "rank": 438,
+    "rookie_bonus": 0,
+    "team_key": "frc6428"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 9,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 20,
+    "rank": 439,
+    "rookie_bonus": 0,
+    "team_key": "frc6098"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 20,
+    "rank": 440,
+    "rookie_bonus": 0,
+    "team_key": "frc8364"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 20,
+    "rank": 441,
+    "rookie_bonus": 0,
+    "team_key": "frc9759"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 20,
+    "rank": 442,
+    "rookie_bonus": 0,
+    "team_key": "frc5470"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 20,
+    "rank": 443,
+    "rookie_bonus": 0,
+    "team_key": "frc9212"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 20,
+    "rank": 444,
+    "rookie_bonus": 0,
+    "team_key": "frc9736"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 20,
+    "rank": 445,
+    "rookie_bonus": 0,
+    "team_key": "frc314"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 20,
+    "rank": 446,
+    "rookie_bonus": 0,
+    "team_key": "frc9238"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 20,
+    "rank": 447,
+    "rookie_bonus": 0,
+    "team_key": "frc9148"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 20,
+    "rank": 448,
+    "rookie_bonus": 0,
+    "team_key": "frc5525"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 20,
+    "rank": 449,
+    "rookie_bonus": 0,
+    "team_key": "frc5517"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 20,
+    "rank": 450,
+    "rookie_bonus": 0,
+    "team_key": "frc5642"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 10,
+        "total": 15
+      }
+    ],
+    "point_total": 20,
+    "rank": 451,
+    "rookie_bonus": 0,
+    "team_key": "frc4395"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 7,
+        "total": 12
+      }
+    ],
+    "point_total": 20,
+    "rank": 452,
+    "rookie_bonus": 0,
+    "team_key": "frc9549"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 6,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 20,
+    "rank": 453,
+    "rookie_bonus": 0,
+    "team_key": "frc5282"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 20,
+    "rank": 454,
+    "rookie_bonus": 0,
+    "team_key": "frc6057"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milac",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 20,
+    "rank": 455,
+    "rookie_bonus": 0,
+    "team_key": "frc3537"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 19,
+    "rank": 456,
+    "rookie_bonus": 0,
+    "team_key": "frc4827"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 19,
+    "rank": 457,
+    "rookie_bonus": 0,
+    "team_key": "frc5065"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 19,
+    "rank": 458,
+    "rookie_bonus": 0,
+    "team_key": "frc6094"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 19,
+    "rank": 459,
+    "rookie_bonus": 0,
+    "team_key": "frc9754"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 19,
+    "rank": 460,
+    "rookie_bonus": 0,
+    "team_key": "frc5162"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 19,
+    "rank": 461,
+    "rookie_bonus": 0,
+    "team_key": "frc6591"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 19,
+    "rank": 462,
+    "rookie_bonus": 0,
+    "team_key": "frc4758"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 19,
+    "rank": 463,
+    "rookie_bonus": 0,
+    "team_key": "frc6067"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 5,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 19,
+    "rank": 464,
+    "rookie_bonus": 5,
+    "team_key": "frc10629"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 18,
+    "rank": 465,
+    "rookie_bonus": 0,
+    "team_key": "frc4768"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 18,
+    "rank": 466,
+    "rookie_bonus": 0,
+    "team_key": "frc5878"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimil",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 18,
+    "rank": 467,
+    "rookie_bonus": 0,
+    "team_key": "frc3302"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 18,
+    "rank": 468,
+    "rookie_bonus": 0,
+    "team_key": "frc6558"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 18,
+    "rank": 469,
+    "rookie_bonus": 0,
+    "team_key": "frc9682"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 18,
+    "rank": 470,
+    "rookie_bonus": 0,
+    "team_key": "frc4453"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 18,
+    "rank": 471,
+    "rookie_bonus": 0,
+    "team_key": "frc4568"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 18,
+    "rank": 472,
+    "rookie_bonus": 0,
+    "team_key": "frc5183"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 18,
+    "rank": 473,
+    "rookie_bonus": 0,
+    "team_key": "frc9722"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 18,
+    "rank": 474,
+    "rookie_bonus": 0,
+    "team_key": "frc9755"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 18,
+    "rank": 475,
+    "rookie_bonus": 0,
+    "team_key": "frc7597"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 18,
+    "rank": 476,
+    "rookie_bonus": 0,
+    "team_key": "frc9672"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 18,
+    "rank": 477,
+    "rookie_bonus": 0,
+    "team_key": "frc5214"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 18,
+    "rank": 478,
+    "rookie_bonus": 0,
+    "team_key": "frc1528"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 18,
+    "rank": 479,
+    "rookie_bonus": 0,
+    "team_key": "frc9662"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimus",
+        "qual_points": 5,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 18,
+    "rank": 480,
+    "rookie_bonus": 0,
+    "team_key": "frc3458"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 18,
+    "rank": 481,
+    "rookie_bonus": 5,
+    "team_key": "frc10613"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 17,
+    "rank": 482,
+    "rookie_bonus": 0,
+    "team_key": "frc7145"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 17,
+    "rank": 483,
+    "rookie_bonus": 0,
+    "team_key": "frc9528"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 17,
+    "rank": 484,
+    "rookie_bonus": 0,
+    "team_key": "frc7813"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 17,
+    "rank": 485,
+    "rookie_bonus": 0,
+    "team_key": "frc5239"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 17,
+    "rank": 486,
+    "rookie_bonus": 0,
+    "team_key": "frc7221"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 17,
+    "rank": 487,
+    "rookie_bonus": 0,
+    "team_key": "frc8899"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 17,
+    "rank": 488,
+    "rookie_bonus": 0,
+    "team_key": "frc5467"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 17,
+    "rank": 489,
+    "rookie_bonus": 0,
+    "team_key": "frc7658"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 17,
+    "rank": 490,
+    "rookie_bonus": 0,
+    "team_key": "frc7203"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifli",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 17,
+    "rank": 491,
+    "rookie_bonus": 5,
+    "team_key": "frc10659"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 17,
+    "rank": 492,
+    "rookie_bonus": 5,
+    "team_key": "frc10590"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 16,
+    "rank": 493,
+    "rookie_bonus": 0,
+    "team_key": "frc5901"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 16,
+    "rank": 494,
+    "rookie_bonus": 0,
+    "team_key": "frc7911"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 16,
+    "rank": 495,
+    "rookie_bonus": 0,
+    "team_key": "frc9206"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 16,
+    "rank": 496,
+    "rookie_bonus": 0,
+    "team_key": "frc9727"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 16,
+    "rank": 497,
+    "rookie_bonus": 0,
+    "team_key": "frc7256"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 16,
+    "rank": 498,
+    "rookie_bonus": 0,
+    "team_key": "frc4994"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 16,
+    "rank": 499,
+    "rookie_bonus": 0,
+    "team_key": "frc8362"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 16,
+    "rank": 500,
+    "rookie_bonus": 0,
+    "team_key": "frc6190"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 16,
+    "rank": 501,
+    "rookie_bonus": 0,
+    "team_key": "frc6533"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 15,
+    "rank": 502,
+    "rookie_bonus": 0,
+    "team_key": "frc9618"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 15,
+    "rank": 503,
+    "rookie_bonus": 0,
+    "team_key": "frc5225"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 15,
+    "rank": 504,
+    "rookie_bonus": 0,
+    "team_key": "frc1504"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miber",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 15,
+    "rank": 505,
+    "rookie_bonus": 0,
+    "team_key": "frc1940"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitr2",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 15,
+    "rank": 506,
+    "rookie_bonus": 0,
+    "team_key": "frc7716"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibat",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 15,
+    "rank": 507,
+    "rookie_bonus": 0,
+    "team_key": "frc6556"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimar",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitry",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 15,
+    "rank": 508,
+    "rookie_bonus": 0,
+    "team_key": "frc9252"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 15,
+    "rank": 509,
+    "rookie_bonus": 0,
+    "team_key": "frc6112"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miche",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 15,
+    "rank": 510,
+    "rookie_bonus": 0,
+    "team_key": "frc5260"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 15,
+    "rank": 511,
+    "rookie_bonus": 0,
+    "team_key": "frc5706"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 14,
+    "rank": 512,
+    "rookie_bonus": 0,
+    "team_key": "frc7818"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibro",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026misal",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 14,
+    "rank": 513,
+    "rookie_bonus": 0,
+    "team_key": "frc6101"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 14,
+    "rank": 514,
+    "rookie_bonus": 0,
+    "team_key": "frc9733"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 13,
+    "rank": 515,
+    "rookie_bonus": 0,
+    "team_key": "frc5231"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 13,
+    "rank": 516,
+    "rookie_bonus": 0,
+    "team_key": "frc9735"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 12,
+    "rank": 517,
+    "rookie_bonus": 0,
+    "team_key": "frc8623"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 12,
+    "rank": 518,
+    "rookie_bonus": 0,
+    "team_key": "frc5504"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 12,
+    "rank": 519,
+    "rookie_bonus": 0,
+    "team_key": "frc5532"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimid",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 12,
+    "rank": 520,
+    "rookie_bonus": 0,
+    "team_key": "frc9731"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimtp",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mifen",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 11,
+    "rank": 521,
+    "rookie_bonus": 0,
+    "team_key": "frc6071"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibkn",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 11,
+    "rank": 522,
+    "rookie_bonus": 0,
+    "team_key": "frc9753"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miliv",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 10,
+    "rank": 523,
+    "rookie_bonus": 0,
+    "team_key": "frc6099"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milsu",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 9,
+    "rank": 524,
+    "rookie_bonus": 0,
+    "team_key": "frc6113"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miwmi",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibig",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 9,
+    "rank": 525,
+    "rookie_bonus": 0,
+    "team_key": "frc9721"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mibel",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 9,
+    "rank": 526,
+    "rookie_bonus": 0,
+    "team_key": "frc94"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026milak",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mimas",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 9,
+    "rank": 527,
+    "rookie_bonus": 0,
+    "team_key": "frc9203"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mitvc",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miken",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 9,
+    "rank": 528,
+    "rookie_bonus": 0,
+    "team_key": "frc904"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026midtr",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 7,
+    "rank": 529,
+    "rookie_bonus": 0,
+    "team_key": "frc4854"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026miesc",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 6,
+    "rank": 530,
+    "rookie_bonus": 0,
+    "team_key": "frc5702"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [],
+    "point_total": 0,
+    "rank": 531,
+    "rookie_bonus": 0,
+    "team_key": "frc5501"
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026fit_awards.json
+++ b/src/backend/common/helpers/tests/data/2026fit_awards.json
@@ -1,0 +1,3330 @@
+[
+  {
+    "award_type": 0,
+    "event_key": "2026txama",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txama",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6773"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10994"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txama",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10994"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txama",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5411"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txama",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9136"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txama",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3310"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txama",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4192"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txama",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3310"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4206"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txama",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5613"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txama",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6773"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txama",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9080"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txama",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1164"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txama",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3561"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txama",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Myles M",
+        "team_key": "frc6974"
+      },
+      {
+        "awardee": "Cora K",
+        "team_key": "frc6773"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txama",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4063"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txama",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4734"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txama",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7540"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txama",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5866"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txbel",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2881"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txbel",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2468"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc148"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txbel",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11178"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txbel",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8769"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txbel",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9121"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txbel",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2468"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txbel",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1296"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txbel",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1296"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9418"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10014"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txbel",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc624"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txbel",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc148"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txbel",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6672"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txbel",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2687"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txbel",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5103"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txbel",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Eddison S",
+        "team_key": "frc2687"
+      },
+      {
+        "awardee": "Atharv J",
+        "team_key": "frc10014"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txbel",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txbel",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8749"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txbel",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2789"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txbel",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txcl2",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5427"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txcl2",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3847"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3676"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txcl2",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11132"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txcl2",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8576"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txcl2",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3735"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txcl2",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5829"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txcl2",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2587"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txcl2",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2587"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc324"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7616"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txcl2",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7616"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txcl2",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txcl2",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc127"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txcl2",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc324"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txcl2",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9181"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txcl2",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Iris Y",
+        "team_key": "frc2585"
+      },
+      {
+        "awardee": "Chanya M",
+        "team_key": "frc5829"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txcl2",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc231"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txcl2",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txcl2",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9512"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txcl2",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3481"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txcle",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5417"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txcle",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9128"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8370"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txcle",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11277"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txcle",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1477"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txcle",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5261"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txcle",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7312"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txcle",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3847"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txcle",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10340"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3847"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6243"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc127"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txcle",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txcle",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txcle",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9181"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txcle",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7492"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txcle",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc127"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txcle",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Lily M",
+        "team_key": "frc324"
+      },
+      {
+        "awardee": "Emma M",
+        "team_key": "frc5892"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txcle",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10340"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txcle",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6377"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txcle",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7616"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txcle",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txcmp",
+    "name": "District Championship FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1477"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txcmp",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9128"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9140"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txcmp",
+    "name": "District Championship Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11242"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11178"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txcmp",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8088"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2587"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 3,
+    "event_key": "2026txcmp",
+    "name": "Woodie Flowers Finalist Award",
+    "recipient_list": [
+      {
+        "awardee": "Rod Shampine",
+        "team_key": "frc5892"
+      },
+      {
+        "awardee": "Lauren Hamel",
+        "team_key": "frc9418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txcmp",
+    "name": "FIRST Leadership Award Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Rishabh Y",
+        "team_key": "frc7492"
+      },
+      {
+        "awardee": "Jose B",
+        "team_key": "frc1477"
+      },
+      {
+        "awardee": "Kaira B",
+        "team_key": "frc2468"
+      },
+      {
+        "awardee": "Katherine G",
+        "team_key": "frc8114"
+      },
+      {
+        "awardee": "Aadya G",
+        "team_key": "frc6800"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 5,
+    "event_key": "2026txcmp",
+    "name": "Volunteer of the Year",
+    "recipient_list": [
+      {
+        "awardee": "Miranda Rodriguez",
+        "team_key": null
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txcmp",
+    "name": "District Championship Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5414"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txcmp1",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8088"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2587"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txcmp1",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2468"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txcmp1",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3005"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txcmp1",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1296"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txcmp1",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6377"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txcmp1",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10340"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3847"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc624"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txcmp1",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5829"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txcmp1",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txcmp1",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txcmp1",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10014"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txcmp1",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7506"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txcmp1",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10340"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txcmp1",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5892"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txcmp1",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10032"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txcmp2",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9128"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9140"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txcmp2",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9136"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txcmp2",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txcmp2",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc148"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txcmp2",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2158"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txcmp2",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2848"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8749"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txcmp2",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txcmp2",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4192"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txcmp2",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc127"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txcmp2",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6773"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txcmp2",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc231"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txcmp2",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txcmp2",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8749"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txcmp2",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10385"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txdri",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2468"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txdri",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2468"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3035"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txdri",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11224"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txdri",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8507"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txdri",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2158"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txdri",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4219"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txdri",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2687"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txdri",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4639"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2687"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9444"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txdri",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8088"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txdri",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3035"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txdri",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4328"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txdri",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4639"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txdri",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txdri",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Kaira B",
+        "team_key": "frc2468"
+      },
+      {
+        "awardee": "Sophie G",
+        "team_key": "frc3035"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txdri",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6357"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txdri",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10032"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txdri",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10385"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txdri",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9577"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txfar",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9128"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txfar",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10340"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9128"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9492"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txfar",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5431"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txfar",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3282"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txfar",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7506"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txfar",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2582"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txfar",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2848"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6773"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5411"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8816"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txfar",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txfar",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6773"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txfar",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9492"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txfar",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4717"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txfar",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9034"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txfar",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Chloe H",
+        "team_key": "frc5431"
+      },
+      {
+        "awardee": "Colton C",
+        "team_key": "frc1296"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txfar",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10340"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txfar",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8749"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txfar",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5682"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txfar",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1296"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txfor",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1164"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txfor",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2728"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2714"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10032"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txfor",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4206"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txfor",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3676"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txfor",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc148"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txfor",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6672"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txfor",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc148"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3005"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txfor",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7540"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txfor",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2714"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txfor",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txfor",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2728"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txfor",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7503"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txfor",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Aditi G",
+        "team_key": "frc5212"
+      },
+      {
+        "awardee": "Ryan J",
+        "team_key": "frc2714"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txfor",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3005"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txfor",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8858"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txfor",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4076"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txfor",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4192"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txhou",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5414"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txhou",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc624"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11277"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txhou",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11242"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txhou",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8515"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txhou",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5070"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txhou",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txhou",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8177"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txhou",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1255"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8515"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4587"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txhou",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5261"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txhou",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7691"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txhou",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5923"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txhou",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc231"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txhou",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10904"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txhou",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Elizabeth C",
+        "team_key": "frc118"
+      },
+      {
+        "awardee": "Chamika U",
+        "team_key": "frc624"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txhou",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc624"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txhou",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8576"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txhou",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11277"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txhou",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txman",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2583"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txman",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7088"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10913"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txman",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10913"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txman",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6901"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txman",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txman",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9577"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txman",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txman",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc418"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9140"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6901"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txman",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5103"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txman",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9140"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txman",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8573"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txman",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txman",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5892"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txman",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Aadya G",
+        "team_key": "frc6800"
+      },
+      {
+        "awardee": "Ashley X",
+        "team_key": "frc418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txman",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc436"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txman",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6377"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txman",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4076"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txman",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6800"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txmca",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txmca",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc118"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2583"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4597"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txmca",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4332"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txmca",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4295"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txmca",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8818"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txmca",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4063"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txmca",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5829"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10385"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8818"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txmca",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5427"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txmca",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2158"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txmca",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6180"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txmca",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2583"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txmca",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7521"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txmca",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Davin I",
+        "team_key": "frc8573"
+      },
+      {
+        "awardee": "Mark R",
+        "team_key": "frc4063"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txmca",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10118"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txmca",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5829"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txmca",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10385"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txmca",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8573"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txsan",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3481"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txsan",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2582"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11169"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txsan",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11169"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txsan",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3735"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txsan",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3561"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txsan",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc457"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txsan",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txsan",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3035"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5572"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10518"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txsan",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txsan",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2582"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txsan",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4610"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txsan",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4717"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txsan",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9034"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txsan",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Isabella T",
+        "team_key": "frc3481"
+      },
+      {
+        "awardee": "Katherine G",
+        "team_key": "frc8114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txsan",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4219"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txsan",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9136"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txsan",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9419"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txsan",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026txwac",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1477"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026txwac",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2848"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026txwac",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026txwac",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9418"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026txwac",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5866"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026txwac",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4295"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026txwac",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8769"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026txwac",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2881"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10014"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10994"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026txwac",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7492"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026txwac",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3679"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026txwac",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8370"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026txwac",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2848"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026txwac",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10994"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026txwac",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Rishabh Y",
+        "team_key": "frc7492"
+      },
+      {
+        "awardee": "Jose B",
+        "team_key": "frc1477"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026txwac",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6369"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026txwac",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5788"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026txwac",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5613"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026txwac",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2881"
+      }
+    ],
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026fit_district_points.json
+++ b/src/backend/common/helpers/tests/data/2026fit_district_points.json
@@ -1,0 +1,6979 @@
+{
+ "2026txama": {
+  "points": {
+   "frc10312": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 17
+   },
+   "frc10994": {
+    "alliance_points": 1,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 51
+   },
+   "frc11200": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc11469": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc1164": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc2657": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 15
+   },
+   "frc3310": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc3561": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc4063": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc4153": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc4192": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc4206": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 54
+   },
+   "frc4734": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 33
+   },
+   "frc5411": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 29
+   },
+   "frc5613": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   },
+   "frc5866": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 17
+   },
+   "frc6369": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 77
+   },
+   "frc6526": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 33
+   },
+   "frc6768": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc6773": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc6974": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 19
+   },
+   "frc7271": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc7540": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc8512": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc8528": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc8732": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 4,
+    "total": 17
+   },
+   "frc9080": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc9105": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc9136": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 50
+   },
+   "frc9457": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc9492": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 31
+   }
+  },
+  "tiebreakers": {
+   "frc10312": {
+    "highest_match_scores": [
+     311,
+     231,
+     134
+    ],
+    "qual_wins": 0
+   },
+   "frc10994": {
+    "highest_match_scores": [
+     508,
+     468,
+     417
+    ],
+    "qual_wins": 0
+   },
+   "frc11200": {
+    "highest_match_scores": [
+     379,
+     317,
+     307
+    ],
+    "qual_wins": 0
+   },
+   "frc11469": {
+    "highest_match_scores": [
+     278,
+     225,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc1164": {
+    "highest_match_scores": [
+     290,
+     228,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc2657": {
+    "highest_match_scores": [
+     248,
+     192,
+     112
+    ],
+    "qual_wins": 0
+   },
+   "frc3310": {
+    "highest_match_scores": [
+     379,
+     317,
+     307
+    ],
+    "qual_wins": 0
+   },
+   "frc3561": {
+    "highest_match_scores": [
+     353,
+     312,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc4063": {
+    "highest_match_scores": [
+     290,
+     257,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc4153": {
+    "highest_match_scores": [
+     329,
+     203,
+     118
+    ],
+    "qual_wins": 0
+   },
+   "frc4192": {
+    "highest_match_scores": [
+     312,
+     311,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc4206": {
+    "highest_match_scores": [
+     399,
+     379,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc4734": {
+    "highest_match_scores": [
+     353,
+     250,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc5411": {
+    "highest_match_scores": [
+     399,
+     272,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc5613": {
+    "highest_match_scores": [
+     250,
+     221,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc5866": {
+    "highest_match_scores": [
+     219,
+     209,
+     132
+    ],
+    "qual_wins": 0
+   },
+   "frc6369": {
+    "highest_match_scores": [
+     508,
+     468,
+     417
+    ],
+    "qual_wins": 0
+   },
+   "frc6526": {
+    "highest_match_scores": [
+     278,
+     223,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc6768": {
+    "highest_match_scores": [
+     261,
+     257,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc6773": {
+    "highest_match_scores": [
+     508,
+     468,
+     417
+    ],
+    "qual_wins": 0
+   },
+   "frc6974": {
+    "highest_match_scores": [
+     335,
+     271,
+     132
+    ],
+    "qual_wins": 0
+   },
+   "frc7271": {
+    "highest_match_scores": [
+     248,
+     222,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc7540": {
+    "highest_match_scores": [
+     271,
+     259,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc8512": {
+    "highest_match_scores": [
+     266,
+     170,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc8528": {
+    "highest_match_scores": [
+     221,
+     174,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc8732": {
+    "highest_match_scores": [
+     218,
+     140,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc9080": {
+    "highest_match_scores": [
+     223,
+     219,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc9105": {
+    "highest_match_scores": [
+     272,
+     266,
+     132
+    ],
+    "qual_wins": 0
+   },
+   "frc9136": {
+    "highest_match_scores": [
+     335,
+     209,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9457": {
+    "highest_match_scores": [
+     209,
+     200,
+     152
+    ],
+    "qual_wins": 0
+   },
+   "frc9492": {
+    "highest_match_scores": [
+     261,
+     150,
+     140
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txbel": {
+  "points": {
+   "frc10014": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 9,
+    "total": 33
+   },
+   "frc10518": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc11178": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 37
+   },
+   "frc1296": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 56
+   },
+   "frc148": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc2468": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc2687": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 31
+   },
+   "frc2689": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 48
+   },
+   "frc2714": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc2728": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 20
+   },
+   "frc2789": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 33
+   },
+   "frc2881": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 43
+   },
+   "frc3240": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc418": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 35
+   },
+   "frc436": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc4364": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc4610": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 26
+   },
+   "frc5103": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 22
+   },
+   "frc5503": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 5,
+    "total": 36
+   },
+   "frc5986": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6171": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc624": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 51
+   },
+   "frc6526": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6672": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 24
+   },
+   "frc7125": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7271": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc8749": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 35
+   },
+   "frc8769": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc9080": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc9121": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc9418": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 54
+   },
+   "frc9506": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc9786": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   }
+  },
+  "tiebreakers": {
+   "frc10014": {
+    "highest_match_scores": [
+     265,
+     261,
+     232
+    ],
+    "qual_wins": 0
+   },
+   "frc10518": {
+    "highest_match_scores": [
+     176,
+     163,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc11178": {
+    "highest_match_scores": [
+     287,
+     204,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc1296": {
+    "highest_match_scores": [
+     333,
+     261,
+     232
+    ],
+    "qual_wins": 0
+   },
+   "frc148": {
+    "highest_match_scores": [
+     390,
+     386,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc2468": {
+    "highest_match_scores": [
+     390,
+     386,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc2687": {
+    "highest_match_scores": [
+     239,
+     232,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc2689": {
+    "highest_match_scores": [
+     272,
+     250,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc2714": {
+    "highest_match_scores": [
+     350,
+     204,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc2728": {
+    "highest_match_scores": [
+     250,
+     207,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc2789": {
+    "highest_match_scores": [
+     223,
+     193,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc2881": {
+    "highest_match_scores": [
+     272,
+     262,
+     232
+    ],
+    "qual_wins": 0
+   },
+   "frc3240": {
+    "highest_match_scores": [
+     171,
+     158,
+     96
+    ],
+    "qual_wins": 0
+   },
+   "frc418": {
+    "highest_match_scores": [
+     298,
+     262,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc436": {
+    "highest_match_scores": [
+     265,
+     204,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc4364": {
+    "highest_match_scores": [
+     146,
+     140,
+     130
+    ],
+    "qual_wins": 0
+   },
+   "frc4610": {
+    "highest_match_scores": [
+     214,
+     179,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc5103": {
+    "highest_match_scores": [
+     239,
+     158,
+     131
+    ],
+    "qual_wins": 0
+   },
+   "frc5503": {
+    "highest_match_scores": [
+     390,
+     386,
+     335
+    ],
+    "qual_wins": 0
+   },
+   "frc5986": {
+    "highest_match_scores": [
+     223,
+     112,
+     80
+    ],
+    "qual_wins": 0
+   },
+   "frc6171": {
+    "highest_match_scores": [
+     176,
+     167,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc624": {
+    "highest_match_scores": [
+     262,
+     261,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc6526": {
+    "highest_match_scores": [
+     298,
+     172,
+     167
+    ],
+    "qual_wins": 0
+   },
+   "frc6672": {
+    "highest_match_scores": [
+     284,
+     159,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc7125": {
+    "highest_match_scores": [
+     172,
+     129,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc7271": {
+    "highest_match_scores": [
+     284,
+     249,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc8749": {
+    "highest_match_scores": [
+     209,
+     193,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc8769": {
+    "highest_match_scores": [
+     207,
+     203,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc9080": {
+    "highest_match_scores": [
+     192,
+     176,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc9121": {
+    "highest_match_scores": [
+     214,
+     204,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc9418": {
+    "highest_match_scores": [
+     232,
+     203,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc9506": {
+    "highest_match_scores": [
+     287,
+     232,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc9786": {
+    "highest_match_scores": [
+     333,
+     172,
+     105
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txcl2": {
+  "points": {
+   "frc10904": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc11132": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc11242": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 28
+   },
+   "frc118": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc127": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc231": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 31
+   },
+   "frc2585": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc2587": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 59
+   },
+   "frc2882": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   },
+   "frc2969": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc324": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 56
+   },
+   "frc3481": {
+    "alliance_points": 10,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc3676": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 43
+   },
+   "frc3728": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc3735": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 35
+   },
+   "frc3847": {
+    "alliance_points": 16,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 18,
+    "total": 64
+   },
+   "frc457": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc4587": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 21
+   },
+   "frc5070": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5427": {
+    "alliance_points": 13,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 52
+   },
+   "frc5829": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 50
+   },
+   "frc5908": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc5986": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6488": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc7091": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7312": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 22
+   },
+   "frc7616": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 5,
+    "total": 33
+   },
+   "frc7691": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 28
+   },
+   "frc8515": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 36
+   },
+   "frc8576": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 21,
+    "total": 48
+   },
+   "frc9181": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc9307": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc9512": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc9658": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   }
+  },
+  "tiebreakers": {
+   "frc10904": {
+    "highest_match_scores": [
+     270,
+     224,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc11132": {
+    "highest_match_scores": [
+     290,
+     224,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc11242": {
+    "highest_match_scores": [
+     230,
+     226,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc118": {
+    "highest_match_scores": [
+     434,
+     423,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc127": {
+    "highest_match_scores": [
+     288,
+     268,
+     262
+    ],
+    "qual_wins": 0
+   },
+   "frc231": {
+    "highest_match_scores": [
+     376,
+     239,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc2585": {
+    "highest_match_scores": [
+     291,
+     260,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc2587": {
+    "highest_match_scores": [
+     332,
+     289,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc2882": {
+    "highest_match_scores": [
+     232,
+     229,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc2969": {
+    "highest_match_scores": [
+     223,
+     202,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc324": {
+    "highest_match_scores": [
+     332,
+     289,
+     267
+    ],
+    "qual_wins": 0
+   },
+   "frc3481": {
+    "highest_match_scores": [
+     235,
+     226,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc3676": {
+    "highest_match_scores": [
+     434,
+     423,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc3728": {
+    "highest_match_scores": [
+     288,
+     189,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc3735": {
+    "highest_match_scores": [
+     311,
+     268,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc3847": {
+    "highest_match_scores": [
+     434,
+     423,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc457": {
+    "highest_match_scores": [
+     340,
+     310,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc4587": {
+    "highest_match_scores": [
+     267,
+     244,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc5070": {
+    "highest_match_scores": [
+     262,
+     260,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc5427": {
+    "highest_match_scores": [
+     340,
+     290,
+     270
+    ],
+    "qual_wins": 0
+   },
+   "frc5829": {
+    "highest_match_scores": [
+     291,
+     269,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc5908": {
+    "highest_match_scores": [
+     206,
+     183,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc5986": {
+    "highest_match_scores": [
+     232,
+     193,
+     184
+    ],
+    "qual_wins": 0
+   },
+   "frc6488": {
+    "highest_match_scores": [
+     225,
+     214,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc7091": {
+    "highest_match_scores": [
+     235,
+     194,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc7312": {
+    "highest_match_scores": [
+     271,
+     238,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc7616": {
+    "highest_match_scores": [
+     332,
+     289,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc7691": {
+    "highest_match_scores": [
+     308,
+     269,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc8515": {
+    "highest_match_scores": [
+     311,
+     288,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc8576": {
+    "highest_match_scores": [
+     367,
+     320,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc9181": {
+    "highest_match_scores": [
+     320,
+     258,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc9307": {
+    "highest_match_scores": [
+     256,
+     239,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc9512": {
+    "highest_match_scores": [
+     367,
+     308,
+     267
+    ],
+    "qual_wins": 0
+   },
+   "frc9658": {
+    "highest_match_scores": [
+     224,
+     200,
+     193
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txcle": {
+  "points": {
+   "frc10118": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc10340": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc11277": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 14
+   },
+   "frc118": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc127": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 14,
+    "qual_points": 13,
+    "total": 32
+   },
+   "frc1477": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 7,
+    "total": 23
+   },
+   "frc324": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 24
+   },
+   "frc3847": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc4639": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 5,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc5261": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 22
+   },
+   "frc5414": {
+    "alliance_points": 10,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 33
+   },
+   "frc5417": {
+    "alliance_points": 3,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 12,
+    "total": 38
+   },
+   "frc5431": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 21
+   },
+   "frc5788": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 9,
+    "qual_points": 11,
+    "total": 20
+   },
+   "frc5790": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc5892": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc5923": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc6243": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 5,
+    "total": 14
+   },
+   "frc6377": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 42
+   },
+   "frc6645": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc6800": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc7115": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc7312": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 41
+   },
+   "frc7492": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc7616": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 25
+   },
+   "frc8177": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 15
+   },
+   "frc8370": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 4,
+    "total": 35
+   },
+   "frc9128": {
+    "alliance_points": 16,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 68
+   },
+   "frc9181": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc9289": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc9307": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc9478": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   }
+  },
+  "tiebreakers": {
+   "frc10118": {
+    "highest_match_scores": [
+     311,
+     281,
+     152
+    ],
+    "qual_wins": 0
+   },
+   "frc10340": {
+    "highest_match_scores": [
+     476,
+     445,
+     431
+    ],
+    "qual_wins": 0
+   },
+   "frc11277": {
+    "highest_match_scores": [
+     290,
+     173,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc118": {
+    "highest_match_scores": [
+     356,
+     299,
+     269
+    ],
+    "qual_wins": 0
+   },
+   "frc127": {
+    "highest_match_scores": [
+     476,
+     431,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc1477": {
+    "highest_match_scores": [
+     269,
+     174,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc324": {
+    "highest_match_scores": [
+     297,
+     209,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc3847": {
+    "highest_match_scores": [
+     476,
+     445,
+     431
+    ],
+    "qual_wins": 0
+   },
+   "frc4639": {
+    "highest_match_scores": [
+     411,
+     370,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc5261": {
+    "highest_match_scores": [
+     392,
+     311,
+     173
+    ],
+    "qual_wins": 0
+   },
+   "frc5414": {
+    "highest_match_scores": [
+     288,
+     285,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc5417": {
+    "highest_match_scores": [
+     200,
+     192,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc5431": {
+    "highest_match_scores": [
+     281,
+     207,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc5788": {
+    "highest_match_scores": [
+     203,
+     151,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc5790": {
+    "highest_match_scores": [
+     351,
+     216,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc5892": {
+    "highest_match_scores": [
+     411,
+     209,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc5923": {
+    "highest_match_scores": [
+     219,
+     152,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc6243": {
+    "highest_match_scores": [
+     445,
+     372,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc6377": {
+    "highest_match_scores": [
+     301,
+     207,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc6645": {
+    "highest_match_scores": [
+     362,
+     351,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc6800": {
+    "highest_match_scores": [
+     587,
+     545,
+     530
+    ],
+    "qual_wins": 0
+   },
+   "frc7115": {
+    "highest_match_scores": [
+     302,
+     224,
+     90
+    ],
+    "qual_wins": 0
+   },
+   "frc7312": {
+    "highest_match_scores": [
+     356,
+     197,
+     174
+    ],
+    "qual_wins": 0
+   },
+   "frc7492": {
+    "highest_match_scores": [
+     285,
+     260,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc7616": {
+    "highest_match_scores": [
+     299,
+     297,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc8177": {
+    "highest_match_scores": [
+     297,
+     128,
+     98
+    ],
+    "qual_wins": 0
+   },
+   "frc8370": {
+    "highest_match_scores": [
+     587,
+     545,
+     530
+    ],
+    "qual_wins": 0
+   },
+   "frc9128": {
+    "highest_match_scores": [
+     587,
+     545,
+     530
+    ],
+    "qual_wins": 0
+   },
+   "frc9181": {
+    "highest_match_scores": [
+     302,
+     197,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc9289": {
+    "highest_match_scores": [
+     283,
+     260,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc9307": {
+    "highest_match_scores": [
+     301,
+     237,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc9478": {
+    "highest_match_scores": [
+     216,
+     150,
+     143
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txcmp": {
+  "points": {
+   "frc11178": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc11242": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc118": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc1477": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc5414": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc6369": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 54
+   },
+   "frc9128": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc9140": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   }
+  },
+  "tiebreakers": {
+   "frc118": {
+    "highest_match_scores": [
+     539,
+     520
+    ],
+    "qual_wins": 0
+   },
+   "frc2587": {
+    "highest_match_scores": [
+     539,
+     520
+    ],
+    "qual_wins": 0
+   },
+   "frc6369": {
+    "highest_match_scores": [
+     656,
+     650
+    ],
+    "qual_wins": 0
+   },
+   "frc6800": {
+    "highest_match_scores": [
+     539,
+     520
+    ],
+    "qual_wins": 0
+   },
+   "frc9128": {
+    "highest_match_scores": [
+     656,
+     650
+    ],
+    "qual_wins": 0
+   },
+   "frc9140": {
+    "highest_match_scores": [
+     656,
+     650
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txcmp1": {
+  "points": {
+   "frc10014": {
+    "alliance_points": 33,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 48,
+    "total": 135
+   },
+   "frc10032": {
+    "alliance_points": 12,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 57
+   },
+   "frc10340": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 60,
+    "total": 180
+   },
+   "frc10994": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc11200": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc11242": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc11277": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc118": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 201
+   },
+   "frc1255": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc1296": {
+    "alliance_points": 33,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 54,
+    "total": 141
+   },
+   "frc1477": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 60,
+    "total": 102
+   },
+   "frc2468": {
+    "alliance_points": 36,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 105
+   },
+   "frc2582": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 90
+   },
+   "frc2587": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 51,
+    "qual_points": 39,
+    "total": 90
+   },
+   "frc2687": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc2728": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 81
+   },
+   "frc2881": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 96
+   },
+   "frc3005": {
+    "alliance_points": 36,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 105
+   },
+   "frc324": {
+    "alliance_points": 24,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 36,
+    "total": 81
+   },
+   "frc3481": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 96
+   },
+   "frc3676": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc3679": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc3735": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc3847": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 45,
+    "total": 150
+   },
+   "frc4295": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc4734": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc5261": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc5417": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc5829": {
+    "alliance_points": 27,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 42,
+    "total": 105
+   },
+   "frc5892": {
+    "alliance_points": 18,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 45,
+    "total": 117
+   },
+   "frc624": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 33,
+    "total": 99
+   },
+   "frc6377": {
+    "alliance_points": 21,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 78
+   },
+   "frc6672": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 90
+   },
+   "frc6800": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 219
+   },
+   "frc6901": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc7503": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc7506": {
+    "alliance_points": 9,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 69
+   },
+   "frc7691": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc8088": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 42,
+    "qual_points": 30,
+    "total": 75
+   },
+   "frc8370": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc8507": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc9418": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 84
+   },
+   "frc9444": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc9492": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc9577": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   }
+  },
+  "tiebreakers": {
+   "frc10014": {
+    "highest_match_scores": [
+     592,
+     439,
+     429
+    ],
+    "qual_wins": 0
+   },
+   "frc10032": {
+    "highest_match_scores": [
+     382,
+     328,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc10340": {
+    "highest_match_scores": [
+     592,
+     572,
+     558
+    ],
+    "qual_wins": 0
+   },
+   "frc10994": {
+    "highest_match_scores": [
+     395,
+     341,
+     314
+    ],
+    "qual_wins": 0
+   },
+   "frc11200": {
+    "highest_match_scores": [
+     366,
+     307,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc11242": {
+    "highest_match_scores": [
+     465,
+     442,
+     439
+    ],
+    "qual_wins": 0
+   },
+   "frc11277": {
+    "highest_match_scores": [
+     379,
+     324,
+     294
+    ],
+    "qual_wins": 0
+   },
+   "frc118": {
+    "highest_match_scores": [
+     574,
+     547,
+     521
+    ],
+    "qual_wins": 0
+   },
+   "frc1255": {
+    "highest_match_scores": [
+     385,
+     349,
+     313
+    ],
+    "qual_wins": 0
+   },
+   "frc1296": {
+    "highest_match_scores": [
+     563,
+     510,
+     439
+    ],
+    "qual_wins": 0
+   },
+   "frc1477": {
+    "highest_match_scores": [
+     469,
+     442,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc2468": {
+    "highest_match_scores": [
+     558,
+     453,
+     442
+    ],
+    "qual_wins": 0
+   },
+   "frc2582": {
+    "highest_match_scores": [
+     476,
+     465,
+     395
+    ],
+    "qual_wins": 0
+   },
+   "frc2587": {
+    "highest_match_scores": [
+     574,
+     521,
+     446
+    ],
+    "qual_wins": 0
+   },
+   "frc2687": {
+    "highest_match_scores": [
+     429,
+     319,
+     274
+    ],
+    "qual_wins": 0
+   },
+   "frc2728": {
+    "highest_match_scores": [
+     426,
+     409,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc2881": {
+    "highest_match_scores": [
+     572,
+     563,
+     536
+    ],
+    "qual_wins": 0
+   },
+   "frc3005": {
+    "highest_match_scores": [
+     429,
+     395,
+     385
+    ],
+    "qual_wins": 0
+   },
+   "frc324": {
+    "highest_match_scores": [
+     592,
+     462,
+     357
+    ],
+    "qual_wins": 0
+   },
+   "frc3481": {
+    "highest_match_scores": [
+     510,
+     469,
+     453
+    ],
+    "qual_wins": 0
+   },
+   "frc3676": {
+    "highest_match_scores": [
+     315,
+     273,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc3679": {
+    "highest_match_scores": [
+     385,
+     324,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc3735": {
+    "highest_match_scores": [
+     353,
+     341,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc3847": {
+    "highest_match_scores": [
+     488,
+     471,
+     453
+    ],
+    "qual_wins": 0
+   },
+   "frc4295": {
+    "highest_match_scores": [
+     419,
+     310,
+     299
+    ],
+    "qual_wins": 0
+   },
+   "frc4734": {
+    "highest_match_scores": [
+     414,
+     408,
+     318
+    ],
+    "qual_wins": 0
+   },
+   "frc5261": {
+    "highest_match_scores": [
+     494,
+     343,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc5417": {
+    "highest_match_scores": [
+     374,
+     350,
+     307
+    ],
+    "qual_wins": 0
+   },
+   "frc5829": {
+    "highest_match_scores": [
+     543,
+     408,
+     384
+    ],
+    "qual_wins": 0
+   },
+   "frc5892": {
+    "highest_match_scores": [
+     399,
+     353,
+     349
+    ],
+    "qual_wins": 0
+   },
+   "frc624": {
+    "highest_match_scores": [
+     488,
+     451,
+     416
+    ],
+    "qual_wins": 0
+   },
+   "frc6377": {
+    "highest_match_scores": [
+     536,
+     476,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc6672": {
+    "highest_match_scores": [
+     563,
+     481,
+     476
+    ],
+    "qual_wins": 0
+   },
+   "frc6800": {
+    "highest_match_scores": [
+     574,
+     558,
+     547
+    ],
+    "qual_wins": 0
+   },
+   "frc6901": {
+    "highest_match_scores": [
+     416,
+     384,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc7503": {
+    "highest_match_scores": [
+     481,
+     429,
+     409
+    ],
+    "qual_wins": 0
+   },
+   "frc7506": {
+    "highest_match_scores": [
+     572,
+     366,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc7691": {
+    "highest_match_scores": [
+     374,
+     267,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc8088": {
+    "highest_match_scores": [
+     547,
+     462,
+     430
+    ],
+    "qual_wins": 0
+   },
+   "frc8370": {
+    "highest_match_scores": [
+     385,
+     324,
+     240
+    ],
+    "qual_wins": 0
+   },
+   "frc8507": {
+    "highest_match_scores": [
+     429,
+     312,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc9418": {
+    "highest_match_scores": [
+     543,
+     494,
+     337
+    ],
+    "qual_wins": 0
+   },
+   "frc9444": {
+    "highest_match_scores": [
+     350,
+     338,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc9492": {
+    "highest_match_scores": [
+     471,
+     276,
+     274
+    ],
+    "qual_wins": 0
+   },
+   "frc9577": {
+    "highest_match_scores": [
+     376,
+     299,
+     283
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txcmp2": {
+  "points": {
+   "frc10385": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc10518": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc10913": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc11169": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc11178": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc127": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc148": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 60,
+    "total": 159
+   },
+   "frc2158": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 60
+   },
+   "frc231": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 45
+   },
+   "frc2583": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 102
+   },
+   "frc2689": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc2714": {
+    "alliance_points": 24,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 63
+   },
+   "frc2848": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 57,
+    "total": 159
+   },
+   "frc3035": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 81
+   },
+   "frc3310": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 42,
+    "total": 81
+   },
+   "frc3561": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc4063": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 93
+   },
+   "frc4153": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc418": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 75
+   },
+   "frc4192": {
+    "alliance_points": 12,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 60
+   },
+   "frc4206": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 63,
+    "total": 147
+   },
+   "frc457": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc4639": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 42
+   },
+   "frc5411": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc5414": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 33,
+    "total": 102
+   },
+   "frc5427": {
+    "alliance_points": 21,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 66
+   },
+   "frc5503": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc5572": {
+    "alliance_points": 36,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 105
+   },
+   "frc6357": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 24,
+    "total": 69
+   },
+   "frc6369": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 204
+   },
+   "frc6773": {
+    "alliance_points": 39,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 93
+   },
+   "frc7312": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 84
+   },
+   "frc7492": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc7616": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc8114": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 45
+   },
+   "frc8177": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc8576": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 72
+   },
+   "frc8749": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 54,
+    "total": 171
+   },
+   "frc8769": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc8818": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc8858": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 51,
+    "total": 105
+   },
+   "frc9128": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 60,
+    "total": 198
+   },
+   "frc9136": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 30
+   },
+   "frc9140": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 42,
+    "total": 135
+   },
+   "frc9506": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 66
+   }
+  },
+  "tiebreakers": {
+   "frc10385": {
+    "highest_match_scores": [
+     590,
+     453,
+     365
+    ],
+    "qual_wins": 0
+   },
+   "frc10518": {
+    "highest_match_scores": [
+     356,
+     341,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc10913": {
+    "highest_match_scores": [
+     348,
+     301,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc11169": {
+    "highest_match_scores": [
+     500,
+     418,
+     322
+    ],
+    "qual_wins": 0
+   },
+   "frc11178": {
+    "highest_match_scores": [
+     416,
+     414,
+     377
+    ],
+    "qual_wins": 0
+   },
+   "frc127": {
+    "highest_match_scores": [
+     542,
+     459,
+     367
+    ],
+    "qual_wins": 0
+   },
+   "frc148": {
+    "highest_match_scores": [
+     557,
+     536,
+     534
+    ],
+    "qual_wins": 0
+   },
+   "frc2158": {
+    "highest_match_scores": [
+     494,
+     450,
+     433
+    ],
+    "qual_wins": 0
+   },
+   "frc231": {
+    "highest_match_scores": [
+     359,
+     335,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc2583": {
+    "highest_match_scores": [
+     494,
+     471,
+     467
+    ],
+    "qual_wins": 0
+   },
+   "frc2689": {
+    "highest_match_scores": [
+     542,
+     529,
+     387
+    ],
+    "qual_wins": 0
+   },
+   "frc2714": {
+    "highest_match_scores": [
+     508,
+     438,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc2848": {
+    "highest_match_scores": [
+     614,
+     536,
+     528
+    ],
+    "qual_wins": 0
+   },
+   "frc3035": {
+    "highest_match_scores": [
+     473,
+     438,
+     437
+    ],
+    "qual_wins": 0
+   },
+   "frc3310": {
+    "highest_match_scores": [
+     467,
+     462,
+     390
+    ],
+    "qual_wins": 0
+   },
+   "frc3561": {
+    "highest_match_scores": [
+     591,
+     433,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc4063": {
+    "highest_match_scores": [
+     500,
+     452,
+     440
+    ],
+    "qual_wins": 0
+   },
+   "frc4153": {
+    "highest_match_scores": [
+     356,
+     333,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc418": {
+    "highest_match_scores": [
+     430,
+     403,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc4192": {
+    "highest_match_scores": [
+     471,
+     383,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc4206": {
+    "highest_match_scores": [
+     628,
+     536,
+     534
+    ],
+    "qual_wins": 0
+   },
+   "frc457": {
+    "highest_match_scores": [
+     557,
+     450,
+     440
+    ],
+    "qual_wins": 0
+   },
+   "frc4639": {
+    "highest_match_scores": [
+     403,
+     354,
+     351
+    ],
+    "qual_wins": 0
+   },
+   "frc5411": {
+    "highest_match_scores": [
+     508,
+     389,
+     381
+    ],
+    "qual_wins": 0
+   },
+   "frc5414": {
+    "highest_match_scores": [
+     536,
+     528,
+     488
+    ],
+    "qual_wins": 0
+   },
+   "frc5427": {
+    "highest_match_scores": [
+     628,
+     459,
+     414
+    ],
+    "qual_wins": 0
+   },
+   "frc5503": {
+    "highest_match_scores": [
+     381,
+     377,
+     344
+    ],
+    "qual_wins": 0
+   },
+   "frc5572": {
+    "highest_match_scores": [
+     614,
+     591,
+     375
+    ],
+    "qual_wins": 0
+   },
+   "frc6357": {
+    "highest_match_scores": [
+     536,
+     417,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc6369": {
+    "highest_match_scores": [
+     757,
+     729,
+     722
+    ],
+    "qual_wins": 0
+   },
+   "frc6773": {
+    "highest_match_scores": [
+     450,
+     437,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc7312": {
+    "highest_match_scores": [
+     534,
+     529,
+     452
+    ],
+    "qual_wins": 0
+   },
+   "frc7492": {
+    "highest_match_scores": [
+     593,
+     438,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc7616": {
+    "highest_match_scores": [
+     488,
+     371,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc8114": {
+    "highest_match_scores": [
+     476,
+     367,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc8177": {
+    "highest_match_scores": [
+     387,
+     371,
+     366
+    ],
+    "qual_wins": 0
+   },
+   "frc8576": {
+    "highest_match_scores": [
+     476,
+     430,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc8749": {
+    "highest_match_scores": [
+     536,
+     528,
+     508
+    ],
+    "qual_wins": 0
+   },
+   "frc8769": {
+    "highest_match_scores": [
+     453,
+     348,
+     295
+    ],
+    "qual_wins": 0
+   },
+   "frc8818": {
+    "highest_match_scores": [
+     473,
+     462,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc8858": {
+    "highest_match_scores": [
+     590,
+     467,
+     390
+    ],
+    "qual_wins": 0
+   },
+   "frc9128": {
+    "highest_match_scores": [
+     757,
+     729,
+     722
+    ],
+    "qual_wins": 0
+   },
+   "frc9136": {
+    "highest_match_scores": [
+     382,
+     316,
+     286
+    ],
+    "qual_wins": 0
+   },
+   "frc9140": {
+    "highest_match_scores": [
+     757,
+     729,
+     722
+    ],
+    "qual_wins": 0
+   },
+   "frc9506": {
+    "highest_match_scores": [
+     437,
+     414,
+     325
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txdri": {
+  "points": {
+   "frc10032": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 23
+   },
+   "frc10385": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 43
+   },
+   "frc10913": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 21
+   },
+   "frc11169": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 27
+   },
+   "frc11224": {
+    "alliance_points": 5,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 25
+   },
+   "frc2158": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 42
+   },
+   "frc2468": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 78
+   },
+   "frc2687": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 55
+   },
+   "frc2689": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc2950": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc3035": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc4219": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc4328": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 30
+   },
+   "frc4332": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc4364": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc4597": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc4639": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc5503": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 6,
+    "total": 37
+   },
+   "frc5894": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc6357": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 45
+   },
+   "frc7088": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc7138": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7521": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc8088": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc8114": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc8507": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc9137": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 11
+   },
+   "frc9311": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc9444": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 32
+   },
+   "frc9478": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 17
+   },
+   "frc9577": {
+    "alliance_points": 9,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 31
+   }
+  },
+  "tiebreakers": {
+   "frc10032": {
+    "highest_match_scores": [
+     199,
+     185,
+     122
+    ],
+    "qual_wins": 0
+   },
+   "frc10385": {
+    "highest_match_scores": [
+     239,
+     211,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc10913": {
+    "highest_match_scores": [
+     254,
+     146,
+     125
+    ],
+    "qual_wins": 0
+   },
+   "frc11169": {
+    "highest_match_scores": [
+     240,
+     204,
+     155
+    ],
+    "qual_wins": 0
+   },
+   "frc11224": {
+    "highest_match_scores": [
+     242,
+     239,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc2158": {
+    "highest_match_scores": [
+     185,
+     179,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc2468": {
+    "highest_match_scores": [
+     383,
+     351,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc2687": {
+    "highest_match_scores": [
+     259,
+     258,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc2689": {
+    "highest_match_scores": [
+     280,
+     240,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc2950": {
+    "highest_match_scores": [
+     273,
+     199,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc3035": {
+    "highest_match_scores": [
+     383,
+     351,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc4219": {
+    "highest_match_scores": [
+     225,
+     210,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc4328": {
+    "highest_match_scores": [
+     199,
+     170,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc4332": {
+    "highest_match_scores": [
+     300,
+     232,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc4364": {
+    "highest_match_scores": [
+     253,
+     161,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc4597": {
+    "highest_match_scores": [
+     187,
+     160,
+     115
+    ],
+    "qual_wins": 0
+   },
+   "frc4639": {
+    "highest_match_scores": [
+     300,
+     258,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc5503": {
+    "highest_match_scores": [
+     383,
+     351,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc5894": {
+    "highest_match_scores": [
+     175,
+     134,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc6357": {
+    "highest_match_scores": [
+     240,
+     232,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc7088": {
+    "highest_match_scores": [
+     193,
+     110,
+     97
+    ],
+    "qual_wins": 0
+   },
+   "frc7138": {
+    "highest_match_scores": [
+     242,
+     112,
+     111
+    ],
+    "qual_wins": 0
+   },
+   "frc7521": {
+    "highest_match_scores": [
+     151,
+     106,
+     89
+    ],
+    "qual_wins": 0
+   },
+   "frc8088": {
+    "highest_match_scores": [
+     225,
+     219,
+     211
+    ],
+    "qual_wins": 0
+   },
+   "frc8114": {
+    "highest_match_scores": [
+     280,
+     253,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc8507": {
+    "highest_match_scores": [
+     259,
+     254,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc9137": {
+    "highest_match_scores": [
+     184,
+     157,
+     132
+    ],
+    "qual_wins": 0
+   },
+   "frc9311": {
+    "highest_match_scores": [
+     242,
+     176,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc9444": {
+    "highest_match_scores": [
+     258,
+     226,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc9478": {
+    "highest_match_scores": [
+     273,
+     210,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc9577": {
+    "highest_match_scores": [
+     193,
+     175,
+     134
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txfar": {
+  "points": {
+   "frc10340": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc1296": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 54
+   },
+   "frc1745": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 21
+   },
+   "frc2582": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc2848": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 55
+   },
+   "frc3005": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 34
+   },
+   "frc3282": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc4641": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 21
+   },
+   "frc4717": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc5411": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 35
+   },
+   "frc5431": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc5682": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 27
+   },
+   "frc5790": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc6171": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6526": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc6773": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 57
+   },
+   "frc7091": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7119": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc7121": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc7125": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc7503": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 31
+   },
+   "frc7506": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 43
+   },
+   "frc8408": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc8749": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc8816": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc8858": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc9034": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc9105": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 5,
+    "total": 21
+   },
+   "frc9128": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 77
+   },
+   "frc9289": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 4,
+    "total": 15
+   },
+   "frc9492": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 47
+   }
+  },
+  "tiebreakers": {
+   "frc10340": {
+    "highest_match_scores": [
+     621,
+     614,
+     585
+    ],
+    "qual_wins": 0
+   },
+   "frc1296": {
+    "highest_match_scores": [
+     558,
+     401,
+     383
+    ],
+    "qual_wins": 0
+   },
+   "frc1745": {
+    "highest_match_scores": [
+     585,
+     348,
+     300
+    ],
+    "qual_wins": 0
+   },
+   "frc2582": {
+    "highest_match_scores": [
+     558,
+     476,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc2848": {
+    "highest_match_scores": [
+     558,
+     526,
+     406
+    ],
+    "qual_wins": 0
+   },
+   "frc3005": {
+    "highest_match_scores": [
+     482,
+     380,
+     348
+    ],
+    "qual_wins": 0
+   },
+   "frc3282": {
+    "highest_match_scores": [
+     334,
+     315,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc4641": {
+    "highest_match_scores": [
+     287,
+     286,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc4717": {
+    "highest_match_scores": [
+     380,
+     237,
+     211
+    ],
+    "qual_wins": 0
+   },
+   "frc5411": {
+    "highest_match_scores": [
+     368,
+     361,
+     323
+    ],
+    "qual_wins": 0
+   },
+   "frc5431": {
+    "highest_match_scores": [
+     411,
+     235,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc5682": {
+    "highest_match_scores": [
+     476,
+     207,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc5790": {
+    "highest_match_scores": [
+     482,
+     316,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc6171": {
+    "highest_match_scores": [
+     287,
+     263,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc6526": {
+    "highest_match_scores": [
+     298,
+     279,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc6773": {
+    "highest_match_scores": [
+     451,
+     368,
+     361
+    ],
+    "qual_wins": 0
+   },
+   "frc7091": {
+    "highest_match_scores": [
+     300,
+     293,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc7119": {
+    "highest_match_scores": [
+     442,
+     411,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc7121": {
+    "highest_match_scores": [
+     316,
+     242,
+     184
+    ],
+    "qual_wins": 0
+   },
+   "frc7125": {
+    "highest_match_scores": [
+     361,
+     316,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc7503": {
+    "highest_match_scores": [
+     442,
+     340,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc7506": {
+    "highest_match_scores": [
+     419,
+     340,
+     315
+    ],
+    "qual_wins": 0
+   },
+   "frc8408": {
+    "highest_match_scores": [
+     451,
+     316,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc8749": {
+    "highest_match_scores": [
+     334,
+     274,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc8816": {
+    "highest_match_scores": [
+     526,
+     419,
+     349
+    ],
+    "qual_wins": 0
+   },
+   "frc8858": {
+    "highest_match_scores": [
+     300,
+     300,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc9034": {
+    "highest_match_scores": [
+     406,
+     286,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc9105": {
+    "highest_match_scores": [
+     401,
+     383,
+     305
+    ],
+    "qual_wins": 0
+   },
+   "frc9128": {
+    "highest_match_scores": [
+     621,
+     614,
+     585
+    ],
+    "qual_wins": 0
+   },
+   "frc9289": {
+    "highest_match_scores": [
+     235,
+     228,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc9492": {
+    "highest_match_scores": [
+     621,
+     614,
+     576
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txfor": {
+  "points": {
+   "frc10032": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 44
+   },
+   "frc1164": {
+    "alliance_points": 5,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc148": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc2714": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 15,
+    "total": 64
+   },
+   "frc2728": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 18,
+    "total": 67
+   },
+   "frc3005": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 61
+   },
+   "frc3310": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc3676": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 25
+   },
+   "frc4076": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 20
+   },
+   "frc4153": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 37
+   },
+   "frc4192": {
+    "alliance_points": 11,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 33
+   },
+   "frc4206": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 48
+   },
+   "frc4641": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc5212": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc6672": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 40
+   },
+   "frc6901": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 8,
+    "total": 17
+   },
+   "frc7119": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 7,
+    "total": 24
+   },
+   "frc7121": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 18
+   },
+   "frc7503": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 46
+   },
+   "frc7534": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc7540": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 21
+   },
+   "frc8858": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc9137": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9786": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc9990": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 9
+   },
+   "frc9991": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 9
+   },
+   "frc9992": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 8
+   }
+  },
+  "tiebreakers": {
+   "frc10032": {
+    "highest_match_scores": [
+     365,
+     363,
+     360
+    ],
+    "qual_wins": 0
+   },
+   "frc1164": {
+    "highest_match_scores": [
+     293,
+     274,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc148": {
+    "highest_match_scores": [
+     478,
+     369,
+     362
+    ],
+    "qual_wins": 0
+   },
+   "frc2714": {
+    "highest_match_scores": [
+     365,
+     363,
+     360
+    ],
+    "qual_wins": 0
+   },
+   "frc2728": {
+    "highest_match_scores": [
+     478,
+     365,
+     363
+    ],
+    "qual_wins": 0
+   },
+   "frc3005": {
+    "highest_match_scores": [
+     369,
+     362,
+     338
+    ],
+    "qual_wins": 0
+   },
+   "frc3310": {
+    "highest_match_scores": [
+     171,
+     168,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc3676": {
+    "highest_match_scores": [
+     255,
+     202,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc4076": {
+    "highest_match_scores": [
+     208,
+     202,
+     180
+    ],
+    "qual_wins": 0
+   },
+   "frc4153": {
+    "highest_match_scores": [
+     369,
+     335,
+     307
+    ],
+    "qual_wins": 0
+   },
+   "frc4192": {
+    "highest_match_scores": [
+     263,
+     202,
+     191
+    ],
+    "qual_wins": 0
+   },
+   "frc4206": {
+    "highest_match_scores": [
+     268,
+     263,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc4641": {
+    "highest_match_scores": [
+     255,
+     170,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc5212": {
+    "highest_match_scores": [
+     338,
+     274,
+     136
+    ],
+    "qual_wins": 0
+   },
+   "frc6672": {
+    "highest_match_scores": [
+     478,
+     317,
+     231
+    ],
+    "qual_wins": 0
+   },
+   "frc6901": {
+    "highest_match_scores": [
+     257,
+     231,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc7119": {
+    "highest_match_scores": [
+     190,
+     179,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc7121": {
+    "highest_match_scores": [
+     191,
+     157,
+     114
+    ],
+    "qual_wins": 0
+   },
+   "frc7503": {
+    "highest_match_scores": [
+     362,
+     179,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc7534": {
+    "highest_match_scores": [
+     286,
+     200,
+     87
+    ],
+    "qual_wins": 0
+   },
+   "frc7540": {
+    "highest_match_scores": [
+     320,
+     256,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc8858": {
+    "highest_match_scores": [
+     252,
+     231,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc9137": {
+    "highest_match_scores": [
+     268,
+     202,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc9786": {
+    "highest_match_scores": [
+     219,
+     200,
+     174
+    ],
+    "qual_wins": 0
+   },
+   "frc9990": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9991": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9992": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txhou": {
+  "points": {
+   "frc10118": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 41
+   },
+   "frc10904": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc11132": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc11178": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc11242": {
+    "alliance_points": 2,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 9,
+    "total": 32
+   },
+   "frc11277": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 10,
+    "total": 46
+   },
+   "frc118": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 76
+   },
+   "frc1255": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 52
+   },
+   "frc231": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 53
+   },
+   "frc2585": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 7,
+    "total": 19
+   },
+   "frc2882": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc4328": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 21
+   },
+   "frc4587": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 8,
+    "total": 31
+   },
+   "frc5070": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 31
+   },
+   "frc5261": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc5414": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 57
+   },
+   "frc5726": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc5908": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 16
+   },
+   "frc5923": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 24
+   },
+   "frc624": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc6488": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6645": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 19
+   },
+   "frc7115": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc7691": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc8177": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 38
+   },
+   "frc8515": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 12,
+    "total": 51
+   },
+   "frc8576": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc8818": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc9512": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc9521": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   }
+  },
+  "tiebreakers": {
+   "frc10118": {
+    "highest_match_scores": [
+     299,
+     201,
+     139
+    ],
+    "qual_wins": 0
+   },
+   "frc10904": {
+    "highest_match_scores": [
+     246,
+     140,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc11132": {
+    "highest_match_scores": [
+     475,
+     201,
+     119
+    ],
+    "qual_wins": 0
+   },
+   "frc11178": {
+    "highest_match_scores": [
+     237,
+     139,
+     110
+    ],
+    "qual_wins": 0
+   },
+   "frc11242": {
+    "highest_match_scores": [
+     196,
+     148,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc11277": {
+    "highest_match_scores": [
+     379,
+     366,
+     364
+    ],
+    "qual_wins": 0
+   },
+   "frc118": {
+    "highest_match_scores": [
+     379,
+     366,
+     364
+    ],
+    "qual_wins": 0
+   },
+   "frc1255": {
+    "highest_match_scores": [
+     251,
+     201,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc231": {
+    "highest_match_scores": [
+     246,
+     164,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc2585": {
+    "highest_match_scores": [
+     237,
+     142,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc2882": {
+    "highest_match_scores": [
+     197,
+     129,
+     94
+    ],
+    "qual_wins": 0
+   },
+   "frc4328": {
+    "highest_match_scores": [
+     206,
+     196,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc4587": {
+    "highest_match_scores": [
+     251,
+     197,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc5070": {
+    "highest_match_scores": [
+     154,
+     148,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc5261": {
+    "highest_match_scores": [
+     299,
+     282,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc5414": {
+    "highest_match_scores": [
+     287,
+     200,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc5726": {
+    "highest_match_scores": [
+     174,
+     157,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc5908": {
+    "highest_match_scores": [
+     201,
+     141,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc5923": {
+    "highest_match_scores": [
+     183,
+     130,
+     122
+    ],
+    "qual_wins": 0
+   },
+   "frc624": {
+    "highest_match_scores": [
+     379,
+     366,
+     364
+    ],
+    "qual_wins": 0
+   },
+   "frc6488": {
+    "highest_match_scores": [
+     200,
+     174,
+     78
+    ],
+    "qual_wins": 0
+   },
+   "frc6645": {
+    "highest_match_scores": [
+     220,
+     183,
+     130
+    ],
+    "qual_wins": 0
+   },
+   "frc7115": {
+    "highest_match_scores": [
+     122,
+     103,
+     89
+    ],
+    "qual_wins": 0
+   },
+   "frc7691": {
+    "highest_match_scores": [
+     206,
+     142,
+     112
+    ],
+    "qual_wins": 0
+   },
+   "frc8177": {
+    "highest_match_scores": [
+     282,
+     164,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc8515": {
+    "highest_match_scores": [
+     475,
+     251,
+     220
+    ],
+    "qual_wins": 0
+   },
+   "frc8576": {
+    "highest_match_scores": [
+     175,
+     158,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc8818": {
+    "highest_match_scores": [
+     165,
+     158,
+     157
+    ],
+    "qual_wins": 0
+   },
+   "frc9512": {
+    "highest_match_scores": [
+     475,
+     183,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc9521": {
+    "highest_match_scores": [
+     179,
+     175,
+     142
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txman": {
+  "points": {
+   "frc10913": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc11224": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc11309": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 26
+   },
+   "frc118": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc1255": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc2583": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc2587": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc2789": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 15
+   },
+   "frc3545": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 15
+   },
+   "frc4076": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 26
+   },
+   "frc418": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 54
+   },
+   "frc436": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 50
+   },
+   "frc5103": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 28
+   },
+   "frc5572": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 45
+   },
+   "frc5892": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc6180": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc6243": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc6377": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc6800": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 75
+   },
+   "frc6901": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 39
+   },
+   "frc7088": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 24,
+    "qual_points": 7,
+    "total": 32
+   },
+   "frc7138": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc8573": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 6,
+    "total": 20
+   },
+   "frc8750": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc9140": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 14,
+    "total": 52
+   },
+   "frc9506": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 23
+   },
+   "frc9577": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 25
+   }
+  },
+  "tiebreakers": {
+   "frc10913": {
+    "highest_match_scores": [
+     347,
+     269,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc11224": {
+    "highest_match_scores": [
+     317,
+     237,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc11309": {
+    "highest_match_scores": [
+     237,
+     196,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc118": {
+    "highest_match_scores": [
+     435,
+     433,
+     428
+    ],
+    "qual_wins": 0
+   },
+   "frc1255": {
+    "highest_match_scores": [
+     433,
+     298,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc2583": {
+    "highest_match_scores": [
+     546,
+     421,
+     353
+    ],
+    "qual_wins": 0
+   },
+   "frc2587": {
+    "highest_match_scores": [
+     247,
+     217,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc2789": {
+    "highest_match_scores": [
+     217,
+     214,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc3545": {
+    "highest_match_scores": [
+     317,
+     217,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc4076": {
+    "highest_match_scores": [
+     196,
+     183,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc418": {
+    "highest_match_scores": [
+     361,
+     315,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc436": {
+    "highest_match_scores": [
+     332,
+     296,
+     269
+    ],
+    "qual_wins": 0
+   },
+   "frc5103": {
+    "highest_match_scores": [
+     280,
+     224,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc5572": {
+    "highest_match_scores": [
+     421,
+     353,
+     332
+    ],
+    "qual_wins": 0
+   },
+   "frc5892": {
+    "highest_match_scores": [
+     421,
+     203,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc6180": {
+    "highest_match_scores": [
+     315,
+     186,
+     165
+    ],
+    "qual_wins": 0
+   },
+   "frc6243": {
+    "highest_match_scores": [
+     270,
+     263,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc6377": {
+    "highest_match_scores": [
+     304,
+     298,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc6800": {
+    "highest_match_scores": [
+     546,
+     435,
+     433
+    ],
+    "qual_wins": 0
+   },
+   "frc6901": {
+    "highest_match_scores": [
+     361,
+     296,
+     268
+    ],
+    "qual_wins": 0
+   },
+   "frc7088": {
+    "highest_match_scores": [
+     435,
+     428,
+     374
+    ],
+    "qual_wins": 0
+   },
+   "frc7138": {
+    "highest_match_scores": [
+     292,
+     219,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc8573": {
+    "highest_match_scores": [
+     353,
+     343,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc8750": {
+    "highest_match_scores": [
+     247,
+     223,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc9140": {
+    "highest_match_scores": [
+     546,
+     361,
+     304
+    ],
+    "qual_wins": 0
+   },
+   "frc9506": {
+    "highest_match_scores": [
+     270,
+     217,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc9577": {
+    "highest_match_scores": [
+     280,
+     186,
+     172
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txmca": {
+  "points": {
+   "frc10118": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 45
+   },
+   "frc10385": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 53
+   },
+   "frc118": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 78
+   },
+   "frc2158": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 41
+   },
+   "frc2583": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc4063": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 33
+   },
+   "frc4295": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 12,
+    "total": 35
+   },
+   "frc4332": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 13
+   },
+   "frc4597": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 7,
+    "total": 38
+   },
+   "frc5427": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 38
+   },
+   "frc5829": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc5894": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc6180": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 36
+   },
+   "frc7521": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc8573": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 39
+   },
+   "frc8591": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc8750": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc8818": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 37
+   },
+   "frc9991": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 11
+   },
+   "frc9992": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 11
+   },
+   "frc9993": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 10
+   },
+   "frc9994": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 10
+   },
+   "frc9995": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 9
+   },
+   "frc9996": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 9
+   },
+   "frc9997": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 8
+   },
+   "frc9998": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 7
+   },
+   "frc9999": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 6
+   }
+  },
+  "tiebreakers": {
+   "frc10118": {
+    "highest_match_scores": [
+     259,
+     253,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc10385": {
+    "highest_match_scores": [
+     199,
+     187,
+     166
+    ],
+    "qual_wins": 0
+   },
+   "frc118": {
+    "highest_match_scores": [
+     328,
+     313,
+     295
+    ],
+    "qual_wins": 0
+   },
+   "frc2158": {
+    "highest_match_scores": [
+     219,
+     213,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc2583": {
+    "highest_match_scores": [
+     328,
+     313,
+     232
+    ],
+    "qual_wins": 0
+   },
+   "frc4063": {
+    "highest_match_scores": [
+     253,
+     144,
+     143
+    ],
+    "qual_wins": 0
+   },
+   "frc4295": {
+    "highest_match_scores": [
+     197,
+     165,
+     140
+    ],
+    "qual_wins": 0
+   },
+   "frc4332": {
+    "highest_match_scores": [
+     113,
+     109,
+     108
+    ],
+    "qual_wins": 0
+   },
+   "frc4597": {
+    "highest_match_scores": [
+     313,
+     232,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc5427": {
+    "highest_match_scores": [
+     328,
+     140,
+     130
+    ],
+    "qual_wins": 0
+   },
+   "frc5829": {
+    "highest_match_scores": [
+     295,
+     199,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc5894": {
+    "highest_match_scores": [
+     197,
+     167,
+     166
+    ],
+    "qual_wins": 0
+   },
+   "frc6180": {
+    "highest_match_scores": [
+     259,
+     167,
+     92
+    ],
+    "qual_wins": 0
+   },
+   "frc7521": {
+    "highest_match_scores": [
+     295,
+     128,
+     92
+    ],
+    "qual_wins": 0
+   },
+   "frc8573": {
+    "highest_match_scores": [
+     160,
+     137,
+     102
+    ],
+    "qual_wins": 0
+   },
+   "frc8591": {
+    "highest_match_scores": [
+     225,
+     165,
+     117
+    ],
+    "qual_wins": 0
+   },
+   "frc8750": {
+    "highest_match_scores": [
+     213,
+     160,
+     128
+    ],
+    "qual_wins": 0
+   },
+   "frc8818": {
+    "highest_match_scores": [
+     225,
+     219,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc9991": {
+    "highest_match_scores": [
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9992": {
+    "highest_match_scores": [
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9995": {
+    "highest_match_scores": [
+     9,
+     3
+    ],
+    "qual_wins": 0
+   },
+   "frc9996": {
+    "highest_match_scores": [
+     9,
+     3
+    ],
+    "qual_wins": 0
+   },
+   "frc9997": {
+    "highest_match_scores": [
+     9,
+     3
+    ],
+    "qual_wins": 0
+   },
+   "frc9999": {
+    "highest_match_scores": [
+     0
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txsan": {
+  "points": {
+   "frc10312": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc10518": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 35
+   },
+   "frc11169": {
+    "alliance_points": 1,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 51
+   },
+   "frc11309": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc1745": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc2582": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc2657": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc2969": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc3035": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 55
+   },
+   "frc3240": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc3481": {
+    "alliance_points": 8,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 28
+   },
+   "frc3545": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc3561": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 42
+   },
+   "frc3679": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 36
+   },
+   "frc3735": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc4219": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 21
+   },
+   "frc457": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 50
+   },
+   "frc4610": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc4717": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc4734": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc5572": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 59
+   },
+   "frc5726": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 4,
+    "qual_points": 13,
+    "total": 17
+   },
+   "frc6155": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6357": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc6369": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 76
+   },
+   "frc6974": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc8088": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 23
+   },
+   "frc8114": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 24
+   },
+   "frc8507": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 27
+   },
+   "frc8732": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc9034": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc9136": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 4,
+    "qual_points": 6,
+    "total": 19
+   },
+   "frc9140": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 14,
+    "total": 30
+   },
+   "frc9311": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9419": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc9444": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc9658": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   }
+  },
+  "tiebreakers": {
+   "frc10312": {
+    "highest_match_scores": [
+     195,
+     131,
+     111
+    ],
+    "qual_wins": 0
+   },
+   "frc10518": {
+    "highest_match_scores": [
+     234,
+     215,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc11169": {
+    "highest_match_scores": [
+     387,
+     383,
+     358
+    ],
+    "qual_wins": 0
+   },
+   "frc11309": {
+    "highest_match_scores": [
+     234,
+     109,
+     87
+    ],
+    "qual_wins": 0
+   },
+   "frc1745": {
+    "highest_match_scores": [
+     219,
+     117,
+     113
+    ],
+    "qual_wins": 0
+   },
+   "frc2582": {
+    "highest_match_scores": [
+     387,
+     383,
+     358
+    ],
+    "qual_wins": 0
+   },
+   "frc2657": {
+    "highest_match_scores": [
+     216,
+     139,
+     88
+    ],
+    "qual_wins": 0
+   },
+   "frc2969": {
+    "highest_match_scores": [
+     234,
+     163,
+     112
+    ],
+    "qual_wins": 0
+   },
+   "frc3035": {
+    "highest_match_scores": [
+     328,
+     275,
+     234
+    ],
+    "qual_wins": 0
+   },
+   "frc3240": {
+    "highest_match_scores": [
+     258,
+     168,
+     91
+    ],
+    "qual_wins": 0
+   },
+   "frc3481": {
+    "highest_match_scores": [
+     251,
+     109,
+     102
+    ],
+    "qual_wins": 0
+   },
+   "frc3545": {
+    "highest_match_scores": [
+     275,
+     98,
+     98
+    ],
+    "qual_wins": 0
+   },
+   "frc3561": {
+    "highest_match_scores": [
+     251,
+     183,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc3679": {
+    "highest_match_scores": [
+     224,
+     150,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc3735": {
+    "highest_match_scores": [
+     216,
+     169,
+     168
+    ],
+    "qual_wins": 0
+   },
+   "frc4219": {
+    "highest_match_scores": [
+     245,
+     146,
+     114
+    ],
+    "qual_wins": 0
+   },
+   "frc457": {
+    "highest_match_scores": [
+     245,
+     178,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc4610": {
+    "highest_match_scores": [
+     117,
+     98,
+     76
+    ],
+    "qual_wins": 0
+   },
+   "frc4717": {
+    "highest_match_scores": [
+     232,
+     107,
+     87
+    ],
+    "qual_wins": 0
+   },
+   "frc4734": {
+    "highest_match_scores": [
+     260,
+     224,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc5572": {
+    "highest_match_scores": [
+     300,
+     234,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc5726": {
+    "highest_match_scores": [
+     233,
+     167,
+     117
+    ],
+    "qual_wins": 0
+   },
+   "frc6155": {
+    "highest_match_scores": [
+     183,
+     158,
+     98
+    ],
+    "qual_wins": 0
+   },
+   "frc6357": {
+    "highest_match_scores": [
+     300,
+     150,
+     117
+    ],
+    "qual_wins": 0
+   },
+   "frc6369": {
+    "highest_match_scores": [
+     387,
+     383,
+     358
+    ],
+    "qual_wins": 0
+   },
+   "frc6974": {
+    "highest_match_scores": [
+     219,
+     177,
+     131
+    ],
+    "qual_wins": 0
+   },
+   "frc8088": {
+    "highest_match_scores": [
+     260,
+     85,
+     74
+    ],
+    "qual_wins": 0
+   },
+   "frc8114": {
+    "highest_match_scores": [
+     328,
+     163,
+     111
+    ],
+    "qual_wins": 0
+   },
+   "frc8507": {
+    "highest_match_scores": [
+     233,
+     113,
+     109
+    ],
+    "qual_wins": 0
+   },
+   "frc8732": {
+    "highest_match_scores": [
+     245,
+     148,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc9034": {
+    "highest_match_scores": [
+     124,
+     118,
+     91
+    ],
+    "qual_wins": 0
+   },
+   "frc9136": {
+    "highest_match_scores": [
+     111,
+     102,
+     88
+    ],
+    "qual_wins": 0
+   },
+   "frc9140": {
+    "highest_match_scores": [
+     245,
+     178,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc9311": {
+    "highest_match_scores": [
+     177,
+     82,
+     61
+    ],
+    "qual_wins": 0
+   },
+   "frc9419": {
+    "highest_match_scores": [
+     81,
+     72,
+     66
+    ],
+    "qual_wins": 0
+   },
+   "frc9444": {
+    "highest_match_scores": [
+     258,
+     195,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc9658": {
+    "highest_match_scores": [
+     139,
+     111,
+     109
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026txwac": {
+  "points": {
+   "frc10014": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 51
+   },
+   "frc10994": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 34
+   },
+   "frc11200": {
+    "alliance_points": 1,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 10,
+    "total": 49
+   },
+   "frc11469": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc1477": {
+    "alliance_points": 10,
+    "award_points": 10,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 41
+   },
+   "frc2848": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc2881": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 62
+   },
+   "frc2950": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 12
+   },
+   "frc2969": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc3282": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc3679": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 32
+   },
+   "frc4295": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc5417": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 23
+   },
+   "frc5613": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 9,
+    "total": 30
+   },
+   "frc5682": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc5788": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc5866": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 25
+   },
+   "frc6369": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc7492": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc7506": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 45
+   },
+   "frc8370": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc8528": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 20
+   },
+   "frc8769": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc9121": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 4,
+    "total": 18
+   },
+   "frc9418": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 30
+   }
+  },
+  "tiebreakers": {
+   "frc10014": {
+    "highest_match_scores": [
+     320,
+     293,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc10994": {
+    "highest_match_scores": [
+     252,
+     233,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc11200": {
+    "highest_match_scores": [
+     372,
+     356,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc11469": {
+    "highest_match_scores": [
+     238,
+     180,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc1477": {
+    "highest_match_scores": [
+     293,
+     242,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc2848": {
+    "highest_match_scores": [
+     372,
+     356,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc2881": {
+    "highest_match_scores": [
+     284,
+     277,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc2950": {
+    "highest_match_scores": [
+     223,
+     217,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc2969": {
+    "highest_match_scores": [
+     320,
+     156,
+     151
+    ],
+    "qual_wins": 0
+   },
+   "frc3282": {
+    "highest_match_scores": [
+     228,
+     127,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc3679": {
+    "highest_match_scores": [
+     237,
+     228,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc4295": {
+    "highest_match_scores": [
+     237,
+     237,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc5417": {
+    "highest_match_scores": [
+     196,
+     180,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc5613": {
+    "highest_match_scores": [
+     212,
+     181,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc5682": {
+    "highest_match_scores": [
+     286,
+     278,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc5788": {
+    "highest_match_scores": [
+     286,
+     165,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc5866": {
+    "highest_match_scores": [
+     248,
+     176,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc6369": {
+    "highest_match_scores": [
+     372,
+     356,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc7492": {
+    "highest_match_scores": [
+     273,
+     248,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc7506": {
+    "highest_match_scores": [
+     237,
+     223,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc8370": {
+    "highest_match_scores": [
+     217,
+     212,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc8528": {
+    "highest_match_scores": [
+     286,
+     284,
+     119
+    ],
+    "qual_wins": 0
+   },
+   "frc8769": {
+    "highest_match_scores": [
+     278,
+     242,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9121": {
+    "highest_match_scores": [
+     277,
+     273,
+     129
+    ],
+    "qual_wins": 0
+   },
+   "frc9418": {
+    "highest_match_scores": [
+     286,
+     190,
+     156
+    ],
+    "qual_wins": 0
+   }
+  }
+ }
+}

--- a/src/backend/common/helpers/tests/data/2026fit_events.json
+++ b/src/backend/common/helpers/tests/data/2026fit_events.json
@@ -1,0 +1,332 @@
+[
+  {
+    "city": "Amarillo",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-04",
+    "event_code": "txama",
+    "event_type": 1,
+    "key": "2026txama",
+    "name": "FIT District Amarillo Event",
+    "start_date": "2026-04-02",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Belton",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-07",
+    "event_code": "txbel",
+    "event_type": 1,
+    "key": "2026txbel",
+    "name": "FIT District Belton Event",
+    "start_date": "2026-03-05",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Friendswood",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-04",
+    "event_code": "txcl2",
+    "event_type": 1,
+    "key": "2026txcl2",
+    "name": "FIT District Space City @ Friendswood Event #2",
+    "start_date": "2026-04-02",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "League City",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-09",
+    "event_code": "txcle",
+    "event_type": 1,
+    "key": "2026txcle",
+    "name": "FIT District Space City @ League City Event #1",
+    "start_date": "2026-03-07",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Houston",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "txcmp",
+    "event_type": 2,
+    "key": "2026txcmp",
+    "name": "FIRST In Texas District Championship",
+    "start_date": "2026-04-18",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Houston",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "txcmp1",
+    "event_type": 5,
+    "key": "2026txcmp1",
+    "name": "FIRST In Texas District Championship - Mercury Division",
+    "start_date": "2026-04-15",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Houston",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "txcmp2",
+    "event_type": 5,
+    "key": "2026txcmp2",
+    "name": "FIRST In Texas District Championship - Apollo Division",
+    "start_date": "2026-04-15",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Dripping Springs",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-04",
+    "event_code": "txdri",
+    "event_type": 1,
+    "key": "2026txdri",
+    "name": "FIT District Dripping Springs Event",
+    "start_date": "2026-04-02",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Farmersville",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "txfar",
+    "event_type": 1,
+    "key": "2026txfar",
+    "name": "FIT District Farmersville Event",
+    "start_date": "2026-03-27",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Fort Worth",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "txfor",
+    "event_type": 1,
+    "key": "2026txfor",
+    "name": "FIT District Fort Worth Event",
+    "start_date": "2026-03-19",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Houston",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "txhou",
+    "event_type": 1,
+    "key": "2026txhou",
+    "name": "FIT District Houston Event",
+    "start_date": "2026-03-19",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Manor",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "txman",
+    "event_type": 1,
+    "key": "2026txman",
+    "name": "FIT District Manor Event",
+    "start_date": "2026-03-27",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "McAllen",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-14",
+    "event_code": "txmca",
+    "event_type": 1,
+    "key": "2026txmca",
+    "name": "FIT District McAllen Event",
+    "start_date": "2026-03-12",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "San Antonio",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-14",
+    "event_code": "txsan",
+    "event_type": 1,
+    "key": "2026txsan",
+    "name": "FIT District San Antonio Event",
+    "start_date": "2026-03-12",
+    "state_prov": "TX",
+    "year": 2026
+  },
+  {
+    "city": "Waco",
+    "country": "USA",
+    "district": {
+      "abbreviation": "fit",
+      "display_name": "FIRST In Texas",
+      "key": "2026fit",
+      "official_advancement_counts": {
+        "cmp": 28,
+        "dcmp": 90
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "txwac",
+    "event_type": 1,
+    "key": "2026txwac",
+    "name": "FIT District Waco Event",
+    "start_date": "2026-03-19",
+    "state_prov": "TX",
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026fit_rankings.json
+++ b/src/backend/common/helpers/tests/data/2026fit_rankings.json
@@ -1,0 +1,5625 @@
+[
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txsan",
+        "qual_points": 22,
+        "total": 76
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txwac",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026txcmp2",
+        "qual_points": 66,
+        "total": 204
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 54
+      }
+    ],
+    "point_total": 407,
+    "rank": 1,
+    "rookie_bonus": 0,
+    "team_key": "frc6369"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txcle",
+        "qual_points": 22,
+        "total": 68
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txfar",
+        "qual_points": 21,
+        "total": 77
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026txcmp2",
+        "qual_points": 60,
+        "total": 198
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 373,
+    "rank": 2,
+    "rookie_bonus": 0,
+    "team_key": "frc9128"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txcle",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txman",
+        "qual_points": 21,
+        "total": 75
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026txcmp1",
+        "qual_points": 66,
+        "total": 219
+      }
+    ],
+    "point_total": 365,
+    "rank": 3,
+    "rookie_bonus": 0,
+    "team_key": "frc6800"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txcle",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txmca",
+        "qual_points": 22,
+        "total": 78
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026txcmp1",
+        "qual_points": 63,
+        "total": 201
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 360,
+    "rank": 4,
+    "rookie_bonus": 0,
+    "team_key": "frc118"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txcle",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txfar",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026txcmp1",
+        "qual_points": 60,
+        "total": 180
+      }
+    ],
+    "point_total": 319,
+    "rank": 5,
+    "rookie_bonus": 5,
+    "team_key": "frc10340"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txbel",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txfor",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026txcmp2",
+        "qual_points": 60,
+        "total": 159
+      }
+    ],
+    "point_total": 294,
+    "rank": 6,
+    "rookie_bonus": 0,
+    "team_key": "frc148"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txwac",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txfar",
+        "qual_points": 20,
+        "total": 55
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026txcmp2",
+        "qual_points": 57,
+        "total": 159
+      }
+    ],
+    "point_total": 286,
+    "rank": 7,
+    "rookie_bonus": 0,
+    "team_key": "frc2848"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txcle",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txcl2",
+        "qual_points": 18,
+        "total": 64
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026txcmp1",
+        "qual_points": 45,
+        "total": 150
+      }
+    ],
+    "point_total": 272,
+    "rank": 8,
+    "rookie_bonus": 0,
+    "team_key": "frc3847"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txbel",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txdri",
+        "qual_points": 22,
+        "total": 78
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 54,
+        "total": 105
+      }
+    ],
+    "point_total": 256,
+    "rank": 9,
+    "rookie_bonus": 0,
+    "team_key": "frc2468"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txbel",
+        "qual_points": 18,
+        "total": 56
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txfar",
+        "qual_points": 19,
+        "total": 54
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026txcmp1",
+        "qual_points": 54,
+        "total": 141
+      }
+    ],
+    "point_total": 251,
+    "rank": 10,
+    "rookie_bonus": 0,
+    "team_key": "frc1296"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txfor",
+        "qual_points": 17,
+        "total": 48
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txama",
+        "qual_points": 19,
+        "total": 54
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026txcmp2",
+        "qual_points": 63,
+        "total": 147
+      }
+    ],
+    "point_total": 249,
+    "rank": 11,
+    "rookie_bonus": 0,
+    "team_key": "frc4206"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txsan",
+        "qual_points": 14,
+        "total": 30
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txman",
+        "qual_points": 14,
+        "total": 52
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026txcmp2",
+        "qual_points": 42,
+        "total": 135
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 247,
+    "rank": 12,
+    "rookie_bonus": 0,
+    "team_key": "frc9140"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txbel",
+        "qual_points": 14,
+        "total": 35
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 16,
+        "total": 32
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026txcmp2",
+        "qual_points": 54,
+        "total": 171
+      }
+    ],
+    "point_total": 238,
+    "rank": 13,
+    "rookie_bonus": 0,
+    "team_key": "frc8749"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txbel",
+        "qual_points": 9,
+        "total": 33
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txwac",
+        "qual_points": 16,
+        "total": 51
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026txcmp1",
+        "qual_points": 48,
+        "total": 135
+      }
+    ],
+    "point_total": 224,
+    "rank": 14,
+    "rookie_bonus": 5,
+    "team_key": "frc10014"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txmca",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txman",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026txcmp2",
+        "qual_points": 48,
+        "total": 102
+      }
+    ],
+    "point_total": 224,
+    "rank": 15,
+    "rookie_bonus": 0,
+    "team_key": "frc2583"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txfar",
+        "qual_points": 17,
+        "total": 57
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txama",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 39,
+        "total": 93
+      }
+    ],
+    "point_total": 223,
+    "rank": 16,
+    "rookie_bonus": 0,
+    "team_key": "frc6773"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txbel",
+        "qual_points": 18,
+        "total": 51
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txhou",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026txcmp1",
+        "qual_points": 33,
+        "total": 99
+      }
+    ],
+    "point_total": 222,
+    "rank": 17,
+    "rookie_bonus": 0,
+    "team_key": "frc624"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 15,
+        "total": 33
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txhou",
+        "qual_points": 19,
+        "total": 57
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026txcmp2",
+        "qual_points": 33,
+        "total": 102
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 216,
+    "rank": 18,
+    "rookie_bonus": 0,
+    "team_key": "frc5414"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txmca",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txcl2",
+        "qual_points": 19,
+        "total": 50
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026txcmp1",
+        "qual_points": 42,
+        "total": 105
+      }
+    ],
+    "point_total": 213,
+    "rank": 19,
+    "rookie_bonus": 0,
+    "team_key": "frc5829"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txsan",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txfar",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 48,
+        "total": 90
+      }
+    ],
+    "point_total": 211,
+    "rank": 20,
+    "rookie_bonus": 0,
+    "team_key": "frc2582"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txsan",
+        "qual_points": 19,
+        "total": 59
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txman",
+        "qual_points": 18,
+        "total": 45
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 54,
+        "total": 105
+      }
+    ],
+    "point_total": 209,
+    "rank": 21,
+    "rookie_bonus": 0,
+    "team_key": "frc5572"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txsan",
+        "qual_points": 20,
+        "total": 55
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txdri",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 51,
+        "total": 81
+      }
+    ],
+    "point_total": 208,
+    "rank": 22,
+    "rookie_bonus": 0,
+    "team_key": "frc3035"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 19,
+        "total": 43
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txwac",
+        "qual_points": 19,
+        "total": 62
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 57,
+        "total": 96
+      }
+    ],
+    "point_total": 201,
+    "rank": 23,
+    "rookie_bonus": 0,
+    "team_key": "frc2881"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txfor",
+        "qual_points": 20,
+        "total": 61
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txfar",
+        "qual_points": 14,
+        "total": 34
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 54,
+        "total": 105
+      }
+    ],
+    "point_total": 200,
+    "rank": 24,
+    "rookie_bonus": 0,
+    "team_key": "frc3005"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcle",
+        "qual_points": 7,
+        "total": 23
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txwac",
+        "qual_points": 14,
+        "total": 41
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 60,
+        "total": 102
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 196,
+    "rank": 25,
+    "rookie_bonus": 0,
+    "team_key": "frc1477"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txfor",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026txcmp2",
+        "qual_points": 51,
+        "total": 105
+      }
+    ],
+    "point_total": 176,
+    "rank": 26,
+    "rookie_bonus": 0,
+    "team_key": "frc8858"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txcl2",
+        "qual_points": 20,
+        "total": 59
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 51,
+        "event_key": "2026txcmp1",
+        "qual_points": 39,
+        "total": 90
+      }
+    ],
+    "point_total": 175,
+    "rank": 27,
+    "rookie_bonus": 0,
+    "team_key": "frc2587"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txmca",
+        "qual_points": 14,
+        "total": 33
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txama",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 54,
+        "total": 93
+      }
+    ],
+    "point_total": 175,
+    "rank": 28,
+    "rookie_bonus": 0,
+    "team_key": "frc4063"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 12,
+        "total": 27
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026txcmp1",
+        "qual_points": 45,
+        "total": 117
+      }
+    ],
+    "point_total": 170,
+    "rank": 29,
+    "rookie_bonus": 0,
+    "team_key": "frc5892"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcle",
+        "qual_points": 17,
+        "total": 42
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txman",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 42,
+        "total": 78
+      }
+    ],
+    "point_total": 169,
+    "rank": 30,
+    "rookie_bonus": 0,
+    "team_key": "frc6377"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txama",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026txcmp2",
+        "qual_points": 42,
+        "total": 81
+      }
+    ],
+    "point_total": 168,
+    "rank": 31,
+    "rookie_bonus": 0,
+    "team_key": "frc3310"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 9,
+        "total": 20
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txfor",
+        "qual_points": 18,
+        "total": 67
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 51,
+        "total": 81
+      }
+    ],
+    "point_total": 168,
+    "rank": 32,
+    "rookie_bonus": 0,
+    "team_key": "frc2728"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txbel",
+        "qual_points": 16,
+        "total": 54
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 13,
+        "total": 30
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 39,
+        "total": 84
+      }
+    ],
+    "point_total": 168,
+    "rank": 33,
+    "rookie_bonus": 0,
+    "team_key": "frc9418"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 15,
+        "total": 35
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txman",
+        "qual_points": 16,
+        "total": 54
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 48,
+        "total": 75
+      }
+    ],
+    "point_total": 164,
+    "rank": 34,
+    "rookie_bonus": 0,
+    "team_key": "frc418"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 13,
+        "total": 24
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txcl2",
+        "qual_points": 17,
+        "total": 56
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026txcmp1",
+        "qual_points": 36,
+        "total": 81
+      }
+    ],
+    "point_total": 161,
+    "rank": 35,
+    "rookie_bonus": 0,
+    "team_key": "frc324"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 10,
+        "total": 28
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026txcmp1",
+        "qual_points": 48,
+        "total": 96
+      }
+    ],
+    "point_total": 158,
+    "rank": 36,
+    "rookie_bonus": 0,
+    "team_key": "frc3481"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txwac",
+        "qual_points": 18,
+        "total": 45
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txfar",
+        "qual_points": 18,
+        "total": 43
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 45,
+        "total": 69
+      }
+    ],
+    "point_total": 157,
+    "rank": 37,
+    "rookie_bonus": 0,
+    "team_key": "frc7506"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txmca",
+        "qual_points": 8,
+        "total": 38
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txcl2",
+        "qual_points": 16,
+        "total": 52
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 45,
+        "total": 66
+      }
+    ],
+    "point_total": 156,
+    "rank": 38,
+    "rookie_bonus": 0,
+    "team_key": "frc5427"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txfor",
+        "qual_points": 15,
+        "total": 64
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 39,
+        "total": 63
+      }
+    ],
+    "point_total": 155,
+    "rank": 39,
+    "rookie_bonus": 0,
+    "team_key": "frc2714"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 9,
+        "total": 24
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txfor",
+        "qual_points": 13,
+        "total": 40
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 51,
+        "total": 90
+      }
+    ],
+    "point_total": 154,
+    "rank": 40,
+    "rookie_bonus": 0,
+    "team_key": "frc6672"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txmca",
+        "qual_points": 13,
+        "total": 53
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txdri",
+        "qual_points": 18,
+        "total": 43
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 152,
+    "rank": 41,
+    "rookie_bonus": 5,
+    "team_key": "frc10385"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcl2",
+        "qual_points": 21,
+        "total": 48
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 45,
+        "total": 72
+      }
+    ],
+    "point_total": 151,
+    "rank": 42,
+    "rookie_bonus": 0,
+    "team_key": "frc8576"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcle",
+        "qual_points": 16,
+        "total": 41
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 9,
+        "total": 22
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 48,
+        "total": 84
+      }
+    ],
+    "point_total": 147,
+    "rank": 43,
+    "rookie_bonus": 0,
+    "team_key": "frc7312"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txmca",
+        "qual_points": 16,
+        "total": 41
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txdri",
+        "qual_points": 17,
+        "total": 42
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 45,
+        "total": 60
+      }
+    ],
+    "point_total": 143,
+    "rank": 44,
+    "rookie_bonus": 0,
+    "team_key": "frc2158"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 5,
+        "event_key": "2026txcle",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txdri",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 27,
+        "total": 42
+      }
+    ],
+    "point_total": 138,
+    "rank": 45,
+    "rookie_bonus": 0,
+    "team_key": "frc4639"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 11,
+        "total": 21
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txdri",
+        "qual_points": 13,
+        "total": 45
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026txcmp2",
+        "qual_points": 24,
+        "total": 69
+      }
+    ],
+    "point_total": 135,
+    "rank": 46,
+    "rookie_bonus": 0,
+    "team_key": "frc6357"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 12,
+        "total": 23
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 16,
+        "total": 32
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 42,
+        "event_key": "2026txcmp1",
+        "qual_points": 30,
+        "total": 75
+      }
+    ],
+    "point_total": 130,
+    "rank": 47,
+    "rookie_bonus": 0,
+    "team_key": "frc8088"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txbel",
+        "qual_points": 20,
+        "total": 48
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txdri",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 130,
+    "rank": 48,
+    "rookie_bonus": 0,
+    "team_key": "frc2689"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txfor",
+        "qual_points": 11,
+        "total": 44
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 10,
+        "total": 23
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 30,
+        "total": 57
+      }
+    ],
+    "point_total": 129,
+    "rank": 49,
+    "rookie_bonus": 5,
+    "team_key": "frc10032"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txhou",
+        "qual_points": 20,
+        "total": 53
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 14,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 30,
+        "total": 45
+      }
+    ],
+    "point_total": 129,
+    "rank": 50,
+    "rookie_bonus": 0,
+    "team_key": "frc231"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txhou",
+        "qual_points": 9,
+        "total": 32
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 17,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 33,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 127,
+    "rank": 51,
+    "rookie_bonus": 10,
+    "team_key": "frc11242"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 14,
+        "total": 33
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 33,
+        "total": 60
+      }
+    ],
+    "point_total": 127,
+    "rank": 52,
+    "rookie_bonus": 0,
+    "team_key": "frc4192"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 17,
+        "total": 37
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 39,
+        "total": 39
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 123,
+    "rank": 53,
+    "rookie_bonus": 10,
+    "team_key": "frc11178"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txwac",
+        "qual_points": 7,
+        "total": 34
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txama",
+        "qual_points": 12,
+        "total": 51
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 122,
+    "rank": 54,
+    "rookie_bonus": 10,
+    "team_key": "frc10994"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txsan",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 18,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 122,
+    "rank": 55,
+    "rookie_bonus": 0,
+    "team_key": "frc3735"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txbel",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 12,
+        "total": 23
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 36,
+        "total": 66
+      }
+    ],
+    "point_total": 120,
+    "rank": 56,
+    "rookie_bonus": 0,
+    "team_key": "frc9506"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txsan",
+        "qual_points": 12,
+        "total": 51
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txdri",
+        "qual_points": 11,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 118,
+    "rank": 57,
+    "rookie_bonus": 10,
+    "team_key": "frc11169"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txsan",
+        "qual_points": 18,
+        "total": 50
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 12,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 114,
+    "rank": 58,
+    "rookie_bonus": 0,
+    "team_key": "frc457"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 14,
+        "total": 29
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txwac",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 114,
+    "rank": 59,
+    "rookie_bonus": 0,
+    "team_key": "frc7492"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 16,
+        "total": 31
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txdri",
+        "qual_points": 15,
+        "total": 55
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 12,
+        "total": 27
+      }
+    ],
+    "point_total": 113,
+    "rank": 60,
+    "rookie_bonus": 0,
+    "team_key": "frc2687"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txfor",
+        "qual_points": 15,
+        "total": 46
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 14,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 113,
+    "rank": 61,
+    "rookie_bonus": 0,
+    "team_key": "frc7503"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026txcle",
+        "qual_points": 13,
+        "total": 32
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 108,
+    "rank": 62,
+    "rookie_bonus": 0,
+    "team_key": "frc127"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txwac",
+        "qual_points": 10,
+        "total": 49
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txama",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 107,
+    "rank": 63,
+    "rookie_bonus": 10,
+    "team_key": "frc11200"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txhou",
+        "qual_points": 18,
+        "total": 52
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 107,
+    "rank": 64,
+    "rookie_bonus": 0,
+    "team_key": "frc1255"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txsan",
+        "qual_points": 16,
+        "total": 36
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 14,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 107,
+    "rank": 65,
+    "rookie_bonus": 0,
+    "team_key": "frc3679"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txfar",
+        "qual_points": 13,
+        "total": 35
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txama",
+        "qual_points": 8,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 103,
+    "rank": 66,
+    "rookie_bonus": 0,
+    "team_key": "frc5411"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txcle",
+        "qual_points": 12,
+        "total": 38
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 12,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 103,
+    "rank": 67,
+    "rookie_bonus": 0,
+    "team_key": "frc5417"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txmca",
+        "qual_points": 12,
+        "total": 35
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txwac",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 101,
+    "rank": 68,
+    "rookie_bonus": 0,
+    "team_key": "frc4295"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txfar",
+        "qual_points": 11,
+        "total": 47
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txama",
+        "qual_points": 13,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 99,
+    "rank": 69,
+    "rookie_bonus": 0,
+    "team_key": "frc9492"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 4,
+        "event_key": "2026txsan",
+        "qual_points": 6,
+        "total": 19
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txama",
+        "qual_points": 18,
+        "total": 50
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 15,
+        "total": 30
+      }
+    ],
+    "point_total": 99,
+    "rank": 70,
+    "rookie_bonus": 0,
+    "team_key": "frc9136"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 13,
+        "total": 24
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 13,
+        "total": 30
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 30,
+        "total": 45
+      }
+    ],
+    "point_total": 99,
+    "rank": 71,
+    "rookie_bonus": 0,
+    "team_key": "frc8114"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txfor",
+        "qual_points": 8,
+        "total": 17
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txman",
+        "qual_points": 10,
+        "total": 39
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 95,
+    "rank": 72,
+    "rookie_bonus": 0,
+    "team_key": "frc6901"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txsan",
+        "qual_points": 17,
+        "total": 42
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 95,
+    "rank": 73,
+    "rookie_bonus": 0,
+    "team_key": "frc3561"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txbel",
+        "qual_points": 5,
+        "total": 36
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txdri",
+        "qual_points": 6,
+        "total": 37
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 94,
+    "rank": 74,
+    "rookie_bonus": 0,
+    "team_key": "frc5503"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 15,
+        "total": 27
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 14,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 92,
+    "rank": 75,
+    "rookie_bonus": 0,
+    "team_key": "frc8507"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 10,
+        "total": 25
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txcl2",
+        "qual_points": 12,
+        "total": 43
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 89,
+    "rank": 76,
+    "rookie_bonus": 0,
+    "team_key": "frc3676"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txcle",
+        "qual_points": 4,
+        "total": 35
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 88,
+    "rank": 77,
+    "rookie_bonus": 0,
+    "team_key": "frc8370"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txhou",
+        "qual_points": 12,
+        "total": 51
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcl2",
+        "qual_points": 14,
+        "total": 36
+      }
+    ],
+    "point_total": 87,
+    "rank": 78,
+    "rookie_bonus": 0,
+    "team_key": "frc8515"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 6,
+        "total": 14
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txhou",
+        "qual_points": 10,
+        "total": 46
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 85,
+    "rank": 79,
+    "rookie_bonus": 10,
+    "team_key": "frc11277"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 12,
+        "total": 25
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txcl2",
+        "qual_points": 5,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 85,
+    "rank": 80,
+    "rookie_bonus": 0,
+    "team_key": "frc7616"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 12,
+        "total": 27
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txcl2",
+        "qual_points": 11,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 85,
+    "rank": 81,
+    "rookie_bonus": 0,
+    "team_key": "frc7691"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txfor",
+        "qual_points": 11,
+        "total": 37
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 13,
+        "total": 20
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 12,
+        "total": 27
+      }
+    ],
+    "point_total": 84,
+    "rank": 82,
+    "rookie_bonus": 0,
+    "team_key": "frc4153"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 16,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 83,
+    "rank": 83,
+    "rookie_bonus": 0,
+    "team_key": "frc4734"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 11,
+        "total": 25
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 14,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 83,
+    "rank": 84,
+    "rookie_bonus": 0,
+    "team_key": "frc9577"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 11,
+        "total": 22
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 81,
+    "rank": 85,
+    "rookie_bonus": 0,
+    "team_key": "frc5261"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 12,
+        "total": 22
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 81,
+    "rank": 86,
+    "rookie_bonus": 0,
+    "team_key": "frc8769"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 8,
+        "total": 15
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txhou",
+        "qual_points": 14,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 80,
+    "rank": 87,
+    "rookie_bonus": 0,
+    "team_key": "frc8177"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txdri",
+        "qual_points": 10,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp1",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 79,
+    "rank": 88,
+    "rookie_bonus": 0,
+    "team_key": "frc9444"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txman",
+        "qual_points": 18,
+        "total": 50
+      }
+    ],
+    "point_total": 77,
+    "rank": 89,
+    "rookie_bonus": 0,
+    "team_key": "frc436"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txman",
+        "qual_points": 13,
+        "total": 28
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 12,
+        "total": 21
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 77,
+    "rank": 90,
+    "rookie_bonus": 10,
+    "team_key": "frc10913"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txmca",
+        "qual_points": 10,
+        "total": 37
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 10,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 74,
+    "rank": 91,
+    "rookie_bonus": 0,
+    "team_key": "frc8818"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txmca",
+        "qual_points": 15,
+        "total": 45
+      }
+    ],
+    "point_total": 73,
+    "rank": 92,
+    "rookie_bonus": 5,
+    "team_key": "frc10118"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txsan",
+        "qual_points": 13,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026txcmp2",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 68,
+    "rank": 93,
+    "rookie_bonus": 5,
+    "team_key": "frc10518"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 12,
+        "total": 27
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 17,
+        "total": 35
+      }
+    ],
+    "point_total": 62,
+    "rank": 94,
+    "rookie_bonus": 0,
+    "team_key": "frc1164"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txmca",
+        "qual_points": 17,
+        "total": 39
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txman",
+        "qual_points": 6,
+        "total": 20
+      }
+    ],
+    "point_total": 59,
+    "rank": 95,
+    "rookie_bonus": 0,
+    "team_key": "frc8573"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 15,
+        "total": 31
+      }
+    ],
+    "point_total": 53,
+    "rank": 96,
+    "rookie_bonus": 0,
+    "team_key": "frc9512"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 9,
+        "total": 21
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 16,
+        "total": 32
+      }
+    ],
+    "point_total": 53,
+    "rank": 97,
+    "rookie_bonus": 0,
+    "team_key": "frc4219"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026txhou",
+        "qual_points": 8,
+        "total": 31
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcl2",
+        "qual_points": 12,
+        "total": 21
+      }
+    ],
+    "point_total": 52,
+    "rank": 98,
+    "rookie_bonus": 0,
+    "team_key": "frc4587"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txfor",
+        "qual_points": 7,
+        "total": 24
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 16,
+        "total": 28
+      }
+    ],
+    "point_total": 52,
+    "rank": 99,
+    "rookie_bonus": 0,
+    "team_key": "frc7119"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 52,
+    "rank": 100,
+    "rookie_bonus": 0,
+    "team_key": "frc5790"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 9,
+        "event_key": "2026txcle",
+        "qual_points": 11,
+        "total": 20
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 15,
+        "total": 31
+      }
+    ],
+    "point_total": 51,
+    "rank": 101,
+    "rookie_bonus": 0,
+    "team_key": "frc5788"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 14,
+        "total": 21
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 15,
+        "total": 30
+      }
+    ],
+    "point_total": 51,
+    "rank": 102,
+    "rookie_bonus": 0,
+    "team_key": "frc4328"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txmca",
+        "qual_points": 11,
+        "total": 36
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 9,
+        "total": 14
+      }
+    ],
+    "point_total": 50,
+    "rank": 103,
+    "rookie_bonus": 0,
+    "team_key": "frc6180"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 11,
+        "total": 22
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 11,
+        "total": 28
+      }
+    ],
+    "point_total": 50,
+    "rank": 104,
+    "rookie_bonus": 0,
+    "team_key": "frc5103"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 10,
+        "total": 21
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 14,
+        "total": 29
+      }
+    ],
+    "point_total": 50,
+    "rank": 105,
+    "rookie_bonus": 0,
+    "team_key": "frc7540"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 7,
+        "total": 17
+      }
+    ],
+    "point_total": 49,
+    "rank": 106,
+    "rookie_bonus": 5,
+    "team_key": "frc10312"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 14,
+        "total": 27
+      }
+    ],
+    "point_total": 49,
+    "rank": 107,
+    "rookie_bonus": 0,
+    "team_key": "frc5682"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txbel",
+        "qual_points": 13,
+        "total": 33
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 9,
+        "total": 15
+      }
+    ],
+    "point_total": 48,
+    "rank": 108,
+    "rookie_bonus": 0,
+    "team_key": "frc2789"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 9,
+        "total": 21
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 12,
+        "total": 27
+      }
+    ],
+    "point_total": 48,
+    "rank": 109,
+    "rookie_bonus": 0,
+    "team_key": "frc5431"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 48,
+    "rank": 110,
+    "rookie_bonus": 10,
+    "team_key": "frc10904"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026txmca",
+        "qual_points": 7,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 47,
+    "rank": 111,
+    "rookie_bonus": 0,
+    "team_key": "frc4597"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txbel",
+        "qual_points": 11,
+        "total": 26
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 11,
+        "total": 21
+      }
+    ],
+    "point_total": 47,
+    "rank": 112,
+    "rookie_bonus": 0,
+    "team_key": "frc4610"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 8,
+        "total": 20
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 13,
+        "total": 26
+      }
+    ],
+    "point_total": 46,
+    "rank": 113,
+    "rookie_bonus": 0,
+    "team_key": "frc4076"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 8,
+        "total": 13
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 46,
+    "rank": 114,
+    "rookie_bonus": 10,
+    "team_key": "frc11469"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txman",
+        "qual_points": 10,
+        "total": 26
+      }
+    ],
+    "point_total": 45,
+    "rank": 115,
+    "rookie_bonus": 10,
+    "team_key": "frc11309"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 12,
+        "total": 21
+      }
+    ],
+    "point_total": 45,
+    "rank": 116,
+    "rookie_bonus": 0,
+    "team_key": "frc4641"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 4,
+        "event_key": "2026txsan",
+        "qual_points": 13,
+        "total": 17
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 16,
+        "total": 27
+      }
+    ],
+    "point_total": 44,
+    "rank": 117,
+    "rookie_bonus": 0,
+    "team_key": "frc5726"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 10,
+        "total": 21
+      }
+    ],
+    "point_total": 44,
+    "rank": 118,
+    "rookie_bonus": 0,
+    "team_key": "frc1745"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 6,
+        "total": 19
+      }
+    ],
+    "point_total": 43,
+    "rank": 119,
+    "rookie_bonus": 0,
+    "team_key": "frc6645"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 10,
+        "total": 19
+      }
+    ],
+    "point_total": 43,
+    "rank": 120,
+    "rookie_bonus": 0,
+    "team_key": "frc6974"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 12,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 9,
+        "total": 17
+      }
+    ],
+    "point_total": 42,
+    "rank": 121,
+    "rookie_bonus": 0,
+    "team_key": "frc5866"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txfar",
+        "qual_points": 5,
+        "total": 21
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 12,
+        "total": 20
+      }
+    ],
+    "point_total": 41,
+    "rank": 122,
+    "rookie_bonus": 0,
+    "team_key": "frc9105"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 24,
+        "event_key": "2026txman",
+        "qual_points": 7,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 40,
+    "rank": 123,
+    "rookie_bonus": 0,
+    "team_key": "frc7088"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026txwac",
+        "qual_points": 9,
+        "total": 30
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 5,
+        "total": 10
+      }
+    ],
+    "point_total": 40,
+    "rank": 124,
+    "rookie_bonus": 0,
+    "team_key": "frc5613"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txcle",
+        "qual_points": 5,
+        "total": 14
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 15,
+        "total": 25
+      }
+    ],
+    "point_total": 39,
+    "rank": 125,
+    "rookie_bonus": 0,
+    "team_key": "frc6243"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txhou",
+        "qual_points": 7,
+        "total": 19
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 13,
+        "total": 20
+      }
+    ],
+    "point_total": 39,
+    "rank": 126,
+    "rookie_bonus": 0,
+    "team_key": "frc2585"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 16,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 39,
+    "rank": 127,
+    "rookie_bonus": 0,
+    "team_key": "frc5070"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 12,
+        "total": 25
+      }
+    ],
+    "point_total": 39,
+    "rank": 128,
+    "rookie_bonus": 10,
+    "team_key": "frc11224"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 12,
+        "total": 20
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txwac",
+        "qual_points": 4,
+        "total": 18
+      }
+    ],
+    "point_total": 38,
+    "rank": 129,
+    "rookie_bonus": 0,
+    "team_key": "frc9121"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txmca",
+        "qual_points": 5,
+        "total": 13
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txdri",
+        "qual_points": 14,
+        "total": 25
+      }
+    ],
+    "point_total": 38,
+    "rank": 130,
+    "rookie_bonus": 0,
+    "team_key": "frc4332"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 11,
+        "total": 21
+      }
+    ],
+    "point_total": 38,
+    "rank": 131,
+    "rookie_bonus": 0,
+    "team_key": "frc9034"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 37,
+    "rank": 132,
+    "rookie_bonus": 0,
+    "team_key": "frc9786"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 11,
+        "total": 19
+      }
+    ],
+    "point_total": 37,
+    "rank": 133,
+    "rookie_bonus": 10,
+    "team_key": "frc11132"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 36,
+    "rank": 134,
+    "rookie_bonus": 0,
+    "team_key": "frc9311"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 8,
+        "total": 13
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 11,
+        "total": 23
+      }
+    ],
+    "point_total": 36,
+    "rank": 135,
+    "rookie_bonus": 0,
+    "team_key": "frc4717"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txmca",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 35,
+    "rank": 136,
+    "rookie_bonus": 0,
+    "team_key": "frc8750"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txmca",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 34,
+    "rank": 137,
+    "rookie_bonus": 0,
+    "team_key": "frc5894"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 33,
+    "rank": 138,
+    "rookie_bonus": 0,
+    "team_key": "frc9307"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 13,
+        "total": 20
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 8,
+        "total": 13
+      }
+    ],
+    "point_total": 33,
+    "rank": 139,
+    "rookie_bonus": 0,
+    "team_key": "frc9080"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 12,
+        "total": 16
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 10,
+        "total": 16
+      }
+    ],
+    "point_total": 32,
+    "rank": 140,
+    "rookie_bonus": 0,
+    "team_key": "frc5908"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 11,
+        "total": 24
+      }
+    ],
+    "point_total": 32,
+    "rank": 141,
+    "rookie_bonus": 0,
+    "team_key": "frc5923"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txama",
+        "qual_points": 4,
+        "total": 17
+      }
+    ],
+    "point_total": 31,
+    "rank": 142,
+    "rookie_bonus": 0,
+    "team_key": "frc8732"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026txfar",
+        "qual_points": 4,
+        "total": 15
+      }
+    ],
+    "point_total": 30,
+    "rank": 143,
+    "rookie_bonus": 0,
+    "team_key": "frc9289"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 11,
+        "total": 20
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 29,
+    "rank": 144,
+    "rookie_bonus": 0,
+    "team_key": "frc8528"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 10,
+        "total": 16
+      }
+    ],
+    "point_total": 28,
+    "rank": 145,
+    "rookie_bonus": 0,
+    "team_key": "frc6526"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 6,
+        "total": 11
+      }
+    ],
+    "point_total": 28,
+    "rank": 146,
+    "rookie_bonus": 0,
+    "team_key": "frc9181"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 11,
+        "total": 17
+      }
+    ],
+    "point_total": 27,
+    "rank": 147,
+    "rookie_bonus": 0,
+    "team_key": "frc9478"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 13,
+        "total": 18
+      }
+    ],
+    "point_total": 27,
+    "rank": 148,
+    "rookie_bonus": 0,
+    "team_key": "frc2882"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 6,
+        "total": 18
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 26,
+    "rank": 149,
+    "rookie_bonus": 0,
+    "team_key": "frc7121"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 10,
+        "total": 16
+      }
+    ],
+    "point_total": 26,
+    "rank": 150,
+    "rookie_bonus": 0,
+    "team_key": "frc2969"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 8,
+        "total": 15
+      }
+    ],
+    "point_total": 23,
+    "rank": 151,
+    "rookie_bonus": 0,
+    "team_key": "frc3545"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 4,
+        "total": 11
+      }
+    ],
+    "point_total": 23,
+    "rank": 152,
+    "rookie_bonus": 0,
+    "team_key": "frc9137"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 8,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 23,
+    "rank": 153,
+    "rookie_bonus": 0,
+    "team_key": "frc2950"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcle",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 21,
+    "rank": 154,
+    "rookie_bonus": 0,
+    "team_key": "frc7115"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 21,
+    "rank": 155,
+    "rookie_bonus": 0,
+    "team_key": "frc9658"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 11,
+        "total": 15
+      }
+    ],
+    "point_total": 20,
+    "rank": 156,
+    "rookie_bonus": 0,
+    "team_key": "frc2657"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 19,
+    "rank": 157,
+    "rookie_bonus": 0,
+    "team_key": "frc4364"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txwac",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 8,
+        "total": 13
+      }
+    ],
+    "point_total": 19,
+    "rank": 158,
+    "rookie_bonus": 0,
+    "team_key": "frc3282"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txmca",
+        "qual_points": 9,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 19,
+    "rank": 159,
+    "rookie_bonus": 0,
+    "team_key": "frc7521"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 16,
+    "rank": 160,
+    "rookie_bonus": 0,
+    "team_key": "frc9457"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 16,
+    "rank": 161,
+    "rookie_bonus": 0,
+    "team_key": "frc7271"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 15,
+    "rank": 162,
+    "rookie_bonus": 0,
+    "team_key": "frc6171"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 14,
+    "rank": 163,
+    "rookie_bonus": 0,
+    "team_key": "frc7091"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txman",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txdri",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 14,
+    "rank": 164,
+    "rookie_bonus": 0,
+    "team_key": "frc7138"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 14,
+        "total": 14
+      }
+    ],
+    "point_total": 14,
+    "rank": 165,
+    "rookie_bonus": 0,
+    "team_key": "frc6768"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 14,
+    "rank": 166,
+    "rookie_bonus": 0,
+    "team_key": "frc5986"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 13,
+    "rank": 167,
+    "rookie_bonus": 0,
+    "team_key": "frc8816"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 13,
+    "rank": 168,
+    "rookie_bonus": 0,
+    "team_key": "frc7125"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txbel",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 13,
+    "rank": 169,
+    "rookie_bonus": 0,
+    "team_key": "frc3240"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 12,
+    "rank": 170,
+    "rookie_bonus": 0,
+    "team_key": "frc6488"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txcl2",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 11,
+    "rank": 171,
+    "rookie_bonus": 0,
+    "team_key": "frc3728"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 6,
+        "total": 11
+      }
+    ],
+    "point_total": 11,
+    "rank": 172,
+    "rookie_bonus": 0,
+    "team_key": "frc9419"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txama",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 10,
+    "rank": 173,
+    "rookie_bonus": 0,
+    "team_key": "frc8512"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txmca",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 10,
+    "rank": 174,
+    "rookie_bonus": 0,
+    "team_key": "frc8591"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [],
+    "point_total": 10,
+    "rank": 175,
+    "rookie_bonus": 10,
+    "team_key": "frc11091"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [],
+    "point_total": 10,
+    "rank": 176,
+    "rookie_bonus": 10,
+    "team_key": "frc11465"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfar",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 9,
+    "rank": 177,
+    "rookie_bonus": 0,
+    "team_key": "frc8408"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 9,
+    "rank": 178,
+    "rookie_bonus": 0,
+    "team_key": "frc5212"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txfor",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 5,
+    "rank": 179,
+    "rookie_bonus": 0,
+    "team_key": "frc7534"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txhou",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 5,
+    "rank": 180,
+    "rookie_bonus": 0,
+    "team_key": "frc9521"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026txsan",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 4,
+    "rank": 181,
+    "rookie_bonus": 0,
+    "team_key": "frc6155"
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026ne_awards.json
+++ b/src/backend/common/helpers/tests/data/2026ne_awards.json
@@ -1,0 +1,3366 @@
+[
+  {
+    "award_type": 0,
+    "event_key": "2026cthar",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2170"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026cthar",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc571"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2067"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1991"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026cthar",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11464"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026cthar",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc558"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026cthar",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9710"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026cthar",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1699"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026cthar",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc236"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026cthar",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7407"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc177"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7760"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3182"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026cthar",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3146"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026cthar",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7407"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026cthar",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3182"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026cthar",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc571"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026cthar",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc429"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026cthar",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Evan S",
+        "team_key": "frc3182"
+      },
+      {
+        "awardee": "Purva M",
+        "team_key": "frc178"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026cthar",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2067"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026cthar",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc175"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026cthar",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10133"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026cthar",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc178"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026ctwat",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6328"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026ctwat",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6328"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc176"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7907"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026ctwat",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11409"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026ctwat",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8889"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026ctwat",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc558"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026ctwat",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2064"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026ctwat",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc173"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026ctwat",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4909"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7127"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026ctwat",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc230"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026ctwat",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3654"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026ctwat",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8085"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026ctwat",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc176"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026ctwat",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026ctwat",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Kimberly T",
+        "team_key": "frc10133"
+      },
+      {
+        "awardee": "Auritro D",
+        "team_key": "frc999"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026ctwat",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4909"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026ctwat",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7127"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026ctwat",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10133"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026ctwat",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc999"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mabil",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4905"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mabil",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6328"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3623"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mabil",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9644"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mabil",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1119"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mabil",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mabil",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5422"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mabil",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4909"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1735"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3182"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mabil",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8013"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mabil",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mabil",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3182"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mabil",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6328"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mabil",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc663"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mabil",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "eleanor g",
+        "team_key": "frc157"
+      },
+      {
+        "awardee": "Maya B",
+        "team_key": "frc157"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mabil",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4909"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mabil",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5962"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mabil",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1735"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mabil",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10063"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mabos",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc190"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mabos",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2877"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc190"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc151"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8626"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mabos",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4572"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mabos",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5962"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mabos",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2713"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mabos",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5813"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mabos",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc88"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2876"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mabos",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2084"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mabos",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mabos",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2423"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mabos",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc131"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mabos",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6201"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mabos",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Felicia J",
+        "team_key": "frc2877"
+      },
+      {
+        "awardee": "Charlotte L",
+        "team_key": "frc8626"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mabos",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc88"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mabos",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mabos",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5491"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mabos",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2877"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026marea",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2877"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026marea",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5813"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3958"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026marea",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10912"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026marea",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6201"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026marea",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc238"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026marea",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026marea",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5735"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026marea",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc238"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2713"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6201"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026marea",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9443"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026marea",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1058"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026marea",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc246"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026marea",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc88"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026marea",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3958"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026marea",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Sharon X",
+        "team_key": "frc246"
+      },
+      {
+        "awardee": "Peter L",
+        "team_key": "frc2084"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026marea",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5813"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026marea",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1922"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026marea",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc97"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026marea",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2713"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mawne",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc173"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mawne",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc176"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc195"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9710"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mawne",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10910"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mawne",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mawne",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2067"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mawne",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2370"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mawne",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc178"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mawne",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2370"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2067"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mawne",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8709"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mawne",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc195"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mawne",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9710"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mawne",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc839"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mawne",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8567"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mawne",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Calvin M",
+        "team_key": "frc1100"
+      },
+      {
+        "awardee": "Jacob J",
+        "team_key": "frc2370"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mawne",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc176"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mawne",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1100"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mawne",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7127"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mawne",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2170"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mawor",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2370"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mawor",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2262"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8567"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026mawor",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11483"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mawor",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8724"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mawor",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1100"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mawor",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mawor",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2079"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mawor",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc190"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5000"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8544"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5347"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mawor",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc237"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mawor",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5000"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mawor",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6333"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mawor",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mawor",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3634"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mawor",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Marin I",
+        "team_key": "frc5112"
+      },
+      {
+        "awardee": "Parnitha K",
+        "team_key": "frc190"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mawor",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10254"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mawor",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1474"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mawor",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9644"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mawor",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8567"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026mefal",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8046"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026mefal",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1307"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026mefal",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8410"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026mefal",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8023"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026mefal",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc172"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026mefal",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc61"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026mefal",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc190"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7407"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3597"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026mefal",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026mefal",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2648"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026mefal",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11131"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026mefal",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026mefal",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4564"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026mefal",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Everett H",
+        "team_key": "frc172"
+      },
+      {
+        "awardee": "Danielle C",
+        "team_key": "frc8046"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026mefal",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7407"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026mefal",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026mefal",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11336"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026mefal",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc190"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026necmp",
+    "name": "District Championship FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6328"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc195"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4905"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc131"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026necmp",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9644"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8724"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026necmp",
+    "name": "District Championship Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11269"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026necmp",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6201"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2648"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 3,
+    "event_key": "2026necmp",
+    "name": "Woodie Flowers Finalist Award",
+    "recipient_list": [
+      {
+        "awardee": "Kyle Herren",
+        "team_key": "frc1071"
+      },
+      {
+        "awardee": "Michelle Leach",
+        "team_key": "frc5112"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026necmp",
+    "name": "FIRST Leadership Award Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Evelyn B",
+        "team_key": "frc4905"
+      },
+      {
+        "awardee": "Parnitha K",
+        "team_key": "frc190"
+      },
+      {
+        "awardee": "Everett H",
+        "team_key": "frc172"
+      },
+      {
+        "awardee": "Auritro D",
+        "team_key": "frc999"
+      },
+      {
+        "awardee": "Charlotte L",
+        "team_key": "frc8626"
+      },
+      {
+        "awardee": "Abinayya A",
+        "team_key": "frc2342"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 5,
+    "event_key": "2026necmp",
+    "name": "Volunteer of the Year",
+    "recipient_list": [
+      {
+        "awardee": "Manisha Rajaghatta",
+        "team_key": "frc1100"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026necmp",
+    "name": "District Championship Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc178"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc999"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026necmp1",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9644"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8724"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026necmp1",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc172"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026necmp1",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc509"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026necmp1",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026necmp1",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026necmp1",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc195"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1729"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026necmp1",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1729"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026necmp1",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1073"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026necmp1",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5112"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026necmp1",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1512"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026necmp1",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3654"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026necmp1",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5000"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026necmp1",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc175"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026necmp1",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10254"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026necmp2",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6201"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2648"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026necmp2",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5962"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026necmp2",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc238"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026necmp2",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026necmp2",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026necmp2",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6328"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc88"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1071"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7674"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026necmp2",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc839"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026necmp2",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc190"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026necmp2",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3182"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026necmp2",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc176"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026necmp2",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5422"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026necmp2",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2877"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026necmp2",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026necmp2",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc558"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026nhbed",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc131"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026nhbed",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4909"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1277"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11157"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026nhbed",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11269"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026nhbed",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4925"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026nhbed",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc467"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026nhbed",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3467"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026nhbed",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1729"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026nhbed",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc95"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1073"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9055"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026nhbed",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4905"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026nhbed",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1073"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026nhbed",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc348"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026nhbed",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4909"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026nhbed",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8724"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026nhbed",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Grady B",
+        "team_key": "frc11269"
+      },
+      {
+        "awardee": "Evelyn B",
+        "team_key": "frc4905"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026nhbed",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc95"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026nhbed",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc509"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026nhbed",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11157"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026nhbed",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026nhdur",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1350"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026nhdur",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc238"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1058"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1512"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9443"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026nhdur",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11157"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026nhdur",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6324"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026nhdur",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4473"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026nhdur",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1058"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026nhdur",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8046"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026nhdur",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6324"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc133"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc3597"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026nhdur",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1922"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026nhdur",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc172"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026nhdur",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc133"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026nhdur",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4925"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026nhdur",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc69"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026nhdur",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Leslie B",
+        "team_key": "frc509"
+      },
+      {
+        "awardee": "Keerthi S",
+        "team_key": "frc5902"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026nhdur",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc238"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026nhdur",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8410"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026nhdur",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6895"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026nhdur",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc509"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026rikin",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2079"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026rikin",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10063"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026rikin",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10973"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026rikin",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6324"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026rikin",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5112"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026rikin",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5000"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026rikin",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1699"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026rikin",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10254"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1699"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc348"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026rikin",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026rikin",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc78"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026rikin",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1119"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026rikin",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1768"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026rikin",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1735"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026rikin",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Jason Z",
+        "team_key": "frc3464"
+      },
+      {
+        "awardee": "Vansh M",
+        "team_key": "frc2079"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026rikin",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1153"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026rikin",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10063"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026rikin",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10254"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026rikin",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1350"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026vtbur",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc195"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026vtbur",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc195"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11175"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026vtbur",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11468"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026vtbur",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11269"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026vtbur",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8085"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026vtbur",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026vtbur",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1073"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026vtbur",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc125"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8708"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026vtbur",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc95"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026vtbur",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6329"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026vtbur",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1729"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026vtbur",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc839"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026vtbur",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc166"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026vtbur",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Vivi S",
+        "team_key": "frc1073"
+      },
+      {
+        "awardee": "Abinayya A",
+        "team_key": "frc2342"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026vtbur",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5687"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026vtbur",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2342"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026vtbur",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2523"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026vtbur",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8708"
+      }
+    ],
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026ne_district_points.json
+++ b/src/backend/common/helpers/tests/data/2026ne_district_points.json
@@ -1,0 +1,7920 @@
+{
+ "2026cthar": {
+  "points": {
+   "frc10133": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 17
+   },
+   "frc10245": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc10266": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc11131": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc11409": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc11464": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 18
+   },
+   "frc126": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 30
+   },
+   "frc155": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 35
+   },
+   "frc1699": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc175": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 25
+   },
+   "frc177": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 53
+   },
+   "frc178": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 44
+   },
+   "frc181": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc1991": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 40
+   },
+   "frc2067": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc2170": {
+    "alliance_points": 5,
+    "award_points": 10,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 36
+   },
+   "frc228": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc236": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc2785": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc3146": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc3182": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 24
+   },
+   "frc3461": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc3634": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc3719": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc429": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 31
+   },
+   "frc4628": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5142": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 17
+   },
+   "frc558": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 27
+   },
+   "frc571": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc5746": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc5856": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6346": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc7407": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc7760": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 14,
+    "qual_points": 10,
+    "total": 26
+   },
+   "frc8889": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc9193": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc9710": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 6,
+    "total": 27
+   }
+  },
+  "tiebreakers": {
+   "frc10133": {
+    "highest_match_scores": [
+     326,
+     308,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc10245": {
+    "highest_match_scores": [
+     362,
+     290,
+     237
+    ],
+    "qual_wins": 0
+   },
+   "frc10266": {
+    "highest_match_scores": [
+     242,
+     163,
+     106
+    ],
+    "qual_wins": 0
+   },
+   "frc11131": {
+    "highest_match_scores": [
+     379,
+     250,
+     232
+    ],
+    "qual_wins": 0
+   },
+   "frc11409": {
+    "highest_match_scores": [
+     263,
+     221,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc11464": {
+    "highest_match_scores": [
+     301,
+     270,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc126": {
+    "highest_match_scores": [
+     326,
+     295,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc155": {
+    "highest_match_scores": [
+     363,
+     353,
+     335
+    ],
+    "qual_wins": 0
+   },
+   "frc1699": {
+    "highest_match_scores": [
+     525,
+     377,
+     341
+    ],
+    "qual_wins": 0
+   },
+   "frc175": {
+    "highest_match_scores": [
+     371,
+     353,
+     231
+    ],
+    "qual_wins": 0
+   },
+   "frc177": {
+    "highest_match_scores": [
+     425,
+     391,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc178": {
+    "highest_match_scores": [
+     362,
+     335,
+     296
+    ],
+    "qual_wins": 0
+   },
+   "frc181": {
+    "highest_match_scores": [
+     284,
+     258,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc1991": {
+    "highest_match_scores": [
+     504,
+     485,
+     468
+    ],
+    "qual_wins": 0
+   },
+   "frc2067": {
+    "highest_match_scores": [
+     504,
+     485,
+     468
+    ],
+    "qual_wins": 0
+   },
+   "frc2170": {
+    "highest_match_scores": [
+     292,
+     270,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc228": {
+    "highest_match_scores": [
+     308,
+     307,
+     282
+    ],
+    "qual_wins": 0
+   },
+   "frc236": {
+    "highest_match_scores": [
+     525,
+     377,
+     371
+    ],
+    "qual_wins": 0
+   },
+   "frc2785": {
+    "highest_match_scores": [
+     234,
+     186,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc3146": {
+    "highest_match_scores": [
+     287,
+     283,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc3182": {
+    "highest_match_scores": [
+     338,
+     315,
+     297
+    ],
+    "qual_wins": 0
+   },
+   "frc3461": {
+    "highest_match_scores": [
+     301,
+     290,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc3634": {
+    "highest_match_scores": [
+     306,
+     283,
+     141
+    ],
+    "qual_wins": 0
+   },
+   "frc3719": {
+    "highest_match_scores": [
+     232,
+     206,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc429": {
+    "highest_match_scores": [
+     363,
+     236,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc4628": {
+    "highest_match_scores": [
+     436,
+     214,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc5142": {
+    "highest_match_scores": [
+     410,
+     287,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc558": {
+    "highest_match_scores": [
+     292,
+     290,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc571": {
+    "highest_match_scores": [
+     525,
+     504,
+     485
+    ],
+    "qual_wins": 0
+   },
+   "frc5746": {
+    "highest_match_scores": [
+     391,
+     224,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc5856": {
+    "highest_match_scores": [
+     169,
+     95,
+     90
+    ],
+    "qual_wins": 0
+   },
+   "frc6346": {
+    "highest_match_scores": [
+     263,
+     263,
+     237
+    ],
+    "qual_wins": 0
+   },
+   "frc7407": {
+    "highest_match_scores": [
+     436,
+     425,
+     371
+    ],
+    "qual_wins": 0
+   },
+   "frc7760": {
+    "highest_match_scores": [
+     425,
+     370,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc8889": {
+    "highest_match_scores": [
+     370,
+     287,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc9193": {
+    "highest_match_scores": [
+     315,
+     282,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc9710": {
+    "highest_match_scores": [
+     377,
+     341,
+     307
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026ctwat": {
+  "points": {
+   "frc10133": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 18
+   },
+   "frc10245": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc10266": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc10592": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc1071": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 28
+   },
+   "frc1099": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc11409": {
+    "alliance_points": 7,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 23
+   },
+   "frc11464": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc173": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 45
+   },
+   "frc176": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc2064": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 8,
+    "total": 23
+   },
+   "frc228": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 41
+   },
+   "frc230": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc2712": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc2785": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc3654": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 32
+   },
+   "frc4572": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 12,
+    "total": 34
+   },
+   "frc4909": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc558": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc5746": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc5856": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc6328": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 78
+   },
+   "frc6933": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 24
+   },
+   "frc7127": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc7153": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 26
+   },
+   "frc716": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7694": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 20
+   },
+   "frc7907": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 6,
+    "total": 37
+   },
+   "frc8085": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 43
+   },
+   "frc8889": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc9193": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc999": {
+    "alliance_points": 6,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 26
+   }
+  },
+  "tiebreakers": {
+   "frc10133": {
+    "highest_match_scores": [
+     409,
+     153,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc10245": {
+    "highest_match_scores": [
+     613,
+     158,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc10266": {
+    "highest_match_scores": [
+     176,
+     162,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc10592": {
+    "highest_match_scores": [
+     241,
+     127,
+     121
+    ],
+    "qual_wins": 0
+   },
+   "frc1071": {
+    "highest_match_scores": [
+     315,
+     286,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc1099": {
+    "highest_match_scores": [
+     409,
+     266,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc11409": {
+    "highest_match_scores": [
+     340,
+     265,
+     171
+    ],
+    "qual_wins": 0
+   },
+   "frc11464": {
+    "highest_match_scores": [
+     357,
+     286,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc173": {
+    "highest_match_scores": [
+     205,
+     205,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc176": {
+    "highest_match_scores": [
+     637,
+     613,
+     516
+    ],
+    "qual_wins": 0
+   },
+   "frc2064": {
+    "highest_match_scores": [
+     274,
+     258,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc228": {
+    "highest_match_scores": [
+     516,
+     425,
+     372
+    ],
+    "qual_wins": 0
+   },
+   "frc230": {
+    "highest_match_scores": [
+     477,
+     252,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc2712": {
+    "highest_match_scores": [
+     159,
+     111,
+     106
+    ],
+    "qual_wins": 0
+   },
+   "frc2785": {
+    "highest_match_scores": [
+     318,
+     182,
+     131
+    ],
+    "qual_wins": 0
+   },
+   "frc3654": {
+    "highest_match_scores": [
+     318,
+     236,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc4572": {
+    "highest_match_scores": [
+     402,
+     334,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc4909": {
+    "highest_match_scores": [
+     516,
+     402,
+     334
+    ],
+    "qual_wins": 0
+   },
+   "frc558": {
+    "highest_match_scores": [
+     357,
+     276,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc5746": {
+    "highest_match_scores": [
+     345,
+     162,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc5856": {
+    "highest_match_scores": [
+     372,
+     236,
+     135
+    ],
+    "qual_wins": 0
+   },
+   "frc6328": {
+    "highest_match_scores": [
+     637,
+     613,
+     511
+    ],
+    "qual_wins": 0
+   },
+   "frc6933": {
+    "highest_match_scores": [
+     398,
+     241,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc7127": {
+    "highest_match_scores": [
+     340,
+     334,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc7153": {
+    "highest_match_scores": [
+     425,
+     150,
+     144
+    ],
+    "qual_wins": 0
+   },
+   "frc716": {
+    "highest_match_scores": [
+     477,
+     157,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc7694": {
+    "highest_match_scores": [
+     345,
+     205,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc7907": {
+    "highest_match_scores": [
+     637,
+     511,
+     506
+    ],
+    "qual_wins": 0
+   },
+   "frc8085": {
+    "highest_match_scores": [
+     335,
+     258,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc8889": {
+    "highest_match_scores": [
+     398,
+     266,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc9193": {
+    "highest_match_scores": [
+     276,
+     158,
+     137
+    ],
+    "qual_wins": 0
+   },
+   "frc999": {
+    "highest_match_scores": [
+     265,
+     198,
+     137
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mabil": {
+  "points": {
+   "frc10063": {
+    "alliance_points": 3,
+    "award_points": 8,
+    "elim_points": 4,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc10393": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc1071": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc1099": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc1119": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 42
+   },
+   "frc157": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 28
+   },
+   "frc1735": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 14,
+    "qual_points": 4,
+    "total": 25
+   },
+   "frc175": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 30
+   },
+   "frc1768": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 59
+   },
+   "frc2064": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 4,
+    "qual_points": 6,
+    "total": 10
+   },
+   "frc3182": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc3464": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc3467": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc3566": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 27
+   },
+   "frc3623": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 8,
+    "total": 39
+   },
+   "frc4169": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc4905": {
+    "alliance_points": 5,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc4909": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc5347": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc5422": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 44
+   },
+   "frc5902": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 14
+   },
+   "frc5962": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 9,
+    "total": 38
+   },
+   "frc6328": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc6620": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc663": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 20
+   },
+   "frc8013": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 44
+   },
+   "frc8708": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 18
+   },
+   "frc9644": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 34
+   },
+   "frc9729": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 17
+   }
+  },
+  "tiebreakers": {
+   "frc10063": {
+    "highest_match_scores": [
+     326,
+     205,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc10393": {
+    "highest_match_scores": [
+     212,
+     200,
+     147
+    ],
+    "qual_wins": 0
+   },
+   "frc1071": {
+    "highest_match_scores": [
+     404,
+     326,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc1099": {
+    "highest_match_scores": [
+     219,
+     179,
+     145
+    ],
+    "qual_wins": 0
+   },
+   "frc1119": {
+    "highest_match_scores": [
+     392,
+     304,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc157": {
+    "highest_match_scores": [
+     383,
+     246,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc1735": {
+    "highest_match_scores": [
+     319,
+     314,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc175": {
+    "highest_match_scores": [
+     364,
+     212,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc1768": {
+    "highest_match_scores": [
+     319,
+     314,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc2064": {
+    "highest_match_scores": [
+     341,
+     261,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc3182": {
+    "highest_match_scores": [
+     261,
+     250,
+     237
+    ],
+    "qual_wins": 0
+   },
+   "frc3464": {
+    "highest_match_scores": [
+     306,
+     283,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc3467": {
+    "highest_match_scores": [
+     526,
+     433,
+     423
+    ],
+    "qual_wins": 0
+   },
+   "frc3566": {
+    "highest_match_scores": [
+     383,
+     361,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc3623": {
+    "highest_match_scores": [
+     526,
+     433,
+     403
+    ],
+    "qual_wins": 0
+   },
+   "frc4169": {
+    "highest_match_scores": [
+     242,
+     209,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc4905": {
+    "highest_match_scores": [
+     361,
+     224,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc4909": {
+    "highest_match_scores": [
+     404,
+     387,
+     319
+    ],
+    "qual_wins": 0
+   },
+   "frc5347": {
+    "highest_match_scores": [
+     228,
+     216,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc5422": {
+    "highest_match_scores": [
+     248,
+     242,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc5902": {
+    "highest_match_scores": [
+     235,
+     152,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc5962": {
+    "highest_match_scores": [
+     261,
+     248,
+     246
+    ],
+    "qual_wins": 0
+   },
+   "frc6328": {
+    "highest_match_scores": [
+     526,
+     433,
+     423
+    ],
+    "qual_wins": 0
+   },
+   "frc6620": {
+    "highest_match_scores": [
+     392,
+     192,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc663": {
+    "highest_match_scores": [
+     341,
+     208,
+     179
+    ],
+    "qual_wins": 0
+   },
+   "frc8013": {
+    "highest_match_scores": [
+     387,
+     304,
+     228
+    ],
+    "qual_wins": 0
+   },
+   "frc8708": {
+    "highest_match_scores": [
+     423,
+     317,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc9644": {
+    "highest_match_scores": [
+     364,
+     317,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc9729": {
+    "highest_match_scores": [
+     200,
+     192,
+     160
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mabos": {
+  "points": {
+   "frc10156": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc10912": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc10973": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 33
+   },
+   "frc1153": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 33
+   },
+   "frc125": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc1277": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 14
+   },
+   "frc131": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 31
+   },
+   "frc151": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 17,
+    "qual_points": 15,
+    "total": 34
+   },
+   "frc1761": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc190": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 74
+   },
+   "frc2084": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   },
+   "frc2423": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 29
+   },
+   "frc246": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc2713": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 34
+   },
+   "frc2876": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 8,
+    "total": 29
+   },
+   "frc2877": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 74
+   },
+   "frc3323": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 12,
+    "total": 29
+   },
+   "frc3958": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc4048": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc4311": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc4572": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc4909": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 44
+   },
+   "frc501": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc5459": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 21
+   },
+   "frc5491": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc5563": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc5735": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 14
+   },
+   "frc5813": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 37
+   },
+   "frc5962": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc6201": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 9,
+    "total": 29
+   },
+   "frc6731": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 28
+   },
+   "frc8013": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 14,
+    "total": 40
+   },
+   "frc8023": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc8626": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 14,
+    "qual_points": 16,
+    "total": 30
+   },
+   "frc8709": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc88": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 61
+   },
+   "frc9729": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   }
+  },
+  "tiebreakers": {
+   "frc10156": {
+    "highest_match_scores": [
+     372,
+     368,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc10912": {
+    "highest_match_scores": [
+     369,
+     308,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc10973": {
+    "highest_match_scores": [
+     505,
+     469,
+     323
+    ],
+    "qual_wins": 0
+   },
+   "frc1153": {
+    "highest_match_scores": [
+     505,
+     458,
+     355
+    ],
+    "qual_wins": 0
+   },
+   "frc125": {
+    "highest_match_scores": [
+     613,
+     580,
+     578
+    ],
+    "qual_wins": 0
+   },
+   "frc1277": {
+    "highest_match_scores": [
+     578,
+     355,
+     347
+    ],
+    "qual_wins": 0
+   },
+   "frc131": {
+    "highest_match_scores": [
+     382,
+     314,
+     300
+    ],
+    "qual_wins": 0
+   },
+   "frc151": {
+    "highest_match_scores": [
+     472,
+     466,
+     424
+    ],
+    "qual_wins": 0
+   },
+   "frc1761": {
+    "highest_match_scores": [
+     329,
+     311,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc190": {
+    "highest_match_scores": [
+     492,
+     472,
+     466
+    ],
+    "qual_wins": 0
+   },
+   "frc2084": {
+    "highest_match_scores": [
+     308,
+     304,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc2423": {
+    "highest_match_scores": [
+     368,
+     348,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc246": {
+    "highest_match_scores": [
+     449,
+     348,
+     318
+    ],
+    "qual_wins": 0
+   },
+   "frc2713": {
+    "highest_match_scores": [
+     462,
+     458,
+     355
+    ],
+    "qual_wins": 0
+   },
+   "frc2876": {
+    "highest_match_scores": [
+     613,
+     580,
+     549
+    ],
+    "qual_wins": 0
+   },
+   "frc2877": {
+    "highest_match_scores": [
+     578,
+     492,
+     472
+    ],
+    "qual_wins": 0
+   },
+   "frc3323": {
+    "highest_match_scores": [
+     420,
+     407,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc3958": {
+    "highest_match_scores": [
+     380,
+     309,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc4048": {
+    "highest_match_scores": [
+     336,
+     329,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc4311": {
+    "highest_match_scores": [
+     458,
+     372,
+     347
+    ],
+    "qual_wins": 0
+   },
+   "frc4572": {
+    "highest_match_scores": [
+     335,
+     305,
+     297
+    ],
+    "qual_wins": 0
+   },
+   "frc4909": {
+    "highest_match_scores": [
+     472,
+     420,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc501": {
+    "highest_match_scores": [
+     418,
+     338,
+     305
+    ],
+    "qual_wins": 0
+   },
+   "frc5459": {
+    "highest_match_scores": [
+     492,
+     382,
+     335
+    ],
+    "qual_wins": 0
+   },
+   "frc5491": {
+    "highest_match_scores": [
+     424,
+     329,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc5563": {
+    "highest_match_scores": [
+     322,
+     272,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc5735": {
+    "highest_match_scores": [
+     323,
+     303,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc5813": {
+    "highest_match_scores": [
+     472,
+     469,
+     357
+    ],
+    "qual_wins": 0
+   },
+   "frc5962": {
+    "highest_match_scores": [
+     399,
+     296,
+     270
+    ],
+    "qual_wins": 0
+   },
+   "frc6201": {
+    "highest_match_scores": [
+     357,
+     299,
+     286
+    ],
+    "qual_wins": 0
+   },
+   "frc6731": {
+    "highest_match_scores": [
+     357,
+     311,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc8013": {
+    "highest_match_scores": [
+     420,
+     407,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc8023": {
+    "highest_match_scores": [
+     297,
+     293,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc8626": {
+    "highest_match_scores": [
+     446,
+     394,
+     314
+    ],
+    "qual_wins": 0
+   },
+   "frc8709": {
+    "highest_match_scores": [
+     449,
+     369,
+     300
+    ],
+    "qual_wins": 0
+   },
+   "frc88": {
+    "highest_match_scores": [
+     613,
+     580,
+     549
+    ],
+    "qual_wins": 0
+   },
+   "frc9729": {
+    "highest_match_scores": [
+     302,
+     261,
+     233
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026marea": {
+  "points": {
+   "frc10156": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc1058": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 40
+   },
+   "frc10912": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 17
+   },
+   "frc11483": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc125": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc133": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 33
+   },
+   "frc151": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 21
+   },
+   "frc1721": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc1761": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc1922": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 41
+   },
+   "frc2084": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc238": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc2423": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 39
+   },
+   "frc246": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 29
+   },
+   "frc2713": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 16,
+    "total": 59
+   },
+   "frc2876": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc2877": {
+    "alliance_points": 11,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 38
+   },
+   "frc3205": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc3566": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 43
+   },
+   "frc3958": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 6,
+    "total": 42
+   },
+   "frc4169": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4311": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 27
+   },
+   "frc433": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc4546": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc4761": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc5459": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 17
+   },
+   "frc5563": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5735": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc5813": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc6201": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 8,
+    "total": 35
+   },
+   "frc6367": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 16
+   },
+   "frc6731": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc69": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 29
+   },
+   "frc78": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 24
+   },
+   "frc8626": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc88": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc9443": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   },
+   "frc97": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   }
+  },
+  "tiebreakers": {
+   "frc10156": {
+    "highest_match_scores": [
+     177,
+     160,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc1058": {
+    "highest_match_scores": [
+     292,
+     251,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc10912": {
+    "highest_match_scores": [
+     218,
+     192,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc11483": {
+    "highest_match_scores": [
+     409,
+     199,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc125": {
+    "highest_match_scores": [
+     464,
+     436,
+     403
+    ],
+    "qual_wins": 0
+   },
+   "frc133": {
+    "highest_match_scores": [
+     409,
+     361,
+     301
+    ],
+    "qual_wins": 0
+   },
+   "frc151": {
+    "highest_match_scores": [
+     326,
+     275,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc1721": {
+    "highest_match_scores": [
+     212,
+     204,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc1761": {
+    "highest_match_scores": [
+     275,
+     250,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc1922": {
+    "highest_match_scores": [
+     381,
+     299,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc2084": {
+    "highest_match_scores": [
+     244,
+     219,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc238": {
+    "highest_match_scores": [
+     408,
+     381,
+     304
+    ],
+    "qual_wins": 0
+   },
+   "frc2423": {
+    "highest_match_scores": [
+     408,
+     336,
+     250
+    ],
+    "qual_wins": 0
+   },
+   "frc246": {
+    "highest_match_scores": [
+     250,
+     220,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc2713": {
+    "highest_match_scores": [
+     304,
+     300,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc2876": {
+    "highest_match_scores": [
+     277,
+     249,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc2877": {
+    "highest_match_scores": [
+     368,
+     247,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc3205": {
+    "highest_match_scores": [
+     212,
+     150,
+     110
+    ],
+    "qual_wins": 0
+   },
+   "frc3566": {
+    "highest_match_scores": [
+     299,
+     275,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc3958": {
+    "highest_match_scores": [
+     464,
+     403,
+     364
+    ],
+    "qual_wins": 0
+   },
+   "frc4169": {
+    "highest_match_scores": [
+     272,
+     156,
+     146
+    ],
+    "qual_wins": 0
+   },
+   "frc4311": {
+    "highest_match_scores": [
+     409,
+     272,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc433": {
+    "highest_match_scores": [
+     204,
+     188,
+     133
+    ],
+    "qual_wins": 0
+   },
+   "frc4546": {
+    "highest_match_scores": [
+     214,
+     188,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc4761": {
+    "highest_match_scores": [
+     436,
+     292,
+     273
+    ],
+    "qual_wins": 0
+   },
+   "frc5459": {
+    "highest_match_scores": [
+     273,
+     267,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc5563": {
+    "highest_match_scores": [
+     368,
+     184,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc5735": {
+    "highest_match_scores": [
+     261,
+     247,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc5813": {
+    "highest_match_scores": [
+     464,
+     436,
+     403
+    ],
+    "qual_wins": 0
+   },
+   "frc6201": {
+    "highest_match_scores": [
+     304,
+     300,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc6367": {
+    "highest_match_scores": [
+     218,
+     185,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc6731": {
+    "highest_match_scores": [
+     318,
+     301,
+     211
+    ],
+    "qual_wins": 0
+   },
+   "frc69": {
+    "highest_match_scores": [
+     299,
+     277,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc78": {
+    "highest_match_scores": [
+     326,
+     247,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc8626": {
+    "highest_match_scores": [
+     292,
+     171,
+     156
+    ],
+    "qual_wins": 0
+   },
+   "frc88": {
+    "highest_match_scores": [
+     408,
+     318,
+     267
+    ],
+    "qual_wins": 0
+   },
+   "frc9443": {
+    "highest_match_scores": [
+     275,
+     155,
+     149
+    ],
+    "qual_wins": 0
+   },
+   "frc97": {
+    "highest_match_scores": [
+     217,
+     202,
+     197
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mawne": {
+  "points": {
+   "frc1027": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc10592": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc10910": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 14
+   },
+   "frc10945": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc1100": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 35
+   },
+   "frc155": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc173": {
+    "alliance_points": 8,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 28
+   },
+   "frc1740": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 12
+   },
+   "frc176": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc177": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc178": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc181": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc195": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 70
+   },
+   "frc1991": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc2067": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 60
+   },
+   "frc2170": {
+    "alliance_points": 3,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 32
+   },
+   "frc230": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 45
+   },
+   "frc236": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 46
+   },
+   "frc237": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc2370": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc3146": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc3461": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 14
+   },
+   "frc3654": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 19
+   },
+   "frc4034": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc4176": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 14
+   },
+   "frc429": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 26
+   },
+   "frc5142": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc571": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 30
+   },
+   "frc6346": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc6895": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7127": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc7153": {
+    "alliance_points": 2,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 37
+   },
+   "frc7694": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc839": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 33
+   },
+   "frc8567": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc8709": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 39
+   },
+   "frc9101": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc9710": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 13,
+    "total": 49
+   }
+  },
+  "tiebreakers": {
+   "frc1027": {
+    "highest_match_scores": [
+     345,
+     113,
+     103
+    ],
+    "qual_wins": 0
+   },
+   "frc10592": {
+    "highest_match_scores": [
+     247,
+     207,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc10910": {
+    "highest_match_scores": [
+     238,
+     182,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc10945": {
+    "highest_match_scores": [
+     159,
+     149,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc1100": {
+    "highest_match_scores": [
+     183,
+     180,
+     178
+    ],
+    "qual_wins": 0
+   },
+   "frc155": {
+    "highest_match_scores": [
+     325,
+     246,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc173": {
+    "highest_match_scores": [
+     228,
+     228,
+     139
+    ],
+    "qual_wins": 0
+   },
+   "frc1740": {
+    "highest_match_scores": [
+     281,
+     253,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc176": {
+    "highest_match_scores": [
+     573,
+     499,
+     468
+    ],
+    "qual_wins": 0
+   },
+   "frc177": {
+    "highest_match_scores": [
+     269,
+     241,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc178": {
+    "highest_match_scores": [
+     276,
+     215,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc181": {
+    "highest_match_scores": [
+     415,
+     306,
+     202
+    ],
+    "qual_wins": 0
+   },
+   "frc195": {
+    "highest_match_scores": [
+     573,
+     499,
+     468
+    ],
+    "qual_wins": 0
+   },
+   "frc1991": {
+    "highest_match_scores": [
+     207,
+     162,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc2067": {
+    "highest_match_scores": [
+     450,
+     397,
+     325
+    ],
+    "qual_wins": 0
+   },
+   "frc2170": {
+    "highest_match_scores": [
+     269,
+     263,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc230": {
+    "highest_match_scores": [
+     375,
+     276,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc236": {
+    "highest_match_scores": [
+     415,
+     325,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc237": {
+    "highest_match_scores": [
+     267,
+     256,
+     196
+    ],
+    "qual_wins": 0
+   },
+   "frc2370": {
+    "highest_match_scores": [
+     450,
+     397,
+     384
+    ],
+    "qual_wins": 0
+   },
+   "frc3146": {
+    "highest_match_scores": [
+     269,
+     208,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc3461": {
+    "highest_match_scores": [
+     384,
+     241,
+     202
+    ],
+    "qual_wins": 0
+   },
+   "frc3654": {
+    "highest_match_scores": [
+     306,
+     196,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc4034": {
+    "highest_match_scores": [
+     324,
+     215,
+     172
+    ],
+    "qual_wins": 0
+   },
+   "frc4176": {
+    "highest_match_scores": [
+     238,
+     187,
+     152
+    ],
+    "qual_wins": 0
+   },
+   "frc429": {
+    "highest_match_scores": [
+     293,
+     219,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc5142": {
+    "highest_match_scores": [
+     288,
+     228,
+     172
+    ],
+    "qual_wins": 0
+   },
+   "frc571": {
+    "highest_match_scores": [
+     324,
+     281,
+     269
+    ],
+    "qual_wins": 0
+   },
+   "frc6346": {
+    "highest_match_scores": [
+     208,
+     196,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc6895": {
+    "highest_match_scores": [
+     247,
+     196,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc7127": {
+    "highest_match_scores": [
+     253,
+     226,
+     219
+    ],
+    "qual_wins": 0
+   },
+   "frc7153": {
+    "highest_match_scores": [
+     450,
+     397,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc7694": {
+    "highest_match_scores": [
+     269,
+     137,
+     127
+    ],
+    "qual_wins": 0
+   },
+   "frc839": {
+    "highest_match_scores": [
+     372,
+     214,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc8567": {
+    "highest_match_scores": [
+     256,
+     231,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc8709": {
+    "highest_match_scores": [
+     288,
+     242,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc9101": {
+    "highest_match_scores": [
+     228,
+     203,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc9710": {
+    "highest_match_scores": [
+     573,
+     499,
+     468
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mawor": {
+  "points": {
+   "frc10254": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc1027": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc10393": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc1100": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc11483": {
+    "alliance_points": 3,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 14,
+    "total": 38
+   },
+   "frc1474": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc157": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 15
+   },
+   "frc1740": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 27
+   },
+   "frc1757": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 23
+   },
+   "frc1768": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 70
+   },
+   "frc190": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 56
+   },
+   "frc2079": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc2168": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc2262": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 14,
+    "qual_points": 11,
+    "total": 26
+   },
+   "frc237": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc2370": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 57
+   },
+   "frc3205": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc3467": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc348": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc3634": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   },
+   "frc4048": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4628": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc467": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 18
+   },
+   "frc5000": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 57
+   },
+   "frc5112": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 32
+   },
+   "frc5347": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5422": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc5491": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5494": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc6333": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 27
+   },
+   "frc6762": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc716": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc7760": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc8544": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc8567": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 17,
+    "qual_points": 15,
+    "total": 40
+   },
+   "frc8724": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 39
+   },
+   "frc9644": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc97": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc999": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   }
+  },
+  "tiebreakers": {
+   "frc10254": {
+    "highest_match_scores": [
+     522,
+     475,
+     412
+    ],
+    "qual_wins": 0
+   },
+   "frc1027": {
+    "highest_match_scores": [
+     480,
+     380,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc10393": {
+    "highest_match_scores": [
+     437,
+     311,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc1100": {
+    "highest_match_scores": [
+     486,
+     387,
+     337
+    ],
+    "qual_wins": 0
+   },
+   "frc11483": {
+    "highest_match_scores": [
+     475,
+     427,
+     412
+    ],
+    "qual_wins": 0
+   },
+   "frc1474": {
+    "highest_match_scores": [
+     266,
+     242,
+     204
+    ],
+    "qual_wins": 0
+   },
+   "frc157": {
+    "highest_match_scores": [
+     276,
+     259,
+     251
+    ],
+    "qual_wins": 0
+   },
+   "frc1740": {
+    "highest_match_scores": [
+     439,
+     433,
+     345
+    ],
+    "qual_wins": 0
+   },
+   "frc1757": {
+    "highest_match_scores": [
+     401,
+     331,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc1768": {
+    "highest_match_scores": [
+     669,
+     619,
+     554
+    ],
+    "qual_wins": 0
+   },
+   "frc190": {
+    "highest_match_scores": [
+     546,
+     480,
+     458
+    ],
+    "qual_wins": 0
+   },
+   "frc2079": {
+    "highest_match_scores": [
+     622,
+     433,
+     415
+    ],
+    "qual_wins": 0
+   },
+   "frc2168": {
+    "highest_match_scores": [
+     337,
+     284,
+     259
+    ],
+    "qual_wins": 0
+   },
+   "frc2262": {
+    "highest_match_scores": [
+     554,
+     548,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc237": {
+    "highest_match_scores": [
+     513,
+     490,
+     401
+    ],
+    "qual_wins": 0
+   },
+   "frc2370": {
+    "highest_match_scores": [
+     490,
+     486,
+     475
+    ],
+    "qual_wins": 0
+   },
+   "frc3205": {
+    "highest_match_scores": [
+     332,
+     312,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc3467": {
+    "highest_match_scores": [
+     669,
+     622,
+     619
+    ],
+    "qual_wins": 0
+   },
+   "frc348": {
+    "highest_match_scores": [
+     400,
+     371,
+     319
+    ],
+    "qual_wins": 0
+   },
+   "frc3634": {
+    "highest_match_scores": [
+     420,
+     354,
+     281
+    ],
+    "qual_wins": 0
+   },
+   "frc4048": {
+    "highest_match_scores": [
+     411,
+     378,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc4628": {
+    "highest_match_scores": [
+     669,
+     546,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc467": {
+    "highest_match_scores": [
+     420,
+     346,
+     312
+    ],
+    "qual_wins": 0
+   },
+   "frc5000": {
+    "highest_match_scores": [
+     546,
+     458,
+     446
+    ],
+    "qual_wins": 0
+   },
+   "frc5112": {
+    "highest_match_scores": [
+     407,
+     340,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc5347": {
+    "highest_match_scores": [
+     458,
+     319,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc5422": {
+    "highest_match_scores": [
+     548,
+     486,
+     480
+    ],
+    "qual_wins": 0
+   },
+   "frc5491": {
+    "highest_match_scores": [
+     315,
+     274,
+     266
+    ],
+    "qual_wins": 0
+   },
+   "frc5494": {
+    "highest_match_scores": [
+     415,
+     253,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc6333": {
+    "highest_match_scores": [
+     548,
+     354,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc6762": {
+    "highest_match_scores": [
+     346,
+     227,
+     189
+    ],
+    "qual_wins": 0
+   },
+   "frc716": {
+    "highest_match_scores": [
+     427,
+     275,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc7760": {
+    "highest_match_scores": [
+     522,
+     446,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc8544": {
+    "highest_match_scores": [
+     427,
+     396,
+     387
+    ],
+    "qual_wins": 0
+   },
+   "frc8567": {
+    "highest_match_scores": [
+     619,
+     481,
+     410
+    ],
+    "qual_wins": 0
+   },
+   "frc8724": {
+    "highest_match_scores": [
+     513,
+     392,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc9644": {
+    "highest_match_scores": [
+     622,
+     340,
+     280
+    ],
+    "qual_wins": 0
+   },
+   "frc97": {
+    "highest_match_scores": [
+     308,
+     275,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc999": {
+    "highest_match_scores": [
+     439,
+     337,
+     263
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026mefal": {
+  "points": {
+   "frc11131": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 29
+   },
+   "frc11336": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 17
+   },
+   "frc1307": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 42
+   },
+   "frc172": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 36
+   },
+   "frc190": {
+    "alliance_points": 15,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 62
+   },
+   "frc2648": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 27
+   },
+   "frc3597": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 12,
+    "total": 34
+   },
+   "frc4041": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 44
+   },
+   "frc4473": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc4564": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 23
+   },
+   "frc5687": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc61": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 38
+   },
+   "frc6153": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc6329": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc6691": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc7407": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc7907": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc8023": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 28
+   },
+   "frc8046": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 52
+   },
+   "frc8410": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 19
+   },
+   "frc9990": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 10
+   },
+   "frc9991": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 10
+   },
+   "frc9992": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 9
+   },
+   "frc9993": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 9
+   },
+   "frc9994": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 8
+   },
+   "frc9995": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 7
+   }
+  },
+  "tiebreakers": {
+   "frc11131": {
+    "highest_match_scores": [
+     284,
+     239,
+     238
+    ],
+    "qual_wins": 0
+   },
+   "frc11336": {
+    "highest_match_scores": [
+     319,
+     247,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc1307": {
+    "highest_match_scores": [
+     534,
+     523,
+     444
+    ],
+    "qual_wins": 0
+   },
+   "frc172": {
+    "highest_match_scores": [
+     295,
+     272,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc190": {
+    "highest_match_scores": [
+     466,
+     418,
+     375
+    ],
+    "qual_wins": 0
+   },
+   "frc2648": {
+    "highest_match_scores": [
+     264,
+     185,
+     175
+    ],
+    "qual_wins": 0
+   },
+   "frc3597": {
+    "highest_match_scores": [
+     466,
+     418,
+     375
+    ],
+    "qual_wins": 0
+   },
+   "frc4041": {
+    "highest_match_scores": [
+     421,
+     243,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc4473": {
+    "highest_match_scores": [
+     446,
+     341,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc4564": {
+    "highest_match_scores": [
+     295,
+     276,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc5687": {
+    "highest_match_scores": [
+     534,
+     523,
+     446
+    ],
+    "qual_wins": 0
+   },
+   "frc61": {
+    "highest_match_scores": [
+     289,
+     199,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc6153": {
+    "highest_match_scores": [
+     375,
+     276,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc6329": {
+    "highest_match_scores": [
+     534,
+     523,
+     487
+    ],
+    "qual_wins": 0
+   },
+   "frc6691": {
+    "highest_match_scores": [
+     337,
+     302,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc7407": {
+    "highest_match_scores": [
+     487,
+     421,
+     418
+    ],
+    "qual_wins": 0
+   },
+   "frc7907": {
+    "highest_match_scores": [
+     337,
+     230,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc8023": {
+    "highest_match_scores": [
+     244,
+     229,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc8046": {
+    "highest_match_scores": [
+     487,
+     319,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc8410": {
+    "highest_match_scores": [
+     375,
+     284,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc9990": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9991": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9992": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9993": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9994": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   },
+   "frc9995": {
+    "highest_match_scores": [
+     0,
+     0
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026necmp": {
+  "points": {
+   "frc11269": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc131": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc1768": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc178": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc195": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc3467": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 0
+   },
+   "frc4905": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc5687": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc6201": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 0
+   },
+   "frc6328": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc6329": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 0
+   },
+   "frc9644": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc999": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   }
+  },
+  "tiebreakers": {
+   "frc1768": {
+    "highest_match_scores": [
+     565,
+     506,
+     418
+    ],
+    "qual_wins": 0
+   },
+   "frc3467": {
+    "highest_match_scores": [
+     520,
+     500,
+     498
+    ],
+    "qual_wins": 0
+   },
+   "frc5687": {
+    "highest_match_scores": [
+     565,
+     506,
+     418
+    ],
+    "qual_wins": 0
+   },
+   "frc6201": {
+    "highest_match_scores": [
+     520,
+     500,
+     498
+    ],
+    "qual_wins": 0
+   },
+   "frc6329": {
+    "highest_match_scores": [
+     520,
+     500,
+     498
+    ],
+    "qual_wins": 0
+   },
+   "frc9644": {
+    "highest_match_scores": [
+     565,
+     506,
+     418
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026necmp1": {
+  "points": {
+   "frc10063": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc10254": {
+    "alliance_points": 24,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 87
+   },
+   "frc1058": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 81
+   },
+   "frc1073": {
+    "alliance_points": 39,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 111
+   },
+   "frc10910": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc11175": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc125": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 63,
+    "total": 183
+   },
+   "frc131": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 87
+   },
+   "frc133": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 60,
+    "total": 141
+   },
+   "frc151": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc1512": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 54
+   },
+   "frc155": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc172": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc1729": {
+    "alliance_points": 6,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 24,
+    "total": 105
+   },
+   "frc173": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc175": {
+    "alliance_points": 21,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 78
+   },
+   "frc1768": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 219
+   },
+   "frc195": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 51,
+    "total": 156
+   },
+   "frc2067": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 81
+   },
+   "frc2079": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 36,
+    "total": 72
+   },
+   "frc2170": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc230": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 42
+   },
+   "frc236": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 45,
+    "total": 93
+   },
+   "frc2370": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 72
+   },
+   "frc2713": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 57,
+    "total": 114
+   },
+   "frc2876": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc3146": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc348": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc3623": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc3654": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 42
+   },
+   "frc3958": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc4311": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc4905": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc4925": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc5000": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 51,
+    "total": 147
+   },
+   "frc509": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc5112": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 60
+   },
+   "frc5687": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 201
+   },
+   "frc571": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 72
+   },
+   "frc58": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc5813": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 54,
+    "total": 111
+   },
+   "frc6324": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 78
+   },
+   "frc7127": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc78": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 54
+   },
+   "frc8567": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc8708": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc8709": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 75
+   },
+   "frc8724": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 45,
+    "total": 66
+   },
+   "frc9644": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 72,
+    "qual_points": 36,
+    "total": 111
+   },
+   "frc9710": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   }
+  },
+  "tiebreakers": {
+   "frc10063": {
+    "highest_match_scores": [
+     582,
+     495,
+     461
+    ],
+    "qual_wins": 0
+   },
+   "frc10254": {
+    "highest_match_scores": [
+     582,
+     555,
+     542
+    ],
+    "qual_wins": 0
+   },
+   "frc1058": {
+    "highest_match_scores": [
+     730,
+     691,
+     523
+    ],
+    "qual_wins": 0
+   },
+   "frc1073": {
+    "highest_match_scores": [
+     533,
+     486,
+     476
+    ],
+    "qual_wins": 0
+   },
+   "frc10910": {
+    "highest_match_scores": [
+     540,
+     504,
+     359
+    ],
+    "qual_wins": 0
+   },
+   "frc11175": {
+    "highest_match_scores": [
+     492,
+     399,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc125": {
+    "highest_match_scores": [
+     691,
+     653,
+     603
+    ],
+    "qual_wins": 0
+   },
+   "frc131": {
+    "highest_match_scores": [
+     699,
+     495,
+     469
+    ],
+    "qual_wins": 0
+   },
+   "frc133": {
+    "highest_match_scores": [
+     665,
+     603,
+     600
+    ],
+    "qual_wins": 0
+   },
+   "frc151": {
+    "highest_match_scores": [
+     465,
+     437,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc1512": {
+    "highest_match_scores": [
+     469,
+     445,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc155": {
+    "highest_match_scores": [
+     413,
+     389,
+     361
+    ],
+    "qual_wins": 0
+   },
+   "frc172": {
+    "highest_match_scores": [
+     533,
+     492,
+     411
+    ],
+    "qual_wins": 0
+   },
+   "frc1729": {
+    "highest_match_scores": [
+     593,
+     575,
+     541
+    ],
+    "qual_wins": 0
+   },
+   "frc173": {
+    "highest_match_scores": [
+     498,
+     398,
+     381
+    ],
+    "qual_wins": 0
+   },
+   "frc175": {
+    "highest_match_scores": [
+     492,
+     473,
+     463
+    ],
+    "qual_wins": 0
+   },
+   "frc1768": {
+    "highest_match_scores": [
+     791,
+     730,
+     672
+    ],
+    "qual_wins": 0
+   },
+   "frc195": {
+    "highest_match_scores": [
+     699,
+     593,
+     575
+    ],
+    "qual_wins": 0
+   },
+   "frc2067": {
+    "highest_match_scores": [
+     691,
+     549,
+     533
+    ],
+    "qual_wins": 0
+   },
+   "frc2079": {
+    "highest_match_scores": [
+     630,
+     583,
+     523
+    ],
+    "qual_wins": 0
+   },
+   "frc2170": {
+    "highest_match_scores": [
+     502,
+     486,
+     473
+    ],
+    "qual_wins": 0
+   },
+   "frc230": {
+    "highest_match_scores": [
+     427,
+     405,
+     385
+    ],
+    "qual_wins": 0
+   },
+   "frc236": {
+    "highest_match_scores": [
+     665,
+     600,
+     580
+    ],
+    "qual_wins": 0
+   },
+   "frc2370": {
+    "highest_match_scores": [
+     548,
+     523,
+     504
+    ],
+    "qual_wins": 0
+   },
+   "frc2713": {
+    "highest_match_scores": [
+     653,
+     630,
+     583
+    ],
+    "qual_wins": 0
+   },
+   "frc2876": {
+    "highest_match_scores": [
+     543,
+     441,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc3146": {
+    "highest_match_scores": [
+     549,
+     486,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc348": {
+    "highest_match_scores": [
+     424,
+     399,
+     389
+    ],
+    "qual_wins": 0
+   },
+   "frc3623": {
+    "highest_match_scores": [
+     445,
+     427,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc3654": {
+    "highest_match_scores": [
+     469,
+     399,
+     398
+    ],
+    "qual_wins": 0
+   },
+   "frc3958": {
+    "highest_match_scores": [
+     479,
+     424,
+     303
+    ],
+    "qual_wins": 0
+   },
+   "frc4311": {
+    "highest_match_scores": [
+     549,
+     404,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc4905": {
+    "highest_match_scores": [
+     555,
+     405,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc4925": {
+    "highest_match_scores": [
+     402,
+     380,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc5000": {
+    "highest_match_scores": [
+     665,
+     600,
+     596
+    ],
+    "qual_wins": 0
+   },
+   "frc509": {
+    "highest_match_scores": [
+     476,
+     383,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc5112": {
+    "highest_match_scores": [
+     461,
+     442,
+     399
+    ],
+    "qual_wins": 0
+   },
+   "frc5687": {
+    "highest_match_scores": [
+     791,
+     730,
+     699
+    ],
+    "qual_wins": 0
+   },
+   "frc571": {
+    "highest_match_scores": [
+     581,
+     495,
+     463
+    ],
+    "qual_wins": 0
+   },
+   "frc58": {
+    "highest_match_scores": [
+     653,
+     473,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc5813": {
+    "highest_match_scores": [
+     630,
+     583,
+     549
+    ],
+    "qual_wins": 0
+   },
+   "frc6324": {
+    "highest_match_scores": [
+     555,
+     540,
+     472
+    ],
+    "qual_wins": 0
+   },
+   "frc7127": {
+    "highest_match_scores": [
+     596,
+     525,
+     498
+    ],
+    "qual_wins": 0
+   },
+   "frc78": {
+    "highest_match_scores": [
+     495,
+     486,
+     435
+    ],
+    "qual_wins": 0
+   },
+   "frc8567": {
+    "highest_match_scores": [
+     603,
+     386,
+     359
+    ],
+    "qual_wins": 0
+   },
+   "frc8708": {
+    "highest_match_scores": [
+     590,
+     407,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc8709": {
+    "highest_match_scores": [
+     552,
+     542,
+     541
+    ],
+    "qual_wins": 0
+   },
+   "frc8724": {
+    "highest_match_scores": [
+     672,
+     492,
+     469
+    ],
+    "qual_wins": 0
+   },
+   "frc9644": {
+    "highest_match_scores": [
+     791,
+     620,
+     544
+    ],
+    "qual_wins": 0
+   },
+   "frc9710": {
+    "highest_match_scores": [
+     581,
+     476,
+     472
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026necmp2": {
+  "points": {
+   "frc1071": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 27,
+    "total": 96
+   },
+   "frc10973": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc1100": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc11131": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc1119": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc11483": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc1153": {
+    "alliance_points": 15,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 36,
+    "total": 105
+   },
+   "frc1350": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc166": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 90
+   },
+   "frc1699": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 96
+   },
+   "frc1735": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc176": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 105
+   },
+   "frc177": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 78
+   },
+   "frc178": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc190": {
+    "alliance_points": 27,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 111
+   },
+   "frc1922": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 54,
+    "total": 129
+   },
+   "frc1991": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc228": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 45
+   },
+   "frc238": {
+    "alliance_points": 33,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 102
+   },
+   "frc2423": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc2648": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 42,
+    "total": 63
+   },
+   "frc2877": {
+    "alliance_points": 36,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 51,
+    "total": 141
+   },
+   "frc3182": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 33
+   },
+   "frc319": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 96
+   },
+   "frc3323": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc3467": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 216
+   },
+   "frc3566": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc3597": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc4041": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc467": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 27
+   },
+   "frc4761": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc4909": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 75
+   },
+   "frc5422": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 54
+   },
+   "frc558": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 36
+   },
+   "frc5962": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 96
+   },
+   "frc61": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc6201": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 72,
+    "qual_points": 36,
+    "total": 111
+   },
+   "frc6328": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 60,
+    "total": 162
+   },
+   "frc6329": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 219
+   },
+   "frc7153": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc7407": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 63,
+    "total": 108
+   },
+   "frc7674": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc8013": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 63
+   },
+   "frc8046": {
+    "alliance_points": 21,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 69
+   },
+   "frc8085": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc839": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc8544": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc88": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 57,
+    "total": 159
+   },
+   "frc8889": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc95": {
+    "alliance_points": 24,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 33,
+    "total": 78
+   }
+  },
+  "tiebreakers": {
+   "frc1071": {
+    "highest_match_scores": [
+     593,
+     516,
+     500
+    ],
+    "qual_wins": 0
+   },
+   "frc10973": {
+    "highest_match_scores": [
+     483,
+     417,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc1100": {
+    "highest_match_scores": [
+     405,
+     402,
+     377
+    ],
+    "qual_wins": 0
+   },
+   "frc11131": {
+    "highest_match_scores": [
+     483,
+     474,
+     464
+    ],
+    "qual_wins": 0
+   },
+   "frc1119": {
+    "highest_match_scores": [
+     410,
+     404,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc11483": {
+    "highest_match_scores": [
+     530,
+     483,
+     354
+    ],
+    "qual_wins": 0
+   },
+   "frc1153": {
+    "highest_match_scores": [
+     566,
+     559,
+     486
+    ],
+    "qual_wins": 0
+   },
+   "frc1350": {
+    "highest_match_scores": [
+     409,
+     357,
+     291
+    ],
+    "qual_wins": 0
+   },
+   "frc166": {
+    "highest_match_scores": [
+     548,
+     530,
+     475
+    ],
+    "qual_wins": 0
+   },
+   "frc1699": {
+    "highest_match_scores": [
+     640,
+     630,
+     546
+    ],
+    "qual_wins": 0
+   },
+   "frc1735": {
+    "highest_match_scores": [
+     450,
+     409,
+     347
+    ],
+    "qual_wins": 0
+   },
+   "frc176": {
+    "highest_match_scores": [
+     597,
+     559,
+     506
+    ],
+    "qual_wins": 0
+   },
+   "frc177": {
+    "highest_match_scores": [
+     488,
+     483,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc178": {
+    "highest_match_scores": [
+     551,
+     435,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc190": {
+    "highest_match_scores": [
+     613,
+     479,
+     473
+    ],
+    "qual_wins": 0
+   },
+   "frc1922": {
+    "highest_match_scores": [
+     566,
+     538,
+     486
+    ],
+    "qual_wins": 0
+   },
+   "frc1991": {
+    "highest_match_scores": [
+     480,
+     375,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc228": {
+    "highest_match_scores": [
+     551,
+     506,
+     443
+    ],
+    "qual_wins": 0
+   },
+   "frc238": {
+    "highest_match_scores": [
+     630,
+     559,
+     475
+    ],
+    "qual_wins": 0
+   },
+   "frc2423": {
+    "highest_match_scores": [
+     623,
+     456,
+     402
+    ],
+    "qual_wins": 0
+   },
+   "frc2648": {
+    "highest_match_scores": [
+     492,
+     436,
+     409
+    ],
+    "qual_wins": 0
+   },
+   "frc2877": {
+    "highest_match_scores": [
+     630,
+     566,
+     486
+    ],
+    "qual_wins": 0
+   },
+   "frc3182": {
+    "highest_match_scores": [
+     511,
+     457,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc319": {
+    "highest_match_scores": [
+     518,
+     479,
+     474
+    ],
+    "qual_wins": 0
+   },
+   "frc3323": {
+    "highest_match_scores": [
+     387,
+     366,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc3467": {
+    "highest_match_scores": [
+     734,
+     578,
+     578
+    ],
+    "qual_wins": 0
+   },
+   "frc3566": {
+    "highest_match_scores": [
+     362,
+     331,
+     318
+    ],
+    "qual_wins": 0
+   },
+   "frc3597": {
+    "highest_match_scores": [
+     381,
+     312,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc4041": {
+    "highest_match_scores": [
+     613,
+     548,
+     299
+    ],
+    "qual_wins": 0
+   },
+   "frc467": {
+    "highest_match_scores": [
+     447,
+     413,
+     318
+    ],
+    "qual_wins": 0
+   },
+   "frc4761": {
+    "highest_match_scores": [
+     475,
+     436,
+     403
+    ],
+    "qual_wins": 0
+   },
+   "frc4909": {
+    "highest_match_scores": [
+     546,
+     496,
+     432
+    ],
+    "qual_wins": 0
+   },
+   "frc5422": {
+    "highest_match_scores": [
+     640,
+     564,
+     420
+    ],
+    "qual_wins": 0
+   },
+   "frc558": {
+    "highest_match_scores": [
+     388,
+     366,
+     347
+    ],
+    "qual_wins": 0
+   },
+   "frc5962": {
+    "highest_match_scores": [
+     449,
+     440,
+     420
+    ],
+    "qual_wins": 0
+   },
+   "frc61": {
+    "highest_match_scores": [
+     475,
+     395,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc6201": {
+    "highest_match_scores": [
+     578,
+     514,
+     498
+    ],
+    "qual_wins": 0
+   },
+   "frc6328": {
+    "highest_match_scores": [
+     623,
+     613,
+     593
+    ],
+    "qual_wins": 0
+   },
+   "frc6329": {
+    "highest_match_scores": [
+     623,
+     597,
+     578
+    ],
+    "qual_wins": 0
+   },
+   "frc7153": {
+    "highest_match_scores": [
+     376,
+     354,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc7407": {
+    "highest_match_scores": [
+     734,
+     518,
+     506
+    ],
+    "qual_wins": 0
+   },
+   "frc7674": {
+    "highest_match_scores": [
+     578,
+     564,
+     435
+    ],
+    "qual_wins": 0
+   },
+   "frc8013": {
+    "highest_match_scores": [
+     488,
+     457,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc8046": {
+    "highest_match_scores": [
+     734,
+     496,
+     456
+    ],
+    "qual_wins": 0
+   },
+   "frc8085": {
+    "highest_match_scores": [
+     449,
+     436,
+     351
+    ],
+    "qual_wins": 0
+   },
+   "frc839": {
+    "highest_match_scores": [
+     597,
+     496,
+     480
+    ],
+    "qual_wins": 0
+   },
+   "frc8544": {
+    "highest_match_scores": [
+     471,
+     432,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc88": {
+    "highest_match_scores": [
+     640,
+     593,
+     578
+    ],
+    "qual_wins": 0
+   },
+   "frc8889": {
+    "highest_match_scores": [
+     387,
+     336,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc95": {
+    "highest_match_scores": [
+     479,
+     473,
+     461
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026nhbed": {
+  "points": {
+   "frc10138": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc1073": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc10937": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc11157": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 26
+   },
+   "frc11175": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc11269": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc1247": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc126": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 12
+   },
+   "frc1277": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 24,
+    "qual_points": 8,
+    "total": 33
+   },
+   "frc131": {
+    "alliance_points": 14,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 50
+   },
+   "frc138": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc166": {
+    "alliance_points": 14,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 54
+   },
+   "frc1729": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc2342": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 18
+   },
+   "frc319": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 30
+   },
+   "frc3323": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc3467": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc348": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 32
+   },
+   "frc467": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc4905": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 36
+   },
+   "frc4909": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc4925": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc501": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 15
+   },
+   "frc509": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 29
+   },
+   "frc58": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc6690": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc7314": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc7674": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 26
+   },
+   "frc811": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 23
+   },
+   "frc8421": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc8724": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc9055": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 37
+   },
+   "frc9096": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   },
+   "frc95": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   }
+  },
+  "tiebreakers": {
+   "frc10138": {
+    "highest_match_scores": [
+     231,
+     217,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc1073": {
+    "highest_match_scores": [
+     381,
+     361,
+     360
+    ],
+    "qual_wins": 0
+   },
+   "frc10937": {
+    "highest_match_scores": [
+     308,
+     169,
+     159
+    ],
+    "qual_wins": 0
+   },
+   "frc11157": {
+    "highest_match_scores": [
+     464,
+     263,
+     194
+    ],
+    "qual_wins": 0
+   },
+   "frc11175": {
+    "highest_match_scores": [
+     278,
+     185,
+     116
+    ],
+    "qual_wins": 0
+   },
+   "frc11269": {
+    "highest_match_scores": [
+     237,
+     171,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc1247": {
+    "highest_match_scores": [
+     308,
+     146,
+     124
+    ],
+    "qual_wins": 0
+   },
+   "frc126": {
+    "highest_match_scores": [
+     417,
+     185,
+     172
+    ],
+    "qual_wins": 0
+   },
+   "frc1277": {
+    "highest_match_scores": [
+     461,
+     415,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc131": {
+    "highest_match_scores": [
+     417,
+     298,
+     294
+    ],
+    "qual_wins": 0
+   },
+   "frc138": {
+    "highest_match_scores": [
+     361,
+     268,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc166": {
+    "highest_match_scores": [
+     314,
+     294,
+     274
+    ],
+    "qual_wins": 0
+   },
+   "frc1729": {
+    "highest_match_scores": [
+     381,
+     230,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc2342": {
+    "highest_match_scores": [
+     274,
+     230,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc319": {
+    "highest_match_scores": [
+     268,
+     216,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc3323": {
+    "highest_match_scores": [
+     431,
+     223,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc3467": {
+    "highest_match_scores": [
+     464,
+     461,
+     431
+    ],
+    "qual_wins": 0
+   },
+   "frc348": {
+    "highest_match_scores": [
+     294,
+     267,
+     264
+    ],
+    "qual_wins": 0
+   },
+   "frc467": {
+    "highest_match_scores": [
+     431,
+     299,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc4905": {
+    "highest_match_scores": [
+     322,
+     298,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc4909": {
+    "highest_match_scores": [
+     464,
+     461,
+     415
+    ],
+    "qual_wins": 0
+   },
+   "frc4925": {
+    "highest_match_scores": [
+     299,
+     237,
+     155
+    ],
+    "qual_wins": 0
+   },
+   "frc501": {
+    "highest_match_scores": [
+     253,
+     247,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc509": {
+    "highest_match_scores": [
+     290,
+     216,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc58": {
+    "highest_match_scores": [
+     286,
+     239,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc6690": {
+    "highest_match_scores": [
+     286,
+     132,
+     100
+    ],
+    "qual_wins": 0
+   },
+   "frc7314": {
+    "highest_match_scores": [
+     361,
+     322,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc7674": {
+    "highest_match_scores": [
+     314,
+     305,
+     207
+    ],
+    "qual_wins": 0
+   },
+   "frc811": {
+    "highest_match_scores": [
+     361,
+     216,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc8421": {
+    "highest_match_scores": [
+     231,
+     226,
+     164
+    ],
+    "qual_wins": 0
+   },
+   "frc8724": {
+    "highest_match_scores": [
+     290,
+     253,
+     247
+    ],
+    "qual_wins": 0
+   },
+   "frc9055": {
+    "highest_match_scores": [
+     360,
+     333,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc9096": {
+    "highest_match_scores": [
+     305,
+     208,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc95": {
+    "highest_match_scores": [
+     360,
+     333,
+     324
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026nhdur": {
+  "points": {
+   "frc1058": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 70
+   },
+   "frc11157": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc11336": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 18
+   },
+   "frc1307": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc133": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc1350": {
+    "alliance_points": 6,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 27
+   },
+   "frc1512": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 25,
+    "qual_points": 9,
+    "total": 35
+   },
+   "frc172": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc1721": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc1922": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc238": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc2523": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc2648": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc2712": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc3597": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 8,
+    "total": 30
+   },
+   "frc4034": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc4041": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc4473": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc4546": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 19
+   },
+   "frc4564": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc4761": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 19,
+    "total": 32
+   },
+   "frc4925": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc509": {
+    "alliance_points": 3,
+    "award_points": 8,
+    "elim_points": 13,
+    "qual_points": 4,
+    "total": 28
+   },
+   "frc58": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc5902": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc6324": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc6762": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc6895": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc69": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 22
+   },
+   "frc7314": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc7674": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc8046": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 52
+   },
+   "frc811": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc8410": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc9055": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc9056": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9443": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 5,
+    "qual_points": 10,
+    "total": 15
+   }
+  },
+  "tiebreakers": {
+   "frc1058": {
+    "highest_match_scores": [
+     490,
+     485,
+     449
+    ],
+    "qual_wins": 0
+   },
+   "frc11157": {
+    "highest_match_scores": [
+     284,
+     245,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc11336": {
+    "highest_match_scores": [
+     303,
+     293,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc1307": {
+    "highest_match_scores": [
+     432,
+     269,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc133": {
+    "highest_match_scores": [
+     490,
+     450,
+     389
+    ],
+    "qual_wins": 0
+   },
+   "frc1350": {
+    "highest_match_scores": [
+     257,
+     190,
+     181
+    ],
+    "qual_wins": 0
+   },
+   "frc1512": {
+    "highest_match_scores": [
+     485,
+     428,
+     415
+    ],
+    "qual_wins": 0
+   },
+   "frc172": {
+    "highest_match_scores": [
+     295,
+     285,
+     269
+    ],
+    "qual_wins": 0
+   },
+   "frc1721": {
+    "highest_match_scores": [
+     244,
+     237,
+     186
+    ],
+    "qual_wins": 0
+   },
+   "frc1922": {
+    "highest_match_scores": [
+     430,
+     383,
+     350
+    ],
+    "qual_wins": 0
+   },
+   "frc238": {
+    "highest_match_scores": [
+     561,
+     485,
+     450
+    ],
+    "qual_wins": 0
+   },
+   "frc2523": {
+    "highest_match_scores": [
+     303,
+     259,
+     245
+    ],
+    "qual_wins": 0
+   },
+   "frc2648": {
+    "highest_match_scores": [
+     305,
+     275,
+     269
+    ],
+    "qual_wins": 0
+   },
+   "frc2712": {
+    "highest_match_scores": [
+     350,
+     209,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc3597": {
+    "highest_match_scores": [
+     369,
+     367,
+     352
+    ],
+    "qual_wins": 0
+   },
+   "frc4034": {
+    "highest_match_scores": [
+     285,
+     257,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc4041": {
+    "highest_match_scores": [
+     287,
+     203,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc4473": {
+    "highest_match_scores": [
+     561,
+     389,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc4546": {
+    "highest_match_scores": [
+     383,
+     321,
+     305
+    ],
+    "qual_wins": 0
+   },
+   "frc4564": {
+    "highest_match_scores": [
+     389,
+     363,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc4761": {
+    "highest_match_scores": [
+     450,
+     295,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc4925": {
+    "highest_match_scores": [
+     437,
+     269,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc509": {
+    "highest_match_scores": [
+     309,
+     298,
+     270
+    ],
+    "qual_wins": 0
+   },
+   "frc58": {
+    "highest_match_scores": [
+     314,
+     305,
+     297
+    ],
+    "qual_wins": 0
+   },
+   "frc5902": {
+    "highest_match_scores": [
+     321,
+     272,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc6324": {
+    "highest_match_scores": [
+     561,
+     490,
+     369
+    ],
+    "qual_wins": 0
+   },
+   "frc6762": {
+    "highest_match_scores": [
+     209,
+     173,
+     150
+    ],
+    "qual_wins": 0
+   },
+   "frc6895": {
+    "highest_match_scores": [
+     243,
+     203,
+     169
+    ],
+    "qual_wins": 0
+   },
+   "frc69": {
+    "highest_match_scores": [
+     314,
+     295,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc7314": {
+    "highest_match_scores": [
+     242,
+     215,
+     148
+    ],
+    "qual_wins": 0
+   },
+   "frc7674": {
+    "highest_match_scores": [
+     430,
+     363,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc8046": {
+    "highest_match_scores": [
+     437,
+     383,
+     382
+    ],
+    "qual_wins": 0
+   },
+   "frc811": {
+    "highest_match_scores": [
+     297,
+     269,
+     243
+    ],
+    "qual_wins": 0
+   },
+   "frc8410": {
+    "highest_match_scores": [
+     281,
+     259,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc9055": {
+    "highest_match_scores": [
+     329,
+     284,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc9056": {
+    "highest_match_scores": [
+     304,
+     244,
+     167
+    ],
+    "qual_wins": 0
+   },
+   "frc9443": {
+    "highest_match_scores": [
+     449,
+     237,
+     197
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026rikin": {
+  "points": {
+   "frc10063": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 5,
+    "total": 41
+   },
+   "frc10066": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc10254": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 56
+   },
+   "frc10973": {
+    "alliance_points": 3,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 28
+   },
+   "frc1119": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc1153": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 43
+   },
+   "frc1350": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 14
+   },
+   "frc1474": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc1699": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 15,
+    "total": 53
+   },
+   "frc1735": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc1757": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 21
+   },
+   "frc1768": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc2079": {
+    "alliance_points": 12,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 38
+   },
+   "frc2168": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc2262": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc3464": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc348": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 13,
+    "total": 37
+   },
+   "frc3623": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc3719": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc4176": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5000": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 53
+   },
+   "frc5112": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 28
+   },
+   "frc5494": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc5687": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc61": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 16
+   },
+   "frc6324": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 50
+   },
+   "frc6333": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 18
+   },
+   "frc6367": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6620": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 25
+   },
+   "frc663": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc78": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 19,
+    "total": 45
+   },
+   "frc8544": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 19
+   }
+  },
+  "tiebreakers": {
+   "frc10063": {
+    "highest_match_scores": [
+     612,
+     595,
+     588
+    ],
+    "qual_wins": 0
+   },
+   "frc10066": {
+    "highest_match_scores": [
+     363,
+     298,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc10254": {
+    "highest_match_scores": [
+     374,
+     368,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc10973": {
+    "highest_match_scores": [
+     341,
+     310,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc1119": {
+    "highest_match_scores": [
+     484,
+     354,
+     348
+    ],
+    "qual_wins": 0
+   },
+   "frc1153": {
+    "highest_match_scores": [
+     408,
+     341,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc1350": {
+    "highest_match_scores": [
+     318,
+     223,
+     154
+    ],
+    "qual_wins": 0
+   },
+   "frc1474": {
+    "highest_match_scores": [
+     291,
+     249,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc1699": {
+    "highest_match_scores": [
+     374,
+     368,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc1735": {
+    "highest_match_scores": [
+     367,
+     354,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc1757": {
+    "highest_match_scores": [
+     291,
+     233,
+     218
+    ],
+    "qual_wins": 0
+   },
+   "frc1768": {
+    "highest_match_scores": [
+     612,
+     595,
+     594
+    ],
+    "qual_wins": 0
+   },
+   "frc2079": {
+    "highest_match_scores": [
+     367,
+     306,
+     304
+    ],
+    "qual_wins": 0
+   },
+   "frc2168": {
+    "highest_match_scores": [
+     408,
+     235,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc2262": {
+    "highest_match_scores": [
+     348,
+     321,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc3464": {
+    "highest_match_scores": [
+     334,
+     302,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc348": {
+    "highest_match_scores": [
+     374,
+     368,
+     356
+    ],
+    "qual_wins": 0
+   },
+   "frc3623": {
+    "highest_match_scores": [
+     360,
+     298,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc3719": {
+    "highest_match_scores": [
+     262,
+     247,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc4176": {
+    "highest_match_scores": [
+     362,
+     306,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc5000": {
+    "highest_match_scores": [
+     501,
+     302,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc5112": {
+    "highest_match_scores": [
+     357,
+     321,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc5494": {
+    "highest_match_scores": [
+     363,
+     310,
+     203
+    ],
+    "qual_wins": 0
+   },
+   "frc5687": {
+    "highest_match_scores": [
+     612,
+     595,
+     594
+    ],
+    "qual_wins": 0
+   },
+   "frc61": {
+    "highest_match_scores": [
+     344,
+     332,
+     231
+    ],
+    "qual_wins": 0
+   },
+   "frc6324": {
+    "highest_match_scores": [
+     360,
+     354,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc6333": {
+    "highest_match_scores": [
+     357,
+     216,
+     183
+    ],
+    "qual_wins": 0
+   },
+   "frc6367": {
+    "highest_match_scores": [
+     344,
+     283,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc6620": {
+    "highest_match_scores": [
+     484,
+     334,
+     278
+    ],
+    "qual_wins": 0
+   },
+   "frc663": {
+    "highest_match_scores": [
+     367,
+     362,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc78": {
+    "highest_match_scores": [
+     594,
+     341,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc8544": {
+    "highest_match_scores": [
+     367,
+     308,
+     283
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026vtbur": {
+  "points": {
+   "frc10066": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc10108": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc10138": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc1073": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 36
+   },
+   "frc10910": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc10937": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc10945": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc11175": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 12,
+    "total": 44
+   },
+   "frc11269": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc11468": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc1247": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc125": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 62
+   },
+   "frc138": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 16
+   },
+   "frc1512": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 14,
+    "total": 26
+   },
+   "frc166": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 49
+   },
+   "frc1729": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 26
+   },
+   "frc195": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 75
+   },
+   "frc2342": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 23
+   },
+   "frc2523": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 29
+   },
+   "frc319": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 42
+   },
+   "frc4909": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 29
+   },
+   "frc5687": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 69
+   },
+   "frc6153": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc6329": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc6690": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6933": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 18
+   },
+   "frc8085": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc839": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 41
+   },
+   "frc8421": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 22
+   },
+   "frc8708": {
+    "alliance_points": 1,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 36
+   },
+   "frc9056": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc9096": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 18
+   },
+   "frc9101": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 23
+   },
+   "frc95": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 37
+   }
+  },
+  "tiebreakers": {
+   "frc10066": {
+    "highest_match_scores": [
+     431,
+     270,
+     260
+    ],
+    "qual_wins": 0
+   },
+   "frc10108": {
+    "highest_match_scores": [
+     447,
+     328,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc10138": {
+    "highest_match_scores": [
+     360,
+     336,
+     294
+    ],
+    "qual_wins": 0
+   },
+   "frc1073": {
+    "highest_match_scores": [
+     664,
+     576,
+     351
+    ],
+    "qual_wins": 0
+   },
+   "frc10910": {
+    "highest_match_scores": [
+     506,
+     411,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc10937": {
+    "highest_match_scores": [
+     262,
+     204,
+     170
+    ],
+    "qual_wins": 0
+   },
+   "frc10945": {
+    "highest_match_scores": [
+     328,
+     232,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc11175": {
+    "highest_match_scores": [
+     657,
+     558,
+     539
+    ],
+    "qual_wins": 0
+   },
+   "frc11269": {
+    "highest_match_scores": [
+     376,
+     331,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc11468": {
+    "highest_match_scores": [
+     651,
+     237,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc1247": {
+    "highest_match_scores": [
+     356,
+     271,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc125": {
+    "highest_match_scores": [
+     651,
+     644,
+     622
+    ],
+    "qual_wins": 0
+   },
+   "frc138": {
+    "highest_match_scores": [
+     351,
+     285,
+     283
+    ],
+    "qual_wins": 0
+   },
+   "frc1512": {
+    "highest_match_scores": [
+     516,
+     471,
+     451
+    ],
+    "qual_wins": 0
+   },
+   "frc166": {
+    "highest_match_scores": [
+     620,
+     451,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc1729": {
+    "highest_match_scores": [
+     453,
+     343,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc195": {
+    "highest_match_scores": [
+     664,
+     657,
+     558
+    ],
+    "qual_wins": 0
+   },
+   "frc2342": {
+    "highest_match_scores": [
+     484,
+     373,
+     343
+    ],
+    "qual_wins": 0
+   },
+   "frc2523": {
+    "highest_match_scores": [
+     431,
+     373,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc319": {
+    "highest_match_scores": [
+     505,
+     426,
+     345
+    ],
+    "qual_wins": 0
+   },
+   "frc4909": {
+    "highest_match_scores": [
+     576,
+     505,
+     395
+    ],
+    "qual_wins": 0
+   },
+   "frc5687": {
+    "highest_match_scores": [
+     657,
+     620,
+     558
+    ],
+    "qual_wins": 0
+   },
+   "frc6153": {
+    "highest_match_scores": [
+     430,
+     426,
+     331
+    ],
+    "qual_wins": 0
+   },
+   "frc6329": {
+    "highest_match_scores": [
+     664,
+     651,
+     644
+    ],
+    "qual_wins": 0
+   },
+   "frc6690": {
+    "highest_match_scores": [
+     402,
+     336,
+     310
+    ],
+    "qual_wins": 0
+   },
+   "frc6933": {
+    "highest_match_scores": [
+     411,
+     303,
+     267
+    ],
+    "qual_wins": 0
+   },
+   "frc8085": {
+    "highest_match_scores": [
+     434,
+     343,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc839": {
+    "highest_match_scores": [
+     557,
+     471,
+     395
+    ],
+    "qual_wins": 0
+   },
+   "frc8421": {
+    "highest_match_scores": [
+     516,
+     434,
+     430
+    ],
+    "qual_wins": 0
+   },
+   "frc8708": {
+    "highest_match_scores": [
+     644,
+     622,
+     622
+    ],
+    "qual_wins": 0
+   },
+   "frc9056": {
+    "highest_match_scores": [
+     411,
+     402,
+     162
+    ],
+    "qual_wins": 0
+   },
+   "frc9096": {
+    "highest_match_scores": [
+     311,
+     310,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc9101": {
+    "highest_match_scores": [
+     449,
+     335,
+     303
+    ],
+    "qual_wins": 0
+   },
+   "frc95": {
+    "highest_match_scores": [
+     506,
+     449,
+     447
+    ],
+    "qual_wins": 0
+   }
+  }
+ }
+}

--- a/src/backend/common/helpers/tests/data/2026ne_events.json
+++ b/src/backend/common/helpers/tests/data/2026ne_events.json
@@ -1,0 +1,332 @@
+[
+  {
+    "city": "Hartford",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "cthar",
+    "event_type": 1,
+    "key": "2026cthar",
+    "name": "NE District Hartford Event",
+    "start_date": "2026-03-27",
+    "state_prov": "CT",
+    "year": 2026
+  },
+  {
+    "city": "Waterbury",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-22",
+    "event_code": "ctwat",
+    "event_type": 1,
+    "key": "2026ctwat",
+    "name": "NE District Waterbury Event",
+    "start_date": "2026-03-20",
+    "state_prov": "CT",
+    "year": 2026
+  },
+  {
+    "city": "Billerica",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-08",
+    "event_code": "mabil",
+    "event_type": 1,
+    "key": "2026mabil",
+    "name": "NE District Minuteman Event",
+    "start_date": "2026-03-06",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "Revere",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "mabos",
+    "event_type": 1,
+    "key": "2026mabos",
+    "name": "NE District Greater Boston Event",
+    "start_date": "2026-03-27",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "Reading",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "marea",
+    "event_type": 1,
+    "key": "2026marea",
+    "name": "NE District North Shore Event",
+    "start_date": "2026-03-13",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "Springfield",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "mawne",
+    "event_type": 1,
+    "key": "2026mawne",
+    "name": "NE District Western NE Event",
+    "start_date": "2026-03-13",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "Worcester",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-05",
+    "event_code": "mawor",
+    "event_type": 1,
+    "key": "2026mawor",
+    "name": "NE District WPI Event",
+    "start_date": "2026-04-03",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "Falmouth",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-08",
+    "event_code": "mefal",
+    "event_type": 1,
+    "key": "2026mefal",
+    "name": "NE District Pine Tree Event",
+    "start_date": "2026-03-06",
+    "state_prov": "ME",
+    "year": 2026
+  },
+  {
+    "city": "West Springfield",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "necmp",
+    "event_type": 2,
+    "key": "2026necmp",
+    "name": "New England FIRST District Championship",
+    "start_date": "2026-04-18",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "West Springfield",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "necmp1",
+    "event_type": 5,
+    "key": "2026necmp1",
+    "name": "New England FIRST District Championship - Burns Division presented by GlobalFoundries",
+    "start_date": "2026-04-15",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "West Springfield",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-18",
+    "event_code": "necmp2",
+    "event_type": 5,
+    "key": "2026necmp2",
+    "name": "New England FIRST District Championship - Newsom Division presented by GE Aerospace",
+    "start_date": "2026-04-15",
+    "state_prov": "MA",
+    "year": 2026
+  },
+  {
+    "city": "Bedford",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "nhbed",
+    "event_type": 1,
+    "key": "2026nhbed",
+    "name": "NE District Granite State Event",
+    "start_date": "2026-03-13",
+    "state_prov": "NH",
+    "year": 2026
+  },
+  {
+    "city": "Durham",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "nhdur",
+    "event_type": 1,
+    "key": "2026nhdur",
+    "name": "NE District UNH Event",
+    "start_date": "2026-03-27",
+    "state_prov": "NH",
+    "year": 2026
+  },
+  {
+    "city": "Kingston",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-21",
+    "event_code": "rikin",
+    "event_type": 1,
+    "key": "2026rikin",
+    "name": "NE District URI Event",
+    "start_date": "2026-03-19",
+    "state_prov": "RI",
+    "year": 2026
+  },
+  {
+    "city": "Burlington",
+    "country": "USA",
+    "district": {
+      "abbreviation": "ne",
+      "display_name": "New England",
+      "key": "2026ne",
+      "official_advancement_counts": {
+        "cmp": 32,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-04",
+    "event_code": "vtbur",
+    "event_type": 1,
+    "key": "2026vtbur",
+    "name": "NE District UVM Event",
+    "start_date": "2026-04-02",
+    "state_prov": "VT",
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026ne_rankings.json
+++ b/src/backend/common/helpers/tests/data/2026ne_rankings.json
@@ -1,0 +1,6392 @@
+[
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mabil",
+        "qual_points": 19,
+        "total": 59
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026rikin",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026necmp1",
+        "qual_points": 66,
+        "total": 219
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 381,
+    "rank": 1,
+    "rookie_bonus": 0,
+    "team_key": "frc1768"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mefal",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026rikin",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026necmp1",
+        "qual_points": 63,
+        "total": 201
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 376,
+    "rank": 2,
+    "rookie_bonus": 0,
+    "team_key": "frc5687"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mabil",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026nhbed",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026necmp2",
+        "qual_points": 63,
+        "total": 216
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 0
+      }
+    ],
+    "point_total": 362,
+    "rank": 3,
+    "rookie_bonus": 0,
+    "team_key": "frc3467"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mefal",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026vtbur",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026necmp2",
+        "qual_points": 66,
+        "total": 219
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 0
+      }
+    ],
+    "point_total": 353,
+    "rank": 4,
+    "rookie_bonus": 0,
+    "team_key": "frc6329"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mabil",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026ctwat",
+        "qual_points": 22,
+        "total": 78
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026necmp2",
+        "qual_points": 60,
+        "total": 162
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 341,
+    "rank": 5,
+    "rookie_bonus": 0,
+    "team_key": "frc6328"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mawne",
+        "qual_points": 19,
+        "total": 70
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026vtbur",
+        "qual_points": 20,
+        "total": 75
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026necmp1",
+        "qual_points": 51,
+        "total": 156
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 331,
+    "rank": 6,
+    "rookie_bonus": 0,
+    "team_key": "frc195"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026marea",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mabos",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026necmp1",
+        "qual_points": 63,
+        "total": 183
+      }
+    ],
+    "point_total": 319,
+    "rank": 7,
+    "rookie_bonus": 0,
+    "team_key": "frc125"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026rikin",
+        "qual_points": 20,
+        "total": 53
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mawor",
+        "qual_points": 17,
+        "total": 57
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026necmp1",
+        "qual_points": 51,
+        "total": 147
+      }
+    ],
+    "point_total": 257,
+    "rank": 8,
+    "rookie_bonus": 0,
+    "team_key": "frc5000"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mabos",
+        "qual_points": 20,
+        "total": 61
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026necmp2",
+        "qual_points": 57,
+        "total": 159
+      }
+    ],
+    "point_total": 256,
+    "rank": 9,
+    "rookie_bonus": 0,
+    "team_key": "frc88"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 17,
+        "total": 38
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mabos",
+        "qual_points": 21,
+        "total": 74
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026necmp2",
+        "qual_points": 51,
+        "total": 141
+      }
+    ],
+    "point_total": 253,
+    "rank": 10,
+    "rookie_bonus": 0,
+    "team_key": "frc2877"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mawne",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026ctwat",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 45,
+        "total": 105
+      }
+    ],
+    "point_total": 250,
+    "rank": 11,
+    "rookie_bonus": 0,
+    "team_key": "frc176"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mefal",
+        "qual_points": 19,
+        "total": 62
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mabos",
+        "qual_points": 19,
+        "total": 74
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp2",
+        "qual_points": 48,
+        "total": 111
+      }
+    ],
+    "point_total": 247,
+    "rank": 12,
+    "rookie_bonus": 0,
+    "team_key": "frc190"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026marea",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026nhdur",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 54,
+        "total": 102
+      }
+    ],
+    "point_total": 235,
+    "rank": 13,
+    "rookie_bonus": 0,
+    "team_key": "frc238"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 19,
+        "total": 33
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026nhdur",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026necmp1",
+        "qual_points": 60,
+        "total": 141
+      }
+    ],
+    "point_total": 232,
+    "rank": 14,
+    "rookie_bonus": 0,
+    "team_key": "frc133"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mefal",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026cthar",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 63,
+        "total": 108
+      }
+    ],
+    "point_total": 226,
+    "rank": 15,
+    "rookie_bonus": 0,
+    "team_key": "frc7407"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026marea",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mabos",
+        "qual_points": 16,
+        "total": 37
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp1",
+        "qual_points": 54,
+        "total": 111
+      }
+    ],
+    "point_total": 220,
+    "rank": 16,
+    "rookie_bonus": 0,
+    "team_key": "frc5813"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026marea",
+        "qual_points": 11,
+        "total": 41
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026nhdur",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026necmp2",
+        "qual_points": 54,
+        "total": 129
+      }
+    ],
+    "point_total": 219,
+    "rank": 17,
+    "rookie_bonus": 0,
+    "team_key": "frc1922"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mawne",
+        "qual_points": 20,
+        "total": 60
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026cthar",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 51,
+        "total": 81
+      }
+    ],
+    "point_total": 213,
+    "rank": 18,
+    "rookie_bonus": 0,
+    "team_key": "frc2067"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mabil",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026nhbed",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 45,
+        "total": 75
+      }
+    ],
+    "point_total": 207,
+    "rank": 19,
+    "rookie_bonus": 0,
+    "team_key": "frc4909"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026marea",
+        "qual_points": 16,
+        "total": 59
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 15,
+        "total": 34
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp1",
+        "qual_points": 57,
+        "total": 114
+      }
+    ],
+    "point_total": 207,
+    "rank": 20,
+    "rookie_bonus": 0,
+    "team_key": "frc2713"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026nhbed",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 17,
+        "total": 36
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 57,
+        "total": 111
+      }
+    ],
+    "point_total": 205,
+    "rank": 21,
+    "rookie_bonus": 0,
+    "team_key": "frc1073"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mabil",
+        "qual_points": 10,
+        "total": 34
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 12,
+        "total": 27
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 72,
+        "event_key": "2026necmp1",
+        "qual_points": 36,
+        "total": 111
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 202,
+    "rank": 22,
+    "rookie_bonus": 0,
+    "team_key": "frc9644"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026rikin",
+        "qual_points": 15,
+        "total": 53
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026cthar",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 57,
+        "total": 96
+      }
+    ],
+    "point_total": 200,
+    "rank": 23,
+    "rookie_bonus": 0,
+    "team_key": "frc1699"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026rikin",
+        "qual_points": 18,
+        "total": 56
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mawor",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 48,
+        "total": 87
+      }
+    ],
+    "point_total": 199,
+    "rank": 24,
+    "rookie_bonus": 5,
+    "team_key": "frc10254"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026nhbed",
+        "qual_points": 13,
+        "total": 50
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 14,
+        "total": 31
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 54,
+        "total": 87
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 198,
+    "rank": 25,
+    "rookie_bonus": 0,
+    "team_key": "frc131"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026nhbed",
+        "qual_points": 19,
+        "total": 54
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026vtbur",
+        "qual_points": 18,
+        "total": 49
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 51,
+        "total": 90
+      }
+    ],
+    "point_total": 193,
+    "rank": 26,
+    "rookie_bonus": 0,
+    "team_key": "frc166"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026marea",
+        "qual_points": 15,
+        "total": 40
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026nhdur",
+        "qual_points": 19,
+        "total": 70
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 48,
+        "total": 81
+      }
+    ],
+    "point_total": 191,
+    "rank": 27,
+    "rookie_bonus": 0,
+    "team_key": "frc1058"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mawne",
+        "qual_points": 19,
+        "total": 46
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026cthar",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026necmp1",
+        "qual_points": 45,
+        "total": 93
+      }
+    ],
+    "point_total": 190,
+    "rank": 28,
+    "rookie_bonus": 0,
+    "team_key": "frc236"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mawne",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mawor",
+        "qual_points": 20,
+        "total": 57
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 45,
+        "total": 72
+      }
+    ],
+    "point_total": 190,
+    "rank": 29,
+    "rookie_bonus": 0,
+    "team_key": "frc2370"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026rikin",
+        "qual_points": 17,
+        "total": 50
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026nhdur",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 39,
+        "total": 78
+      }
+    ],
+    "point_total": 189,
+    "rank": 30,
+    "rookie_bonus": 0,
+    "team_key": "frc6324"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026rikin",
+        "qual_points": 17,
+        "total": 43
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 17,
+        "total": 33
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026necmp2",
+        "qual_points": 36,
+        "total": 105
+      }
+    ],
+    "point_total": 181,
+    "rank": 31,
+    "rookie_bonus": 0,
+    "team_key": "frc1153"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026nhbed",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 18,
+        "total": 37
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp2",
+        "qual_points": 33,
+        "total": 78
+      }
+    ],
+    "point_total": 176,
+    "rank": 32,
+    "rookie_bonus": 0,
+    "team_key": "frc95"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026marea",
+        "qual_points": 8,
+        "total": 35
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mabos",
+        "qual_points": 9,
+        "total": 29
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 72,
+        "event_key": "2026necmp2",
+        "qual_points": 36,
+        "total": 111
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 0
+      }
+    ],
+    "point_total": 175,
+    "rank": 33,
+    "rookie_bonus": 0,
+    "team_key": "frc6201"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 17,
+        "total": 30
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026cthar",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 42,
+        "total": 72
+      }
+    ],
+    "point_total": 175,
+    "rank": 34,
+    "rookie_bonus": 0,
+    "team_key": "frc571"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mefal",
+        "qual_points": 15,
+        "total": 52
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026nhdur",
+        "qual_points": 20,
+        "total": 52
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 48,
+        "total": 69
+      }
+    ],
+    "point_total": 173,
+    "rank": 35,
+    "rookie_bonus": 0,
+    "team_key": "frc8046"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhbed",
+        "qual_points": 12,
+        "total": 30
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026vtbur",
+        "qual_points": 16,
+        "total": 42
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp2",
+        "qual_points": 48,
+        "total": 96
+      }
+    ],
+    "point_total": 168,
+    "rank": 36,
+    "rookie_bonus": 0,
+    "team_key": "frc319"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 10,
+        "total": 26
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026necmp1",
+        "qual_points": 24,
+        "total": 105
+      }
+    ],
+    "point_total": 160,
+    "rank": 37,
+    "rookie_bonus": 0,
+    "team_key": "frc1729"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026cthar",
+        "qual_points": 18,
+        "total": 53
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 45,
+        "total": 78
+      }
+    ],
+    "point_total": 154,
+    "rank": 38,
+    "rookie_bonus": 0,
+    "team_key": "frc177"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026ctwat",
+        "qual_points": 10,
+        "total": 28
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026necmp2",
+        "qual_points": 27,
+        "total": 96
+      }
+    ],
+    "point_total": 153,
+    "rank": 39,
+    "rookie_bonus": 0,
+    "team_key": "frc1071"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mabil",
+        "qual_points": 9,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 51,
+        "total": 96
+      }
+    ],
+    "point_total": 149,
+    "rank": 40,
+    "rookie_bonus": 0,
+    "team_key": "frc5962"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mabil",
+        "qual_points": 18,
+        "total": 44
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mabos",
+        "qual_points": 14,
+        "total": 40
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 45,
+        "total": 63
+      }
+    ],
+    "point_total": 147,
+    "rank": 41,
+    "rookie_bonus": 0,
+    "team_key": "frc8013"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 16,
+        "total": 38
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp1",
+        "qual_points": 36,
+        "total": 72
+      }
+    ],
+    "point_total": 146,
+    "rank": 42,
+    "rookie_bonus": 0,
+    "team_key": "frc2079"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mawor",
+        "qual_points": 16,
+        "total": 39
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp1",
+        "qual_points": 45,
+        "total": 66
+      }
+    ],
+    "point_total": 140,
+    "rank": 43,
+    "rookie_bonus": 0,
+    "team_key": "frc8724"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 15,
+        "total": 29
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026cthar",
+        "qual_points": 17,
+        "total": 44
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 36,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 133,
+    "rank": 44,
+    "rookie_bonus": 0,
+    "team_key": "frc178"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 17,
+        "total": 30
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 13,
+        "total": 25
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 42,
+        "total": 78
+      }
+    ],
+    "point_total": 133,
+    "rank": 45,
+    "rookie_bonus": 0,
+    "team_key": "frc175"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mawne",
+        "qual_points": 18,
+        "total": 45
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026ctwat",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 30,
+        "total": 42
+      }
+    ],
+    "point_total": 132,
+    "rank": 46,
+    "rookie_bonus": 0,
+    "team_key": "frc230"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mawne",
+        "qual_points": 16,
+        "total": 39
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 11,
+        "total": 16
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 48,
+        "total": 75
+      }
+    ],
+    "point_total": 130,
+    "rank": 47,
+    "rookie_bonus": 0,
+    "team_key": "frc8709"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mabil",
+        "qual_points": 15,
+        "total": 44
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 39,
+        "total": 54
+      }
+    ],
+    "point_total": 124,
+    "rank": 48,
+    "rookie_bonus": 0,
+    "team_key": "frc5422"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026ctwat",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 123,
+    "rank": 49,
+    "rookie_bonus": 0,
+    "team_key": "frc7127"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 13,
+        "total": 24
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026rikin",
+        "qual_points": 19,
+        "total": 45
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 36,
+        "total": 54
+      }
+    ],
+    "point_total": 123,
+    "rank": 50,
+    "rookie_bonus": 0,
+    "team_key": "frc78"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mefal",
+        "qual_points": 12,
+        "total": 36
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 122,
+    "rank": 51,
+    "rookie_bonus": 0,
+    "team_key": "frc172"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 16,
+        "total": 33
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026vtbur",
+        "qual_points": 17,
+        "total": 41
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 122,
+    "rank": 52,
+    "rookie_bonus": 0,
+    "team_key": "frc839"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 13,
+        "total": 28
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 27,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 121,
+    "rank": 53,
+    "rookie_bonus": 0,
+    "team_key": "frc4905"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 12,
+        "total": 28
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mawor",
+        "qual_points": 14,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 45,
+        "total": 60
+      }
+    ],
+    "point_total": 120,
+    "rank": 54,
+    "rookie_bonus": 0,
+    "team_key": "frc5112"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 9,
+        "total": 27
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026necmp2",
+        "qual_points": 42,
+        "total": 63
+      }
+    ],
+    "point_total": 118,
+    "rank": 55,
+    "rookie_bonus": 0,
+    "team_key": "frc2648"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mawne",
+        "qual_points": 13,
+        "total": 49
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026cthar",
+        "qual_points": 6,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 115,
+    "rank": 56,
+    "rookie_bonus": 0,
+    "team_key": "frc9710"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 4,
+        "event_key": "2026mabil",
+        "qual_points": 12,
+        "total": 27
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026rikin",
+        "qual_points": 5,
+        "total": 41
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 115,
+    "rank": 57,
+    "rookie_bonus": 5,
+    "team_key": "frc10063"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 25,
+        "event_key": "2026nhdur",
+        "qual_points": 9,
+        "total": 35
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026vtbur",
+        "qual_points": 14,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 39,
+        "total": 54
+      }
+    ],
+    "point_total": 115,
+    "rank": 58,
+    "rookie_bonus": 0,
+    "team_key": "frc1512"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mawne",
+        "qual_points": 8,
+        "total": 32
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026cthar",
+        "qual_points": 14,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 110,
+    "rank": 59,
+    "rookie_bonus": 0,
+    "team_key": "frc2170"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026marea",
+        "qual_points": 19,
+        "total": 39
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 13,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 110,
+    "rank": 60,
+    "rookie_bonus": 0,
+    "team_key": "frc2423"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026ctwat",
+        "qual_points": 16,
+        "total": 41
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 12,
+        "total": 22
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 39,
+        "total": 45
+      }
+    ],
+    "point_total": 108,
+    "rank": 61,
+    "rookie_bonus": 0,
+    "team_key": "frc228"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026rikin",
+        "qual_points": 10,
+        "total": 28
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 19,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 107,
+    "rank": 62,
+    "rookie_bonus": 10,
+    "team_key": "frc10973"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 12,
+        "total": 29
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026nhdur",
+        "qual_points": 4,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 105,
+    "rank": 63,
+    "rookie_bonus": 0,
+    "team_key": "frc509"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026ctwat",
+        "qual_points": 17,
+        "total": 43
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 16,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 105,
+    "rank": 64,
+    "rookie_bonus": 0,
+    "team_key": "frc8085"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mabil",
+        "qual_points": 16,
+        "total": 42
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 104,
+    "rank": 65,
+    "rookie_bonus": 0,
+    "team_key": "frc1119"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mawne",
+        "qual_points": 12,
+        "total": 35
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 18,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 104,
+    "rank": 66,
+    "rookie_bonus": 0,
+    "team_key": "frc1100"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026nhbed",
+        "qual_points": 11,
+        "total": 32
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026rikin",
+        "qual_points": 13,
+        "total": 37
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 102,
+    "rank": 67,
+    "rookie_bonus": 0,
+    "team_key": "frc348"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mawor",
+        "qual_points": 14,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 102,
+    "rank": 68,
+    "rookie_bonus": 10,
+    "team_key": "frc11483"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 10,
+        "total": 28
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026ctwat",
+        "qual_points": 15,
+        "total": 45
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 100,
+    "rank": 69,
+    "rookie_bonus": 0,
+    "team_key": "frc173"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhdur",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 100,
+    "rank": 70,
+    "rookie_bonus": 0,
+    "team_key": "frc7674"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 13,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 21,
+        "total": 36
+      }
+    ],
+    "point_total": 98,
+    "rank": 71,
+    "rookie_bonus": 0,
+    "team_key": "frc558"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 15,
+        "total": 27
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026marea",
+        "qual_points": 18,
+        "total": 43
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 97,
+    "rank": 72,
+    "rookie_bonus": 0,
+    "team_key": "frc3566"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mabos",
+        "qual_points": 12,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 97,
+    "rank": 73,
+    "rookie_bonus": 0,
+    "team_key": "frc3323"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mefal",
+        "qual_points": 8,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 95,
+    "rank": 74,
+    "rookie_bonus": 10,
+    "team_key": "frc11131"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026vtbur",
+        "qual_points": 12,
+        "total": 44
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 94,
+    "rank": 75,
+    "rookie_bonus": 10,
+    "team_key": "frc11175"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 12,
+        "total": 19
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 14,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 27,
+        "total": 42
+      }
+    ],
+    "point_total": 93,
+    "rank": 76,
+    "rookie_bonus": 0,
+    "team_key": "frc3654"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 19,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 89,
+    "rank": 77,
+    "rookie_bonus": 0,
+    "team_key": "frc4761"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mawne",
+        "qual_points": 10,
+        "total": 37
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 13,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 87,
+    "rank": 78,
+    "rookie_bonus": 0,
+    "team_key": "frc7153"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026mabil",
+        "qual_points": 4,
+        "total": 25
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 16,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 87,
+    "rank": 79,
+    "rookie_bonus": 0,
+    "team_key": "frc1735"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 86,
+    "rank": 80,
+    "rookie_bonus": 0,
+    "team_key": "frc3146"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 17,
+        "total": 27
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 86,
+    "rank": 81,
+    "rookie_bonus": 0,
+    "team_key": "frc4311"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mabil",
+        "qual_points": 8,
+        "total": 39
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 83,
+    "rank": 82,
+    "rookie_bonus": 0,
+    "team_key": "frc3623"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhbed",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 83,
+    "rank": 83,
+    "rookie_bonus": 0,
+    "team_key": "frc58"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mabil",
+        "qual_points": 11,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026cthar",
+        "qual_points": 12,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 18,
+        "total": 33
+      }
+    ],
+    "point_total": 80,
+    "rank": 84,
+    "rookie_bonus": 0,
+    "team_key": "frc3182"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 16,
+        "total": 26
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mabos",
+        "qual_points": 8,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 79,
+    "rank": 85,
+    "rookie_bonus": 0,
+    "team_key": "frc2876"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 14,
+        "total": 21
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 17,
+        "event_key": "2026mabos",
+        "qual_points": 15,
+        "total": 34
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 79,
+    "rank": 86,
+    "rookie_bonus": 0,
+    "team_key": "frc151"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 6,
+        "total": 14
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 79,
+    "rank": 87,
+    "rookie_bonus": 10,
+    "team_key": "frc10910"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026mefal",
+        "qual_points": 17,
+        "total": 44
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 77,
+    "rank": 88,
+    "rookie_bonus": 0,
+    "team_key": "frc4041"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mefal",
+        "qual_points": 12,
+        "total": 34
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026nhdur",
+        "qual_points": 8,
+        "total": 30
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 76,
+    "rank": 89,
+    "rookie_bonus": 0,
+    "team_key": "frc3597"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026cthar",
+        "qual_points": 16,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 76,
+    "rank": 90,
+    "rookie_bonus": 0,
+    "team_key": "frc155"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 17,
+        "event_key": "2026mawor",
+        "qual_points": 15,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 75,
+    "rank": 91,
+    "rookie_bonus": 0,
+    "team_key": "frc8567"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 14,
+        "total": 29
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 11,
+        "total": 18
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 15,
+        "total": 27
+      }
+    ],
+    "point_total": 74,
+    "rank": 92,
+    "rookie_bonus": 0,
+    "team_key": "frc467"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026cthar",
+        "qual_points": 9,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 73,
+    "rank": 93,
+    "rookie_bonus": 0,
+    "team_key": "frc1991"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 13,
+        "total": 19
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026mawor",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 73,
+    "rank": 94,
+    "rookie_bonus": 0,
+    "team_key": "frc8544"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mefal",
+        "qual_points": 14,
+        "total": 38
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 9,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 72,
+    "rank": 95,
+    "rookie_bonus": 0,
+    "team_key": "frc61"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 14,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 8,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 69,
+    "rank": 96,
+    "rookie_bonus": 10,
+    "team_key": "frc11269"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 67,
+    "rank": 97,
+    "rookie_bonus": 0,
+    "team_key": "frc8889"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 12,
+        "total": 26
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 12,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 67,
+    "rank": 98,
+    "rookie_bonus": 0,
+    "team_key": "frc999"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 8,
+        "total": 18
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026vtbur",
+        "qual_points": 7,
+        "total": 36
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 66,
+    "rank": 99,
+    "rookie_bonus": 0,
+    "team_key": "frc8708"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 6,
+        "total": 14
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 11,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 65,
+    "rank": 100,
+    "rookie_bonus": 0,
+    "team_key": "frc1350"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026vtbur",
+        "qual_points": 13,
+        "total": 30
+      }
+    ],
+    "point_total": 64,
+    "rank": 101,
+    "rookie_bonus": 0,
+    "team_key": "frc6153"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 64,
+    "rank": 102,
+    "rookie_bonus": 0,
+    "team_key": "frc4925"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026marea",
+        "qual_points": 6,
+        "total": 42
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026necmp1",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 62,
+    "rank": 103,
+    "rookie_bonus": 0,
+    "team_key": "frc3958"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026ctwat",
+        "qual_points": 12,
+        "total": 34
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 13,
+        "total": 28
+      }
+    ],
+    "point_total": 62,
+    "rank": 104,
+    "rookie_bonus": 0,
+    "team_key": "frc4572"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026nhbed",
+        "qual_points": 15,
+        "total": 37
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 60,
+    "rank": 105,
+    "rookie_bonus": 0,
+    "team_key": "frc9055"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mawne",
+        "qual_points": 13,
+        "total": 26
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 13,
+        "total": 31
+      }
+    ],
+    "point_total": 57,
+    "rank": 106,
+    "rookie_bonus": 0,
+    "team_key": "frc429"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 14,
+        "total": 25
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 16,
+        "total": 32
+      }
+    ],
+    "point_total": 57,
+    "rank": 107,
+    "rookie_bonus": 0,
+    "team_key": "frc4473"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026mefal",
+        "qual_points": 11,
+        "total": 42
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 55,
+    "rank": 108,
+    "rookie_bonus": 0,
+    "team_key": "frc1307"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhbed",
+        "qual_points": 14,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 11,
+        "total": 19
+      }
+    ],
+    "point_total": 55,
+    "rank": 109,
+    "rookie_bonus": 10,
+    "team_key": "frc11157"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 7,
+        "total": 23
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhdur",
+        "qual_points": 13,
+        "total": 30
+      }
+    ],
+    "point_total": 53,
+    "rank": 110,
+    "rookie_bonus": 0,
+    "team_key": "frc4564"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026marea",
+        "qual_points": 11,
+        "total": 29
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 9,
+        "total": 22
+      }
+    ],
+    "point_total": 51,
+    "rank": 111,
+    "rookie_bonus": 0,
+    "team_key": "frc69"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 24,
+        "event_key": "2026nhbed",
+        "qual_points": 8,
+        "total": 33
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 8,
+        "total": 14
+      }
+    ],
+    "point_total": 47,
+    "rank": 112,
+    "rookie_bonus": 0,
+    "team_key": "frc1277"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 47,
+    "rank": 113,
+    "rookie_bonus": 0,
+    "team_key": "frc237"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhbed",
+        "qual_points": 10,
+        "total": 23
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 13,
+        "total": 22
+      }
+    ],
+    "point_total": 45,
+    "rank": 114,
+    "rookie_bonus": 0,
+    "team_key": "frc811"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 10,
+        "total": 18
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 13,
+        "total": 27
+      }
+    ],
+    "point_total": 45,
+    "rank": 115,
+    "rookie_bonus": 0,
+    "team_key": "frc6333"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 6,
+        "total": 17
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 14,
+        "total": 18
+      }
+    ],
+    "point_total": 45,
+    "rank": 116,
+    "rookie_bonus": 10,
+    "team_key": "frc11336"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 12,
+        "total": 21
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mawor",
+        "qual_points": 10,
+        "total": 23
+      }
+    ],
+    "point_total": 44,
+    "rank": 117,
+    "rookie_bonus": 0,
+    "team_key": "frc1757"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 7,
+        "total": 20
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 14,
+        "total": 24
+      }
+    ],
+    "point_total": 44,
+    "rank": 118,
+    "rookie_bonus": 0,
+    "team_key": "frc663"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 11,
+        "total": 15
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 17,
+        "total": 29
+      }
+    ],
+    "point_total": 44,
+    "rank": 119,
+    "rookie_bonus": 0,
+    "team_key": "frc501"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 44,
+    "rank": 120,
+    "rookie_bonus": 5,
+    "team_key": "frc10245"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 8,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 44,
+    "rank": 121,
+    "rookie_bonus": 10,
+    "team_key": "frc11409"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 15,
+        "total": 28
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 7,
+        "total": 15
+      }
+    ],
+    "point_total": 43,
+    "rank": 122,
+    "rookie_bonus": 0,
+    "team_key": "frc157"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026ctwat",
+        "qual_points": 6,
+        "total": 37
+      }
+    ],
+    "point_total": 42,
+    "rank": 123,
+    "rookie_bonus": 0,
+    "team_key": "frc7907"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026mabos",
+        "qual_points": 16,
+        "total": 30
+      }
+    ],
+    "point_total": 42,
+    "rank": 124,
+    "rookie_bonus": 0,
+    "team_key": "frc8626"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 13,
+        "total": 24
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 8,
+        "total": 18
+      }
+    ],
+    "point_total": 42,
+    "rank": 125,
+    "rookie_bonus": 0,
+    "team_key": "frc6933"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 5,
+        "total": 12
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 17,
+        "total": 30
+      }
+    ],
+    "point_total": 42,
+    "rank": 126,
+    "rookie_bonus": 0,
+    "team_key": "frc126"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026marea",
+        "qual_points": 13,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 41,
+    "rank": 127,
+    "rookie_bonus": 0,
+    "team_key": "frc246"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 9,
+        "total": 18
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 12,
+        "total": 23
+      }
+    ],
+    "point_total": 41,
+    "rank": 128,
+    "rookie_bonus": 0,
+    "team_key": "frc2342"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 15,
+        "total": 29
+      }
+    ],
+    "point_total": 41,
+    "rank": 129,
+    "rookie_bonus": 0,
+    "team_key": "frc2523"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 10,
+        "total": 14
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026nhdur",
+        "qual_points": 12,
+        "total": 26
+      }
+    ],
+    "point_total": 40,
+    "rank": 130,
+    "rookie_bonus": 0,
+    "team_key": "frc5902"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mabos",
+        "qual_points": 12,
+        "total": 28
+      }
+    ],
+    "point_total": 40,
+    "rank": 131,
+    "rookie_bonus": 0,
+    "team_key": "frc6731"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 40,
+    "rank": 132,
+    "rookie_bonus": 5,
+    "team_key": "frc10592"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 9,
+        "total": 18
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 8,
+        "total": 17
+      }
+    ],
+    "point_total": 40,
+    "rank": 133,
+    "rookie_bonus": 5,
+    "team_key": "frc10133"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 10,
+        "total": 18
+      }
+    ],
+    "point_total": 40,
+    "rank": 134,
+    "rookie_bonus": 10,
+    "team_key": "frc11464"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 8,
+        "total": 12
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 15,
+        "total": 27
+      }
+    ],
+    "point_total": 39,
+    "rank": 135,
+    "rookie_bonus": 0,
+    "team_key": "frc1740"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 39,
+    "rank": 136,
+    "rookie_bonus": 5,
+    "team_key": "frc10066"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 14,
+        "total": 25
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 11,
+        "total": 14
+      }
+    ],
+    "point_total": 39,
+    "rank": 137,
+    "rookie_bonus": 0,
+    "team_key": "frc5735"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 9,
+        "total": 14
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 38,
+    "rank": 138,
+    "rookie_bonus": 0,
+    "team_key": "frc3461"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 14,
+        "total": 17
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 14,
+        "total": 21
+      }
+    ],
+    "point_total": 38,
+    "rank": 139,
+    "rookie_bonus": 0,
+    "team_key": "frc5459"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026rikin",
+        "qual_points": 10,
+        "total": 25
+      }
+    ],
+    "point_total": 37,
+    "rank": 140,
+    "rookie_bonus": 0,
+    "team_key": "frc6620"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 37,
+    "rank": 141,
+    "rookie_bonus": 0,
+    "team_key": "frc5347"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 14,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 37,
+    "rank": 142,
+    "rookie_bonus": 5,
+    "team_key": "frc10393"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 13,
+        "total": 18
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 11,
+        "total": 18
+      }
+    ],
+    "point_total": 36,
+    "rank": 143,
+    "rookie_bonus": 0,
+    "team_key": "frc9096"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 16,
+        "total": 26
+      }
+    ],
+    "point_total": 36,
+    "rank": 144,
+    "rookie_bonus": 0,
+    "team_key": "frc181"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 9,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 36,
+    "rank": 145,
+    "rookie_bonus": 10,
+    "team_key": "frc10912"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026mawor",
+        "qual_points": 11,
+        "total": 26
+      }
+    ],
+    "point_total": 35,
+    "rank": 146,
+    "rookie_bonus": 0,
+    "team_key": "frc2262"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 11,
+        "total": 19
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 13,
+        "total": 16
+      }
+    ],
+    "point_total": 35,
+    "rank": 147,
+    "rookie_bonus": 0,
+    "team_key": "frc138"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 10,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 11,
+        "total": 16
+      }
+    ],
+    "point_total": 35,
+    "rank": 148,
+    "rookie_bonus": 0,
+    "team_key": "frc8410"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026mefal",
+        "qual_points": 11,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 34,
+    "rank": 149,
+    "rookie_bonus": 0,
+    "team_key": "frc8023"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 4,
+        "event_key": "2026mabil",
+        "qual_points": 6,
+        "total": 10
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026ctwat",
+        "qual_points": 8,
+        "total": 23
+      }
+    ],
+    "point_total": 33,
+    "rank": 150,
+    "rookie_bonus": 0,
+    "team_key": "frc2064"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 33,
+    "rank": 151,
+    "rookie_bonus": 0,
+    "team_key": "frc6346"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026cthar",
+        "qual_points": 10,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 32,
+    "rank": 152,
+    "rookie_bonus": 0,
+    "team_key": "frc7760"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 14,
+        "total": 23
+      }
+    ],
+    "point_total": 31,
+    "rank": 153,
+    "rookie_bonus": 0,
+    "team_key": "frc9101"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 15,
+        "total": 25
+      }
+    ],
+    "point_total": 30,
+    "rank": 154,
+    "rookie_bonus": 0,
+    "team_key": "frc1099"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 14,
+        "total": 22
+      }
+    ],
+    "point_total": 30,
+    "rank": 155,
+    "rookie_bonus": 0,
+    "team_key": "frc8421"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 14,
+        "total": 19
+      }
+    ],
+    "point_total": 30,
+    "rank": 156,
+    "rookie_bonus": 0,
+    "team_key": "frc4546"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 29,
+    "rank": 157,
+    "rookie_bonus": 0,
+    "team_key": "frc3464"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 11,
+        "total": 19
+      }
+    ],
+    "point_total": 29,
+    "rank": 158,
+    "rookie_bonus": 10,
+    "team_key": "frc11468"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 15,
+        "total": 24
+      }
+    ],
+    "point_total": 28,
+    "rank": 159,
+    "rookie_bonus": 0,
+    "team_key": "frc3205"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 8,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 28,
+    "rank": 160,
+    "rookie_bonus": 0,
+    "team_key": "frc6367"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 10,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 28,
+    "rank": 161,
+    "rookie_bonus": 0,
+    "team_key": "frc9729"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 11,
+        "total": 17
+      }
+    ],
+    "point_total": 28,
+    "rank": 162,
+    "rookie_bonus": 0,
+    "team_key": "frc5142"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 13,
+        "total": 18
+      }
+    ],
+    "point_total": 28,
+    "rank": 163,
+    "rookie_bonus": 0,
+    "team_key": "frc2084"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 7,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 5,
+        "event_key": "2026nhdur",
+        "qual_points": 10,
+        "total": 15
+      }
+    ],
+    "point_total": 27,
+    "rank": 164,
+    "rookie_bonus": 0,
+    "team_key": "frc9443"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 14,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 25,
+    "rank": 165,
+    "rookie_bonus": 0,
+    "team_key": "frc4176"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 10,
+        "total": 20
+      }
+    ],
+    "point_total": 24,
+    "rank": 166,
+    "rookie_bonus": 0,
+    "team_key": "frc7694"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 10,
+        "total": 15
+      }
+    ],
+    "point_total": 24,
+    "rank": 167,
+    "rookie_bonus": 0,
+    "team_key": "frc6895"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 11,
+        "total": 11
+      }
+    ],
+    "point_total": 23,
+    "rank": 168,
+    "rookie_bonus": 0,
+    "team_key": "frc9056"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabil",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 23,
+    "rank": 169,
+    "rookie_bonus": 0,
+    "team_key": "frc4169"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 13,
+        "total": 18
+      }
+    ],
+    "point_total": 23,
+    "rank": 170,
+    "rookie_bonus": 0,
+    "team_key": "frc3634"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 23,
+    "rank": 171,
+    "rookie_bonus": 5,
+    "team_key": "frc10156"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 22,
+    "rank": 172,
+    "rookie_bonus": 0,
+    "team_key": "frc4048"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 15,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 22,
+    "rank": 173,
+    "rookie_bonus": 0,
+    "team_key": "frc4034"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 8,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 21,
+    "rank": 174,
+    "rookie_bonus": 0,
+    "team_key": "frc2168"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 21,
+    "rank": 175,
+    "rookie_bonus": 0,
+    "team_key": "frc4628"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 21,
+    "rank": 176,
+    "rookie_bonus": 10,
+    "team_key": "frc10945"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 6,
+        "total": 6
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 21,
+    "rank": 177,
+    "rookie_bonus": 10,
+    "team_key": "frc10937"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 19,
+    "rank": 178,
+    "rookie_bonus": 0,
+    "team_key": "frc2785"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 7,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 19,
+    "rank": 179,
+    "rookie_bonus": 0,
+    "team_key": "frc5491"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 18,
+    "rank": 180,
+    "rookie_bonus": 0,
+    "team_key": "frc716"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 18,
+    "rank": 181,
+    "rookie_bonus": 0,
+    "team_key": "frc7314"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 18,
+    "rank": 182,
+    "rookie_bonus": 0,
+    "team_key": "frc9193"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 18,
+    "rank": 183,
+    "rookie_bonus": 5,
+    "team_key": "frc10138"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 5,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 18,
+    "rank": 184,
+    "rookie_bonus": 0,
+    "team_key": "frc97"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 18,
+    "rank": 185,
+    "rookie_bonus": 5,
+    "team_key": "frc10266"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawne",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 17,
+    "rank": 186,
+    "rookie_bonus": 0,
+    "team_key": "frc1027"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 16,
+    "rank": 187,
+    "rookie_bonus": 0,
+    "team_key": "frc5494"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 16,
+    "rank": 188,
+    "rookie_bonus": 0,
+    "team_key": "frc6690"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 16,
+    "rank": 189,
+    "rookie_bonus": 0,
+    "team_key": "frc3719"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 16,
+    "rank": 190,
+    "rookie_bonus": 0,
+    "team_key": "frc1721"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 15,
+    "rank": 191,
+    "rookie_bonus": 0,
+    "team_key": "frc5856"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026rikin",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 6,
+        "total": 11
+      }
+    ],
+    "point_total": 15,
+    "rank": 192,
+    "rookie_bonus": 0,
+    "team_key": "frc1474"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 14,
+    "rank": 193,
+    "rookie_bonus": 0,
+    "team_key": "frc5563"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhbed",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 14,
+    "rank": 194,
+    "rookie_bonus": 0,
+    "team_key": "frc1247"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026marea",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mabos",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 14,
+    "rank": 195,
+    "rookie_bonus": 0,
+    "team_key": "frc1761"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026vtbur",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 14,
+    "rank": 196,
+    "rookie_bonus": 5,
+    "team_key": "frc10108"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026cthar",
+        "qual_points": 9,
+        "total": 9
+      }
+    ],
+    "point_total": 13,
+    "rank": 197,
+    "rookie_bonus": 0,
+    "team_key": "frc5746"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ctwat",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 8,
+        "total": 8
+      }
+    ],
+    "point_total": 13,
+    "rank": 198,
+    "rookie_bonus": 0,
+    "team_key": "frc2712"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mefal",
+        "qual_points": 13,
+        "total": 13
+      }
+    ],
+    "point_total": 13,
+    "rank": 199,
+    "rookie_bonus": 0,
+    "team_key": "frc6691"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026nhdur",
+        "qual_points": 5,
+        "total": 5
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026mawor",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 9,
+    "rank": 200,
+    "rookie_bonus": 0,
+    "team_key": "frc6762"
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026ont_awards.json
+++ b/src/backend/common/helpers/tests/data/2026ont_awards.json
@@ -1,0 +1,2358 @@
+[
+  {
+    "award_type": 0,
+    "event_key": "2026onbar",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onbar",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7558"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc188"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10611"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onbar",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5885"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onbar",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7659"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onbar",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onbar",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7558"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onbar",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8884"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5885"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8349"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onbar",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7603"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onbar",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1305"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onbar",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2706"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onbar",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8884"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onbar",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9782"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onbar",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Violet M",
+        "team_key": "frc1310"
+      },
+      {
+        "awardee": "Amara W",
+        "team_key": "frc6865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onbar",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc188"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onbar",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4069"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onbar",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10611"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onbar",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026oncmp",
+    "name": "District Championship FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc772"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026oncmp",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026oncmp",
+    "name": "District Championship Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11270"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026oncmp",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7558"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9785"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8349"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 3,
+    "event_key": "2026oncmp",
+    "name": "Woodie Flowers Finalist Award",
+    "recipient_list": [
+      {
+        "awardee": "Terry Fisher",
+        "team_key": "frc2702"
+      },
+      {
+        "awardee": "Cole Cyr",
+        "team_key": "frc4946"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026oncmp",
+    "name": "FIRST Leadership Award Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Ryan Z",
+        "team_key": "frc10015"
+      },
+      {
+        "awardee": "Mathew R",
+        "team_key": "frc7712"
+      },
+      {
+        "awardee": "Amara W",
+        "team_key": "frc6865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 5,
+    "event_key": "2026oncmp",
+    "name": "Volunteer of the Year",
+    "recipient_list": [
+      {
+        "awardee": "Thuvishan Rajagulasingam",
+        "team_key": null
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026oncmp",
+    "name": "District Championship Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1360"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026oncmp1",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026oncmp1",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1325"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026oncmp1",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3756"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026oncmp1",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10015"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026oncmp1",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026oncmp1",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4678"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1325"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc772"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026oncmp1",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4907"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026oncmp1",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026oncmp1",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5672"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026oncmp1",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5406"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026oncmp1",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7757"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026oncmp1",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4476"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026oncmp1",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4069"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026oncmp1",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc919"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026oncmp2",
+    "name": "District Championship Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7558"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9785"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8349"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026oncmp2",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3739"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026oncmp2",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4917"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026oncmp2",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc610"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026oncmp2",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4039"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026oncmp2",
+    "name": "District Championship Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1241"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4946"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1310"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7480"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026oncmp2",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3683"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026oncmp2",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4946"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026oncmp2",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1229"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026oncmp2",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8089"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026oncmp2",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8789"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026oncmp2",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8884"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026oncmp2",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3543"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026oncmp2",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10167"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026onham",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1325"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onham",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9062"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026onham",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11428"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onham",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5406"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onham",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10167"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onham",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onham",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9098"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onham",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2200"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7902"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11362"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onham",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4907"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onham",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onham",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4917"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onham",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10554"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onham",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onham",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "lingfeng w",
+        "team_key": "frc4308"
+      },
+      {
+        "awardee": "Vienna W",
+        "team_key": "frc7200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onham",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onham",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6135"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onham",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1229"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onham",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4308"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026onnob",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onnob",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11270"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9785"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2013"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onnob",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9785"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onnob",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11270"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onnob",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4152"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onnob",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1334"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onnob",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc610"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc10015"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6864"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onnob",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5036"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onnob",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10015"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onnob",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7476"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onnob",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2609"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onnob",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2708"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onnob",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Ryan Z",
+        "team_key": "frc10015"
+      },
+      {
+        "awardee": "Mathew R",
+        "team_key": "frc7712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onnob",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc610"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onnob",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3543"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onnob",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9589"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onnob",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2706"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026onosh",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4476"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onosh",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4946"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1241"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc781"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026onosh",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11227"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onosh",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2708"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onosh",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6135"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onosh",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5032"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onosh",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5409"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onosh",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4476"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc188"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7480"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onosh",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5024"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onosh",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4946"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onosh",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8089"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onosh",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4152"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onosh",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5870"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onosh",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Kaiah S",
+        "team_key": "frc8729"
+      },
+      {
+        "awardee": "Sarthak P",
+        "team_key": "frc188"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onosh",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7712"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onosh",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3543"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onosh",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10015"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onosh",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1241"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026ontor",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1360"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026ontor",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9785"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc7558"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc9575"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026ontor",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11270"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026ontor",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3161"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026ontor",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10554"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026ontor",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9785"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026ontor",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7558"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026ontor",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1325"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2935"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6632"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026ontor",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2935"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026ontor",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6632"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026ontor",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9659"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026ontor",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4039"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026ontor",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1310"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026ontor",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Kieran K",
+        "team_key": "frc4039"
+      },
+      {
+        "awardee": "Pirabaharan N",
+        "team_key": "frc1325"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026ontor",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7520"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026ontor",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1325"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026ontor",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8850"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026ontor",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4069"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026onwat",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc772"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onwat",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4946"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4678"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4308"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onwat",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc610"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onwat",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6725"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onwat",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2702"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onwat",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2200"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onwat",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2200"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc610"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc6875"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onwat",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2386"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onwat",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5409"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onwat",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1334"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onwat",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2609"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onwat",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8089"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onwat",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Ben M",
+        "team_key": "frc4946"
+      },
+      {
+        "awardee": "Andrew N",
+        "team_key": "frc8089"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onwat",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3683"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onwat",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10514"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onwat",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11227"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onwat",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4946"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026onwel",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onwel",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc2056"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc919"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026onwel",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11002"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onwel",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1114"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onwel",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc10514"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onwel",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1241"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onwel",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4476"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onwel",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4476"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc1360"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc8349"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onwel",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc7757"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onwel",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1325"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onwel",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5672"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onwel",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc9562"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onwel",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2013"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onwel",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Julia K",
+        "team_key": "frc3161"
+      },
+      {
+        "awardee": "Shayon M",
+        "team_key": "frc4476"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onwel",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3683"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onwel",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onwel",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc919"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onwel",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1360"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 0,
+    "event_key": "2026onwin",
+    "name": "District FIRST Impact Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5719"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 1,
+    "event_key": "2026onwin",
+    "name": "District Event Winner",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2702"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5406"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc771"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 10,
+    "event_key": "2026onwin",
+    "name": "Rookie All Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc11362"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 11,
+    "event_key": "2026onwin",
+    "name": "Gracious Professionalism Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4039"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 13,
+    "event_key": "2026onwin",
+    "name": "Judges' Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc865"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 16,
+    "event_key": "2026onwin",
+    "name": "Industrial Design Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3739"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 17,
+    "event_key": "2026onwin",
+    "name": "Quality Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5024"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 2,
+    "event_key": "2026onwin",
+    "name": "District Event Finalist",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4039"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc4678"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc5689"
+      },
+      {
+        "awardee": null,
+        "team_key": "frc11215"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 20,
+    "event_key": "2026onwin",
+    "name": "Creativity Award sponsored by Rockwell Automation",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5406"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 21,
+    "event_key": "2026onwin",
+    "name": "Excellence in Engineering Award sponsored by Littelfuse",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4907"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 27,
+    "event_key": "2026onwin",
+    "name": "Imagery Award in honor of Jack Kamen",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc6725"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 29,
+    "event_key": "2026onwin",
+    "name": "Innovation in Control Award sponsored by nVent",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc3756"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 30,
+    "event_key": "2026onwin",
+    "name": "Team Spirit Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc8789"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 4,
+    "event_key": "2026onwin",
+    "name": "District Championship FIRST Leadership Award Semi-Finalist",
+    "recipient_list": [
+      {
+        "awardee": "Aiden B",
+        "team_key": "frc2702"
+      },
+      {
+        "awardee": "Lizzie K",
+        "team_key": "frc4617"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 71,
+    "event_key": "2026onwin",
+    "name": "Autonomous Award sponsored by Google.org",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc2386"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 82,
+    "event_key": "2026onwin",
+    "name": "Team Sustainability Award sponsored by Dow",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc4617"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 83,
+    "event_key": "2026onwin",
+    "name": "Rising All-Star Award",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc1229"
+      }
+    ],
+    "year": 2026
+  },
+  {
+    "award_type": 9,
+    "event_key": "2026onwin",
+    "name": "District Engineering Inspiration Award sponsored by SpaceX",
+    "recipient_list": [
+      {
+        "awardee": null,
+        "team_key": "frc5885"
+      }
+    ],
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026ont_district_points.json
+++ b/src/backend/common/helpers/tests/data/2026ont_district_points.json
@@ -1,0 +1,5199 @@
+{
+ "2026onbar": {
+  "points": {
+   "frc10611": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 45
+   },
+   "frc1305": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc1310": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc188": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 71
+   },
+   "frc2706": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc3739": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 35
+   },
+   "frc4015": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc4069": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 50
+   },
+   "frc4688": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 11
+   },
+   "frc4920": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc4951": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 27
+   },
+   "frc5031": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc5672": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc5885": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 57
+   },
+   "frc6110": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 21
+   },
+   "frc6397": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc6859": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc6864": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6865": {
+    "alliance_points": 0,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 19
+   },
+   "frc7200": {
+    "alliance_points": 13,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 45
+   },
+   "frc7558": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc7603": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc7659": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc8081": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc8349": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 11,
+    "total": 33
+   },
+   "frc854": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc865": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc8884": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc9569": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 15
+   },
+   "frc9580": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 11,
+    "total": 27
+   },
+   "frc9592": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc9782": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 12
+   }
+  },
+  "tiebreakers": {
+   "frc10611": {
+    "highest_match_scores": [
+     470,
+     387,
+     361
+    ],
+    "qual_wins": 0
+   },
+   "frc1305": {
+    "highest_match_scores": [
+     396,
+     363,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc1310": {
+    "highest_match_scores": [
+     271,
+     268,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc188": {
+    "highest_match_scores": [
+     470,
+     465,
+     397
+    ],
+    "qual_wins": 0
+   },
+   "frc2706": {
+    "highest_match_scores": [
+     446,
+     268,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc3739": {
+    "highest_match_scores": [
+     380,
+     302,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc4015": {
+    "highest_match_scores": [
+     411,
+     225,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc4069": {
+    "highest_match_scores": [
+     538,
+     396,
+     363
+    ],
+    "qual_wins": 0
+   },
+   "frc4688": {
+    "highest_match_scores": [
+     225,
+     181,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc4920": {
+    "highest_match_scores": [
+     497,
+     375,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc4951": {
+    "highest_match_scores": [
+     396,
+     318,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc5031": {
+    "highest_match_scores": [
+     446,
+     375,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc5672": {
+    "highest_match_scores": [
+     210,
+     205,
+     185
+    ],
+    "qual_wins": 0
+   },
+   "frc5885": {
+    "highest_match_scores": [
+     380,
+     336,
+     335
+    ],
+    "qual_wins": 0
+   },
+   "frc6110": {
+    "highest_match_scores": [
+     538,
+     302,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc6397": {
+    "highest_match_scores": [
+     259,
+     256,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc6859": {
+    "highest_match_scores": [
+     283,
+     211,
+     210
+    ],
+    "qual_wins": 0
+   },
+   "frc6864": {
+    "highest_match_scores": [
+     252,
+     197,
+     153
+    ],
+    "qual_wins": 0
+   },
+   "frc6865": {
+    "highest_match_scores": [
+     138,
+     135,
+     128
+    ],
+    "qual_wins": 0
+   },
+   "frc7200": {
+    "highest_match_scores": [
+     411,
+     302,
+     291
+    ],
+    "qual_wins": 0
+   },
+   "frc7558": {
+    "highest_match_scores": [
+     538,
+     497,
+     470
+    ],
+    "qual_wins": 0
+   },
+   "frc7603": {
+    "highest_match_scores": [
+     364,
+     342,
+     223
+    ],
+    "qual_wins": 0
+   },
+   "frc7659": {
+    "highest_match_scores": [
+     242,
+     224,
+     205
+    ],
+    "qual_wins": 0
+   },
+   "frc8081": {
+    "highest_match_scores": [
+     364,
+     246,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc8349": {
+    "highest_match_scores": [
+     341,
+     336,
+     335
+    ],
+    "qual_wins": 0
+   },
+   "frc854": {
+    "highest_match_scores": [
+     306,
+     217,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc865": {
+    "highest_match_scores": [
+     397,
+     396,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc8884": {
+    "highest_match_scores": [
+     497,
+     397,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc9569": {
+    "highest_match_scores": [
+     318,
+     283,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc9580": {
+    "highest_match_scores": [
+     363,
+     328,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc9592": {
+    "highest_match_scores": [
+     465,
+     223,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc9782": {
+    "highest_match_scores": [
+     341,
+     201,
+     194
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026oncmp": {
+  "points": {
+   "frc1114": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc11270": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc1360": {
+    "alliance_points": 0,
+    "award_points": 24,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 24
+   },
+   "frc2056": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc6865": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc7712": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 0,
+    "total": 30
+   },
+   "frc772": {
+    "alliance_points": 0,
+    "award_points": 30,
+    "elim_points": 0,
+    "qual_points": 0,
+    "total": 30
+   }
+  },
+  "tiebreakers": {
+   "frc1114": {
+    "highest_match_scores": [
+     647,
+     630
+    ],
+    "qual_wins": 0
+   },
+   "frc2056": {
+    "highest_match_scores": [
+     647,
+     630
+    ],
+    "qual_wins": 0
+   },
+   "frc7558": {
+    "highest_match_scores": [
+     626,
+     548
+    ],
+    "qual_wins": 0
+   },
+   "frc7712": {
+    "highest_match_scores": [
+     647,
+     630
+    ],
+    "qual_wins": 0
+   },
+   "frc8349": {
+    "highest_match_scores": [
+     626,
+     548
+    ],
+    "qual_wins": 0
+   },
+   "frc9785": {
+    "highest_match_scores": [
+     626,
+     548
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026oncmp1": {
+  "points": {
+   "frc10015": {
+    "alliance_points": 27,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 87
+   },
+   "frc10514": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc1114": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 66,
+    "total": 219
+   },
+   "frc11227": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc11428": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc1305": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 72
+   },
+   "frc1325": {
+    "alliance_points": 45,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 57,
+    "total": 177
+   },
+   "frc1334": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc1360": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 51,
+    "total": 105
+   },
+   "frc2056": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 90,
+    "qual_points": 63,
+    "total": 216
+   },
+   "frc2200": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 81
+   },
+   "frc2386": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc2706": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc2708": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc3161": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 96
+   },
+   "frc3560": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc3756": {
+    "alliance_points": 18,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 30,
+    "total": 84
+   },
+   "frc4069": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 96
+   },
+   "frc4308": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc4476": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 60,
+    "total": 156
+   },
+   "frc4678": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 63,
+    "total": 168
+   },
+   "frc4907": {
+    "alliance_points": 33,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 117
+   },
+   "frc4920": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 90
+   },
+   "frc4976": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc5036": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 39
+   },
+   "frc5406": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 39,
+    "qual_points": 54,
+    "total": 150
+   },
+   "frc5409": {
+    "alliance_points": 21,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 66
+   },
+   "frc5596": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc5672": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc5689": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc5870": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc6875": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc6975": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc7200": {
+    "alliance_points": 24,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 69
+   },
+   "frc7476": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc7520": {
+    "alliance_points": 39,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 90
+   },
+   "frc7659": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc7712": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 42,
+    "total": 135
+   },
+   "frc772": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 24,
+    "total": 90
+   },
+   "frc7757": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 36
+   },
+   "frc7902": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 57
+   },
+   "frc865": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 75
+   },
+   "frc919": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 33
+   },
+   "frc9262": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc9263": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   },
+   "frc9562": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 39,
+    "total": 87
+   },
+   "frc9569": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 48
+   },
+   "frc9575": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc9580": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc9659": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 30
+   }
+  },
+  "tiebreakers": {
+   "frc10015": {
+    "highest_match_scores": [
+     413,
+     401,
+     383
+    ],
+    "qual_wins": 0
+   },
+   "frc10514": {
+    "highest_match_scores": [
+     459,
+     407,
+     309
+    ],
+    "qual_wins": 0
+   },
+   "frc1114": {
+    "highest_match_scores": [
+     868,
+     775,
+     768
+    ],
+    "qual_wins": 0
+   },
+   "frc11227": {
+    "highest_match_scores": [
+     407,
+     346,
+     341
+    ],
+    "qual_wins": 0
+   },
+   "frc11428": {
+    "highest_match_scores": [
+     577,
+     284,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc1305": {
+    "highest_match_scores": [
+     775,
+     483,
+     435
+    ],
+    "qual_wins": 0
+   },
+   "frc1325": {
+    "highest_match_scores": [
+     768,
+     535,
+     498
+    ],
+    "qual_wins": 0
+   },
+   "frc1334": {
+    "highest_match_scores": [
+     423,
+     307,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc1360": {
+    "highest_match_scores": [
+     493,
+     476,
+     441
+    ],
+    "qual_wins": 0
+   },
+   "frc2056": {
+    "highest_match_scores": [
+     868,
+     729,
+     693
+    ],
+    "qual_wins": 0
+   },
+   "frc2200": {
+    "highest_match_scores": [
+     690,
+     546,
+     539
+    ],
+    "qual_wins": 0
+   },
+   "frc2386": {
+    "highest_match_scores": [
+     483,
+     389,
+     363
+    ],
+    "qual_wins": 0
+   },
+   "frc2706": {
+    "highest_match_scores": [
+     369,
+     259,
+     226
+    ],
+    "qual_wins": 0
+   },
+   "frc2708": {
+    "highest_match_scores": [
+     447,
+     285,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc3161": {
+    "highest_match_scores": [
+     693,
+     498,
+     492
+    ],
+    "qual_wins": 0
+   },
+   "frc3560": {
+    "highest_match_scores": [
+     503,
+     344,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc3756": {
+    "highest_match_scores": [
+     476,
+     450,
+     381
+    ],
+    "qual_wins": 0
+   },
+   "frc4069": {
+    "highest_match_scores": [
+     485,
+     454,
+     427
+    ],
+    "qual_wins": 0
+   },
+   "frc4308": {
+    "highest_match_scores": [
+     471,
+     447,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc4476": {
+    "highest_match_scores": [
+     650,
+     574,
+     493
+    ],
+    "qual_wins": 0
+   },
+   "frc4678": {
+    "highest_match_scores": [
+     775,
+     546,
+     535
+    ],
+    "qual_wins": 0
+   },
+   "frc4907": {
+    "highest_match_scores": [
+     476,
+     471,
+     454
+    ],
+    "qual_wins": 0
+   },
+   "frc4920": {
+    "highest_match_scores": [
+     494,
+     483,
+     418
+    ],
+    "qual_wins": 0
+   },
+   "frc4976": {
+    "highest_match_scores": [
+     385,
+     303,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc5036": {
+    "highest_match_scores": [
+     492,
+     448,
+     423
+    ],
+    "qual_wins": 0
+   },
+   "frc5406": {
+    "highest_match_scores": [
+     584,
+     574,
+     539
+    ],
+    "qual_wins": 0
+   },
+   "frc5409": {
+    "highest_match_scores": [
+     690,
+     488,
+     409
+    ],
+    "qual_wins": 0
+   },
+   "frc5596": {
+    "highest_match_scores": [
+     498,
+     418,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc5672": {
+    "highest_match_scores": [
+     488,
+     339,
+     302
+    ],
+    "qual_wins": 0
+   },
+   "frc5689": {
+    "highest_match_scores": [
+     468,
+     345,
+     344
+    ],
+    "qual_wins": 0
+   },
+   "frc5870": {
+    "highest_match_scores": [
+     342,
+     298,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc6875": {
+    "highest_match_scores": [
+     344,
+     245,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc6975": {
+    "highest_match_scores": [
+     417,
+     322,
+     305
+    ],
+    "qual_wins": 0
+   },
+   "frc7200": {
+    "highest_match_scores": [
+     601,
+     584,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc7476": {
+    "highest_match_scores": [
+     729,
+     350,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc7520": {
+    "highest_match_scores": [
+     584,
+     485,
+     483
+    ],
+    "qual_wins": 0
+   },
+   "frc7659": {
+    "highest_match_scores": [
+     768,
+     530,
+     427
+    ],
+    "qual_wins": 0
+   },
+   "frc7712": {
+    "highest_match_scores": [
+     868,
+     623,
+     610
+    ],
+    "qual_wins": 0
+   },
+   "frc772": {
+    "highest_match_scores": [
+     535,
+     427,
+     406
+    ],
+    "qual_wins": 0
+   },
+   "frc7757": {
+    "highest_match_scores": [
+     413,
+     341,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc7902": {
+    "highest_match_scores": [
+     650,
+     494,
+     415
+    ],
+    "qual_wins": 0
+   },
+   "frc865": {
+    "highest_match_scores": [
+     693,
+     539,
+     483
+    ],
+    "qual_wins": 0
+   },
+   "frc919": {
+    "highest_match_scores": [
+     441,
+     277,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc9262": {
+    "highest_match_scores": [
+     460,
+     363,
+     349
+    ],
+    "qual_wins": 0
+   },
+   "frc9263": {
+    "highest_match_scores": [
+     601,
+     572,
+     485
+    ],
+    "qual_wins": 0
+   },
+   "frc9562": {
+    "highest_match_scores": [
+     574,
+     546,
+     530
+    ],
+    "qual_wins": 0
+   },
+   "frc9569": {
+    "highest_match_scores": [
+     577,
+     460,
+     459
+    ],
+    "qual_wins": 0
+   },
+   "frc9575": {
+    "highest_match_scores": [
+     572,
+     362,
+     344
+    ],
+    "qual_wins": 0
+   },
+   "frc9580": {
+    "highest_match_scores": [
+     277,
+     273,
+     244
+    ],
+    "qual_wins": 0
+   },
+   "frc9659": {
+    "highest_match_scores": [
+     423,
+     369,
+     357
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026oncmp2": {
+  "points": {
+   "frc10167": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc10554": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 48,
+    "total": 123
+   },
+   "frc10611": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc11002": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 15
+   },
+   "frc11270": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 72
+   },
+   "frc1229": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 54
+   },
+   "frc1241": {
+    "alliance_points": 48,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 66,
+    "total": 174
+   },
+   "frc1310": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 60,
+    "qual_points": 39,
+    "total": 102
+   },
+   "frc188": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 30,
+    "total": 78
+   },
+   "frc2013": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc2609": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 36
+   },
+   "frc2634": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 27
+   },
+   "frc2702": {
+    "alliance_points": 42,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 99
+   },
+   "frc2852": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc2935": {
+    "alliance_points": 33,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 84
+   },
+   "frc3543": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 51
+   },
+   "frc3683": {
+    "alliance_points": 30,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 96
+   },
+   "frc3739": {
+    "alliance_points": 12,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 30,
+    "total": 57
+   },
+   "frc4039": {
+    "alliance_points": 39,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 51,
+    "total": 105
+   },
+   "frc4152": {
+    "alliance_points": 27,
+    "award_points": 0,
+    "elim_points": 21,
+    "qual_points": 48,
+    "total": 96
+   },
+   "frc4688": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc4917": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 48
+   },
+   "frc4946": {
+    "alliance_points": 48,
+    "award_points": 15,
+    "elim_points": 60,
+    "qual_points": 63,
+    "total": 186
+   },
+   "frc4951": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 33,
+    "total": 33
+   },
+   "frc5024": {
+    "alliance_points": 21,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 66
+   },
+   "frc5031": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc5032": {
+    "alliance_points": 18,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 60
+   },
+   "frc5408": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 39,
+    "total": 39
+   },
+   "frc5719": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc5885": {
+    "alliance_points": 30,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 48,
+    "total": 78
+   },
+   "frc610": {
+    "alliance_points": 42,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 54,
+    "total": 111
+   },
+   "frc6632": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 45,
+    "total": 45
+   },
+   "frc6865": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6978": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 30,
+    "total": 84
+   },
+   "frc7480": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 42,
+    "total": 42
+   },
+   "frc7558": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 60,
+    "total": 195
+   },
+   "frc771": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 21,
+    "total": 21
+   },
+   "frc781": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc8089": {
+    "alliance_points": 24,
+    "award_points": 15,
+    "elim_points": 21,
+    "qual_points": 45,
+    "total": 105
+   },
+   "frc8349": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 15,
+    "total": 111
+   },
+   "frc854": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc8729": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc8789": {
+    "alliance_points": 0,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 27,
+    "total": 42
+   },
+   "frc8884": {
+    "alliance_points": 39,
+    "award_points": 15,
+    "elim_points": 0,
+    "qual_points": 57,
+    "total": 111
+   },
+   "frc9062": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 36,
+    "total": 36
+   },
+   "frc9098": {
+    "alliance_points": 36,
+    "award_points": 0,
+    "elim_points": 39,
+    "qual_points": 54,
+    "total": 129
+   },
+   "frc9589": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 18
+   },
+   "frc9782": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 24,
+    "total": 24
+   },
+   "frc9785": {
+    "alliance_points": 45,
+    "award_points": 0,
+    "elim_points": 90,
+    "qual_points": 60,
+    "total": 195
+   }
+  },
+  "tiebreakers": {
+   "frc10167": {
+    "highest_match_scores": [
+     457,
+     382,
+     357
+    ],
+    "qual_wins": 0
+   },
+   "frc10554": {
+    "highest_match_scores": [
+     774,
+     620,
+     490
+    ],
+    "qual_wins": 0
+   },
+   "frc10611": {
+    "highest_match_scores": [
+     419,
+     340,
+     314
+    ],
+    "qual_wins": 0
+   },
+   "frc11002": {
+    "highest_match_scores": [
+     370,
+     261,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc11270": {
+    "highest_match_scores": [
+     576,
+     564,
+     507
+    ],
+    "qual_wins": 0
+   },
+   "frc1229": {
+    "highest_match_scores": [
+     507,
+     434,
+     400
+    ],
+    "qual_wins": 0
+   },
+   "frc1241": {
+    "highest_match_scores": [
+     649,
+     647,
+     644
+    ],
+    "qual_wins": 0
+   },
+   "frc1310": {
+    "highest_match_scores": [
+     649,
+     647,
+     620
+    ],
+    "qual_wins": 0
+   },
+   "frc188": {
+    "highest_match_scores": [
+     562,
+     479,
+     459
+    ],
+    "qual_wins": 0
+   },
+   "frc2013": {
+    "highest_match_scores": [
+     590,
+     400,
+     380
+    ],
+    "qual_wins": 0
+   },
+   "frc2609": {
+    "highest_match_scores": [
+     508,
+     477,
+     434
+    ],
+    "qual_wins": 0
+   },
+   "frc2634": {
+    "highest_match_scores": [
+     475,
+     297,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc2702": {
+    "highest_match_scores": [
+     774,
+     578,
+     570
+    ],
+    "qual_wins": 0
+   },
+   "frc2852": {
+    "highest_match_scores": [
+     486,
+     431,
+     390
+    ],
+    "qual_wins": 0
+   },
+   "frc2935": {
+    "highest_match_scores": [
+     658,
+     564,
+     562
+    ],
+    "qual_wins": 0
+   },
+   "frc3543": {
+    "highest_match_scores": [
+     440,
+     353,
+     327
+    ],
+    "qual_wins": 0
+   },
+   "frc3683": {
+    "highest_match_scores": [
+     578,
+     463,
+     436
+    ],
+    "qual_wins": 0
+   },
+   "frc3739": {
+    "highest_match_scores": [
+     402,
+     378,
+     353
+    ],
+    "qual_wins": 0
+   },
+   "frc4039": {
+    "highest_match_scores": [
+     463,
+     402,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc4152": {
+    "highest_match_scores": [
+     479,
+     459,
+     448
+    ],
+    "qual_wins": 0
+   },
+   "frc4688": {
+    "highest_match_scores": [
+     437,
+     410,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc4917": {
+    "highest_match_scores": [
+     435,
+     355,
+     342
+    ],
+    "qual_wins": 0
+   },
+   "frc4946": {
+    "highest_match_scores": [
+     774,
+     649,
+     647
+    ],
+    "qual_wins": 0
+   },
+   "frc4951": {
+    "highest_match_scores": [
+     431,
+     321,
+     310
+    ],
+    "qual_wins": 0
+   },
+   "frc5024": {
+    "highest_match_scores": [
+     406,
+     380,
+     378
+    ],
+    "qual_wins": 0
+   },
+   "frc5031": {
+    "highest_match_scores": [
+     435,
+     376,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc5032": {
+    "highest_match_scores": [
+     644,
+     564,
+     458
+    ],
+    "qual_wins": 0
+   },
+   "frc5408": {
+    "highest_match_scores": [
+     420,
+     410,
+     370
+    ],
+    "qual_wins": 0
+   },
+   "frc5719": {
+    "highest_match_scores": [
+     570,
+     382,
+     249
+    ],
+    "qual_wins": 0
+   },
+   "frc5885": {
+    "highest_match_scores": [
+     600,
+     406,
+     392
+    ],
+    "qual_wins": 0
+   },
+   "frc610": {
+    "highest_match_scores": [
+     658,
+     576,
+     508
+    ],
+    "qual_wins": 0
+   },
+   "frc6632": {
+    "highest_match_scores": [
+     437,
+     427,
+     376
+    ],
+    "qual_wins": 0
+   },
+   "frc6865": {
+    "highest_match_scores": [
+     337,
+     295,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc6978": {
+    "highest_match_scores": [
+     490,
+     486,
+     431
+    ],
+    "qual_wins": 0
+   },
+   "frc7480": {
+    "highest_match_scores": [
+     427,
+     419,
+     392
+    ],
+    "qual_wins": 0
+   },
+   "frc7558": {
+    "highest_match_scores": [
+     644,
+     621,
+     620
+    ],
+    "qual_wins": 0
+   },
+   "frc771": {
+    "highest_match_scores": [
+     576,
+     259,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc781": {
+    "highest_match_scores": [
+     448,
+     410,
+     349
+    ],
+    "qual_wins": 0
+   },
+   "frc8089": {
+    "highest_match_scores": [
+     560,
+     479,
+     459
+    ],
+    "qual_wins": 0
+   },
+   "frc8349": {
+    "highest_match_scores": [
+     621,
+     578,
+     478
+    ],
+    "qual_wins": 0
+   },
+   "frc854": {
+    "highest_match_scores": [
+     346,
+     297,
+     261
+    ],
+    "qual_wins": 0
+   },
+   "frc8729": {
+    "highest_match_scores": [
+     468,
+     450,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc8789": {
+    "highest_match_scores": [
+     468,
+     401,
+     326
+    ],
+    "qual_wins": 0
+   },
+   "frc8884": {
+    "highest_match_scores": [
+     562,
+     457,
+     417
+    ],
+    "qual_wins": 0
+   },
+   "frc9062": {
+    "highest_match_scores": [
+     440,
+     349,
+     333
+    ],
+    "qual_wins": 0
+   },
+   "frc9098": {
+    "highest_match_scores": [
+     658,
+     560,
+     490
+    ],
+    "qual_wins": 0
+   },
+   "frc9589": {
+    "highest_match_scores": [
+     436,
+     296,
+     254
+    ],
+    "qual_wins": 0
+   },
+   "frc9782": {
+    "highest_match_scores": [
+     407,
+     374,
+     352
+    ],
+    "qual_wins": 0
+   },
+   "frc9785": {
+    "highest_match_scores": [
+     621,
+     600,
+     590
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026onham": {
+  "points": {
+   "frc10167": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc10554": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc11002": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc1114": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 72
+   },
+   "frc11362": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 5,
+    "total": 28
+   },
+   "frc11428": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc1229": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 20
+   },
+   "frc1325": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 13,
+    "qual_points": 18,
+    "total": 56
+   },
+   "frc2056": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc2200": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 58
+   },
+   "frc2852": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 20
+   },
+   "frc3560": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc4308": {
+    "alliance_points": 9,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 31
+   },
+   "frc4327": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc4907": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc4917": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc5032": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 28
+   },
+   "frc5406": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 20,
+    "total": 53
+   },
+   "frc6135": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 12,
+    "total": 28
+   },
+   "frc6162": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc6632": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 17
+   },
+   "frc6978": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 37
+   },
+   "frc7200": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 24
+   },
+   "frc7902": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 51
+   },
+   "frc8764": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc8850": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   },
+   "frc9062": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 7,
+    "total": 38
+   },
+   "frc9098": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 40
+   },
+   "frc9575": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc9659": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 18
+   }
+  },
+  "tiebreakers": {
+   "frc10167": {
+    "highest_match_scores": [
+     343,
+     226,
+     198
+    ],
+    "qual_wins": 0
+   },
+   "frc10554": {
+    "highest_match_scores": [
+     352,
+     326,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc11002": {
+    "highest_match_scores": [
+     304,
+     293,
+     255
+    ],
+    "qual_wins": 0
+   },
+   "frc1114": {
+    "highest_match_scores": [
+     667,
+     661,
+     648
+    ],
+    "qual_wins": 0
+   },
+   "frc11362": {
+    "highest_match_scores": [
+     379,
+     374,
+     336
+    ],
+    "qual_wins": 0
+   },
+   "frc11428": {
+    "highest_match_scores": [
+     423,
+     293,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc1229": {
+    "highest_match_scores": [
+     468,
+     293,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc1325": {
+    "highest_match_scores": [
+     608,
+     468,
+     431
+    ],
+    "qual_wins": 0
+   },
+   "frc2056": {
+    "highest_match_scores": [
+     667,
+     661,
+     648
+    ],
+    "qual_wins": 0
+   },
+   "frc2200": {
+    "highest_match_scores": [
+     639,
+     397,
+     379
+    ],
+    "qual_wins": 0
+   },
+   "frc2852": {
+    "highest_match_scores": [
+     324,
+     289,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc3560": {
+    "highest_match_scores": [
+     423,
+     250,
+     214
+    ],
+    "qual_wins": 0
+   },
+   "frc4308": {
+    "highest_match_scores": [
+     441,
+     413,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc4327": {
+    "highest_match_scores": [
+     437,
+     397,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc4907": {
+    "highest_match_scores": [
+     431,
+     385,
+     289
+    ],
+    "qual_wins": 0
+   },
+   "frc4917": {
+    "highest_match_scores": [
+     366,
+     352,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc5032": {
+    "highest_match_scores": [
+     424,
+     259,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc5406": {
+    "highest_match_scores": [
+     468,
+     441,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc6135": {
+    "highest_match_scores": [
+     317,
+     252,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc6162": {
+    "highest_match_scores": [
+     388,
+     239,
+     199
+    ],
+    "qual_wins": 0
+   },
+   "frc6632": {
+    "highest_match_scores": [
+     579,
+     424,
+     343
+    ],
+    "qual_wins": 0
+   },
+   "frc6978": {
+    "highest_match_scores": [
+     608,
+     312,
+     252
+    ],
+    "qual_wins": 0
+   },
+   "frc7200": {
+    "highest_match_scores": [
+     388,
+     346,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc7902": {
+    "highest_match_scores": [
+     639,
+     399,
+     385
+    ],
+    "qual_wins": 0
+   },
+   "frc8764": {
+    "highest_match_scores": [
+     470,
+     407,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc8850": {
+    "highest_match_scores": [
+     399,
+     385,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc9062": {
+    "highest_match_scores": [
+     667,
+     661,
+     648
+    ],
+    "qual_wins": 0
+   },
+   "frc9098": {
+    "highest_match_scores": [
+     470,
+     413,
+     318
+    ],
+    "qual_wins": 0
+   },
+   "frc9575": {
+    "highest_match_scores": [
+     437,
+     431,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc9659": {
+    "highest_match_scores": [
+     401,
+     385,
+     366
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026onnob": {
+  "points": {
+   "frc10015": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 62
+   },
+   "frc11270": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 69
+   },
+   "frc1305": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 12,
+    "total": 38
+   },
+   "frc1334": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 25
+   },
+   "frc2013": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 43
+   },
+   "frc2609": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 37
+   },
+   "frc2706": {
+    "alliance_points": 6,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 22
+   },
+   "frc2708": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   },
+   "frc2935": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc3543": {
+    "alliance_points": 4,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 30
+   },
+   "frc4152": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 41
+   },
+   "frc5036": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 27
+   },
+   "frc5596": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 9
+   },
+   "frc610": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc6859": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 4
+   },
+   "frc6864": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 7,
+    "total": 28
+   },
+   "frc7476": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc7480": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 25
+   },
+   "frc7520": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 43
+   },
+   "frc7712": {
+    "alliance_points": 11,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 31
+   },
+   "frc8729": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 18
+   },
+   "frc8884": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 11,
+    "total": 30
+   },
+   "frc9580": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 20
+   },
+   "frc9589": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 27
+   },
+   "frc9785": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 16,
+    "total": 66
+   }
+  },
+  "tiebreakers": {
+   "frc10015": {
+    "highest_match_scores": [
+     444,
+     433,
+     411
+    ],
+    "qual_wins": 0
+   },
+   "frc11270": {
+    "highest_match_scores": [
+     433,
+     374,
+     373
+    ],
+    "qual_wins": 0
+   },
+   "frc1305": {
+    "highest_match_scores": [
+     387,
+     373,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc1334": {
+    "highest_match_scores": [
+     300,
+     290,
+     222
+    ],
+    "qual_wins": 0
+   },
+   "frc2013": {
+    "highest_match_scores": [
+     366,
+     358,
+     310
+    ],
+    "qual_wins": 0
+   },
+   "frc2609": {
+    "highest_match_scores": [
+     387,
+     311,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc2706": {
+    "highest_match_scores": [
+     433,
+     215,
+     213
+    ],
+    "qual_wins": 0
+   },
+   "frc2708": {
+    "highest_match_scores": [
+     451,
+     373,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc2935": {
+    "highest_match_scores": [
+     370,
+     349,
+     338
+    ],
+    "qual_wins": 0
+   },
+   "frc3543": {
+    "highest_match_scores": [
+     373,
+     346,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc4152": {
+    "highest_match_scores": [
+     418,
+     396,
+     329
+    ],
+    "qual_wins": 0
+   },
+   "frc5036": {
+    "highest_match_scores": [
+     311,
+     290,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc5596": {
+    "highest_match_scores": [
+     338,
+     280,
+     273
+    ],
+    "qual_wins": 0
+   },
+   "frc610": {
+    "highest_match_scores": [
+     444,
+     418,
+     411
+    ],
+    "qual_wins": 0
+   },
+   "frc6859": {
+    "highest_match_scores": [
+     396,
+     306,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc6864": {
+    "highest_match_scores": [
+     444,
+     411,
+     357
+    ],
+    "qual_wins": 0
+   },
+   "frc7476": {
+    "highest_match_scores": [
+     298,
+     271,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc7480": {
+    "highest_match_scores": [
+     374,
+     370,
+     298
+    ],
+    "qual_wins": 0
+   },
+   "frc7520": {
+    "highest_match_scores": [
+     451,
+     396,
+     387
+    ],
+    "qual_wins": 0
+   },
+   "frc7712": {
+    "highest_match_scores": [
+     249,
+     228,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc8729": {
+    "highest_match_scores": [
+     349,
+     297,
+     248
+    ],
+    "qual_wins": 0
+   },
+   "frc8884": {
+    "highest_match_scores": [
+     309,
+     300,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc9580": {
+    "highest_match_scores": [
+     329,
+     249,
+     221
+    ],
+    "qual_wins": 0
+   },
+   "frc9589": {
+    "highest_match_scores": [
+     311,
+     309,
+     276
+    ],
+    "qual_wins": 0
+   },
+   "frc9785": {
+    "highest_match_scores": [
+     451,
+     418,
+     373
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026onosh": {
+  "points": {
+   "frc10015": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc11227": {
+    "alliance_points": 7,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 24
+   },
+   "frc1241": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 73
+   },
+   "frc188": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 52
+   },
+   "frc2708": {
+    "alliance_points": 6,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 17
+   },
+   "frc3543": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 11
+   },
+   "frc4152": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 39
+   },
+   "frc4476": {
+    "alliance_points": 15,
+    "award_points": 10,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 66
+   },
+   "frc4946": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc4976": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 42
+   },
+   "frc5024": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 31
+   },
+   "frc5032": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 32
+   },
+   "frc5036": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 13
+   },
+   "frc5409": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 30
+   },
+   "frc5596": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc5689": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 22
+   },
+   "frc5870": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 26
+   },
+   "frc6135": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 8,
+    "total": 29
+   },
+   "frc7480": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 4,
+    "total": 26
+   },
+   "frc7603": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc7712": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 40
+   },
+   "frc7757": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc781": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 42
+   },
+   "frc7902": {
+    "alliance_points": 13,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 18,
+    "total": 31
+   },
+   "frc8089": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 25
+   },
+   "frc8729": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 21
+   },
+   "frc9569": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc9589": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 10,
+    "total": 22
+   }
+  },
+  "tiebreakers": {
+   "frc10015": {
+    "highest_match_scores": [
+     488,
+     394,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc11227": {
+    "highest_match_scores": [
+     468,
+     404,
+     187
+    ],
+    "qual_wins": 0
+   },
+   "frc1241": {
+    "highest_match_scores": [
+     562,
+     512,
+     510
+    ],
+    "qual_wins": 0
+   },
+   "frc188": {
+    "highest_match_scores": [
+     581,
+     371,
+     324
+    ],
+    "qual_wins": 0
+   },
+   "frc2708": {
+    "highest_match_scores": [
+     429,
+     330,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc3543": {
+    "highest_match_scores": [
+     344,
+     330,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc4152": {
+    "highest_match_scores": [
+     257,
+     224,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc4476": {
+    "highest_match_scores": [
+     581,
+     468,
+     371
+    ],
+    "qual_wins": 0
+   },
+   "frc4946": {
+    "highest_match_scores": [
+     581,
+     562,
+     512
+    ],
+    "qual_wins": 0
+   },
+   "frc4976": {
+    "highest_match_scores": [
+     424,
+     324,
+     295
+    ],
+    "qual_wins": 0
+   },
+   "frc5024": {
+    "highest_match_scores": [
+     429,
+     250,
+     200
+    ],
+    "qual_wins": 0
+   },
+   "frc5032": {
+    "highest_match_scores": [
+     353,
+     281,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc5036": {
+    "highest_match_scores": [
+     379,
+     296,
+     295
+    ],
+    "qual_wins": 0
+   },
+   "frc5409": {
+    "highest_match_scores": [
+     342,
+     257,
+     230
+    ],
+    "qual_wins": 0
+   },
+   "frc5596": {
+    "highest_match_scores": [
+     379,
+     242,
+     160
+    ],
+    "qual_wins": 0
+   },
+   "frc5689": {
+    "highest_match_scores": [
+     271,
+     205,
+     195
+    ],
+    "qual_wins": 0
+   },
+   "frc5870": {
+    "highest_match_scores": [
+     306,
+     224,
+     158
+    ],
+    "qual_wins": 0
+   },
+   "frc6135": {
+    "highest_match_scores": [
+     286,
+     276,
+     247
+    ],
+    "qual_wins": 0
+   },
+   "frc7480": {
+    "highest_match_scores": [
+     371,
+     324,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc7603": {
+    "highest_match_scores": [
+     488,
+     324,
+     257
+    ],
+    "qual_wins": 0
+   },
+   "frc7712": {
+    "highest_match_scores": [
+     562,
+     424,
+     330
+    ],
+    "qual_wins": 0
+   },
+   "frc7757": {
+    "highest_match_scores": [
+     394,
+     306,
+     212
+    ],
+    "qual_wins": 0
+   },
+   "frc781": {
+    "highest_match_scores": [
+     512,
+     510,
+     366
+    ],
+    "qual_wins": 0
+   },
+   "frc7902": {
+    "highest_match_scores": [
+     404,
+     327,
+     296
+    ],
+    "qual_wins": 0
+   },
+   "frc8089": {
+    "highest_match_scores": [
+     342,
+     224,
+     190
+    ],
+    "qual_wins": 0
+   },
+   "frc8729": {
+    "highest_match_scores": [
+     353,
+     327,
+     288
+    ],
+    "qual_wins": 0
+   },
+   "frc9569": {
+    "highest_match_scores": [
+     344,
+     224,
+     202
+    ],
+    "qual_wins": 0
+   },
+   "frc9589": {
+    "highest_match_scores": [
+     281,
+     242,
+     189
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026ontor": {
+  "points": {
+   "frc10167": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 12
+   },
+   "frc10554": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc11270": {
+    "alliance_points": 13,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 36
+   },
+   "frc1310": {
+    "alliance_points": 8,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 22
+   },
+   "frc1325": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc1360": {
+    "alliance_points": 12,
+    "award_points": 10,
+    "elim_points": 7,
+    "qual_points": 15,
+    "total": 44
+   },
+   "frc2634": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 24
+   },
+   "frc2935": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 20,
+    "total": 61
+   },
+   "frc3161": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 49
+   },
+   "frc3560": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc4015": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc4039": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc4069": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 43
+   },
+   "frc5031": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 21
+   },
+   "frc5719": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc6397": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc6632": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 5,
+    "total": 31
+   },
+   "frc7520": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 51
+   },
+   "frc7558": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 18,
+    "total": 68
+   },
+   "frc771": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 4,
+    "total": 20
+   },
+   "frc854": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 8,
+    "total": 20
+   },
+   "frc8850": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 15
+   },
+   "frc919": {
+    "alliance_points": 10,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 24
+   },
+   "frc9262": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 19
+   },
+   "frc9562": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 11
+   },
+   "frc9575": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 11,
+    "total": 43
+   },
+   "frc9659": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc9782": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc9785": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 71
+   }
+  },
+  "tiebreakers": {
+   "frc10167": {
+    "highest_match_scores": [
+     425,
+     250,
+     192
+    ],
+    "qual_wins": 0
+   },
+   "frc10554": {
+    "highest_match_scores": [
+     400,
+     273,
+     215
+    ],
+    "qual_wins": 0
+   },
+   "frc11270": {
+    "highest_match_scores": [
+     321,
+     287,
+     274
+    ],
+    "qual_wins": 0
+   },
+   "frc1310": {
+    "highest_match_scores": [
+     459,
+     188,
+     182
+    ],
+    "qual_wins": 0
+   },
+   "frc1325": {
+    "highest_match_scores": [
+     459,
+     425,
+     414
+    ],
+    "qual_wins": 0
+   },
+   "frc1360": {
+    "highest_match_scores": [
+     346,
+     294,
+     275
+    ],
+    "qual_wins": 0
+   },
+   "frc2634": {
+    "highest_match_scores": [
+     273,
+     220,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc2935": {
+    "highest_match_scores": [
+     414,
+     400,
+     391
+    ],
+    "qual_wins": 0
+   },
+   "frc3161": {
+    "highest_match_scores": [
+     389,
+     388,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc3560": {
+    "highest_match_scores": [
+     224,
+     224,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc4015": {
+    "highest_match_scores": [
+     274,
+     206,
+     176
+    ],
+    "qual_wins": 0
+   },
+   "frc4039": {
+    "highest_match_scores": [
+     425,
+     343,
+     296
+    ],
+    "qual_wins": 0
+   },
+   "frc4069": {
+    "highest_match_scores": [
+     349,
+     230,
+     218
+    ],
+    "qual_wins": 0
+   },
+   "frc5031": {
+    "highest_match_scores": [
+     325,
+     233,
+     216
+    ],
+    "qual_wins": 0
+   },
+   "frc5719": {
+    "highest_match_scores": [
+     287,
+     273,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc6397": {
+    "highest_match_scores": [
+     308,
+     273,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc6632": {
+    "highest_match_scores": [
+     414,
+     391,
+     313
+    ],
+    "qual_wins": 0
+   },
+   "frc7520": {
+    "highest_match_scores": [
+     459,
+     389,
+     346
+    ],
+    "qual_wins": 0
+   },
+   "frc7558": {
+    "highest_match_scores": [
+     396,
+     388,
+     368
+    ],
+    "qual_wins": 0
+   },
+   "frc771": {
+    "highest_match_scores": [
+     389,
+     301,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc854": {
+    "highest_match_scores": [
+     388,
+     220,
+     218
+    ],
+    "qual_wins": 0
+   },
+   "frc8850": {
+    "highest_match_scores": [
+     230,
+     215,
+     209
+    ],
+    "qual_wins": 0
+   },
+   "frc919": {
+    "highest_match_scores": [
+     294,
+     221,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc9262": {
+    "highest_match_scores": [
+     250,
+     237,
+     224
+    ],
+    "qual_wins": 0
+   },
+   "frc9562": {
+    "highest_match_scores": [
+     256,
+     230,
+     197
+    ],
+    "qual_wins": 0
+   },
+   "frc9575": {
+    "highest_match_scores": [
+     396,
+     368,
+     336
+    ],
+    "qual_wins": 0
+   },
+   "frc9659": {
+    "highest_match_scores": [
+     290,
+     263,
+     193
+    ],
+    "qual_wins": 0
+   },
+   "frc9782": {
+    "highest_match_scores": [
+     296,
+     230,
+     206
+    ],
+    "qual_wins": 0
+   },
+   "frc9785": {
+    "highest_match_scores": [
+     396,
+     368,
+     349
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026onwat": {
+  "points": {
+   "frc10514": {
+    "alliance_points": 3,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 4,
+    "total": 19
+   },
+   "frc11227": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 27
+   },
+   "frc1334": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc2200": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 21,
+    "total": 61
+   },
+   "frc2386": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 23
+   },
+   "frc2609": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 32
+   },
+   "frc2702": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 47
+   },
+   "frc3683": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 17,
+    "total": 48
+   },
+   "frc3756": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 30
+   },
+   "frc4308": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 7,
+    "total": 38
+   },
+   "frc4617": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc4678": {
+    "alliance_points": 16,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 19,
+    "total": 65
+   },
+   "frc4917": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 25
+   },
+   "frc4940": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc4946": {
+    "alliance_points": 16,
+    "award_points": 8,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 76
+   },
+   "frc4976": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc5408": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 13
+   },
+   "frc5409": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 17,
+    "total": 43
+   },
+   "frc5870": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 17
+   },
+   "frc5912": {
+    "alliance_points": 7,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 18
+   },
+   "frc610": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 58
+   },
+   "frc6725": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 10
+   },
+   "frc6854": {
+    "alliance_points": 5,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 13
+   },
+   "frc6875": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 32
+   },
+   "frc6975": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 11
+   },
+   "frc7058": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc772": {
+    "alliance_points": 10,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 34
+   },
+   "frc8089": {
+    "alliance_points": 12,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 33
+   },
+   "frc8764": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 6
+   },
+   "frc9098": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 20,
+    "total": 41
+   },
+   "frc9263": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 16
+   }
+  },
+  "tiebreakers": {
+   "frc10514": {
+    "highest_match_scores": [
+     384,
+     324,
+     310
+    ],
+    "qual_wins": 0
+   },
+   "frc11227": {
+    "highest_match_scores": [
+     397,
+     368,
+     340
+    ],
+    "qual_wins": 0
+   },
+   "frc1334": {
+    "highest_match_scores": [
+     462,
+     408,
+     332
+    ],
+    "qual_wins": 0
+   },
+   "frc2200": {
+    "highest_match_scores": [
+     615,
+     448,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc2386": {
+    "highest_match_scores": [
+     372,
+     360,
+     177
+    ],
+    "qual_wins": 0
+   },
+   "frc2609": {
+    "highest_match_scores": [
+     439,
+     337,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc2702": {
+    "highest_match_scores": [
+     397,
+     363,
+     360
+    ],
+    "qual_wins": 0
+   },
+   "frc3683": {
+    "highest_match_scores": [
+     546,
+     402,
+     363
+    ],
+    "qual_wins": 0
+   },
+   "frc3756": {
+    "highest_match_scores": [
+     363,
+     325,
+     317
+    ],
+    "qual_wins": 0
+   },
+   "frc4308": {
+    "highest_match_scores": [
+     671,
+     534,
+     504
+    ],
+    "qual_wins": 0
+   },
+   "frc4617": {
+    "highest_match_scores": [
+     615,
+     429,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc4678": {
+    "highest_match_scores": [
+     671,
+     615,
+     534
+    ],
+    "qual_wins": 0
+   },
+   "frc4917": {
+    "highest_match_scores": [
+     408,
+     372,
+     352
+    ],
+    "qual_wins": 0
+   },
+   "frc4940": {
+    "highest_match_scores": [
+     381,
+     296,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc4946": {
+    "highest_match_scores": [
+     671,
+     546,
+     533
+    ],
+    "qual_wins": 0
+   },
+   "frc4976": {
+    "highest_match_scores": [
+     393,
+     381,
+     352
+    ],
+    "qual_wins": 0
+   },
+   "frc5408": {
+    "highest_match_scores": [
+     340,
+     311,
+     242
+    ],
+    "qual_wins": 0
+   },
+   "frc5409": {
+    "highest_match_scores": [
+     546,
+     439,
+     422
+    ],
+    "qual_wins": 0
+   },
+   "frc5870": {
+    "highest_match_scores": [
+     448,
+     397,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc5912": {
+    "highest_match_scores": [
+     269,
+     267,
+     262
+    ],
+    "qual_wins": 0
+   },
+   "frc610": {
+    "highest_match_scores": [
+     534,
+     533,
+     438
+    ],
+    "qual_wins": 0
+   },
+   "frc6725": {
+    "highest_match_scores": [
+     389,
+     275,
+     258
+    ],
+    "qual_wins": 0
+   },
+   "frc6854": {
+    "highest_match_scores": [
+     368,
+     279,
+     235
+    ],
+    "qual_wins": 0
+   },
+   "frc6875": {
+    "highest_match_scores": [
+     438,
+     423,
+     422
+    ],
+    "qual_wins": 0
+   },
+   "frc6975": {
+    "highest_match_scores": [
+     325,
+     262,
+     239
+    ],
+    "qual_wins": 0
+   },
+   "frc7058": {
+    "highest_match_scores": [
+     533,
+     288,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc772": {
+    "highest_match_scores": [
+     429,
+     317,
+     313
+    ],
+    "qual_wins": 0
+   },
+   "frc8089": {
+    "highest_match_scores": [
+     393,
+     332,
+     315
+    ],
+    "qual_wins": 0
+   },
+   "frc8764": {
+    "highest_match_scores": [
+     389,
+     235,
+     163
+    ],
+    "qual_wins": 0
+   },
+   "frc9098": {
+    "highest_match_scores": [
+     466,
+     462,
+     448
+    ],
+    "qual_wins": 0
+   },
+   "frc9263": {
+    "highest_match_scores": [
+     466,
+     315,
+     256
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026onwel": {
+  "points": {
+   "frc10514": {
+    "alliance_points": 9,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 28
+   },
+   "frc11002": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 12
+   },
+   "frc1114": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 22,
+    "total": 73
+   },
+   "frc11428": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   },
+   "frc1241": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 16,
+    "total": 49
+   },
+   "frc1325": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 44
+   },
+   "frc1360": {
+    "alliance_points": 13,
+    "award_points": 8,
+    "elim_points": 20,
+    "qual_points": 17,
+    "total": 58
+   },
+   "frc2013": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 28
+   },
+   "frc2056": {
+    "alliance_points": 16,
+    "award_points": 10,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 77
+   },
+   "frc2852": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 6,
+    "total": 12
+   },
+   "frc3161": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 19,
+    "total": 47
+   },
+   "frc3683": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 16,
+    "total": 42
+   },
+   "frc4476": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 18,
+    "total": 56
+   },
+   "frc5672": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 29
+   },
+   "frc6110": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 22
+   },
+   "frc6854": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 8,
+    "total": 18
+   },
+   "frc6865": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 23
+   },
+   "frc6975": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 12
+   },
+   "frc6978": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 25
+   },
+   "frc7476": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 20
+   },
+   "frc7659": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 25
+   },
+   "frc7757": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 17
+   },
+   "frc8349": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 10,
+    "total": 34
+   },
+   "frc9062": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 27
+   },
+   "frc919": {
+    "alliance_points": 1,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 9,
+    "total": 45
+   },
+   "frc9263": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 16
+   },
+   "frc9562": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 31
+   }
+  },
+  "tiebreakers": {
+   "frc10514": {
+    "highest_match_scores": [
+     534,
+     387,
+     375
+    ],
+    "qual_wins": 0
+   },
+   "frc11002": {
+    "highest_match_scores": [
+     452,
+     368,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc1114": {
+    "highest_match_scores": [
+     799,
+     797,
+     739
+    ],
+    "qual_wins": 0
+   },
+   "frc11428": {
+    "highest_match_scores": [
+     563,
+     503,
+     400
+    ],
+    "qual_wins": 0
+   },
+   "frc1241": {
+    "highest_match_scores": [
+     587,
+     546,
+     517
+    ],
+    "qual_wins": 0
+   },
+   "frc1325": {
+    "highest_match_scores": [
+     797,
+     694,
+     581
+    ],
+    "qual_wins": 0
+   },
+   "frc1360": {
+    "highest_match_scores": [
+     534,
+     514,
+     503
+    ],
+    "qual_wins": 0
+   },
+   "frc2013": {
+    "highest_match_scores": [
+     694,
+     491,
+     344
+    ],
+    "qual_wins": 0
+   },
+   "frc2056": {
+    "highest_match_scores": [
+     799,
+     739,
+     710
+    ],
+    "qual_wins": 0
+   },
+   "frc2852": {
+    "highest_match_scores": [
+     541,
+     440,
+     265
+    ],
+    "qual_wins": 0
+   },
+   "frc3161": {
+    "highest_match_scores": [
+     710,
+     587,
+     546
+    ],
+    "qual_wins": 0
+   },
+   "frc3683": {
+    "highest_match_scores": [
+     640,
+     541,
+     496
+    ],
+    "qual_wins": 0
+   },
+   "frc4476": {
+    "highest_match_scores": [
+     581,
+     563,
+     536
+    ],
+    "qual_wins": 0
+   },
+   "frc5672": {
+    "highest_match_scores": [
+     602,
+     536,
+     416
+    ],
+    "qual_wins": 0
+   },
+   "frc6110": {
+    "highest_match_scores": [
+     522,
+     339,
+     296
+    ],
+    "qual_wins": 0
+   },
+   "frc6854": {
+    "highest_match_scores": [
+     496,
+     475,
+     471
+    ],
+    "qual_wins": 0
+   },
+   "frc6865": {
+    "highest_match_scores": [
+     517,
+     508,
+     375
+    ],
+    "qual_wins": 0
+   },
+   "frc6975": {
+    "highest_match_scores": [
+     640,
+     416,
+     387
+    ],
+    "qual_wins": 0
+   },
+   "frc6978": {
+    "highest_match_scores": [
+     602,
+     522,
+     400
+    ],
+    "qual_wins": 0
+   },
+   "frc7476": {
+    "highest_match_scores": [
+     581,
+     416,
+     387
+    ],
+    "qual_wins": 0
+   },
+   "frc7659": {
+    "highest_match_scores": [
+     587,
+     546,
+     460
+    ],
+    "qual_wins": 0
+   },
+   "frc7757": {
+    "highest_match_scores": [
+     525,
+     340,
+     284
+    ],
+    "qual_wins": 0
+   },
+   "frc8349": {
+    "highest_match_scores": [
+     521,
+     489,
+     484
+    ],
+    "qual_wins": 0
+   },
+   "frc9062": {
+    "highest_match_scores": [
+     534,
+     521,
+     491
+    ],
+    "qual_wins": 0
+   },
+   "frc919": {
+    "highest_match_scores": [
+     799,
+     739,
+     677
+    ],
+    "qual_wins": 0
+   },
+   "frc9263": {
+    "highest_match_scores": [
+     514,
+     508,
+     397
+    ],
+    "qual_wins": 0
+   },
+   "frc9562": {
+    "highest_match_scores": [
+     797,
+     395,
+     361
+    ],
+    "qual_wins": 0
+   }
+  }
+ },
+ "2026onwin": {
+  "points": {
+   "frc10611": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 8,
+    "total": 8
+   },
+   "frc11215": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 14,
+    "qual_points": 13,
+    "total": 27
+   },
+   "frc11362": {
+    "alliance_points": 0,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 4,
+    "total": 12
+   },
+   "frc1229": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 15,
+    "total": 43
+   },
+   "frc2386": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 35
+   },
+   "frc2634": {
+    "alliance_points": 3,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 9,
+    "total": 19
+   },
+   "frc2702": {
+    "alliance_points": 15,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 21,
+    "total": 66
+   },
+   "frc3739": {
+    "alliance_points": 14,
+    "award_points": 5,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 44
+   },
+   "frc3756": {
+    "alliance_points": 7,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 10,
+    "total": 35
+   },
+   "frc4039": {
+    "alliance_points": 16,
+    "award_points": 5,
+    "elim_points": 20,
+    "qual_points": 22,
+    "total": 63
+   },
+   "frc4617": {
+    "alliance_points": 5,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 22
+   },
+   "frc4678": {
+    "alliance_points": 16,
+    "award_points": 0,
+    "elim_points": 20,
+    "qual_points": 19,
+    "total": 55
+   },
+   "frc4688": {
+    "alliance_points": 12,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 17,
+    "total": 29
+   },
+   "frc4907": {
+    "alliance_points": 13,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 34
+   },
+   "frc4920": {
+    "alliance_points": 14,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 18,
+    "total": 39
+   },
+   "frc4940": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc4951": {
+    "alliance_points": 4,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 16
+   },
+   "frc5024": {
+    "alliance_points": 10,
+    "award_points": 5,
+    "elim_points": 13,
+    "qual_points": 13,
+    "total": 41
+   },
+   "frc5406": {
+    "alliance_points": 15,
+    "award_points": 5,
+    "elim_points": 30,
+    "qual_points": 20,
+    "total": 70
+   },
+   "frc5408": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc5689": {
+    "alliance_points": 1,
+    "award_points": 0,
+    "elim_points": 7,
+    "qual_points": 6,
+    "total": 14
+   },
+   "frc5719": {
+    "alliance_points": 9,
+    "award_points": 10,
+    "elim_points": 0,
+    "qual_points": 13,
+    "total": 32
+   },
+   "frc5885": {
+    "alliance_points": 12,
+    "award_points": 8,
+    "elim_points": 0,
+    "qual_points": 16,
+    "total": 36
+   },
+   "frc5912": {
+    "alliance_points": 8,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 19
+   },
+   "frc6162": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 7,
+    "total": 7
+   },
+   "frc6725": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 12,
+    "total": 17
+   },
+   "frc6875": {
+    "alliance_points": 6,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 20
+   },
+   "frc7058": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 5,
+    "total": 5
+   },
+   "frc771": {
+    "alliance_points": 2,
+    "award_points": 0,
+    "elim_points": 30,
+    "qual_points": 8,
+    "total": 40
+   },
+   "frc772": {
+    "alliance_points": 9,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 24
+   },
+   "frc781": {
+    "alliance_points": 11,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 15,
+    "total": 26
+   },
+   "frc8081": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 10,
+    "total": 10
+   },
+   "frc865": {
+    "alliance_points": 11,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 14,
+    "total": 30
+   },
+   "frc8789": {
+    "alliance_points": 0,
+    "award_points": 5,
+    "elim_points": 0,
+    "qual_points": 11,
+    "total": 16
+   },
+   "frc9262": {
+    "alliance_points": 0,
+    "award_points": 0,
+    "elim_points": 0,
+    "qual_points": 9,
+    "total": 9
+   }
+  },
+  "tiebreakers": {
+   "frc10611": {
+    "highest_match_scores": [
+     292,
+     287,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc11215": {
+    "highest_match_scores": [
+     411,
+     406,
+     292
+    ],
+    "qual_wins": 0
+   },
+   "frc11362": {
+    "highest_match_scores": [
+     369,
+     254,
+     233
+    ],
+    "qual_wins": 0
+   },
+   "frc1229": {
+    "highest_match_scores": [
+     516,
+     376,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc2386": {
+    "highest_match_scores": [
+     460,
+     311,
+     271
+    ],
+    "qual_wins": 0
+   },
+   "frc2634": {
+    "highest_match_scores": [
+     325,
+     294,
+     291
+    ],
+    "qual_wins": 0
+   },
+   "frc2702": {
+    "highest_match_scores": [
+     557,
+     547,
+     529
+    ],
+    "qual_wins": 0
+   },
+   "frc3739": {
+    "highest_match_scores": [
+     516,
+     414,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc3756": {
+    "highest_match_scores": [
+     398,
+     342,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc4039": {
+    "highest_match_scores": [
+     416,
+     409,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc4617": {
+    "highest_match_scores": [
+     489,
+     401,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc4678": {
+    "highest_match_scores": [
+     557,
+     516,
+     489
+    ],
+    "qual_wins": 0
+   },
+   "frc4688": {
+    "highest_match_scores": [
+     452,
+     365,
+     311
+    ],
+    "qual_wins": 0
+   },
+   "frc4907": {
+    "highest_match_scores": [
+     369,
+     345,
+     293
+    ],
+    "qual_wins": 0
+   },
+   "frc4920": {
+    "highest_match_scores": [
+     411,
+     408,
+     398
+    ],
+    "qual_wins": 0
+   },
+   "frc4940": {
+    "highest_match_scores": [
+     557,
+     306,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc4951": {
+    "highest_match_scores": [
+     460,
+     271,
+     256
+    ],
+    "qual_wins": 0
+   },
+   "frc5024": {
+    "highest_match_scores": [
+     342,
+     311,
+     285
+    ],
+    "qual_wins": 0
+   },
+   "frc5406": {
+    "highest_match_scores": [
+     547,
+     529,
+     520
+    ],
+    "qual_wins": 0
+   },
+   "frc5408": {
+    "highest_match_scores": [
+     408,
+     335,
+     225
+    ],
+    "qual_wins": 0
+   },
+   "frc5689": {
+    "highest_match_scores": [
+     414,
+     409,
+     407
+    ],
+    "qual_wins": 0
+   },
+   "frc5719": {
+    "highest_match_scores": [
+     325,
+     287,
+     263
+    ],
+    "qual_wins": 0
+   },
+   "frc5885": {
+    "highest_match_scores": [
+     308,
+     306,
+     290
+    ],
+    "qual_wins": 0
+   },
+   "frc5912": {
+    "highest_match_scores": [
+     345,
+     291,
+     240
+    ],
+    "qual_wins": 0
+   },
+   "frc6162": {
+    "highest_match_scores": [
+     395,
+     324,
+     208
+    ],
+    "qual_wins": 0
+   },
+   "frc6725": {
+    "highest_match_scores": [
+     376,
+     291,
+     217
+    ],
+    "qual_wins": 0
+   },
+   "frc6875": {
+    "highest_match_scores": [
+     365,
+     351,
+     306
+    ],
+    "qual_wins": 0
+   },
+   "frc7058": {
+    "highest_match_scores": [
+     306,
+     233,
+     229
+    ],
+    "qual_wins": 0
+   },
+   "frc771": {
+    "highest_match_scores": [
+     547,
+     529,
+     520
+    ],
+    "qual_wins": 0
+   },
+   "frc772": {
+    "highest_match_scores": [
+     452,
+     416,
+     227
+    ],
+    "qual_wins": 0
+   },
+   "frc781": {
+    "highest_match_scores": [
+     292,
+     285,
+     253
+    ],
+    "qual_wins": 0
+   },
+   "frc8081": {
+    "highest_match_scores": [
+     245,
+     217,
+     201
+    ],
+    "qual_wins": 0
+   },
+   "frc865": {
+    "highest_match_scores": [
+     519,
+     342,
+     272
+    ],
+    "qual_wins": 0
+   },
+   "frc8789": {
+    "highest_match_scores": [
+     519,
+     351,
+     308
+    ],
+    "qual_wins": 0
+   },
+   "frc9262": {
+    "highest_match_scores": [
+     335,
+     324,
+     291
+    ],
+    "qual_wins": 0
+   }
+  }
+ }
+}

--- a/src/backend/common/helpers/tests/data/2026ont_events.json
+++ b/src/backend/common/helpers/tests/data/2026ont_events.json
@@ -1,0 +1,244 @@
+[
+  {
+    "city": "Barrie",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-29",
+    "event_code": "onbar",
+    "event_type": 1,
+    "key": "2026onbar",
+    "name": "ONT District Georgian College Event",
+    "start_date": "2026-03-27",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Niagara Falls",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-19",
+    "event_code": "oncmp",
+    "event_type": 2,
+    "key": "2026oncmp",
+    "name": "FIRST Ontario Provincial Championship",
+    "start_date": "2026-04-19",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Niagara Falls",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-19",
+    "event_code": "oncmp1",
+    "event_type": 5,
+    "key": "2026oncmp1",
+    "name": "FIRST Ontario Provincial Championship - Science Division",
+    "start_date": "2026-04-16",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Niagara Falls",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-19",
+    "event_code": "oncmp2",
+    "event_type": 5,
+    "key": "2026oncmp2",
+    "name": "FIRST Ontario Provincial Championship - Technology Division",
+    "start_date": "2026-04-16",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Hamilton",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-22",
+    "event_code": "onham",
+    "event_type": 1,
+    "key": "2026onham",
+    "name": "ONT District McMaster University Event",
+    "start_date": "2026-03-20",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "North Bay",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-22",
+    "event_code": "onnob",
+    "event_type": 1,
+    "key": "2026onnob",
+    "name": "ONT District North Bay Event",
+    "start_date": "2026-03-20",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Oshawa",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-15",
+    "event_code": "onosh",
+    "event_type": 1,
+    "key": "2026onosh",
+    "name": "ONT District Durham College Event",
+    "start_date": "2026-03-13",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Etobicoke",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-14",
+    "event_code": "ontor",
+    "event_type": 1,
+    "key": "2026ontor",
+    "name": "ONT District Humber Polytechnic Event",
+    "start_date": "2026-03-12",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Waterloo",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-03-28",
+    "event_code": "onwat",
+    "event_type": 1,
+    "key": "2026onwat",
+    "name": "ONT District University of Waterloo Event",
+    "start_date": "2026-03-26",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Welland",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-12",
+    "event_code": "onwel",
+    "event_type": 1,
+    "key": "2026onwel",
+    "name": "ONT District Niagara College Event",
+    "start_date": "2026-04-10",
+    "state_prov": "ON",
+    "year": 2026
+  },
+  {
+    "city": "Windsor",
+    "country": "Canada",
+    "district": {
+      "abbreviation": "ont",
+      "display_name": "FIRST Canada - Ontario",
+      "key": "2026ont",
+      "official_advancement_counts": {
+        "cmp": 21,
+        "dcmp": 100
+      },
+      "year": 2026
+    },
+    "end_date": "2026-04-11",
+    "event_code": "onwin",
+    "event_type": 1,
+    "key": "2026onwin",
+    "name": "ONT District Windsor Essex Great Lake Event",
+    "start_date": "2026-04-09",
+    "state_prov": "ON",
+    "year": 2026
+  }
+]

--- a/src/backend/common/helpers/tests/data/2026ont_rankings.json
+++ b/src/backend/common/helpers/tests/data/2026ont_rankings.json
@@ -1,0 +1,4150 @@
+[
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onham",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwel",
+        "qual_points": 21,
+        "total": 77
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026oncmp1",
+        "qual_points": 63,
+        "total": 216
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 396,
+    "rank": 1,
+    "rookie_bonus": 0,
+    "team_key": "frc2056"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onham",
+        "qual_points": 21,
+        "total": 72
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwel",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026oncmp1",
+        "qual_points": 66,
+        "total": 219
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 394,
+    "rank": 2,
+    "rookie_bonus": 0,
+    "team_key": "frc1114"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026ontor",
+        "qual_points": 18,
+        "total": 68
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onbar",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026oncmp2",
+        "qual_points": 60,
+        "total": 195
+      }
+    ],
+    "point_total": 336,
+    "rank": 3,
+    "rookie_bonus": 0,
+    "team_key": "frc7558"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onosh",
+        "qual_points": 22,
+        "total": 73
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwat",
+        "qual_points": 22,
+        "total": 76
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026oncmp2",
+        "qual_points": 63,
+        "total": 186
+      }
+    ],
+    "point_total": 335,
+    "rank": 4,
+    "rookie_bonus": 0,
+    "team_key": "frc4946"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026ontor",
+        "qual_points": 21,
+        "total": 71
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onnob",
+        "qual_points": 16,
+        "total": 66
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026oncmp2",
+        "qual_points": 60,
+        "total": 195
+      }
+    ],
+    "point_total": 332,
+    "rank": 5,
+    "rookie_bonus": 0,
+    "team_key": "frc9785"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onosh",
+        "qual_points": 19,
+        "total": 73
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwel",
+        "qual_points": 16,
+        "total": 49
+      },
+      {
+        "alliance_points": 48,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026oncmp2",
+        "qual_points": 66,
+        "total": 174
+      }
+    ],
+    "point_total": 296,
+    "rank": 6,
+    "rookie_bonus": 0,
+    "team_key": "frc1241"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026ontor",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onham",
+        "qual_points": 18,
+        "total": 56
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026oncmp1",
+        "qual_points": 57,
+        "total": 177
+      }
+    ],
+    "point_total": 296,
+    "rank": 7,
+    "rookie_bonus": 0,
+    "team_key": "frc1325"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwat",
+        "qual_points": 19,
+        "total": 65
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwin",
+        "qual_points": 19,
+        "total": 55
+      },
+      {
+        "alliance_points": 45,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026oncmp1",
+        "qual_points": 63,
+        "total": 168
+      }
+    ],
+    "point_total": 288,
+    "rank": 8,
+    "rookie_bonus": 0,
+    "team_key": "frc4678"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onosh",
+        "qual_points": 21,
+        "total": 66
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwel",
+        "qual_points": 18,
+        "total": 56
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026oncmp1",
+        "qual_points": 60,
+        "total": 156
+      }
+    ],
+    "point_total": 278,
+    "rank": 9,
+    "rookie_bonus": 0,
+    "team_key": "frc4476"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onham",
+        "qual_points": 20,
+        "total": 53
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwin",
+        "qual_points": 20,
+        "total": 70
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026oncmp1",
+        "qual_points": 54,
+        "total": 150
+      }
+    ],
+    "point_total": 273,
+    "rank": 10,
+    "rookie_bonus": 0,
+    "team_key": "frc5406"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onosh",
+        "qual_points": 16,
+        "total": 40
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 10,
+        "total": 31
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026oncmp1",
+        "qual_points": 42,
+        "total": 135
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 30,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 236,
+    "rank": 11,
+    "rookie_bonus": 0,
+    "team_key": "frc7712"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onnob",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwat",
+        "qual_points": 18,
+        "total": 58
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 54,
+        "total": 111
+      }
+    ],
+    "point_total": 232,
+    "rank": 12,
+    "rookie_bonus": 0,
+    "team_key": "frc610"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026ontor",
+        "qual_points": 15,
+        "total": 44
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwel",
+        "qual_points": 17,
+        "total": 58
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026oncmp1",
+        "qual_points": 51,
+        "total": 105
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 231,
+    "rank": 13,
+    "rookie_bonus": 0,
+    "team_key": "frc1360"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwat",
+        "qual_points": 16,
+        "total": 47
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwin",
+        "qual_points": 21,
+        "total": 66
+      },
+      {
+        "alliance_points": 42,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 57,
+        "total": 99
+      }
+    ],
+    "point_total": 212,
+    "rank": 14,
+    "rookie_bonus": 0,
+    "team_key": "frc2702"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 15,
+        "total": 36
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onnob",
+        "qual_points": 19,
+        "total": 69
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 39,
+        "total": 72
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 24,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 24
+      }
+    ],
+    "point_total": 211,
+    "rank": 15,
+    "rookie_bonus": 10,
+    "team_key": "frc11270"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onham",
+        "qual_points": 15,
+        "total": 40
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwat",
+        "qual_points": 20,
+        "total": 41
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026oncmp2",
+        "qual_points": 54,
+        "total": 129
+      }
+    ],
+    "point_total": 210,
+    "rank": 16,
+    "rookie_bonus": 0,
+    "team_key": "frc9098"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onosh",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onnob",
+        "qual_points": 21,
+        "total": 62
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 45,
+        "total": 87
+      }
+    ],
+    "point_total": 205,
+    "rank": 17,
+    "rookie_bonus": 5,
+    "team_key": "frc10015"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwin",
+        "qual_points": 22,
+        "total": 63
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 51,
+        "total": 105
+      }
+    ],
+    "point_total": 203,
+    "rank": 18,
+    "rookie_bonus": 0,
+    "team_key": "frc4039"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onnob",
+        "qual_points": 11,
+        "total": 30
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onbar",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 57,
+        "total": 111
+      }
+    ],
+    "point_total": 202,
+    "rank": 19,
+    "rookie_bonus": 0,
+    "team_key": "frc8884"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onosh",
+        "qual_points": 17,
+        "total": 52
+      },
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onbar",
+        "qual_points": 20,
+        "total": 71
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026oncmp2",
+        "qual_points": 30,
+        "total": 78
+      }
+    ],
+    "point_total": 201,
+    "rank": 20,
+    "rookie_bonus": 0,
+    "team_key": "frc188"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onham",
+        "qual_points": 19,
+        "total": 58
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwat",
+        "qual_points": 21,
+        "total": 61
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 45,
+        "total": 81
+      }
+    ],
+    "point_total": 200,
+    "rank": 21,
+    "rookie_bonus": 0,
+    "team_key": "frc2200"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026ontor",
+        "qual_points": 17,
+        "total": 49
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwel",
+        "qual_points": 19,
+        "total": 47
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 57,
+        "total": 96
+      }
+    ],
+    "point_total": 192,
+    "rank": 22,
+    "rookie_bonus": 0,
+    "team_key": "frc3161"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026ontor",
+        "qual_points": 16,
+        "total": 43
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onbar",
+        "qual_points": 18,
+        "total": 50
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 51,
+        "total": 96
+      }
+    ],
+    "point_total": 189,
+    "rank": 23,
+    "rookie_bonus": 0,
+    "team_key": "frc4069"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwat",
+        "qual_points": 17,
+        "total": 48
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwel",
+        "qual_points": 16,
+        "total": 42
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 51,
+        "total": 96
+      }
+    ],
+    "point_total": 186,
+    "rank": 24,
+    "rookie_bonus": 0,
+    "team_key": "frc3683"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 13,
+        "total": 28
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 14,
+        "total": 29
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026oncmp2",
+        "qual_points": 48,
+        "total": 123
+      }
+    ],
+    "point_total": 185,
+    "rank": 25,
+    "rookie_bonus": 5,
+    "team_key": "frc10554"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026ontor",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onnob",
+        "qual_points": 17,
+        "total": 43
+      },
+      {
+        "alliance_points": 39,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 51,
+        "total": 90
+      }
+    ],
+    "point_total": 184,
+    "rank": 26,
+    "rookie_bonus": 0,
+    "team_key": "frc7520"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 16,
+        "total": 34
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026oncmp1",
+        "qual_points": 48,
+        "total": 117
+      }
+    ],
+    "point_total": 183,
+    "rank": 27,
+    "rookie_bonus": 0,
+    "team_key": "frc4907"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onbar",
+        "qual_points": 11,
+        "total": 33
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwel",
+        "qual_points": 10,
+        "total": 34
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 90,
+        "event_key": "2026oncmp2",
+        "qual_points": 15,
+        "total": 111
+      }
+    ],
+    "point_total": 178,
+    "rank": 28,
+    "rookie_bonus": 0,
+    "team_key": "frc8349"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 14,
+        "total": 34
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 15,
+        "total": 24
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026oncmp1",
+        "qual_points": 24,
+        "total": 90
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 178,
+    "rank": 29,
+    "rookie_bonus": 0,
+    "team_key": "frc772"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onosh",
+        "qual_points": 15,
+        "total": 39
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onnob",
+        "qual_points": 17,
+        "total": 41
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026oncmp2",
+        "qual_points": 48,
+        "total": 96
+      }
+    ],
+    "point_total": 176,
+    "rank": 30,
+    "rookie_bonus": 0,
+    "team_key": "frc4152"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 16,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026ontor",
+        "qual_points": 20,
+        "total": 61
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 33,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 51,
+        "total": 84
+      }
+    ],
+    "point_total": 173,
+    "rank": 31,
+    "rookie_bonus": 0,
+    "team_key": "frc2935"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 15,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onbar",
+        "qual_points": 17,
+        "total": 57
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 16,
+        "total": 36
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 48,
+        "total": 78
+      }
+    ],
+    "point_total": 171,
+    "rank": 32,
+    "rookie_bonus": 0,
+    "team_key": "frc5885"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 12,
+        "total": 25
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 16,
+        "total": 33
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026oncmp2",
+        "qual_points": 45,
+        "total": 105
+      }
+    ],
+    "point_total": 163,
+    "rank": 33,
+    "rookie_bonus": 0,
+    "team_key": "frc8089"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onnob",
+        "qual_points": 12,
+        "total": 38
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onbar",
+        "qual_points": 19,
+        "total": 51
+      },
+      {
+        "alliance_points": 30,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 42,
+        "total": 72
+      }
+    ],
+    "point_total": 161,
+    "rank": 34,
+    "rookie_bonus": 0,
+    "team_key": "frc1305"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwin",
+        "qual_points": 18,
+        "total": 39
+      },
+      {
+        "alliance_points": 36,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 54,
+        "total": 90
+      }
+    ],
+    "point_total": 157,
+    "rank": 35,
+    "rookie_bonus": 0,
+    "team_key": "frc4920"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwat",
+        "qual_points": 13,
+        "total": 30
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwin",
+        "qual_points": 10,
+        "total": 35
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 21,
+        "event_key": "2026oncmp1",
+        "qual_points": 30,
+        "total": 84
+      }
+    ],
+    "point_total": 149,
+    "rank": 36,
+    "rookie_bonus": 0,
+    "team_key": "frc3756"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 9,
+        "total": 22
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 60,
+        "event_key": "2026oncmp2",
+        "qual_points": 39,
+        "total": 102
+      }
+    ],
+    "point_total": 148,
+    "rank": 37,
+    "rookie_bonus": 0,
+    "team_key": "frc1310"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onham",
+        "qual_points": 17,
+        "total": 37
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 13,
+        "total": 25
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026oncmp2",
+        "qual_points": 30,
+        "total": 84
+      }
+    ],
+    "point_total": 146,
+    "rank": 38,
+    "rookie_bonus": 0,
+    "team_key": "frc6978"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 18,
+        "total": 31
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onham",
+        "qual_points": 17,
+        "total": 51
+      },
+      {
+        "alliance_points": 15,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 42,
+        "total": 57
+      }
+    ],
+    "point_total": 139,
+    "rank": 39,
+    "rookie_bonus": 0,
+    "team_key": "frc7902"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 14,
+        "total": 30
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwat",
+        "qual_points": 17,
+        "total": 43
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 45,
+        "total": 66
+      }
+    ],
+    "point_total": 139,
+    "rank": 40,
+    "rookie_bonus": 0,
+    "team_key": "frc5409"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 13,
+        "total": 31
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwin",
+        "qual_points": 13,
+        "total": 41
+      },
+      {
+        "alliance_points": 21,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 45,
+        "total": 66
+      }
+    ],
+    "point_total": 138,
+    "rank": 41,
+    "rookie_bonus": 0,
+    "team_key": "frc5024"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 10,
+        "total": 24
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onbar",
+        "qual_points": 17,
+        "total": 45
+      },
+      {
+        "alliance_points": 24,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 45,
+        "total": 69
+      }
+    ],
+    "point_total": 138,
+    "rank": 42,
+    "rookie_bonus": 0,
+    "team_key": "frc7200"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 14,
+        "total": 30
+      },
+      {
+        "alliance_points": 27,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 48,
+        "total": 75
+      }
+    ],
+    "point_total": 137,
+    "rank": 43,
+    "rookie_bonus": 0,
+    "team_key": "frc865"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 13,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onbar",
+        "qual_points": 15,
+        "total": 35
+      },
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwin",
+        "qual_points": 18,
+        "total": 44
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 30,
+        "total": 57
+      }
+    ],
+    "point_total": 136,
+    "rank": 44,
+    "rookie_bonus": 0,
+    "team_key": "frc3739"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 7,
+        "total": 11
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 39,
+        "event_key": "2026oncmp1",
+        "qual_points": 39,
+        "total": 87
+      }
+    ],
+    "point_total": 129,
+    "rank": 45,
+    "rookie_bonus": 0,
+    "team_key": "frc9562"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 16,
+        "total": 32
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 16,
+        "total": 28
+      },
+      {
+        "alliance_points": 18,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 42,
+        "total": 60
+      }
+    ],
+    "point_total": 120,
+    "rank": 46,
+    "rookie_bonus": 0,
+    "team_key": "frc5032"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 8,
+        "total": 20
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwin",
+        "qual_points": 15,
+        "total": 43
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 39,
+        "total": 54
+      }
+    ],
+    "point_total": 117,
+    "rank": 47,
+    "rookie_bonus": 0,
+    "team_key": "frc1229"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 14,
+        "total": 31
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwat",
+        "qual_points": 7,
+        "total": 38
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 105,
+    "rank": 48,
+    "rookie_bonus": 0,
+    "team_key": "frc4308"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 18,
+        "total": 37
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 15,
+        "total": 32
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 27,
+        "total": 36
+      }
+    ],
+    "point_total": 105,
+    "rank": 49,
+    "rookie_bonus": 0,
+    "team_key": "frc2609"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 16,
+        "total": 32
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 14,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 105,
+    "rank": 50,
+    "rookie_bonus": 0,
+    "team_key": "frc4917"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026ontor",
+        "qual_points": 11,
+        "total": 43
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onham",
+        "qual_points": 13,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 104,
+    "rank": 51,
+    "rookie_bonus": 0,
+    "team_key": "frc9575"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onosh",
+        "qual_points": 11,
+        "total": 42
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 104,
+    "rank": 52,
+    "rookie_bonus": 0,
+    "team_key": "frc781"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onnob",
+        "qual_points": 11,
+        "total": 43
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 13,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 104,
+    "rank": 53,
+    "rookie_bonus": 0,
+    "team_key": "frc2013"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 14,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onosh",
+        "qual_points": 15,
+        "total": 42
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 104,
+    "rank": 54,
+    "rookie_bonus": 0,
+    "team_key": "frc4976"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwel",
+        "qual_points": 9,
+        "total": 45
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 18,
+        "total": 33
+      }
+    ],
+    "point_total": 102,
+    "rank": 55,
+    "rookie_bonus": 0,
+    "team_key": "frc919"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onham",
+        "qual_points": 7,
+        "total": 38
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 15,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 101,
+    "rank": 56,
+    "rookie_bonus": 0,
+    "team_key": "frc9062"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 9,
+        "total": 23
+      },
+      {
+        "alliance_points": 13,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 17,
+        "total": 35
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 100,
+    "rank": 57,
+    "rookie_bonus": 0,
+    "team_key": "frc2386"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 9,
+        "total": 24
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 12,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 100,
+    "rank": 58,
+    "rookie_bonus": 10,
+    "team_key": "frc11227"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onosh",
+        "qual_points": 4,
+        "total": 26
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 15,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 93,
+    "rank": 59,
+    "rookie_bonus": 0,
+    "team_key": "frc7480"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026ontor",
+        "qual_points": 5,
+        "total": 31
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 9,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 45,
+        "total": 45
+      }
+    ],
+    "point_total": 93,
+    "rank": 60,
+    "rookie_bonus": 0,
+    "team_key": "frc6632"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 6,
+        "total": 11
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onnob",
+        "qual_points": 8,
+        "total": 30
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 92,
+    "rank": 61,
+    "rookie_bonus": 0,
+    "team_key": "frc3543"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onbar",
+        "qual_points": 9,
+        "total": 45
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 91,
+    "rank": 62,
+    "rookie_bonus": 5,
+    "team_key": "frc10611"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 8,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 12,
+        "total": 25
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 89,
+    "rank": 63,
+    "rookie_bonus": 0,
+    "team_key": "frc1334"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 14,
+        "total": 29
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 12,
+        "total": 20
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 88,
+    "rank": 64,
+    "rookie_bonus": 0,
+    "team_key": "frc7476"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 12,
+        "total": 21
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 87,
+    "rank": 65,
+    "rookie_bonus": 0,
+    "team_key": "frc5031"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 14,
+        "total": 24
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 8,
+        "total": 15
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 48,
+        "total": 48
+      }
+    ],
+    "point_total": 87,
+    "rank": 66,
+    "rookie_bonus": 0,
+    "team_key": "frc9569"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 10,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 14,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 33,
+        "total": 48
+      }
+    ],
+    "point_total": 85,
+    "rank": 67,
+    "rookie_bonus": 0,
+    "team_key": "frc5672"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 9,
+        "total": 19
+      },
+      {
+        "alliance_points": 7,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 11,
+        "total": 23
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 30,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp",
+        "qual_points": 0,
+        "total": 30
+      }
+    ],
+    "point_total": 84,
+    "rank": 68,
+    "rookie_bonus": 0,
+    "team_key": "frc6865"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 5,
+        "total": 11
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 17,
+        "total": 29
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 42,
+        "total": 42
+      }
+    ],
+    "point_total": 82,
+    "rank": 69,
+    "rookie_bonus": 0,
+    "team_key": "frc4688"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026ontor",
+        "qual_points": 4,
+        "total": 20
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 30,
+        "event_key": "2026onwin",
+        "qual_points": 8,
+        "total": 40
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 81,
+    "rank": 70,
+    "rookie_bonus": 0,
+    "team_key": "frc771"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 9,
+        "total": 13
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 13,
+        "total": 27
+      },
+      {
+        "alliance_points": 12,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 27,
+        "total": 39
+      }
+    ],
+    "point_total": 79,
+    "rank": 71,
+    "rookie_bonus": 0,
+    "team_key": "frc5036"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 6,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 6,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 36,
+        "total": 51
+      }
+    ],
+    "point_total": 79,
+    "rank": 72,
+    "rookie_bonus": 5,
+    "team_key": "frc10167"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 6,
+        "total": 17
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 78,
+    "rank": 73,
+    "rookie_bonus": 0,
+    "team_key": "frc2708"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwat",
+        "qual_points": 4,
+        "total": 19
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 76,
+    "rank": 74,
+    "rookie_bonus": 5,
+    "team_key": "frc10514"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 16,
+        "total": 27
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 12,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 76,
+    "rank": 75,
+    "rookie_bonus": 0,
+    "team_key": "frc4951"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 14,
+        "total": 28
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 13,
+        "total": 18
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 76,
+    "rank": 76,
+    "rookie_bonus": 0,
+    "team_key": "frc9659"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onwat",
+        "qual_points": 10,
+        "total": 32
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 14,
+        "total": 20
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 73,
+    "rank": 77,
+    "rookie_bonus": 0,
+    "team_key": "frc6875"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 13,
+        "total": 24
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwin",
+        "qual_points": 9,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 70,
+    "rank": 78,
+    "rookie_bonus": 0,
+    "team_key": "frc2634"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwin",
+        "qual_points": 6,
+        "total": 14
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 69,
+    "rank": 79,
+    "rookie_bonus": 0,
+    "team_key": "frc5689"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onosh",
+        "qual_points": 10,
+        "total": 22
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onnob",
+        "qual_points": 10,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 67,
+    "rank": 80,
+    "rookie_bonus": 0,
+    "team_key": "frc9589"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 2,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onwel",
+        "qual_points": 10,
+        "total": 25
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 67,
+    "rank": 81,
+    "rookie_bonus": 0,
+    "team_key": "frc7659"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 12,
+        "total": 26
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 9,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 67,
+    "rank": 82,
+    "rookie_bonus": 0,
+    "team_key": "frc5870"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 13,
+        "total": 20
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onbar",
+        "qual_points": 11,
+        "total": 27
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 65,
+    "rank": 83,
+    "rookie_bonus": 0,
+    "team_key": "frc9580"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 8,
+        "total": 22
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 15,
+        "total": 31
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 65,
+    "rank": 84,
+    "rookie_bonus": 0,
+    "team_key": "frc2706"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 7,
+        "total": 17
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 21,
+        "total": 36
+      }
+    ],
+    "point_total": 65,
+    "rank": 85,
+    "rookie_bonus": 0,
+    "team_key": "frc7757"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 11,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 27,
+        "total": 27
+      }
+    ],
+    "point_total": 65,
+    "rank": 86,
+    "rookie_bonus": 10,
+    "team_key": "frc11428"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 10,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 13,
+        "total": 32
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 21,
+        "total": 21
+      }
+    ],
+    "point_total": 63,
+    "rank": 87,
+    "rookie_bonus": 0,
+    "team_key": "frc5719"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 10,
+        "total": 16
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 7,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 30,
+        "total": 30
+      }
+    ],
+    "point_total": 62,
+    "rank": 88,
+    "rookie_bonus": 0,
+    "team_key": "frc9263"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 12,
+        "total": 19
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 9,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 33,
+        "total": 33
+      }
+    ],
+    "point_total": 61,
+    "rank": 89,
+    "rookie_bonus": 0,
+    "team_key": "frc9262"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 13,
+        "total": 13
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 39,
+        "total": 39
+      }
+    ],
+    "point_total": 59,
+    "rank": 90,
+    "rookie_bonus": 0,
+    "team_key": "frc5408"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 11,
+        "total": 16
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 15,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 27,
+        "total": 42
+      }
+    ],
+    "point_total": 58,
+    "rank": 91,
+    "rookie_bonus": 0,
+    "team_key": "frc8789"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 13,
+        "event_key": "2026onosh",
+        "qual_points": 8,
+        "total": 29
+      },
+      {
+        "alliance_points": 4,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onham",
+        "qual_points": 12,
+        "total": 28
+      }
+    ],
+    "point_total": 57,
+    "rank": 92,
+    "rookie_bonus": 0,
+    "team_key": "frc6135"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 10,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 11,
+        "total": 21
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 9,
+        "total": 18
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 18,
+        "total": 18
+      }
+    ],
+    "point_total": 57,
+    "rank": 93,
+    "rookie_bonus": 0,
+    "team_key": "frc8729"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 9,
+        "total": 20
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 6,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 56,
+    "rank": 94,
+    "rookie_bonus": 0,
+    "team_key": "frc2852"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026ontor",
+        "qual_points": 8,
+        "total": 20
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 6,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 55,
+    "rank": 95,
+    "rookie_bonus": 0,
+    "team_key": "frc854"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 6,
+        "total": 9
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 36,
+        "total": 36
+      }
+    ],
+    "point_total": 55,
+    "rank": 96,
+    "rookie_bonus": 0,
+    "team_key": "frc5596"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onham",
+        "qual_points": 5,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 4,
+        "total": 12
+      }
+    ],
+    "point_total": 50,
+    "rank": 97,
+    "rookie_bonus": 10,
+    "team_key": "frc11362"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 8,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 4,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 49,
+    "rank": 98,
+    "rookie_bonus": 10,
+    "team_key": "frc11002"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 15,
+        "total": 26
+      },
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 13,
+        "total": 22
+      }
+    ],
+    "point_total": 48,
+    "rank": 99,
+    "rookie_bonus": 0,
+    "team_key": "frc6397"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 10,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 7,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp2",
+        "qual_points": 24,
+        "total": 24
+      }
+    ],
+    "point_total": 46,
+    "rank": 100,
+    "rookie_bonus": 0,
+    "team_key": "frc9782"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 4,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onbar",
+        "qual_points": 10,
+        "total": 21
+      },
+      {
+        "alliance_points": 11,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 11,
+        "total": 22
+      }
+    ],
+    "point_total": 43,
+    "rank": 101,
+    "rookie_bonus": 0,
+    "team_key": "frc6110"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwel",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 15,
+        "total": 15
+      }
+    ],
+    "point_total": 38,
+    "rank": 102,
+    "rookie_bonus": 0,
+    "team_key": "frc6975"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 14,
+        "event_key": "2026onwin",
+        "qual_points": 13,
+        "total": 27
+      }
+    ],
+    "point_total": 37,
+    "rank": 103,
+    "rookie_bonus": 10,
+    "team_key": "frc11215"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 7,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 11,
+        "total": 18
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 11,
+        "total": 19
+      }
+    ],
+    "point_total": 37,
+    "rank": 104,
+    "rookie_bonus": 0,
+    "team_key": "frc5912"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 5,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 12,
+        "total": 22
+      }
+    ],
+    "point_total": 33,
+    "rank": 105,
+    "rookie_bonus": 0,
+    "team_key": "frc4617"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 1,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 20,
+        "event_key": "2026onnob",
+        "qual_points": 7,
+        "total": 28
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 4,
+        "total": 4
+      }
+    ],
+    "point_total": 32,
+    "rank": 106,
+    "rookie_bonus": 0,
+    "team_key": "frc6864"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 9,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 13,
+        "total": 22
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 32,
+    "rank": 107,
+    "rookie_bonus": 0,
+    "team_key": "frc8081"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 5,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 8,
+        "total": 13
+      },
+      {
+        "alliance_points": 3,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 7,
+        "event_key": "2026onwel",
+        "qual_points": 8,
+        "total": 18
+      }
+    ],
+    "point_total": 31,
+    "rank": 108,
+    "rookie_bonus": 0,
+    "team_key": "frc6854"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 10,
+        "total": 15
+      },
+      {
+        "alliance_points": 6,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 10,
+        "total": 16
+      }
+    ],
+    "point_total": 31,
+    "rank": 109,
+    "rookie_bonus": 0,
+    "team_key": "frc8850"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": true,
+        "elim_points": 0,
+        "event_key": "2026oncmp1",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 27,
+    "rank": 110,
+    "rookie_bonus": 0,
+    "team_key": "frc3560"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 5,
+        "total": 10
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 12,
+        "total": 17
+      }
+    ],
+    "point_total": 27,
+    "rank": 111,
+    "rookie_bonus": 0,
+    "team_key": "frc6725"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onnob",
+        "qual_points": 4,
+        "total": 4
+      },
+      {
+        "alliance_points": 8,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 12,
+        "total": 20
+      }
+    ],
+    "point_total": 24,
+    "rank": 112,
+    "rookie_bonus": 0,
+    "team_key": "frc6859"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onosh",
+        "qual_points": 7,
+        "total": 7
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 5,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 12,
+        "total": 17
+      }
+    ],
+    "point_total": 24,
+    "rank": 113,
+    "rookie_bonus": 0,
+    "team_key": "frc7603"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 18,
+    "rank": 114,
+    "rookie_bonus": 0,
+    "team_key": "frc4940"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026ontor",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 10,
+        "total": 10
+      }
+    ],
+    "point_total": 18,
+    "rank": 115,
+    "rookie_bonus": 0,
+    "team_key": "frc4015"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 12,
+        "total": 12
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 5,
+        "total": 5
+      }
+    ],
+    "point_total": 17,
+    "rank": 116,
+    "rookie_bonus": 0,
+    "team_key": "frc7058"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 11,
+        "total": 11
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwat",
+        "qual_points": 6,
+        "total": 6
+      }
+    ],
+    "point_total": 17,
+    "rank": 117,
+    "rookie_bonus": 0,
+    "team_key": "frc8764"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onham",
+        "qual_points": 8,
+        "total": 8
+      },
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onwin",
+        "qual_points": 7,
+        "total": 7
+      }
+    ],
+    "point_total": 15,
+    "rank": 118,
+    "rookie_bonus": 0,
+    "team_key": "frc6162"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [
+      {
+        "alliance_points": 0,
+        "award_points": 0,
+        "district_cmp": false,
+        "elim_points": 0,
+        "event_key": "2026onbar",
+        "qual_points": 12,
+        "total": 12
+      }
+    ],
+    "point_total": 12,
+    "rank": 119,
+    "rookie_bonus": 0,
+    "team_key": "frc9592"
+  },
+  {
+    "adjustments": 0,
+    "event_points": [],
+    "point_total": 10,
+    "rank": 120,
+    "rookie_bonus": 10,
+    "team_key": "frc10924"
+  }
+]

--- a/src/backend/common/helpers/tests/district_advancement_helper_test.py
+++ b/src/backend/common/helpers/tests/district_advancement_helper_test.py
@@ -1,0 +1,527 @@
+import json
+from typing import Dict, List, Set
+
+import pytest
+from google.appengine.ext import ndb
+
+from backend.common.consts.award_type import AwardType
+from backend.common.consts.event_type import EventType
+from backend.common.helpers.district_advancement_helper import (
+    DistrictAdvancementHelper,
+)
+from backend.common.models.award import Award
+from backend.common.models.district import District
+from backend.common.models.district_ranking import DistrictRanking
+from backend.common.models.event import Event
+from backend.common.models.event_details import EventDetails
+from backend.common.models.event_district_points import TeamAtEventDistrictPoints
+from backend.common.models.keys import EventKey, TeamKey
+from backend.common.models.team import Team
+
+
+def _points(
+    event_key: EventKey,
+    *,
+    district_cmp: bool = False,
+    qual: int = 0,
+    elim: int = 0,
+    alliance: int = 0,
+    award: int = 0,
+) -> TeamAtEventDistrictPoints:
+    return TeamAtEventDistrictPoints(
+        event_key=event_key,
+        district_cmp=district_cmp,
+        qual_points=qual,
+        elim_points=elim,
+        alliance_points=alliance,
+        award_points=award,
+        total=qual + elim + alliance + award,
+    )
+
+
+def _ranking(
+    rank: int,
+    team_key: TeamKey,
+    *event_points: TeamAtEventDistrictPoints,
+    rookie_bonus: int = 0,
+    adjustments: int = 0,
+) -> DistrictRanking:
+    ranking = DistrictRanking(
+        rank=rank,
+        team_key=team_key,
+        point_total=sum(ep["total"] for ep in event_points)
+        + rookie_bonus
+        + adjustments,
+        rookie_bonus=rookie_bonus,
+        event_points=list(event_points),
+    )
+    if adjustments:
+        ranking["adjustments"] = adjustments
+    return ranking
+
+
+def _descending_rankings(count: int, top_points: int = 100) -> List[DistrictRanking]:
+    return [
+        _ranking(i + 1, f"frc{i + 1}", _points("2026qual", qual=top_points - i))
+        for i in range(count)
+    ]
+
+
+def _team_keys(*numbers: int) -> Set[TeamKey]:
+    return {f"frc{n}" for n in numbers}
+
+
+def test_no_declines_effective_matches_original() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings, slots=5, auto_qualified=set(), attendance=_team_keys(1, 2, 3, 4, 5)
+    )
+
+    assert cutoffs.original == 96
+    assert cutoffs.effective == 96
+    assert cutoffs.declined == []
+
+
+def test_decline_passes_slot_down() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings, slots=5, auto_qualified=set(), attendance=_team_keys(1, 3, 4, 5, 6)
+    )
+
+    assert cutoffs.original == 96
+    assert cutoffs.effective == 95
+    assert cutoffs.declined == ["frc2"]
+
+
+def test_award_winner_below_cutoff_consumes_a_slot() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings,
+        slots=5,
+        auto_qualified=_team_keys(8),
+        attendance=_team_keys(1, 2, 3, 4, 8),
+    )
+
+    assert cutoffs.original == 97
+    assert cutoffs.effective == 97
+    assert cutoffs.declined == []
+
+
+def test_award_winner_above_cutoff_changes_nothing() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings,
+        slots=5,
+        auto_qualified=_team_keys(2),
+        attendance=_team_keys(1, 2, 3, 4, 5),
+    )
+
+    assert cutoffs.original == 96
+    assert cutoffs.effective == 96
+    assert cutoffs.declined == []
+
+
+def test_award_winner_below_cutoff_does_not_lower_effective() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings,
+        slots=4,
+        auto_qualified=_team_keys(9),
+        attendance=_team_keys(1, 2, 3, 9),
+    )
+
+    assert cutoffs.original == 98
+    assert cutoffs.effective == 98
+
+
+def test_more_slots_than_teams() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings, slots=20, auto_qualified=set(), attendance=_team_keys(*range(1, 11))
+    )
+
+    assert cutoffs.original == 91
+    assert cutoffs.effective == 91
+
+
+def test_no_attendance_yields_zero_effective() -> None:
+    rankings = _descending_rankings(10)
+
+    cutoffs = DistrictAdvancementHelper.calculate_dcmp_cutoffs(
+        rankings, slots=5, auto_qualified=set(), attendance=set()
+    )
+
+    assert cutoffs.original == 96
+    assert cutoffs.effective == 0
+    assert cutoffs.declined == []
+
+
+def test_attendance_ignores_award_only_dcmp_entry() -> None:
+    competed = _ranking(
+        1,
+        "frc1",
+        _points("2026qual", qual=50),
+        _points("2026necmp1", district_cmp=True, qual=24),
+    )
+    award_only = _ranking(
+        2,
+        "frc2",
+        _points("2026qual", qual=40),
+        _points("2026necmp", district_cmp=True, award=24),
+    )
+    no_dcmp = _ranking(3, "frc3", _points("2026qual", qual=30))
+
+    attendance = DistrictAdvancementHelper.dcmp_attendance(
+        [competed, award_only, no_dcmp]
+    )
+
+    assert attendance == {"frc1"}
+
+
+def test_attendance_counts_elim_only_finals_entry() -> None:
+    finals_only = _ranking(
+        1,
+        "frc1",
+        _points("2026qual", qual=50),
+        _points("2026necmp", district_cmp=True, elim=30),
+    )
+
+    assert DistrictAdvancementHelper.dcmp_attendance([finals_only]) == {"frc1"}
+
+
+def test_pre_dcmp_rankings_reorders_after_removing_dcmp_points() -> None:
+    boosted_by_dcmp = _ranking(
+        1,
+        "frc1",
+        _points("2026qual", qual=50),
+        _points("2026necmp1", district_cmp=True, qual=30),
+    )
+    stronger_in_quals = _ranking(
+        2,
+        "frc2",
+        _points("2026qual", qual=60),
+        _points("2026necmp1", district_cmp=True, qual=5),
+    )
+
+    pre_dcmp = DistrictAdvancementHelper.pre_dcmp_rankings(
+        [boosted_by_dcmp, stronger_in_quals]
+    )
+
+    assert [(r["rank"], r["team_key"], r["point_total"]) for r in pre_dcmp] == [
+        (1, "frc2", 60),
+        (2, "frc1", 50),
+    ]
+    assert all(not ep.get("district_cmp") for r in pre_dcmp for ep in r["event_points"])
+
+
+def test_pre_dcmp_rankings_preserves_bonuses() -> None:
+    ranking = _ranking(
+        1,
+        "frc1",
+        _points("2026qual", qual=50),
+        _points("2026necmp1", district_cmp=True, qual=30),
+        rookie_bonus=10,
+        adjustments=5,
+    )
+
+    pre_dcmp = DistrictAdvancementHelper.pre_dcmp_rankings([ranking])[0]
+
+    assert pre_dcmp["point_total"] == 65
+    assert pre_dcmp["rookie_bonus"] == 10
+    assert pre_dcmp["adjustments"] == 5
+
+
+def test_pre_dcmp_rankings_breaks_ties_on_playoff_points() -> None:
+    fewer_playoff_points = _ranking(
+        1, "frc1", _points("2026qual", qual=50, elim=0), _points("2026b", qual=10)
+    )
+    more_playoff_points = _ranking(
+        2, "frc2", _points("2026qual", qual=30, elim=20), _points("2026b", qual=10)
+    )
+
+    pre_dcmp = DistrictAdvancementHelper.pre_dcmp_rankings(
+        [fewer_playoff_points, more_playoff_points]
+    )
+
+    assert [r["team_key"] for r in pre_dcmp] == ["frc2", "frc1"]
+
+
+def test_pre_dcmp_rankings_breaks_ties_on_highest_match_score() -> None:
+    pre_dcmp = DistrictAdvancementHelper.pre_dcmp_rankings(
+        [
+            _ranking(1, "frc1", _points("2026qual", qual=20)),
+            _ranking(2, "frc2", _points("2026qual", qual=20)),
+        ],
+        {"2026qual": {"frc1": [300, 200, 100], "frc2": [400, 100, 50]}},
+    )
+
+    assert [r["team_key"] for r in pre_dcmp] == ["frc2", "frc1"]
+
+
+def test_pre_dcmp_rankings_breaks_ties_on_second_highest_match_score() -> None:
+    pre_dcmp = DistrictAdvancementHelper.pre_dcmp_rankings(
+        [
+            _ranking(1, "frc1", _points("2026qual", qual=20)),
+            _ranking(2, "frc2", _points("2026qual", qual=20)),
+        ],
+        {"2026qual": {"frc1": [400, 200, 100], "frc2": [400, 300, 50]}},
+    )
+
+    assert [r["team_key"] for r in pre_dcmp] == ["frc2", "frc1"]
+
+
+def test_pre_dcmp_rankings_ignores_dcmp_match_scores() -> None:
+    pre_dcmp = DistrictAdvancementHelper.pre_dcmp_rankings(
+        [
+            _ranking(
+                1,
+                "frc1",
+                _points("2026qual", qual=20),
+                _points("2026necmp", district_cmp=True, qual=50),
+            ),
+            _ranking(
+                2,
+                "frc2",
+                _points("2026qual", qual=20),
+                _points("2026necmp", district_cmp=True, qual=50),
+            ),
+        ],
+        {
+            "2026qual": {"frc1": [100], "frc2": [200]},
+            "2026necmp": {"frc1": [999], "frc2": [0]},
+        },
+    )
+
+    assert [r["team_key"] for r in pre_dcmp] == ["frc2", "frc1"]
+
+
+def _load(test_data_importer, filename: str):
+    with open(test_data_importer._get_path(__file__, f"data/{filename}")) as f:
+        return json.load(f)
+
+
+def _setup_district(test_data_importer, district_key: str) -> District:
+    year = int(district_key[:4])
+    rankings = _load(test_data_importer, f"{district_key}_rankings.json")
+    awards = _load(test_data_importer, f"{district_key}_awards.json")
+
+    district = District(id=district_key, year=year, abbreviation=district_key[4:])
+    district.rankings = rankings
+    district.put()
+
+    district_points = _load(test_data_importer, f"{district_key}_district_points.json")
+
+    events: Dict[EventKey, Event] = {}
+    for event_data in _load(test_data_importer, f"{district_key}_events.json"):
+        event_key = event_data["key"]
+        event = Event(
+            id=event_key,
+            year=year,
+            event_short=event_data["event_code"],
+            event_type_enum=EventType(event_data["event_type"]),
+            district_key=district.key,
+        )
+        event.put()
+        EventDetails(id=event_key, district_points=district_points[event_key]).put()
+        events[event_key] = event
+
+    for award in awards:
+        event = events[award["event_key"]]
+        Award(
+            id=Award.render_key_name(award["event_key"], award["award_type"]),
+            name_str=award["name"],
+            award_type_enum=award["award_type"],
+            year=year,
+            event=event.key,
+            event_type_enum=event.event_type_enum,
+            team_list=[
+                ndb.Key(Team, recipient["team_key"])
+                for recipient in award["recipient_list"]
+                if recipient["team_key"]
+            ],
+        ).put()
+
+    return district
+
+
+def test_2026ne_impact_winners(ndb_stub, test_data_importer) -> None:
+    district = _setup_district(test_data_importer, "2026ne")
+    events = Event.query(Event.district_key == district.key).fetch()
+
+    winners = DistrictAdvancementHelper.impact_award_winners(events)
+
+    assert winners == {
+        "frc131",
+        "frc1350",
+        "frc173",
+        "frc190",
+        "frc195",
+        "frc2079",
+        "frc2170",
+        "frc2370",
+        "frc2877",
+        "frc4905",
+        "frc6328",
+        "frc8046",
+    }
+
+
+def test_impact_winners_only_count_district_qualifying_events(ndb_stub) -> None:
+    district = District(id="2026ne", year=2026, abbreviation="ne")
+    district.put()
+
+    events = []
+    for team_number, (event_key, event_type) in enumerate(
+        [
+            ("2026qual", EventType.DISTRICT),
+            ("2026necmp1", EventType.DISTRICT_CMP_DIVISION),
+            ("2026necmp", EventType.DISTRICT_CMP),
+            ("2026reg", EventType.REGIONAL),
+            ("2026off", EventType.OFFSEASON),
+            ("2026pre", EventType.PRESEASON),
+        ],
+        start=1,
+    ):
+        event = Event(
+            id=event_key,
+            year=2026,
+            event_short=event_key[4:],
+            event_type_enum=event_type,
+            district_key=district.key,
+        )
+        event.put()
+        events.append(event)
+        Award(
+            id=Award.render_key_name(event_key, AwardType.CHAIRMANS),
+            name_str="FIRST Impact Award",
+            award_type_enum=AwardType.CHAIRMANS,
+            year=2026,
+            event=event.key,
+            event_type_enum=event_type,
+            team_list=[ndb.Key(Team, f"frc{team_number}")],
+        ).put()
+
+    assert DistrictAdvancementHelper.impact_award_winners(events) == {"frc1"}
+
+
+@pytest.mark.parametrize(
+    "district_key,expected_attendance",
+    [("2026ne", 100), ("2026ont", 99), ("2026fim", 161), ("2026fit", 90)],
+)
+def test_attendance_matches_division_rosters(
+    district_key: str, expected_attendance: int, ndb_stub, test_data_importer
+) -> None:
+    district = _setup_district(test_data_importer, district_key)
+
+    attendance = DistrictAdvancementHelper.dcmp_attendance(district.rankings)
+
+    assert len(attendance) == expected_attendance
+
+
+def test_2026ne_attendance_excludes_award_only_teams(
+    ndb_stub, test_data_importer
+) -> None:
+    district = _setup_district(test_data_importer, "2026ne")
+
+    attendance = DistrictAdvancementHelper.dcmp_attendance(district.rankings)
+
+    assert "frc11269" not in attendance
+    assert "frc999" not in attendance
+
+
+EXPECTED_CUTOFFS = {
+    "2026ne": {
+        "dcmp_original": 53,
+        "dcmp_effective": 46,
+        "dcmp_declines": [
+            "frc6153",
+            "frc4572",
+            "frc9055",
+            "frc429",
+            "frc4473",
+            "frc1307",
+            "frc11157",
+            "frc4564",
+            "frc69",
+            "frc1277",
+            "frc237",
+        ],
+        "cmp_original": 0,
+        "cmp_effective": 0,
+        "cmp_declines": [],
+    },
+    "2026ont": {
+        "dcmp_original": 31,
+        "dcmp_effective": 15,
+        "dcmp_declines": [
+            "frc6135",
+            "frc11362",
+            "frc6397",
+            "frc6110",
+            "frc11215",
+            "frc5912",
+            "frc4617",
+            "frc6864",
+            "frc8081",
+            "frc6854",
+            "frc8850",
+            "frc6725",
+            "frc6859",
+            "frc7603",
+            "frc4940",
+            "frc4015",
+            "frc7058",
+            "frc8764",
+        ],
+        "cmp_original": 0,
+        "cmp_effective": 0,
+        "cmp_declines": [],
+    },
+    "2026fim": {
+        "dcmp_original": 64,
+        "dcmp_effective": 64,
+        "dcmp_declines": [],
+        "cmp_original": 0,
+        "cmp_effective": 0,
+        "cmp_declines": [],
+    },
+    "2026fit": {
+        "dcmp_original": 54,
+        "dcmp_effective": 53,
+        "dcmp_declines": ["frc8515", "frc436", "frc10118", "frc8573"],
+        "cmp_original": 0,
+        "cmp_effective": 0,
+        "cmp_declines": [],
+    },
+}
+
+
+@pytest.mark.parametrize("district_key", sorted(EXPECTED_CUTOFFS))
+def test_district_cutoffs(district_key: str, ndb_stub, test_data_importer) -> None:
+    district = _setup_district(test_data_importer, district_key)
+    events = Event.query(Event.district_key == district.key).fetch()
+
+    cutoffs = DistrictAdvancementHelper.calculate_for_district(district, events)
+
+    assert cutoffs == EXPECTED_CUTOFFS[district_key]
+
+
+def test_no_dcmp_attendance_returns_none(ndb_stub) -> None:
+    district = District(id="2026ne", year=2026, abbreviation="ne")
+    district.rankings = _descending_rankings(10)
+    district.put()
+
+    assert DistrictAdvancementHelper.calculate_for_district(district, []) is None
+
+
+def test_no_rankings_returns_none(ndb_stub) -> None:
+    district = District(id="2026ne", year=2026, abbreviation="ne")
+    district.put()
+
+    assert DistrictAdvancementHelper.calculate_for_district(district, []) is None

--- a/src/backend/common/models/district.py
+++ b/src/backend/common/models/district.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Optional, Set
+from typing import cast, Dict, List, Optional, Set
 
 from google.appengine.ext import ndb
 from pyre_extensions import safe_cast
@@ -12,6 +12,7 @@ from backend.common.models.cached_model import CachedModel
 from backend.common.models.district_advancement import (
     AdvancementCounts,
     DistrictAdvancement,
+    DistrictAdvancementCutoffs,
 )
 from backend.common.models.district_ranking import DistrictRanking
 from backend.common.models.keys import DistrictAbbreviation, DistrictKey, TeamKey, Year
@@ -40,6 +41,10 @@ class District(CachedModel):
         DistrictAdvancement, ndb.JsonProperty()
     )
 
+    advancement_cutoffs: Optional[DistrictAdvancementCutoffs] = cast(
+        Optional[DistrictAdvancementCutoffs], ndb.JsonProperty()
+    )
+
     # other changes from FIRST to correct errors
     adjustments: Dict[TeamKey, int] = ndb.JsonProperty()
 
@@ -59,6 +64,7 @@ class District(CachedModel):
     _mutable_attrs: Set[str] = {
         "adjustments",
         "advancement",
+        "advancement_cutoffs",
         "display_name",
         "elasticsearch_name",
         "rankings",

--- a/src/backend/common/models/district_advancement.py
+++ b/src/backend/common/models/district_advancement.py
@@ -1,4 +1,4 @@
-from typing import Dict, TypedDict
+from typing import Dict, List, TypedDict
 
 from backend.common.models.keys import TeamKey
 
@@ -14,3 +14,12 @@ DistrictAdvancement = Dict[TeamKey, TeamDistrictAdvancement]
 class AdvancementCounts(TypedDict):
     dcmp: int
     cmp: int
+
+
+class DistrictAdvancementCutoffs(TypedDict):
+    dcmp_original: int
+    dcmp_effective: int
+    dcmp_declines: List[TeamKey]
+    cmp_original: int
+    cmp_effective: int
+    cmp_declines: List[TeamKey]

--- a/src/backend/tasks_io/handlers/math.py
+++ b/src/backend/tasks_io/handlers/math.py
@@ -10,6 +10,9 @@ from werkzeug.wrappers import Response
 
 from backend.common.consts.event_type import EventType, SEASON_EVENT_TYPES
 from backend.common.futures import InstantFuture, TypedFuture
+from backend.common.helpers.district_advancement_helper import (
+    DistrictAdvancementHelper,
+)
 from backend.common.helpers.district_helper import DistrictHelper
 from backend.common.helpers.event_helper import EventHelper
 from backend.common.helpers.event_insights_helper import EventInsightsHelper
@@ -311,6 +314,9 @@ def district_rankings_calc(district_key: DistrictKey) -> Response:
 
     if rankings:
         district.rankings = rankings
+        cutoffs = DistrictAdvancementHelper.calculate_for_district(district, events)
+        if cutoffs:
+            district.advancement_cutoffs = cutoffs
         DistrictManipulator.createOrUpdate(district)
 
     if (

--- a/src/backend/tasks_io/handlers/tests/district_rankings_calc_test.py
+++ b/src/backend/tasks_io/handlers/tests/district_rankings_calc_test.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -207,6 +208,122 @@ def test_calc_no_output_in_taskqueue(
     )
     assert resp.status_code == 200
     assert resp.data == b""
+
+
+def _team_total(
+    qual_event: Event,
+    qual_points: int,
+    dcmp_event: Optional[Event] = None,
+    dcmp_points: int = 0,
+    dcmp_award_points: int = 0,
+) -> DistrictRankingTeamTotal:
+    event_points = [
+        (
+            qual_event,
+            TeamAtEventDistrictPoints(
+                event_key=qual_event.key_name,
+                district_cmp=False,
+                qual_points=qual_points,
+                elim_points=0,
+                alliance_points=0,
+                award_points=0,
+                total=qual_points,
+            ),
+        )
+    ]
+    if dcmp_event is not None:
+        event_points.append(
+            (
+                dcmp_event,
+                TeamAtEventDistrictPoints(
+                    event_key=dcmp_event.key_name,
+                    district_cmp=True,
+                    qual_points=dcmp_points,
+                    elim_points=0,
+                    alliance_points=0,
+                    award_points=dcmp_award_points,
+                    total=dcmp_points + dcmp_award_points,
+                ),
+            )
+        )
+    return DistrictRankingTeamTotal(
+        event_points=event_points,
+        point_total=qual_points + dcmp_points + dcmp_award_points,
+        tiebreakers=[],
+        match_scores=[],
+        rookie_bonus=0,
+        single_event_bonus=0,
+        other_bonus=0,
+        adjustments=0,
+    )
+
+
+@mock.patch.object(DistrictHelper, "calculate_rankings")
+def test_calc_writes_advancement_cutoffs(
+    calc_mock: mock.Mock, tasks_client: Client
+) -> None:
+    District(id="2020ne", year=2020, abbreviation="ne").put()
+    qual_event = Event(
+        id="2020ndis", year=2020, event_short="ndis", event_type_enum=EventType.DISTRICT
+    )
+    dcmp_event = Event(
+        id="2020necmp",
+        year=2020,
+        event_short="necmp",
+        event_type_enum=EventType.DISTRICT_CMP,
+    )
+
+    # 64 DCMP slots; frc10 declines, so frc65 takes the passed-down slot.
+    attending = (set(range(1, 65)) - {10}) | {65}
+    calc_mock.return_value = {
+        f"frc{i}": _team_total(
+            qual_event,
+            100 - i,
+            dcmp_event if i in attending else None,
+            5 if i in attending else 0,
+        )
+        for i in range(1, 71)
+    }
+
+    resp = tasks_client.get("/tasks/math/do/district_rankings_calc/2020ne")
+    assert resp.status_code == 200
+
+    district = District.get_by_id("2020ne")
+    assert district is not None
+    assert district.advancement_cutoffs == {
+        "dcmp_original": 36,
+        "dcmp_effective": 35,
+        "dcmp_declines": ["frc10"],
+        "cmp_original": 0,
+        "cmp_effective": 0,
+        "cmp_declines": [],
+    }
+
+
+@mock.patch.object(DistrictHelper, "calculate_rankings")
+def test_calc_skips_cutoffs_when_dcmp_award_only(
+    calc_mock: mock.Mock, tasks_client: Client
+) -> None:
+    District(id="2020ne", year=2020, abbreviation="ne").put()
+    qual_event = Event(
+        id="2020ndis", year=2020, event_short="ndis", event_type_enum=EventType.DISTRICT
+    )
+    dcmp_event = Event(
+        id="2020necmp",
+        year=2020,
+        event_short="necmp",
+        event_type_enum=EventType.DISTRICT_CMP,
+    )
+    calc_mock.return_value = {
+        "frc254": _team_total(qual_event, 50, dcmp_event, 0, dcmp_award_points=24)
+    }
+
+    resp = tasks_client.get("/tasks/math/do/district_rankings_calc/2020ne")
+    assert resp.status_code == 200
+
+    district = District.get_by_id("2020ne")
+    assert district is not None
+    assert district.advancement_cutoffs is None
 
 
 @mock.patch.object(DistrictHelper, "calculate_rankings")


### PR DESCRIPTION
## Description
Adds `DistrictAdvancementHelper`, which calculates DCMP advancement point cutoffs for a district:

- **Original cutoff**: the point total of the last team that would have been invited to DCMP, based on rank alone.
- **Effective cutoff**: the point total of the last team that actually attended, after accounting for declines and backfill invites.

The helper re-ranks teams using only their pre-DCMP event points (so a team's own DCMP performance doesn't affect its own cutoff), then walks the ranked list to find both cutoffs. Results are stored on `District.advancement_cutoffs`. The district rankings task now runs this calculation and saves it whenever it recomputes rankings.

This lays the groundwork for the CMP cutoff calculation added later in this stack.

## Motivation and Context
Today, users can see who made DCMP but not the point total required to qualify, or how that cutoff shifted once declines and backfills happened. This data answers both questions.

## How Has This Been Tested?
New unit tests in `district_advancement_helper_test.py` and `district_rankings_calc_test.py`, run via `make test`.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
