### PR TITLE
Make FRC API response dedupe resilient to str/bytes mismatch

### DIFF
--- a/src/backend/common/frc_api/frc_api.py
+++ b/src/backend/common/frc_api/frc_api.py
@@ -293,7 +293,23 @@ class FRCAPI:
 
             return response
 
-    def _maybe_save_response(self, url: str, content: str) -> None:
+    @staticmethod
+    def _as_bytes(value: str | bytes | None) -> bytes | None:
+        """Normalize storage/urlfetch payloads for comparison.
+
+        `StorageClient.read` returns `str | bytes` depending on which client the
+        environment selects (GCloudStorageClient opens in text mode, the
+        cloudstorage and local clients open in binary), and urlfetch content is
+        bytes. Comparing across those types is silently always False in Python 3,
+        which is how the dedupe below broke for all of 2025 -- see #6894 and the
+        ~300 GiB of duplicate snapshots it wrote. Normalize both sides instead of
+        trusting either one's type.
+        """
+        if value is None:
+            return None
+        return value.encode() if isinstance(value, str) else value
+
+    def _maybe_save_response(self, url: str, content: str | bytes) -> None:
         if not Environment.save_frc_api_response() or not self._save_response:
             return
 
@@ -315,7 +331,7 @@ class FRCAPI:
             write_new = True
             if last_item_filename is not None:
                 last_json_file = cloud_storage_read(last_item_filename)
-                if last_json_file == content:
+                if self._as_bytes(last_json_file) == self._as_bytes(content):
                     write_new = False  # Do not write if content didn't change
 
             if write_new:

--- a/src/backend/common/frc_api/tests/frcapi_test.py
+++ b/src/backend/common/frc_api/tests/frcapi_test.py
@@ -388,3 +388,94 @@ def test_save_response_updated(
     f2 = cloud_storage_read(files[1])
     assert f2 is not None
     assert f2 == json.dumps(content2).encode()
+
+
+# --- response-archive deduplication -----------------------------------------
+#
+# `_maybe_save_response` only writes a new snapshot when the upstream content
+# actually changed. That comparison spans two type boundaries: urlfetch content
+# is bytes, while `StorageClient.read` returns str or bytes depending on which
+# client the environment selects. A `bytes == str` comparison is always False in
+# Python 3, which silently disabled the dedupe for all of 2025 (#6894) and wrote
+# ~300 GiB of byte-identical snapshots. These tests pin both sides.
+
+
+@pytest.fixture
+def saving_api() -> Any:
+    with patch.dict("os.environ", {"SAVE_FRC_API_RESPONSE": "true"}):
+        yield FRCAPI("test", save_response=True)
+
+
+@pytest.mark.parametrize(
+    "stored_content",
+    [
+        pytest.param(b'{"a": 1}', id="storage_returns_bytes"),
+        pytest.param('{"a": 1}', id="storage_returns_str"),
+    ],
+)
+def test_maybe_save_response_skips_write_when_unchanged(
+    saving_api: FRCAPI, stored_content: Any
+) -> None:
+    """Identical content must not produce a second snapshot.
+
+    Parameterized over both storage-client return types: the cloudstorage and
+    local clients read binary, GCloudStorageClient reads text.
+    """
+    url = f"{FRCAPI.BASE_URL}/2025/scores/CASJ/qual"
+
+    with (
+        patch("backend.common.storage.get_files", return_value=["existing.json"]),
+        patch("backend.common.storage.read", return_value=stored_content),
+        patch("backend.common.storage.write") as mock_write,
+    ):
+        saving_api._maybe_save_response(url, b'{"a": 1}')
+
+    mock_write.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "outgoing_content",
+    [
+        pytest.param(b'{"a": 1}', id="content_is_bytes"),
+        pytest.param('{"a": 1}', id="content_is_str"),
+    ],
+)
+def test_maybe_save_response_skips_write_for_either_content_type(
+    saving_api: FRCAPI, outgoing_content: Any
+) -> None:
+    """The urlfetch side may also be str or bytes; neither should force a write."""
+    url = f"{FRCAPI.BASE_URL}/2025/scores/CASJ/qual"
+
+    with (
+        patch("backend.common.storage.get_files", return_value=["existing.json"]),
+        patch("backend.common.storage.read", return_value=b'{"a": 1}'),
+        patch("backend.common.storage.write") as mock_write,
+    ):
+        saving_api._maybe_save_response(url, outgoing_content)
+
+    mock_write.assert_not_called()
+
+
+def test_maybe_save_response_writes_when_content_changed(saving_api: FRCAPI) -> None:
+    url = f"{FRCAPI.BASE_URL}/2025/scores/CASJ/qual"
+
+    with (
+        patch("backend.common.storage.get_files", return_value=["existing.json"]),
+        patch("backend.common.storage.read", return_value=b'{"a": 1}'),
+        patch("backend.common.storage.write") as mock_write,
+    ):
+        saving_api._maybe_save_response(url, b'{"a": 2}')
+
+    mock_write.assert_called_once()
+
+
+def test_maybe_save_response_writes_when_no_prior_snapshot(saving_api: FRCAPI) -> None:
+    url = f"{FRCAPI.BASE_URL}/2025/scores/CASJ/qual"
+
+    with (
+        patch("backend.common.storage.get_files", return_value=[]),
+        patch("backend.common.storage.write") as mock_write,
+    ):
+        saving_api._maybe_save_response(url, b'{"a": 1}')
+
+    mock_write.assert_called_once()


### PR DESCRIPTION
## The bug this prevents

`FRCAPI._maybe_save_response` archives upstream FRC API responses and is meant to write a new snapshot **only when the content changed**. That comparison spans two type boundaries:

| Side | Type |
|---|---|
| `TypedURLFetchResult.content` (urlfetch) | **bytes** — despite being annotated `str` |
| `StorageClient.read()` | **`str \| bytes`**, depending on the client |

And the clients genuinely disagree:

```python
cloudstorage_client.py:39   with gcs_open(..., mode="rb")   ->  bytes
local_client.py:31          with path.open(mode="rb")       ->  bytes
gcloud_client.py:35         with blob.open("r")             ->  str     # <-- the odd one out
```

`bytes == str` is always `False` in Python 3. So when #6894 (`18fd3d653`, Jan 2025) dropped a `.decode()` at the call site, the dedupe silently stopped matching and **every poll wrote a fresh copy**. #7377 (`454242513`, Mar 2025) then moved the save from the parser into `FRCAPI._get()`, applying the broken comparison to every HTTP 200 instead of just parsed responses.

The `scores` histogram shows the moment it landed:

```
2025-02      2.14 GiB
2025-03    139.91 GiB   <- 454242513 lands 2025-03-16
2025-04     51.24 GiB
2025-05      1.29 GiB
```

`frc-api-response/v3.0/2025/` now holds **303 GiB across ~11M objects — 120x the bytes and 145x the object count of the adjacent 2024 and 2026 seasons.** Two files 62 minutes apart in one alliances directory are byte-identical: same 1,033 bytes, same MD5. There are 179 such files in that one directory.

It was fixed **by accident** in Jan 2026 by #8741 (`c61d7f543`, "Import legacy cloudstorage library"), which switched prod to a bytes-returning client. Writes collapsed immediately. But nothing stops it regressing — the annotations that hid it are still wrong.

## The fix

Normalize both sides to bytes before comparing, rather than trusting either one's type, and widen the `content` annotation to match reality.

```python
if self._as_bytes(last_json_file) == self._as_bytes(content):
    write_new = False
```

## Testing

Four new tests in `frcapi_test.py`, parameterized across both storage-client return types **and** both urlfetch content types. Verified that reverting the fix fails exactly the two mixed-type cases (`storage_returns_str` and `content_is_str`) and passes the same-type ones — which is precisely the shape of the original bug.

## @phil-lopreiato — worth a wider decision?

This fixes the comparison, but the underlying sharp edge is that `StorageClient.read()` is typed and implemented as `str | bytes` and callers have to guess. Options:

1. **This PR only** — normalize at the one site that compares. Minimal blast radius.
2. **Make `read()` uniform** across all four clients (probably always bytes, with an explicit `read_text()` for callers that want str). Correct, but touches every caller.

I went with (1) since it's the one site where the ambiguity actually costs money, but (2) is the real fix if you want it. Happy to do it as a follow-up.

## Not included: cleaning up the 303 GiB

Deduplicating the existing 2025 archive is worth ~$93/yr and is **not** part of this PR. Note for whoever does it: do **not** use an age-based lifecycle rule — that archive is deliberately permanent and is read back by the sim/replay path and the admin API-history page. Dedupe by content hash instead; `md5Hash` comes back in object listings, so keeping the first object of each run of identical hashes costs ~11k list ops (~$0.06) and is loss-free by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<details>
<summary><b>Context: this is one of six PRs from a year-over-year GCP cost audit</b></summary>

Total spend went $4,600 → $5,043 (+9.6%), but the offseason monthly run-rate is up **45.7%** ($270.57 → $394.14, Aug 2025 vs Aug 2026) — a one-time backend-instance reduction masked growth elsewhere.

**Cloud Logging PRs** (independent; ingestion is 158 GiB/mo, $54/mo, against a 50 GiB/mo free tier):

| PR | Change | GiB/mo |
|---|---|---:|
| #10488 | Deferred header dump → DEBUG | 26.5 |
| #10489 | Remove per-request auth log line | 14.4 |
| #10490 | PWA hot-path logs → debug | 6.2 |

All three together take ingestion to ~111 GiB/mo (**$30/mo**). Reverting the deferred GA tracking discussed in #10488 would take it to ~74 GiB/mo (**$12/mo**), below the pre-regression bill — but that's Eugene's call, not part of any of these PRs.

**Other PRs:** #10491 (FRC API archive dedupe), #10493 (dead cron cleanup + route test), #10496 (flaky Playwright test).

**Issues:** #10492 (crawler blocking), #10494 (py3-api concurrency), #10495 (**favorite button broken for logged-in users** — the most urgent finding), #10497 (Firestore backups).

⚠️ Two estimates from this audit were later **withdrawn** as wrong — see the correction notes in #10492 and #10494. Cloud Monitoring's idle instance-hours are not billed; the FOCUS export is the authority.

</details>
