### PR TITLE
Remove per-request API auth log line (~14 GiB/mo of logs)

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from functools import wraps
 from typing import Callable, Type, TypeVar
 
@@ -42,10 +41,6 @@ def api_authenticated(func):
                     # Add to trace span for visibility in Cloud Trace
                     span.set_label("api_auth_key", auth_key)
                     span.set_label("auth_owner_id", str(auth_owner_id))
-                    # Log API key usage for visibility in GCP Console
-                    logging.info(
-                        f"API request authenticated with key: {auth_key[:16]}... (owner: {auth_owner_id})"
-                    )
                 else:
                     return (
                         {

--- a/src/backend/api/handlers/tests/auth_logging_test.py
+++ b/src/backend/api/handlers/tests/auth_logging_test.py
@@ -107,3 +107,39 @@ def test_require_write_auth_sets_logging_context(api_client: Client, ndb_stub) -
     context = get_logging_context()
     assert "api_auth_key" in context
     assert context["api_auth_key"] == "test_auth_id"
+
+
+def test_api_authenticated_does_not_log_key_per_request(
+    api_client: Client, caplog
+) -> None:
+    """The auth key is attached as a log label and two trace-span labels.
+
+    It must not also be written as its own INFO log line -- at TBA's APIv3
+    volume that was ~14 GiB/month of Cloud Logging ingestion for information
+    already present on every entry.
+    """
+    from backend.common.models.team import Team
+
+    Team(
+        id="frc254",
+        team_number=254,
+    ).put()
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        description="Test auth key",
+        event_list=[],
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    with caplog.at_level("INFO"):
+        resp = api_client.get(
+            "/api/v3/status", headers={"X-TBA-Auth-Key": "test_auth_key"}
+        )
+
+    assert resp.status_code == 200
+    assert not any(
+        "authenticated with key" in record.getMessage() for record in caplog.records
+    )
+    # ...but the key is still attached as a log label
+    assert get_logging_context().get("api_auth_key") == "test_auth_key"


### PR DESCRIPTION
## What

Removes the `logging.info` added in #9123 (`4392619ad`, "Add trace points to api auth"):

```python
# src/backend/api/handlers/decorators.py
set_logging_context("api_auth_key", auth_key)     # <- already searchable
span.set_label("api_auth_key", auth_key)          # <- already on the trace
span.set_label("auth_owner_id", str(auth_owner_id))
logging.info(                                     # <- removed
    f"API request authenticated with key: {auth_key[:16]}... (owner: {auth_owner_id})"
)
```

The key is attached as a Cloud Logging **label** and as two Cloud Trace span labels three lines earlier, so this line duplicates information already present on every entry from the request.

## Why

Cloud Logging ingestion went **69 → 158 GiB/month** year over year, pushing cost **$10 → $54/month** (the 50 GiB/mo free tier used to absorb most of it and now barely dents it).

This line is **14.4 GiB/month of that — 9% of all log volume on the project.** Measured from `log_entry_count` grouped by `module_id`/`log`/`severity`, cross-checked against payload samples: **489 of 500** sampled `py3-api` stderr INFO entries are this message.

## @phil-lopreiato

You added this in #9123 — flagging in case the standalone line was deliberate. My read is that the label + trace-span coverage from the same commit makes it redundant for GCP Console searchability, but if you were relying on it in a context where labels aren't surfaced, say so and I'll close this.

## Testing

New regression test asserts no `"authenticated with key"` INFO record is emitted for an authenticated request *and* that the `api_auth_key` log label is still set. Verified it fails without the change. `make lint` clean, existing auth logging tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<details>
<summary><b>Context: this is one of six PRs from a year-over-year GCP cost audit</b></summary>

Total spend went $4,600 → $5,043 (+9.6%), but the offseason monthly run-rate is up **45.7%** ($270.57 → $394.14, Aug 2025 vs Aug 2026) — a one-time backend-instance reduction masked growth elsewhere.

**Cloud Logging PRs** (independent; ingestion is 158 GiB/mo, $54/mo, against a 50 GiB/mo free tier):

| PR | Change | GiB/mo |
|---|---|---:|
| #10488 | Deferred header dump → DEBUG | 26.5 |
| #10489 | Remove per-request auth log line | 14.4 |
| #10490 | PWA hot-path logs → debug | 6.2 |

All three together take ingestion to ~111 GiB/mo (**$30/mo**). Reverting the deferred GA tracking discussed in #10488 would take it to ~74 GiB/mo (**$12/mo**), below the pre-regression bill — but that's Eugene's call, not part of any of these PRs.

**Other PRs:** #10491 (FRC API archive dedupe), #10493 (dead cron cleanup + route test), #10496 (flaky Playwright test).

**Issues:** #10492 (crawler blocking), #10494 (py3-api concurrency), #10495 (**favorite button broken for logged-in users** — the most urgent finding), #10497 (Firestore backups).

⚠️ Two estimates from this audit were later **withdrawn** as wrong — see the correction notes in #10492 and #10494. Cloud Monitoring's idle instance-hours are not billed; the FOCUS export is the authority.

</details>
