### PR TITLE
Remove three cron jobs that have 404'd since the Py3 migration

### DIFF
--- a/src/backend/tests/cron_routes_test.py
+++ b/src/backend/tests/cron_routes_test.py
@@ -1,0 +1,91 @@
+"""Every URL in cron.yaml must resolve to a route on the service that serves it.
+
+Three cron entries (`/backend-tasks/backup/enqueue`,
+`/tasks/enqueue/update_all_team_search_index`, `/tasks/get/hof_teams`) survived the
+Python 2 -> 3 migration without their handlers and returned 404 on every run for
+roughly four years. Nothing alerted, because nothing checks. This does.
+"""
+
+import fnmatch
+from typing import Dict, List, Optional
+
+import pytest
+import yaml
+from werkzeug.exceptions import MethodNotAllowed
+from werkzeug.routing import Map
+
+CRON_YAML = "src/cron.yaml"
+DISPATCH_YAML = "src/dispatch.yaml"
+
+# Service name -> module path of the Flask app that serves it.
+SERVICE_MODULES = {
+    "py3-web": "backend.web.main",
+    "py3-api": "backend.api.main",
+    "py3-tasks-io": "backend.tasks_io.main",
+    "py3-tasks-cpu": "backend.tasks_cpu.main",
+    "py3-tasks-cpu-enqueue": "backend.tasks_cpu.main",
+}
+
+
+def _dispatch_rules() -> List[Dict[str, str]]:
+    with open(DISPATCH_YAML) as f:
+        return yaml.safe_load(f)["dispatch"]
+
+
+def _cron_entries() -> List[Dict[str, str]]:
+    with open(CRON_YAML) as f:
+        return yaml.safe_load(f)["cron"]
+
+
+def _service_for(path: str, rules: List[Dict[str, str]]) -> str:
+    """Resolve a path to a service the way App Engine's dispatch does.
+
+    Cron requests arrive on the app's default hostname, so host-specific rules
+    (e.g. `beta.thebluealliance.com/*`) never apply to them.
+    """
+    for rule in rules:
+        host, _, pattern = rule["url"].partition("/")
+        if host not in ("*", ""):
+            continue
+        if fnmatch.fnmatch(path.lstrip("/"), pattern.lstrip("/")):
+            return rule["service"]
+    return "py3-web"
+
+
+def _url_map(service: str) -> Optional[Map]:
+    module_path = SERVICE_MODULES.get(service)
+    if module_path is None:
+        return None
+    module = __import__(module_path, fromlist=["app"])
+    return module.app.url_map
+
+
+def _resolves(path: str, url_map: Map) -> bool:
+    adapter = url_map.bind("localhost")
+    try:
+        adapter.match(path, method="GET")
+        return True
+    except MethodNotAllowed:
+        # The route exists, it just does not accept GET. App Engine cron issues
+        # GET, but a POST-only handler is a separate concern from a missing one.
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.parametrize("entry", _cron_entries(), ids=lambda e: e["url"])
+def test_cron_url_resolves_to_a_real_route(entry: Dict[str, str]) -> None:
+    path = entry["url"].split("?")[0]
+    service = _service_for(path, _dispatch_rules())
+
+    url_map = _url_map(service)
+    assert url_map is not None, (
+        f"cron entry {path!r} dispatches to unknown service {service!r}; "
+        f"add it to SERVICE_MODULES or fix dispatch.yaml"
+    )
+
+    assert _resolves(path, url_map), (
+        f"cron entry {path!r} dispatches to {service} but no route matches it. "
+        f"It will 404 on every run ({entry.get('schedule')}). Either remove the "
+        f"cron entry or add the handler."
+    )

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -50,11 +50,6 @@ cron:
     schedule: every day 02:00
     timezone: America/Los_Angeles
 
-  - description: Hall of Fame team list scraping
-    url: /tasks/get/hof_teams
-    schedule: every thursday 01:00
-    timezone: America/Los_Angeles
-
   - description: Typeahead Calculation
     url: /backend-tasks-b2/enqueue/math/typeaheadcalc
     schedule: every day 01:00
@@ -174,11 +169,6 @@ cron:
     schedule: every day 08:00
     timezone: America/Los_Angeles
 
-  - description: Backup Cron job
-    url: /backend-tasks/backup/enqueue
-    schedule: every monday 03:00
-    timezone: America/Los_Angeles
-
   # - description: BlueZone Update
   #   url: /tasks/do/bluezone_update
   #   schedule: every 1 minutes
@@ -186,10 +176,6 @@ cron:
   - description: Update Match Suggestions
     url: /tasks/do/update_match_suggestions
     schedule: every 1 minutes
-
-  - description: Update Team Search Indexes
-    url: /tasks/enqueue/update_all_team_search_index
-    schedule: every monday 04:00
 
   - description: Archive Old API Keys
     url: /tasks/do/archive_api_keys

--- a/src/queue.yaml
+++ b/src/queue.yaml
@@ -52,6 +52,3 @@ queue:
   retry_parameters:
     task_retry_limit: 0
 
-- name: backups
-  rate: 6/m
-  max_concurrent_requests: 1


### PR DESCRIPTION
## What

`cron.yaml` still schedules three URLs whose handlers were never ported from Python 2. Every run has returned **404 for roughly four years** — confirmed in production logs:

| `cron.yaml` | URL | Schedule | Most recent 404 |
|---|---|---|---|
| :178 | `/backend-tasks/backup/enqueue` | every monday 03:00 | 2026-08-31 |
| :187 | `/tasks/enqueue/update_all_team_search_index` | every monday 04:00 | 2026-08-31 |
| :54 | `/tasks/get/hof_teams` | every thursday 01:00 | 2026-08-27 |

Handlers exist only under `old_py2/` (`backend_main.py`, `cron_main.py`, `admin_cron_controller.py`).

## Why none of them needs reimplementing as-is

- **Backups** are handled by a Firestore backup schedule created in January 2026, not by this cron. This also drops the `backups` push queue (`queue.yaml:55`), which nothing enqueues to — `grep` finds only its own definition.
- **Team search indexes** were the App Engine Search API, which doesn't exist in Py3. What survives is the computed `/api/v3/search_index` endpoint and `/_/typeahead/<key>`.
- **Hall of Fame** is derived, not scraped. `TeamRenderer._fetch_hof_async` (`team_renderer.py:502`) builds it from `TeamEventTypeAwardsQuery(CMP_FINALS, CHAIRMANS)` plus Media tag queries. The `/hall-of-fame` page works; the scrape was vestigial.

> [!NOTE]
> Deleting the backup cron does **not** mean TBA shouldn't have a scheduled export — it means *this* entry has done nothing for four years and its presence made it look like backups were covered when they weren't. A separate issue proposes replacing it with a scheduled kind-filtered Datastore export, which is a different (working) thing.

## The actual bug is that nobody noticed

Nothing alerts on cron failures — the repo's own `tasks/TODO-backend-simplicity.md` already flags this. Removing three lines resets the clock without fixing the class of problem.

So this adds `src/backend/tests/cron_routes_test.py`, which resolves **every** `cron.yaml` URL through `dispatch.yaml` to the serving Flask app's `url_map`. A cron entry can no longer silently point at a route that doesn't exist.

It's parametrized per entry (35 cases), so a failure names the offending URL and its schedule directly:

```
cron entry '/backend-tasks/backup/enqueue' dispatches to py3-tasks-io but no
route matches it. It will 404 on every run (every monday 03:00). Either remove
the cron entry or add the handler.
```

One deliberate leniency: a route that exists but rejects GET passes. App Engine cron issues GET, but a POST-only handler is a different problem from a missing one, and I didn't want this test to start failing for an unrelated reason.

## Testing

`make test ARGS='src/backend/tests/cron_routes_test.py'` → 35 passed. Verified the test fails when a dead entry is reintroduced (1 failed, 35 passed). `make lint` and `make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<details>
<summary><b>Context: this is one of six PRs from a year-over-year GCP cost audit</b></summary>

Total spend went $4,600 → $5,043 (+9.6%), but the offseason monthly run-rate is up **45.7%** ($270.57 → $394.14, Aug 2025 vs Aug 2026) — a one-time backend-instance reduction masked growth elsewhere.

**Cloud Logging PRs** (independent; ingestion is 158 GiB/mo, $54/mo, against a 50 GiB/mo free tier):

| PR | Change | GiB/mo |
|---|---|---:|
| #10488 | Deferred header dump → DEBUG | 26.5 |
| #10489 | Remove per-request auth log line | 14.4 |
| #10490 | PWA hot-path logs → debug | 6.2 |

All three together take ingestion to ~111 GiB/mo (**$30/mo**). Reverting the deferred GA tracking discussed in #10488 would take it to ~74 GiB/mo (**$12/mo**), below the pre-regression bill — but that's Eugene's call, not part of any of these PRs.

**Other PRs:** #10491 (FRC API archive dedupe), #10493 (dead cron cleanup + route test), #10496 (flaky Playwright test).

**Issues:** #10492 (crawler blocking), #10494 (py3-api concurrency), #10495 (**favorite button broken for logged-in users** — the most urgent finding), #10497 (Firestore backups).

⚠️ Two estimates from this audit were later **withdrawn** as wrong — see the correction notes in #10492 and #10494. Cloud Monitoring's idle instance-hours are not billed; the FOCUS export is the authority.

</details>
