### PR TITLE
port hof parser py3

### DIFF
--- a/src/backend/tasks_io/datafeeds/datafeed_resource_library.py
+++ b/src/backend/tasks_io/datafeeds/datafeed_resource_library.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from backend.tasks_io.datafeeds.datafeed_html import DatafeedHTML
+from backend.tasks_io.datafeeds.parsers.first.resource_library_parser import (
+    ParsedHallOfFameTeam,
+    ResourceLibraryParser,
+)
+
+
+class DatafeedResourceLibrary(
+    DatafeedHTML[ResourceLibraryParser, ParsedHallOfFameTeam]
+):
+    HALL_OF_FAME_URL = "https://www.firstinspires.org/resource-library/frc/past-winners-of-the-chairmans-award"
+
+    def get_hall_of_fame_teams(self) -> List[ParsedHallOfFameTeam]:
+        teams, _ = self.parse(self.HALL_OF_FAME_URL, ResourceLibraryParser())
+        return teams

--- a/src/backend/tasks_io/datafeeds/parsers/first/resource_library_parser.py
+++ b/src/backend/tasks_io/datafeeds/parsers/first/resource_library_parser.py
@@ -1,0 +1,76 @@
+import re
+from typing import List, Optional, Tuple, TypedDict
+
+from backend.common.helpers.youtube_video_helper import YouTubeVideoHelper
+from backend.tasks_io.datafeeds.parsers.parser_html import ParserHTML
+
+
+class ParsedHallOfFameTeam(TypedDict):
+    team_id: str
+    team_number: int
+    year: int
+    video: Optional[str]
+    presentation: Optional[str]
+    essay: Optional[str]
+
+
+class ResourceLibraryParser(ParserHTML[Tuple[List[ParsedHallOfFameTeam], bool]]):
+    SUMMARY_RE = re.compile(r"^\s*(\d{4})\s*[-–]\s*Team\s+(\d+)")
+
+    def parse(self, response: bytes) -> Tuple[List[ParsedHallOfFameTeam], bool]:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(response, "html.parser")
+
+        teams: List[ParsedHallOfFameTeam] = []
+        for details in soup.find_all("details"):
+            summary = details.find("summary")
+            if summary is None:
+                continue
+
+            match = self.SUMMARY_RE.match(summary.get_text(" ", strip=True))
+            if match is None:
+                continue
+
+            year = int(match.group(1))
+            team_number = int(match.group(2))
+
+            video: Optional[str] = None
+            presentation: Optional[str] = None
+            essay: Optional[str] = None
+
+            for frame in details.find_all("iframe"):
+                src = frame.get("src") or frame.get("data-src")
+                if not src:
+                    continue
+                video = YouTubeVideoHelper.parse_id_from_url(src)
+                if video is not None:
+                    break
+
+            for link in details.find_all("a"):
+                href = link.get("href")
+                if not href:
+                    continue
+                label = link.get_text(" ", strip=True).lower()
+
+                if "essay" in label and essay is None:
+                    essay = href
+                    if essay.startswith("/"):
+                        essay = "https://www.firstinspires.org" + essay
+                elif "presentation" in label and presentation is None:
+                    presentation = YouTubeVideoHelper.parse_id_from_url(href)
+                elif "video" in label and video is None:
+                    video = YouTubeVideoHelper.parse_id_from_url(href)
+
+            teams.append(
+                ParsedHallOfFameTeam(
+                    team_id=f"frc{team_number}",
+                    team_number=team_number,
+                    year=year,
+                    video=video,
+                    presentation=presentation,
+                    essay=essay,
+                )
+            )
+
+        return teams, False

--- a/src/backend/tasks_io/datafeeds/parsers/first/tests/data/hall_of_fame.html
+++ b/src/backend/tasks_io/datafeeds/parsers/first/tests/data/hall_of_fame.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+<body>
+<div class="accordion">
+  <details>
+    <summary>2024 - Team 2486, CocoNuts - Flagstaff, Arizona, USA</summary>
+    <div class="accordion-content">
+      <h5>Team 2486, CocoNuts from Flagstaff, AZ USA was honored to win the 2024 FIRST Impact Award.</h5>
+      <iframe src="https://www.youtube.com/embed/9oBL8s2Y7tA?si=3b44ehxqwSOhanpl" allowfullscreen></iframe>
+      <ul>
+        <li><a href="https://team2486.org/">www.team2486.org</a></li>
+        <li><a href="https://www.firstinspires.org/hubfs/web/program/frc/awards/fia-essays/2024/2486.pdf?hsLang=en">2486 Essay &amp; Executive Summaries</a></li>
+        <li><a href="https://youtu.be/TIFLhevHf7k">2486 FIRST Impact Award Presentation</a></li>
+      </ul>
+    </div>
+  </details>
+  <details>
+    <summary>2021 - Team 503, Frog Force - Novi, Michigan, USA</summary>
+    <div class="accordion-content">
+      <h5>Team 503, Frog Force was honored to win the 2021 Chairman's Award.</h5>
+      <iframe src="https://www.youtube.com/embed/34gb_BMgnw8?si=o6GXpKiW4k4KBEsP"></iframe>
+      <ul>
+        <li><a href="https://www.firstinspires.org/hubfs/web/program/frc/awards/fia-essays/2021/503.pdf?hsLang=en">503 Essay &amp; Executive Summaries</a></li>
+        <li><a href="https://www.youtube.com/watch?v=_o9urZ-pkxw">503 Chairman's Presentation</a></li>
+      </ul>
+    </div>
+  </details>
+  <details>
+    <summary>2019 - Team 1816, "The Green Machine" - Edina, Minnesota, USA</summary>
+    <div class="accordion-content">
+      <h5>Team 1816 was honored to win the 2019 Chairman's Award.</h5>
+      <ul>
+        <li><a href="https://www.firstinspires.org/hubfs/web/program/frc/awards/fia-essays/2019/1816.pdf?hsLang=en">1816 Essay &amp; Executive Summaries</a></li>
+        <li><a href="https://firstfrc.blob.core.windows.net/frc2019/1816%20Chairman's%20Presentation.mp4">1816 Chairman's Presentation</a></li>
+      </ul>
+    </div>
+  </details>
+  <details>
+    <summary>1993 - Team 7, The Labsters - Newark, New Jersey, USA</summary>
+    <div class="accordion-content">
+      <h5>Team 7 was honored to win the 1993 Chairman's Award.</h5>
+    </div>
+  </details>
+  <details>
+    <summary>About the FIRST Impact Award</summary>
+    <div class="accordion-content">
+      <p>This award is given to the team that best represents a role model.</p>
+    </div>
+  </details>
+</div>
+</body>
+</html>

--- a/src/backend/tasks_io/datafeeds/parsers/first/tests/resource_library_parser_test.py
+++ b/src/backend/tasks_io/datafeeds/parsers/first/tests/resource_library_parser_test.py
@@ -1,0 +1,65 @@
+from backend.tasks_io.datafeeds.parsers.first.resource_library_parser import (
+    ResourceLibraryParser,
+)
+
+
+def _parse(test_data_importer):
+    path = test_data_importer._get_path(__file__, "data/hall_of_fame.html")
+    with open(path, "rb") as f:
+        return ResourceLibraryParser().parse(f.read())
+
+
+def test_parses_all_winner_entries(test_data_importer) -> None:
+    teams, more = _parse(test_data_importer)
+
+    assert more is False
+    assert {t["year"] for t in teams} == {2024, 2021, 2019, 1993}
+
+
+def test_impact_era_entry(test_data_importer) -> None:
+    teams, _ = _parse(test_data_importer)
+    team = next(t for t in teams if t["year"] == 2024)
+
+    assert team["team_id"] == "frc2486"
+    assert team["team_number"] == 2486
+    assert team["video"] == "9oBL8s2Y7tA"
+    assert team["presentation"] == "TIFLhevHf7k"
+    assert (
+        team["essay"]
+        == "https://www.firstinspires.org/hubfs/web/program/frc/awards/fia-essays/2024/2486.pdf?hsLang=en"
+    )
+
+
+def test_chairmans_era_entry(test_data_importer) -> None:
+    teams, _ = _parse(test_data_importer)
+    team = next(t for t in teams if t["year"] == 2021)
+
+    assert team["team_id"] == "frc503"
+    assert team["video"] == "34gb_BMgnw8"
+    assert team["presentation"] == "_o9urZ-pkxw"
+    assert team["essay"].endswith("2021/503.pdf?hsLang=en")
+
+
+def test_non_youtube_presentation_is_dropped(test_data_importer) -> None:
+    teams, _ = _parse(test_data_importer)
+    team = next(t for t in teams if t["year"] == 2019)
+
+    assert team["presentation"] is None
+    assert team["essay"].endswith("2019/1816.pdf?hsLang=en")
+
+
+def test_entry_without_materials(test_data_importer) -> None:
+    teams, _ = _parse(test_data_importer)
+    team = next(t for t in teams if t["year"] == 1993)
+
+    assert team["team_id"] == "frc7"
+    assert team["video"] is None
+    assert team["presentation"] is None
+    assert team["essay"] is None
+
+
+def test_no_details_returns_empty() -> None:
+    teams, more = ResourceLibraryParser().parse(b"<html><body>nope</body></html>")
+
+    assert teams == []
+    assert more is False

--- a/src/backend/tasks_io/datafeeds/tests/datafeed_resource_library_test.py
+++ b/src/backend/tasks_io/datafeeds/tests/datafeed_resource_library_test.py
@@ -1,0 +1,46 @@
+from unittest.mock import Mock, patch
+
+from backend.tasks_io.datafeeds.datafeed_resource_library import (
+    DatafeedResourceLibrary,
+)
+
+HTML = b"""
+<html><body>
+<details>
+  <summary>2021 - Team 503, Frog Force - Novi, Michigan, USA</summary>
+  <iframe src="https://www.youtube.com/embed/34gb_BMgnw8?si=abc"></iframe>
+  <ul>
+    <li><a href="https://www.firstinspires.org/essays/2021/503.pdf">503 Essay &amp; Executive Summaries</a></li>
+    <li><a href="https://youtu.be/_o9urZ-pkxw">503 Chairman's Presentation</a></li>
+  </ul>
+</details>
+</body></html>
+"""
+
+
+def test_get_hall_of_fame_teams() -> None:
+    with patch(
+        "requests.get", return_value=Mock(status_code=200, content=HTML)
+    ) as mock_get:
+        teams = DatafeedResourceLibrary().get_hall_of_fame_teams()
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args[0][0] == DatafeedResourceLibrary.HALL_OF_FAME_URL
+
+    assert teams == [
+        {
+            "team_id": "frc503",
+            "team_number": 503,
+            "year": 2021,
+            "video": "34gb_BMgnw8",
+            "presentation": "_o9urZ-pkxw",
+            "essay": "https://www.firstinspires.org/essays/2021/503.pdf",
+        }
+    ]
+
+
+def test_get_hall_of_fame_teams_fetch_failure() -> None:
+    with patch("requests.get", return_value=Mock(status_code=500, content=b"")):
+        teams = DatafeedResourceLibrary().get_hall_of_fame_teams()
+
+    assert teams == []

--- a/src/backend/tasks_io/handlers/hall_of_fame.py
+++ b/src/backend/tasks_io/handlers/hall_of_fame.py
@@ -1,0 +1,51 @@
+import logging
+from typing import List
+
+from flask import Blueprint
+
+from backend.common.consts.media_tag import MediaTag
+from backend.common.consts.media_type import MediaType
+from backend.common.manipulators.media_manipulator import MediaManipulator
+from backend.common.models.media import Media
+from backend.tasks_io.datafeeds.datafeed_resource_library import (
+    DatafeedResourceLibrary,
+)
+
+blueprint = Blueprint("hall_of_fame", __name__)
+
+
+@blueprint.route("/tasks/get/hof_teams")
+def get_hall_of_fame_teams() -> str:
+    teams = DatafeedResourceLibrary().get_hall_of_fame_teams()
+    if not teams:
+        logging.warning("No Hall of Fame teams found")
+        return "No Hall of Fame teams found"
+
+    media_to_update: List[Media] = []
+    for team in teams:
+        team_reference = Media.create_reference("team", team["team_id"])
+
+        for foreign_key, media_type, media_tag in (
+            (team["video"], MediaType.YOUTUBE_VIDEO, MediaTag.CHAIRMANS_VIDEO),
+            (
+                team["presentation"],
+                MediaType.YOUTUBE_VIDEO,
+                MediaTag.CHAIRMANS_PRESENTATION,
+            ),
+            (team["essay"], MediaType.EXTERNAL_LINK, MediaTag.CHAIRMANS_ESSAY),
+        ):
+            if not foreign_key:
+                continue
+            media_to_update.append(
+                Media(
+                    id=Media.render_key_name(media_type, foreign_key),
+                    media_type_enum=media_type,
+                    media_tag_enum=[media_tag],
+                    references=[team_reference],
+                    year=team["year"],
+                    foreign_key=foreign_key,
+                )
+            )
+
+    MediaManipulator.createOrUpdate(media_to_update)
+    return f"Updated {len(media_to_update)} Hall of Fame media items"

--- a/src/backend/tasks_io/handlers/tests/hall_of_fame_test.py
+++ b/src/backend/tasks_io/handlers/tests/hall_of_fame_test.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+
+from werkzeug.test import Client
+
+from backend.common.consts.media_tag import MediaTag
+from backend.common.consts.media_type import MediaType
+from backend.common.models.media import Media
+from backend.tasks_io.datafeeds.parsers.first.resource_library_parser import (
+    ParsedHallOfFameTeam,
+)
+
+PARSED_TEAMS = [
+    ParsedHallOfFameTeam(
+        team_id="frc2486",
+        team_number=2486,
+        year=2024,
+        video="9oBL8s2Y7tA",
+        presentation="TIFLhevHf7k",
+        essay="https://www.firstinspires.org/essays/2024/2486.pdf",
+    ),
+    ParsedHallOfFameTeam(
+        team_id="frc1629",
+        team_number=1629,
+        year=2022,
+        video=None,
+        presentation=None,
+        essay="https://www.firstinspires.org/essays/2022/1629.pdf",
+    ),
+]
+
+
+def test_get_hof_teams(tasks_client: Client, ndb_stub) -> None:
+    with patch(
+        "backend.tasks_io.handlers.hall_of_fame.DatafeedResourceLibrary.get_hall_of_fame_teams",
+        return_value=PARSED_TEAMS,
+    ):
+        resp = tasks_client.get("/tasks/get/hof_teams")
+
+    assert resp.status_code == 200
+
+    video = Media.get_by_id(
+        Media.render_key_name(MediaType.YOUTUBE_VIDEO, "9oBL8s2Y7tA")
+    )
+    assert video is not None
+    assert video.media_tag_enum == [MediaTag.CHAIRMANS_VIDEO]
+    assert video.year == 2024
+
+    presentation = Media.get_by_id(
+        Media.render_key_name(MediaType.YOUTUBE_VIDEO, "TIFLhevHf7k")
+    )
+    assert presentation is not None
+    assert presentation.media_tag_enum == [MediaTag.CHAIRMANS_PRESENTATION]
+    assert presentation.year == 2024
+    assert presentation.references == [Media.create_reference("team", "frc2486")]
+
+    essay = Media.get_by_id(
+        Media.render_key_name(
+            MediaType.EXTERNAL_LINK,
+            "https://www.firstinspires.org/essays/2024/2486.pdf",
+        )
+    )
+    assert essay is not None
+    assert essay.media_tag_enum == [MediaTag.CHAIRMANS_ESSAY]
+
+    all_media = Media.query().fetch()
+    assert len(all_media) == 4
+
+
+def test_get_hof_teams_no_data(tasks_client: Client, ndb_stub) -> None:
+    with patch(
+        "backend.tasks_io.handlers.hall_of_fame.DatafeedResourceLibrary.get_hall_of_fame_teams",
+        return_value=[],
+    ):
+        resp = tasks_client.get("/tasks/get/hof_teams")
+
+    assert resp.status_code == 200
+    assert Media.query().fetch() == []

--- a/src/backend/tasks_io/main.py
+++ b/src/backend/tasks_io/main.py
@@ -7,6 +7,7 @@ from backend.common.middleware import install_middleware
 from backend.tasks_io.handlers.admin.blueprint import admin_routes as admin_blueprint
 from backend.tasks_io.handlers.cron_misc import blueprint as cron_misc_blueprint
 from backend.tasks_io.handlers.frc_api import blueprint as frc_api_blueprint
+from backend.tasks_io.handlers.hall_of_fame import blueprint as hall_of_fame_blueprint
 from backend.tasks_io.handlers.live_events import blueprint as live_events_blueprint
 from backend.tasks_io.handlers.math import blueprint as math_blueprint
 from backend.tasks_io.handlers.nexus_api import blueprint as nexus_api_blueprint
@@ -22,6 +23,7 @@ install_defer_routes(app)
 app.register_blueprint(admin_blueprint)
 app.register_blueprint(cron_misc_blueprint)
 app.register_blueprint(frc_api_blueprint)
+app.register_blueprint(hall_of_fame_blueprint)
 app.register_blueprint(live_events_blueprint)
 app.register_blueprint(math_blueprint)
 app.register_blueprint(tasks_blueprint)


### PR DESCRIPTION
The current HOF page is missing videos, essays, and more, because the original HOF parser never got ported to py3.