### PR TITLE
Demote App Engine deferred header dump to DEBUG (~26 GiB/mo of logs)

### DIFF
--- a/src/backend/common/helpers/deferred.py
+++ b/src/backend/common/helpers/deferred.py
@@ -12,9 +12,21 @@ from google.appengine.ext.deferred.deferred import (
     _TASKQUEUE_HEADERS,
     run,
     run_from_datastore,
+    set_log_level,
 )
 
 _DEFAULT_URL = "/_ah/queue/deferred_encoded"
+
+
+def set_deferred_log_level(log_level: int) -> None:
+    """Set the level the App Engine deferred library logs task headers at.
+
+    On every deferred task execution the library logs the full set of
+    X-AppEngine-* request headers via `logging.log(_DEFAULT_LOG_LEVEL, ...)`.
+    Exposed here so callers do not have to import the App Engine deferred
+    module directly.
+    """
+    set_log_level(log_level)
 
 
 def _serialize(obj: Any, *args, **kwargs) -> bytes:

--- a/src/backend/common/logging.py
+++ b/src/backend/common/logging.py
@@ -167,6 +167,15 @@ def configure_logging() -> None:
 
         root_logger.addHandler(handler)
 
+    # The App Engine deferred library logs the full set of X-AppEngine-* request
+    # headers on every deferred task execution. Each entry is ~1.4KB, and at TBA's
+    # deferred task volume that is ~26 GiB/month of Cloud Logging ingestion for a
+    # header dump nobody reads. Demote it to DEBUG so it stays reachable via
+    # LOG_LEVEL=DEBUG when actually debugging a deferred task.
+    from backend.common.helpers.deferred import set_deferred_log_level
+
+    set_deferred_log_level(logging.DEBUG)
+
     ndb_log_level = Environment.ndb_log_level()
     if ndb_log_level:
         from google.appengine.ext import ndb

--- a/src/backend/common/tests/logging_test.py
+++ b/src/backend/common/tests/logging_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from werkzeug.test import create_environ
 
+from backend.common.environment import Environment
 from backend.common.logging import (
     clear_logging_context,
     configure_logging,
@@ -519,3 +520,22 @@ def test_configure_logging_dev_uses_non_label_mode() -> None:
 
         assert context_filter is not None
         assert context_filter.use_labels is False
+
+
+def test_configure_logging_demotes_deferred_header_dump() -> None:
+    """The GAE deferred library dumps all X-AppEngine-* headers on every task.
+
+    At INFO that is ~26 GiB/month of log ingestion, so configure_logging drops it
+    to DEBUG. It stays reachable by setting LOG_LEVEL=DEBUG.
+    """
+    from google.appengine.ext.deferred import deferred  # noqa: ETBA2
+
+    from backend.common.helpers.deferred import set_deferred_log_level
+
+    set_deferred_log_level(logging.INFO)
+    assert deferred._DEFAULT_LOG_LEVEL == logging.INFO
+
+    with patch.object(Environment, "is_prod", return_value=False):
+        configure_logging()
+
+    assert deferred._DEFAULT_LOG_LEVEL == logging.DEBUG

--- a/stubs/google/appengine/ext/deferred/deferred.pyi
+++ b/stubs/google/appengine/ext/deferred/deferred.pyi
@@ -5,6 +5,7 @@ from typing import Any, Dict
 _TASKQUEUE_HEADERS: Dict
 _DEFAULT_URL: str
 _DEFAULT_QUEUE: str
+_DEFAULT_LOG_LEVEL: int
 
 class Error(Exception): ...
 class PermanentTaskFailure(Error): ...


### PR DESCRIPTION
## What

On every deferred task execution, the App Engine deferred library logs the full set of `X-AppEngine-*` request headers:

```python
# google/appengine/ext/deferred/deferred.py:358
logging.log(_DEFAULT_LOG_LEVEL, ", ".join(headers))   # _DEFAULT_LOG_LEVEL = logging.INFO
```

Each entry is ~1.4KB (it includes the API ticket blob). This demotes it to `DEBUG` via the SDK's own `set_log_level`, exposed through `backend.common.helpers.deferred` so callers don't import the App Engine deferred module directly (ETBA2 lint rule).

## Why

We're paying for it. Cloud Logging ingestion went **69 → 158 GiB/month** year over year, and cost went **$10 → $54/month** — a 463% cost increase on a 128% volume increase, because the 50 GiB/month free tier used to absorb most of the volume and now barely dents it.

This header dump is **26.5 GiB/month of that — 17% of all log volume on the project.** Measured from `log_entry_count` by `module_id`/`log`/`severity`, cross-checked against 150-entry payload samples: 490 of 500 sampled `py3-tasks-io` stderr INFO entries are the header dump.

Nothing reads it. It stays available via `LOG_LEVEL=DEBUG` when debugging a deferred task.

## Testing

New regression test in `logging_test.py` asserts `configure_logging()` leaves the deferred logger at DEBUG. `make lint` clean; 973 tests pass.

---

## @fangeugene — a related question, no action needed in this PR

While tracking this down, the bigger half of the same regression traces to #8599 (`a2a1837bd`, "Use deferred for google analytics tracking"), which moved GA tracking from an in-process `run_after_response` callback to `defer_safe(..., _queue="api-track-call")`.

That means every APIv3 request now spawns a task-queue request, and each one emits **two** log entries: this header dump (26.5 GiB/mo, fixed here) *plus* a full GAE request log for the task itself (**36.9 GiB/mo, not fixed here**). In a 500-entry sample, 492 of `py3-tasks-io`'s request logs were `taskQueueName=api-track-call`.

Together that's ~63 GiB/month, the single largest driver of the logging bill.

**Is the deferred path still needed for GA tracking?** If it was to get tracking off the request path for latency, `run_after_response` already did that. If it was for delivery reliability under load, that's a real reason to keep it and we should instead look at batching, or excluding those request logs at the sink.

Happy to open a follow-up either way — just don't want to revert your change without knowing what it was solving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<details>
<summary><b>Context: this is one of six PRs from a year-over-year GCP cost audit</b></summary>

Total spend went $4,600 → $5,043 (+9.6%), but the offseason monthly run-rate is up **45.7%** ($270.57 → $394.14, Aug 2025 vs Aug 2026) — a one-time backend-instance reduction masked growth elsewhere.

**Cloud Logging PRs** (independent; ingestion is 158 GiB/mo, $54/mo, against a 50 GiB/mo free tier):

| PR | Change | GiB/mo |
|---|---|---:|
| #10488 | Deferred header dump → DEBUG | 26.5 |
| #10489 | Remove per-request auth log line | 14.4 |
| #10490 | PWA hot-path logs → debug | 6.2 |

All three together take ingestion to ~111 GiB/mo (**$30/mo**). Reverting the deferred GA tracking discussed in #10488 would take it to ~74 GiB/mo (**$12/mo**), below the pre-regression bill — but that's Eugene's call, not part of any of these PRs.

**Other PRs:** #10491 (FRC API archive dedupe), #10493 (dead cron cleanup + route test), #10496 (flaky Playwright test).

**Issues:** #10492 (crawler blocking), #10494 (py3-api concurrency), #10495 (**favorite button broken for logged-in users** — the most urgent finding), #10497 (Firestore backups).

⚠️ Two estimates from this audit were later **withdrawn** as wrong — see the correction notes in #10492 and #10494. Cloud Monitoring's idle instance-hours are not billed; the FOCUS export is the authority.

</details>
