### PR TITLE
[pwa] Demote hot-path logs to debug (~6 GiB/mo of logs)

### DIFF
--- a/pwa/app/lib/logger.test.ts
+++ b/pwa/app/lib/logger.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { createLogger } from '~/lib/logger';
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalLogLevel = process.env.LOG_LEVEL;
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+  process.env.LOG_LEVEL = originalLogLevel;
+});
+
+describe('createLogger', () => {
+  test('defaults to info in production, so debug hot-path logs are not emitted', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.LOG_LEVEL;
+
+    const logger = createLogger('test');
+
+    expect(logger.level).toEqual('info');
+    expect(logger.isLevelEnabled('debug')).toBe(false);
+    expect(logger.isLevelEnabled('warn')).toBe(true);
+  });
+
+  test('honors LOG_LEVEL so hot-path diagnostics can be turned back on', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.LOG_LEVEL = 'debug';
+
+    const logger = createLogger('test');
+
+    expect(logger.level).toEqual('debug');
+    expect(logger.isLevelEnabled('debug')).toBe(true);
+  });
+});

--- a/pwa/app/lib/logger.ts
+++ b/pwa/app/lib/logger.ts
@@ -25,7 +25,8 @@ export function createLogger(name: string) {
   // See: https://cloud.google.com/run/docs/logging#writing-structured-logs
   return pino({
     name,
-    level: 'info',
+    // Hot-path diagnostics log at debug; set LOG_LEVEL=debug to see them.
+    level: process.env.LOG_LEVEL ?? 'info',
     // Use 'message' instead of 'msg' for Google Cloud Logging compatibility
     messageKey: 'message',
     // Omit default base fields (pid, hostname) - not needed for Cloud Logging

--- a/pwa/app/router.tsx
+++ b/pwa/app/router.tsx
@@ -22,7 +22,7 @@ export function getRouter() {
     // Only log "added" events (new queries) and "updated" events when query completes successfully
     // This reduces noise from intermediate state transitions (loading states)
     if (event.type === 'added') {
-      queryCacheLogger.info(
+      queryCacheLogger.debug(
         {
           type: event.type,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -38,7 +38,7 @@ export function getRouter() {
       event.query.state.data !== undefined
     ) {
       // Only log successful updates with data (not loading states)
-      queryCacheLogger.info(
+      queryCacheLogger.debug(
         {
           type: event.type,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/pwa/app/routes/__root.tsx
+++ b/pwa/app/routes/__root.tsx
@@ -58,7 +58,7 @@ const ReactQueryDevtools = import.meta.env.PROD
 client.interceptors.request.use((request) => {
   request.headers.set('X-TBA-Auth-Key', import.meta.env.VITE_TBA_API_READ_KEY);
 
-  logger.info(
+  logger.debug(
     {
       method: request.method,
       url: request.url,

--- a/pwa/server.ts
+++ b/pwa/server.ts
@@ -51,7 +51,11 @@ app.use(
 // Everything else is cached for 24 hours.
 app.use(express.static('build/client', { maxAge: '24h' }));
 
-app.use(morgan('tiny'));
+// App Engine already emits a request log for every request; morgan would
+// duplicate it into stdout at our own expense.
+if (process.env.NODE_ENV !== 'production') {
+  app.use(morgan('tiny'));
+}
 
 // handle SSR requests
 const { default: handler } = await import('./build/server/server.js');


### PR DESCRIPTION
## What

The PWA emits **~10.6 log lines per request** — 11.6M entries/month against 1.1M requests/month. Three loggers on per-request paths account for essentially all of it:

- `app/router.tsx` — `'Query cache event'`, fired on both `added` and successful `updated`, so roughly two per query during SSR
- `app/routes/__root.tsx` — `'Sending request to TBA API'`, on every outbound API call

These are genuinely useful when debugging, so this moves them to `debug` rather than deleting them, and makes the production level configurable (`LOG_LEVEL=debug`) to turn them back on. Previously `logger.ts` hard-pinned `level: 'info'` in production with no override.

Also gates `morgan` behind non-production in `server.ts` — App Engine already writes a request log for every request, so morgan duplicates it into stdout at our expense.

## Why

Cloud Logging ingestion across the project went **69 → 158 GiB/month** year over year, pushing the bill **$10 → $54/month**. The 50 GiB/month free tier used to absorb most of the volume; now it barely dents it, so every additional GiB bills at the full $0.50.

The PWA's share is **~6.2 GiB/month** (5.9 from pino, 0.3 from morgan). Measured from `log_entry_count` grouped by `module_id`/`log`/`severity`, cross-checked against payload samples.

## @tervay

These came in with #8583 (`daee2aaba`, "[pwa] cache improvements"). Nothing wrong with them — the query-cache logging in particular is clearly deliberate instrumentation. The only issue is that they're at `info` in production, where they cost real money at SSR volume. `LOG_LEVEL=debug` gets them back. Shout if you'd rather keep any of them at `info`.

## Testing

New `app/lib/logger.test.ts` asserts the production logger defaults to `info` (so `debug` hot-path logs are suppressed) and honors `LOG_LEVEL` to re-enable them. `pnpm lint`, `prettier --check`, and `pnpm typecheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<details>
<summary><b>Context: this is one of six PRs from a year-over-year GCP cost audit</b></summary>

Total spend went $4,600 → $5,043 (+9.6%), but the offseason monthly run-rate is up **45.7%** ($270.57 → $394.14, Aug 2025 vs Aug 2026) — a one-time backend-instance reduction masked growth elsewhere.

**Cloud Logging PRs** (independent; ingestion is 158 GiB/mo, $54/mo, against a 50 GiB/mo free tier):

| PR | Change | GiB/mo |
|---|---|---:|
| #10488 | Deferred header dump → DEBUG | 26.5 |
| #10489 | Remove per-request auth log line | 14.4 |
| #10490 | PWA hot-path logs → debug | 6.2 |

All three together take ingestion to ~111 GiB/mo (**$30/mo**). Reverting the deferred GA tracking discussed in #10488 would take it to ~74 GiB/mo (**$12/mo**), below the pre-regression bill — but that's Eugene's call, not part of any of these PRs.

**Other PRs:** #10491 (FRC API archive dedupe), #10493 (dead cron cleanup + route test), #10496 (flaky Playwright test).

**Issues:** #10492 (crawler blocking), #10494 (py3-api concurrency), #10495 (**favorite button broken for logged-in users** — the most urgent finding), #10497 (Firestore backups).

⚠️ Two estimates from this audit were later **withdrawn** as wrong — see the correction notes in #10492 and #10494. Cloud Monitoring's idle instance-hours are not billed; the FOCUS export is the authority.

</details>
