### PR TITLE
[pwa] Replace networkidle waits with the data-hydrated wait in Playwright tests

### DIFF
--- a/pwa/tests/dialog-focus.spec.ts
+++ b/pwa/tests/dialog-focus.spec.ts
@@ -10,7 +10,7 @@ test('match modal focuses the dialog content container on open', async ({
   page,
 }) => {
   await page.goto('/event/2024mil');
-  await page.waitForLoadState('networkidle');
+  await page.locator('body[data-hydrated]').waitFor();
 
   // Open the match modal via a match link (adds ?matchKey= search param)
   await page.getByRole('link', { name: 'Quals 1', exact: true }).click();

--- a/pwa/tests/navigation.spec.ts
+++ b/pwa/tests/navigation.spec.ts
@@ -13,7 +13,7 @@ test('nav popup portal is not mounted while the menu is closed', async ({
   page,
 }) => {
   await page.goto('/');
-  await page.waitForLoadState('networkidle');
+  await page.locator('body[data-hydrated]').waitFor();
 
   await expect(
     page.locator('[data-slot="navigation-menu-viewport"]'),
@@ -25,7 +25,7 @@ test.describe('hamburger menu (narrow viewport)', () => {
 
   test('does not open on hover', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.locator('body[data-hydrated]').waitFor();
 
     const trigger = page.getByRole('button', { name: 'Toggle Menu' });
     await trigger.hover();
@@ -41,7 +41,7 @@ test.describe('hamburger menu (narrow viewport)', () => {
     page,
   }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.locator('body[data-hydrated]').waitFor();
 
     const trigger = page.getByRole('button', { name: 'Toggle Menu' });
     await trigger.click();

--- a/pwa/tests/select.spec.ts
+++ b/pwa/tests/select.spec.ts
@@ -10,7 +10,7 @@ test('teams page selector shows range labels, not raw page numbers', async ({
   page,
 }) => {
   await page.goto('/teams/2');
-  await page.waitForLoadState('networkidle');
+  await page.locator('body[data-hydrated]').waitFor();
 
   // The trigger renders the selected item's label ("1000s"), not the raw
   // value ("2")
@@ -23,7 +23,7 @@ test('teams page selector opens a list taller than the trigger', async ({
   page,
 }) => {
   await page.goto('/teams');
-  await page.waitForLoadState('networkidle');
+  await page.locator('body[data-hydrated]').waitFor();
 
   const trigger = page.getByRole('combobox');
   await expect(trigger).toContainText('1-999');
@@ -43,7 +43,7 @@ test('events page district selector shows "All Events" label', async ({
   page,
 }) => {
   await page.goto('/events');
-  await page.waitForLoadState('networkidle');
+  await page.locator('body[data-hydrated]').waitFor();
 
   // The trigger renders the "All Events" label, not the raw value "all"
   const trigger = page.getByRole('combobox').filter({ hasText: 'All Events' });


### PR DESCRIPTION
## Problem

`pwa/tests/dialog-focus.spec.ts` — *"match modal focuses the dialog content container on open"* — has failed on every `[pwa] Playwright Tests (1, 4)` run since ~2026-09-03T01:30Z, on all 3 retries, with:

```
Error: page.waitForLoadState: Test timeout of 30000ms exceeded.
  12 |   await page.goto('/event/2024mil');
> 13 |   await page.waitForLoadState('networkidle');
```

The other 20 tests in the same shard pass — including `rankings-table.spec.ts`, which loads **the same** `/event/2024mil` page and clicks a tab, in 2.8s.

## This is not a code regression

A CI run that was green at 2026-09-02T23:20Z was re-run unchanged and now fails on this same test. Same commit, same code, opposite result. The trigger is environmental (third-party/API latency + runner load), not a bad commit — so the fix belongs in the test's wait strategy, not in a bisect.

## Root cause

`networkidle` resolves only after a continuous **500 ms window with zero in-flight requests**. On `/event/2024mil` that window is not reliably reachable, because the test is implicitly waiting on five origins it does not control.

I instrumented a local production build (`NODE_ENV=production node ./server.js`, cold server, `page.on('request'/'requestfinished')`) against `/event/2024mil`. Hydration fans out to ~15 cross-origin requests:

| origin | requests |
| --- | --- |
| `www.thebluealliance.com` (live prod API) | `search_index`, `insights/2024/game_stats`, `event/2024mil/{awards,coprs,rankings,teams,team_media,teams/statuses,district_points,regional_champs_pool_points}` |
| `firebase.googleapis.com` | Remote Config `webConfig` |
| `firebaseinstallations.googleapis.com` | installation registration (new browser profile every test) |
| `www.googletagmanager.com` | `gtag/js` + GA4 beacons |
| `o4507688293695488.ingest.us.sentry.io` | envelope (Sentry is `enabled: NODE_ENV === 'production'`, which is exactly how CI runs) |

Two things make this page the one that tips over:

1. **Volume.** The route's loader `ensureQueryData`s only ~7 queries; the remaining ~13 `useQuery`/`useQueries` hooks fetch client-side after hydration by design. `/` and `/teams` (the other two `networkidle` specs) issue a fraction of that, which is the only reason they still pass.
2. **Runner contention.** `/event/2024mil` (Milstein Division, a 2024 Championship division) renders a **1.09 MB** SSR document, which the Node server brotli-compresses on the same two vCPUs that are running the browser. The CI log shows this directly, firing on each event-page load and on each retry:
   ```
   [WebServer] MaxListenersExceededWarning: Possible EventEmitter memory leak
   detected. 11 drain listeners added to [BrotliCompress].
   ```
   Notably, `dialog-focus.spec.ts` is **test #1 in the shard** — it runs ~1s after the web server boots, so it eats the cold-start cost with nothing warmed.

With ~15 requests spread over five origins, each needing DNS + TLS, all competing with brotli compression, the requests stagger and overlap so that no 500 ms gap ever appears inside the 30 s budget. Nothing here is a bug in the page — I confirmed in-flight count reaches **0** and stays there (no runaway poller, no retry loop, no live-match `refetchInterval`, no Firebase Realtime listener on this route). There is no production bug to fix; there is a test that asserts something it never meant to assert.

## Fix

The test's intent is "the dialog content container is focused when the modal opens." It needs the page to be **hydrated** (so the router `<Link>` click is handled client-side and the open-autofocus effect runs) — it does not need the network to be silent.

This repo already has exactly that primitive. `app/routes/__root.tsx:183` sets `data-hydrated` on `<body>` after React mounts, with the comment *"so Playwright tests can [wait for hydration]"*, and six specs already use it (`lazy-chunks`, `rankings-table`, `team`, `search`, `district-insights-table`). This PR switches the last three `networkidle` holdouts to the house pattern:

```diff
-  await page.waitForLoadState('networkidle');
+  await page.locator('body[data-hydrated]').waitFor();
```

7 call sites across `dialog-focus.spec.ts` (1), `navigation.spec.ts` (3), and `select.spec.ts` (3). `navigation` and `select` were latently fragile for the same reason and are fixed here too.

### Why this and not a timeout bump

Raising the timeout would only move the cliff. The wait is unbounded *in kind*, not just slow: it is a function of production API latency, Google/Sentry endpoint latency, and runner load on the day. Any threshold is a guess that fails again the next time the API has a slow minute. Playwright's own docs mark `networkidle` **discouraged** — *"don't use this method for testing"* — for precisely this reason. The `data-hydrated` wait is bounded, deterministic, tied to the actual precondition the test needs, and consistent with the rest of the suite.

## Verification

- `pnpm exec playwright test tests/dialog-focus.spec.ts tests/navigation.spec.ts tests/select.spec.ts --project=chromium` against a **cold** production server, `CI=1`: **7 passed (7.2s)**. `dialog-focus` went from a 30s timeout to **1.6s** as the first request against an unwarmed server — the same position it occupies in the CI shard.
- `pnpm run lint` — exit 0 (only pre-existing `app/` warnings, none in `tests/`)
- `pnpm exec prettier --check` on the 3 changed files — clean
- `pnpm run typecheck` — clean

## Confidence

**High** on the fix, **high** on the mechanism (`networkidle` cannot settle because ~15 uncontrolled third-party/production requests never leave a 500 ms gap under CI contention). Medium on precisely *which* origin got slower at 01:30Z — that is unknowable from outside and, notably, does not matter: the fix removes the dependency on all of them rather than betting on any one staying fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

<details>
<summary><b>Context: this is one of six PRs from a year-over-year GCP cost audit</b></summary>

Total spend went $4,600 → $5,043 (+9.6%), but the offseason monthly run-rate is up **45.7%** ($270.57 → $394.14, Aug 2025 vs Aug 2026) — a one-time backend-instance reduction masked growth elsewhere.

**Cloud Logging PRs** (independent; ingestion is 158 GiB/mo, $54/mo, against a 50 GiB/mo free tier):

| PR | Change | GiB/mo |
|---|---|---:|
| #10488 | Deferred header dump → DEBUG | 26.5 |
| #10489 | Remove per-request auth log line | 14.4 |
| #10490 | PWA hot-path logs → debug | 6.2 |

All three together take ingestion to ~111 GiB/mo (**$30/mo**). Reverting the deferred GA tracking discussed in #10488 would take it to ~74 GiB/mo (**$12/mo**), below the pre-regression bill — but that's Eugene's call, not part of any of these PRs.

**Other PRs:** #10491 (FRC API archive dedupe), #10493 (dead cron cleanup + route test), #10496 (flaky Playwright test).

**Issues:** #10492 (crawler blocking), #10494 (py3-api concurrency), #10495 (**favorite button broken for logged-in users** — the most urgent finding), #10497 (Firestore backups).

⚠️ Two estimates from this audit were later **withdrawn** as wrong — see the correction notes in #10492 and #10494. Cloud Monitoring's idle instance-hours are not billed; the FOCUS export is the authority.

</details>
