### PR TITLE
Add smugmug support

### DIFF
--- a/pwa/app/api/tba/read/index.ts
+++ b/pwa/app/api/tba/read/index.ts
@@ -625,6 +625,8 @@ export {
   type MediaGrabCad,
   type MediaNoDetails,
   type MediaOnshape,
+  type MediaSmugmugAlbum,
+  type MediaSmugmugPhoto,
   type MediaTag,
   MobilityRobot2023,
   type NexusEventInfo,

--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -2683,7 +2683,13 @@ export type Media =
     } & MediaNoDetails)
   | ({
       type: 'onshape';
-    } & MediaOnshape);
+    } & MediaOnshape)
+  | ({
+      type: 'smugmug-album';
+    } & MediaSmugmugAlbum)
+  | ({
+      type: 'smugmug-photo';
+    } & MediaSmugmugPhoto);
 
 export type MediaAvatar = MediaBase & MediaAvatarExtras;
 
@@ -2714,7 +2720,9 @@ export type MediaBase = {
     | 'external-link'
     | 'avatar'
     | 'onshape'
-    | 'cd-thread';
+    | 'cd-thread'
+    | 'smugmug-photo'
+    | 'smugmug-album';
   /**
    * The key used to identify this media on the media site.
    */
@@ -2785,6 +2793,30 @@ export type MediaOnshape = MediaBase & {
     model_description: string | null;
     model_image: string;
     model_name: string;
+  };
+};
+
+export type MediaSmugmugAlbum = MediaBase & {
+  type?: 'smugmug-album';
+  details?: {
+    cover_url: string;
+    cover_url_med: string;
+    cover_url_sm: string;
+    image_count: number;
+    title: string;
+    web_uri: string;
+  };
+};
+
+export type MediaSmugmugPhoto = MediaBase & {
+  type?: 'smugmug-photo';
+  details?: {
+    caption: string;
+    image_url: string;
+    image_url_med: string;
+    image_url_sm: string;
+    title: string;
+    web_uri: string;
   };
 };
 

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -865,6 +865,8 @@ export const zMediaBase = z.object({
     'avatar',
     'onshape',
     'cd-thread',
+    'smugmug-photo',
+    'smugmug-album',
   ]),
   foreign_key: z.string(),
   preferred: z.boolean().optional(),
@@ -942,6 +944,38 @@ export const zMediaOnshape = zMediaBase.and(
         model_description: z.string().nullable(),
         model_image: z.url(),
         model_name: z.string(),
+      })
+      .optional(),
+  }),
+);
+
+export const zMediaSmugmugAlbum = zMediaBase.and(
+  z.object({
+    type: z.literal('smugmug-album').optional(),
+    details: z
+      .object({
+        cover_url: z.url(),
+        cover_url_med: z.url(),
+        cover_url_sm: z.url(),
+        image_count: z.int(),
+        title: z.string(),
+        web_uri: z.url(),
+      })
+      .optional(),
+  }),
+);
+
+export const zMediaSmugmugPhoto = zMediaBase.and(
+  z.object({
+    type: z.literal('smugmug-photo').optional(),
+    details: z
+      .object({
+        caption: z.string(),
+        image_url: z.url(),
+        image_url_med: z.url(),
+        image_url_sm: z.url(),
+        title: z.string(),
+        web_uri: z.url(),
       })
       .optional(),
   }),
@@ -1031,6 +1065,16 @@ export const zMedia = z.union([
       type: z.literal('onshape'),
     })
     .and(zMediaOnshape),
+  z
+    .object({
+      type: z.literal('smugmug-album'),
+    })
+    .and(zMediaSmugmugAlbum),
+  z
+    .object({
+      type: z.literal('smugmug-photo'),
+    })
+    .and(zMediaSmugmugPhoto),
 ]);
 
 export const zMobilityRobot2023 = z.enum(['No', 'Yes']);

--- a/src/backend/common/consts/media_type.py
+++ b/src/backend/common/consts/media_type.py
@@ -29,6 +29,8 @@ class MediaType(enum.IntEnum):
     ONSHAPE = 13
     GITLAB_PROFILE = 14
     CD_THREAD = 15
+    SMUGMUG_PHOTO = 16
+    SMUGMUG_ALBUM = 17
 
 
 MEDIA_TYPES: Set[MediaType] = {t for t in MediaType}
@@ -51,6 +53,8 @@ SLUG_NAMES: Dict[MediaType, str] = {
     MediaType.AVATAR: "avatar",
     MediaType.GITLAB_PROFILE: "gitlab-profile",
     MediaType.CD_THREAD: "cd-thread",
+    MediaType.SMUGMUG_PHOTO: "smugmug-photo",
+    MediaType.SMUGMUG_ALBUM: "smugmug-album",
 }
 
 SLUG_NAME_TO_TYPE: Dict[str, MediaType] = {
@@ -74,12 +78,15 @@ TYPE_NAMES: Dict[MediaType, str] = {
     MediaType.ONSHAPE: "Onshape",
     MediaType.GITLAB_PROFILE: "GitLab Profile",
     MediaType.CD_THREAD: "Chief Delphi Thread",
+    MediaType.SMUGMUG_PHOTO: "SmugMug Photo",
+    MediaType.SMUGMUG_ALBUM: "SmugMug Album",
 }
 
 IMAGE_TYPES: Set[MediaType] = {
     MediaType.CD_PHOTO_THREAD,
     MediaType.IMGUR,
     MediaType.INSTAGRAM_IMAGE,
+    MediaType.SMUGMUG_PHOTO,
 }
 
 SOCIAL_TYPES: Set[MediaType] = {
@@ -90,6 +97,12 @@ SOCIAL_TYPES: Set[MediaType] = {
     MediaType.INSTAGRAM_PROFILE,
     MediaType.PERISCOPE_PROFILE,
     MediaType.GITLAB_PROFILE,
+}
+
+# Media that may be attached to an Event
+EVENT_MEDIA_TYPES: Set[MediaType] = {
+    MediaType.YOUTUBE_VIDEO,
+    MediaType.SMUGMUG_ALBUM,
 }
 
 # Media used to back a Robot Profile

--- a/src/backend/common/manipulators/media_manipulator.py
+++ b/src/backend/common/manipulators/media_manipulator.py
@@ -1,6 +1,8 @@
-from typing import List
+import logging
+from typing import List, Set
 
 from backend.common.cache_clearing import get_affected_queries
+from backend.common.consts.media_type import MediaType
 from backend.common.manipulators.manipulator_base import ManipulatorBase
 from backend.common.models.cached_model import TAffectedReferences
 from backend.common.models.media import Media
@@ -25,5 +27,41 @@ class MediaManipulator(ManipulatorBase[Media]):
         auto_union: bool = True,
         update_manual_attrs: bool = True,
     ) -> Media:
+        old_reference_kinds = {r.kind() for r in old_model.references}
         cls._update_attrs(new_model, old_model, auto_union, update_manual_attrs)
+        cls._enforce_smugmug_reference_kinds(old_model, old_reference_kinds)
         return old_model
+
+    @classmethod
+    def _enforce_smugmug_reference_kinds(
+        cls, media: Media, old_reference_kinds: Set[str]
+    ) -> None:
+        """
+        A SmugMug photo belongs to a team, and a SmugMug album belongs to either a
+        team or an event but never both. References are auto-unioned on merge, so
+        drop anything the incoming write would have added in violation of that.
+        """
+        if media.media_type_enum == MediaType.SMUGMUG_PHOTO:
+            allowed_kinds = {"Team"}
+        elif media.media_type_enum == MediaType.SMUGMUG_ALBUM:
+            allowed_kinds = old_reference_kinds or {
+                r.kind() for r in media.references[:1]
+            }
+        else:
+            return
+
+        allowed = [r for r in media.references if r.kind() in allowed_kinds]
+        if len(allowed) == len(media.references):
+            return
+
+        logging.warning(
+            "Dropping references {} from {} - only {} references are allowed".format(
+                [r.id() for r in media.references if r.kind() not in allowed_kinds],
+                media.key_name,
+                sorted(allowed_kinds),
+            )
+        )
+        media.references = allowed
+        media.preferred_references = [
+            r for r in media.preferred_references if r.kind() in allowed_kinds
+        ]

--- a/src/backend/common/manipulators/tests/media_manipulator_test.py
+++ b/src/backend/common/manipulators/tests/media_manipulator_test.py
@@ -2,9 +2,11 @@ import unittest
 
 import pytest
 from google.appengine.ext import ndb
+from pyre_extensions import none_throws
 
 from backend.common.consts.media_type import MediaType
 from backend.common.manipulators.media_manipulator import MediaManipulator
+from backend.common.models.event import Event
 from backend.common.models.media import Media
 from backend.common.models.team import Team
 
@@ -52,3 +54,76 @@ class TestMediaManipulator(unittest.TestCase):
         self.assertMergedMedia(
             MediaManipulator.updateMerge(self.new_media, self.old_media)
         )
+
+
+@pytest.mark.usefixtures("ndb_context", "taskqueue_stub")
+class TestSmugmugReferenceKinds(unittest.TestCase):
+    def _media(self, media_type: MediaType, references) -> Media:
+        return Media(
+            id=Media.render_key_name(media_type, "asdf"),
+            media_type_enum=media_type,
+            foreign_key="asdf",
+            year=2026,
+            references=references,
+        )
+
+    def test_album_on_team_rejects_an_event(self) -> None:
+        media_id = Media.render_key_name(MediaType.SMUGMUG_ALBUM, "asdf")
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_ALBUM, [ndb.Key(Team, "frc177")])
+        )
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_ALBUM, [ndb.Key(Event, "2026necmp")])
+        )
+        assert none_throws(Media.get_by_id(media_id)).references == [
+            ndb.Key(Team, "frc177")
+        ]
+
+    def test_album_on_event_rejects_a_team(self) -> None:
+        media_id = Media.render_key_name(MediaType.SMUGMUG_ALBUM, "asdf")
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_ALBUM, [ndb.Key(Event, "2026necmp")])
+        )
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_ALBUM, [ndb.Key(Team, "frc177")])
+        )
+        assert none_throws(Media.get_by_id(media_id)).references == [
+            ndb.Key(Event, "2026necmp")
+        ]
+
+    def test_album_accepts_more_of_the_same_kind(self) -> None:
+        media_id = Media.render_key_name(MediaType.SMUGMUG_ALBUM, "asdf")
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_ALBUM, [ndb.Key(Team, "frc177")])
+        )
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_ALBUM, [ndb.Key(Team, "frc176")])
+        )
+        assert set(none_throws(Media.get_by_id(media_id)).references) == {
+            ndb.Key(Team, "frc177"),
+            ndb.Key(Team, "frc176"),
+        }
+
+    def test_photo_rejects_an_event(self) -> None:
+        media_id = Media.render_key_name(MediaType.SMUGMUG_PHOTO, "asdf")
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_PHOTO, [ndb.Key(Team, "frc177")])
+        )
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.SMUGMUG_PHOTO, [ndb.Key(Event, "2026necmp")])
+        )
+        assert none_throws(Media.get_by_id(media_id)).references == [
+            ndb.Key(Team, "frc177")
+        ]
+
+    def test_other_media_types_are_untouched(self) -> None:
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.YOUTUBE_VIDEO, [ndb.Key(Team, "frc177")])
+        )
+        MediaManipulator.createOrUpdate(
+            self._media(MediaType.YOUTUBE_VIDEO, [ndb.Key(Event, "2026necmp")])
+        )
+        assert set(none_throws(Media.get_by_id("youtube_asdf")).references) == {
+            ndb.Key(Team, "frc177"),
+            ndb.Key(Event, "2026necmp"),
+        }

--- a/src/backend/common/models/media.py
+++ b/src/backend/common/models/media.py
@@ -185,6 +185,8 @@ class Media(CachedModel):
             return self.instagram_url
         elif self.media_type_enum == MediaType.CD_THREAD:
             return "https://www.chiefdelphi.com/t/{}".format(self.foreign_key)
+        elif self.media_type_enum in {MediaType.SMUGMUG_PHOTO, MediaType.SMUGMUG_ALBUM}:
+            return none_throws(self.details)["web_uri"]
         else:
             return ""
 
@@ -205,6 +207,8 @@ class Media(CachedModel):
             )
         elif self.media_type_enum == MediaType.INSTAGRAM_IMAGE:
             return self.instagram_url
+        elif self.media_type_enum == MediaType.SMUGMUG_PHOTO:
+            return none_throws(self.details)["image_url"]
         else:
             return ""
 
@@ -240,6 +244,8 @@ class Media(CachedModel):
             return none_throws(self.details)["model_image"]
         elif self.media_type_enum == MediaType.INSTAGRAM_IMAGE:
             return self.instagram_url
+        elif self.media_type_enum == MediaType.SMUGMUG_PHOTO:
+            return none_throws(self.details)["image_url_med"]
         else:
             return ""
 
@@ -259,6 +265,8 @@ class Media(CachedModel):
             )
         elif self.media_type_enum == MediaType.INSTAGRAM_IMAGE:
             return self.instagram_url
+        elif self.media_type_enum == MediaType.SMUGMUG_PHOTO:
+            return none_throws(self.details)["image_url_sm"]
         else:
             return ""
 

--- a/src/backend/common/models/tests/media_test.py
+++ b/src/backend/common/models/tests/media_test.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from google.appengine.api import datastore_errors
 
@@ -41,3 +43,71 @@ def test_media_tag_validation() -> None:
             foreign_key="abc",
             media_tag_enum=[1337],
         )
+
+
+SMUGMUG_PHOTO_DETAILS = json.dumps(
+    {
+        "title": "",
+        "caption": "A robot",
+        "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+        "image_url": "https://photos.smugmug.com/L/x-L.jpg",
+        "image_url_med": "https://photos.smugmug.com/M/x-M.jpg",
+        "image_url_sm": "https://photos.smugmug.com/S/x-S.jpg",
+    }
+)
+
+SMUGMUG_ALBUM_DETAILS = json.dumps(
+    {
+        "title": "2026 FIRST Championship - BAE Systems",
+        "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+        "image_count": 81,
+        "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+        "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+        "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+    }
+)
+
+
+def test_smugmug_photo_urls() -> None:
+    m = Media(
+        id="smugmug-photo_xxrbgK6",
+        media_type_enum=MediaType.SMUGMUG_PHOTO,
+        foreign_key="xxrbgK6",
+        details_json=SMUGMUG_PHOTO_DETAILS,
+    )
+    assert m.key_name == "smugmug-photo_xxrbgK6"
+    assert m.slug_name == "smugmug-photo"
+    assert Media.validate_key_name(m.key_name) is True
+    assert (
+        m.view_image_url
+        == "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6"
+    )
+    assert m.image_direct_url == "https://photos.smugmug.com/L/x-L.jpg"
+    assert m.image_direct_url_med == "https://photos.smugmug.com/M/x-M.jpg"
+    assert m.image_direct_url_sm == "https://photos.smugmug.com/S/x-S.jpg"
+
+
+def test_smugmug_album_urls() -> None:
+    m = Media(
+        id="smugmug-album_4RWMLM",
+        media_type_enum=MediaType.SMUGMUG_ALBUM,
+        foreign_key="4RWMLM",
+        details_json=SMUGMUG_ALBUM_DETAILS,
+    )
+    assert m.key_name == "smugmug-album_4RWMLM"
+    assert m.slug_name == "smugmug-album"
+    assert Media.validate_key_name(m.key_name) is True
+    assert m.view_image_url == "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+    # An album has no single image to link directly to
+    assert m.image_direct_url == ""
+    assert m.image_direct_url_med == ""
+    assert m.image_direct_url_sm == ""
+
+
+@pytest.mark.parametrize(
+    "media_type,is_image",
+    [(MediaType.SMUGMUG_PHOTO, True), (MediaType.SMUGMUG_ALBUM, False)],
+)
+def test_smugmug_is_image(media_type: MediaType, is_image: bool) -> None:
+    m = Media(id="smugmug_abc", media_type_enum=media_type, foreign_key="abc")
+    assert m.is_image is is_image

--- a/src/backend/common/queries/dict_converters/tests/media_converter_test.py
+++ b/src/backend/common/queries/dict_converters/tests/media_converter_test.py
@@ -1,3 +1,5 @@
+import json
+
 from google.appengine.ext import ndb
 
 from backend.common.consts.media_type import MediaType
@@ -75,3 +77,55 @@ def test_mediaConverter_v3_twitter_profile_url(ndb_context) -> None:
     result = MediaConverter.mediaConverter_v3(media)
     assert result["view_url"] == "https://twitter.com/frc4"
     assert result["direct_url"] == "https://twitter.com/frc4"
+
+
+def test_mediaConverter_v3_smugmug_photo(ndb_context) -> None:
+    media = Media(
+        id="smugmug-photo_xxrbgK6",
+        media_type_enum=MediaType.SMUGMUG_PHOTO,
+        foreign_key="xxrbgK6",
+        details_json=json.dumps(
+            {
+                "title": "",
+                "caption": "A robot",
+                "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+                "image_url": "https://photos.smugmug.com/L/x-L.jpg",
+                "image_url_med": "https://photos.smugmug.com/M/x-M.jpg",
+                "image_url_sm": "https://photos.smugmug.com/S/x-S.jpg",
+            }
+        ),
+        references=[ndb.Key("Team", "frc4")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["type"] == "smugmug-photo"
+    assert (
+        result["view_url"]
+        == "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6"
+    )
+    assert result["direct_url"] == "https://photos.smugmug.com/L/x-L.jpg"
+
+
+def test_mediaConverter_v3_smugmug_album(ndb_context) -> None:
+    media = Media(
+        id="smugmug-album_4RWMLM",
+        media_type_enum=MediaType.SMUGMUG_ALBUM,
+        foreign_key="4RWMLM",
+        details_json=json.dumps(
+            {
+                "title": "2026 FIRST Championship - BAE Systems",
+                "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+                "image_count": 81,
+                "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+                "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+                "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+            }
+        ),
+        references=[ndb.Key("Event", "2026necmp")],
+    )
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["type"] == "smugmug-album"
+    assert (
+        result["view_url"] == "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+    )
+    assert result["direct_url"] == ""
+    assert result["team_keys"] == []

--- a/src/backend/common/sitevars/smugmug_api_secret.py
+++ b/src/backend/common/sitevars/smugmug_api_secret.py
@@ -1,0 +1,27 @@
+from typing import Optional, TypedDict
+
+from backend.common.sitevars.sitevar import Sitevar
+
+
+class ContentType(TypedDict):
+    api_key: str
+    api_secret: str
+
+
+class SmugmugApiSecret(Sitevar[ContentType]):
+    @staticmethod
+    def key() -> str:
+        return "smugmug.secrets"
+
+    @staticmethod
+    def description() -> str:
+        return "For SmugMug API Calls"
+
+    @staticmethod
+    def default_value() -> ContentType:
+        return ContentType(api_key="", api_secret="")
+
+    @classmethod
+    def api_key(cls) -> Optional[str]:
+        api_key = cls.get().get("api_key")
+        return api_key if api_key else None  # Drop empty strings

--- a/src/backend/common/sitevars/tests/smugmug_api_secret_test.py
+++ b/src/backend/common/sitevars/tests/smugmug_api_secret_test.py
@@ -1,0 +1,28 @@
+from backend.common.sitevars.smugmug_api_secret import ContentType, SmugmugApiSecret
+
+
+def test_key():
+    assert SmugmugApiSecret.key() == "smugmug.secrets"
+
+
+def test_description():
+    assert SmugmugApiSecret.description() == "For SmugMug API Calls"
+
+
+def test_default_sitevar():
+    default_sitevar = SmugmugApiSecret._fetch_sitevar()
+    assert default_sitevar is not None
+
+    default_json = {"api_key": "", "api_secret": ""}
+    assert default_sitevar.contents == default_json
+    assert default_sitevar.description == "For SmugMug API Calls"
+
+
+def test_api_key_empty():
+    assert SmugmugApiSecret.api_key() is None
+
+
+def test_secrets():
+    SmugmugApiSecret.put(ContentType(api_key="abc", api_secret="def"))
+    assert SmugmugApiSecret.api_key() == "abc"
+    assert SmugmugApiSecret.get()["api_secret"] == "def"

--- a/src/backend/common/suggestions/media_parser.py
+++ b/src/backend/common/suggestions/media_parser.py
@@ -14,6 +14,7 @@ from backend.common.consts.media_type import (
 )
 from backend.common.models.suggestion_dict import SuggestionDict
 from backend.common.sitevars.cd_request_user_agent import CdRequestUserAgent
+from backend.common.sitevars.smugmug_api_secret import SmugmugApiSecret
 from backend.common.tasklets import typed_tasklet
 from backend.common.urlfetch import URLFetchResult
 
@@ -75,6 +76,8 @@ class MediaParser:
         ("grabcad.com/library/", MediaType.GRABCAD),
         ("cad.onshape.com/documents/", MediaType.ONSHAPE),
         ("instagram.com/p/", MediaType.INSTAGRAM_IMAGE),
+        # The API resolves photo vs album, so the type here is only a routing hint
+        ("smugmug.com/", MediaType.SMUGMUG_PHOTO),
         # Keep these last, so they don't greedy match over other more specific urls
         ("youtube.com/", MediaType.YOUTUBE_CHANNEL),
         ("instagram.com/", MediaType.INSTAGRAM_PROFILE),
@@ -89,6 +92,8 @@ class MediaParser:
     GRABCAD_DETAIL_URL = (
         "https://grabcad.com/community/api/v1/models/{}"  # Format w/ foreign key
     )
+    SMUGMUG_WEBURI_LOOKUP_URL = "https://api.smugmug.com/api/v2!weburilookup"
+
     ONSHAPE_DETAIL_URL = (
         "https://cad.onshape.com/api/documents/{}"  # Format w/ stripped foreign key
     )
@@ -125,6 +130,9 @@ class MediaParser:
                     return result
                 elif media_type == MediaType.CD_THREAD:
                     result = yield cls._parse_cd_thread(url)
+                    return result
+                elif media_type == MediaType.SMUGMUG_PHOTO:
+                    result = yield cls._parse_smugmug(url)
                     return result
                 else:
                     raise ndb.Return(cls._create_media_dict(media_type, url))
@@ -435,3 +443,141 @@ class MediaParser:
         )
 
         raise ndb.Return(media_dict)
+
+    @classmethod
+    @typed_tasklet
+    def _parse_smugmug(cls, url: str) -> Generator[Any, Any, Optional[SuggestionDict]]:
+        api_key = SmugmugApiSecret.api_key()
+        if not api_key:
+            logging.warning("No SmugMug API key! Configure SmugmugApiSecret sitevar")
+            raise ndb.Return(None)
+
+        web_uri = cls._sanitize_media_url(MediaType.SMUGMUG_PHOTO, url)
+        lookup_url = "{}?{}".format(
+            cls.SMUGMUG_WEBURI_LOOKUP_URL,
+            urlencode(
+                {
+                    "WebUri": web_uri,
+                    "APIKey": api_key,
+                    "_expand": "ImageSizeDetails,AlbumHighlightImage.ImageSizeDetails",
+                }
+            ),
+        )
+
+        ndb_context = ndb.get_context()
+        urlfetch_response = yield ndb_context.urlfetch(
+            lookup_url, deadline=10, headers={"Accept": "application/json"}
+        )
+        urlfetch_result = URLFetchResult(lookup_url, urlfetch_response)
+
+        if urlfetch_result.status_code != 200:
+            logging.warning(
+                "Unable to retreive url: {} (status code: {})".format(
+                    cls.SMUGMUG_WEBURI_LOOKUP_URL, urlfetch_result.status_code
+                )
+            )
+            raise ndb.Return(None)
+
+        smugmug_data = cls._as_dict(urlfetch_result.json())
+        response = cls._as_dict(smugmug_data.get("Response"))
+        if not response:
+            logging.warning("No data returned for SmugMug url: {}".format(web_uri))
+            raise ndb.Return(None)
+
+        # A url that doesn't resolve still returns a 200, with a Locator naming every
+        # type it could have been and no object alongside it
+        locator = response.get("Locator")
+        expansions = cls._as_dict(smugmug_data.get("Expansions"))
+        if locator == "Album":
+            media_dict = cls._smugmug_album_dict(
+                cls._as_dict(response.get("Album")), expansions
+            )
+        elif locator == "AlbumImage":
+            media_dict = cls._smugmug_photo_dict(
+                cls._as_dict(response.get("AlbumImage")), expansions
+            )
+        else:
+            logging.warning(
+                "SmugMug url is neither an album nor a photo: {} (locator: {})".format(
+                    web_uri, locator
+                )
+            )
+            raise ndb.Return(None)
+
+        raise ndb.Return(media_dict)
+
+    @staticmethod
+    def _as_dict(value: Any) -> Dict:
+        return value if isinstance(value, dict) else {}
+
+    @classmethod
+    def _smugmug_size_urls(cls, expansions: Dict) -> Dict[str, str]:
+        """
+        Every size carries its own signature, so the urls can't be derived from each
+        other - they only come from the ImageSizeDetails expansion. For an album that
+        expansion belongs to its highlight (cover) image.
+        """
+        size_details: Dict = {}
+        for expansion in expansions.values():
+            size_details = cls._as_dict(cls._as_dict(expansion).get("ImageSizeDetails"))
+            if size_details:
+                break
+
+        return {
+            size: cls._as_dict(size_details.get(size)).get("Url", "")
+            for size in ("ImageSizeSmall", "ImageSizeMedium", "ImageSizeLarge")
+        }
+
+    @classmethod
+    def _smugmug_album_dict(
+        cls, album: Dict, expansions: Dict
+    ) -> Optional[SuggestionDict]:
+        album_key = album.get("AlbumKey")
+        if not album_key:
+            logging.warning("SmugMug album response is missing an AlbumKey")
+            return None
+
+        size_urls = cls._smugmug_size_urls(expansions)
+        return {
+            "media_type_enum": MediaType.SMUGMUG_ALBUM,
+            "is_social": False,
+            "foreign_key": album_key,
+            "site_name": TYPE_NAMES[MediaType.SMUGMUG_ALBUM],
+            "details_json": json.dumps(
+                {
+                    "title": album.get("Title") or album.get("Name", ""),
+                    "web_uri": album.get("WebUri", ""),
+                    "image_count": album.get("ImageCount", 0),
+                    "cover_url": size_urls["ImageSizeLarge"],
+                    "cover_url_med": size_urls["ImageSizeMedium"],
+                    "cover_url_sm": size_urls["ImageSizeSmall"],
+                }
+            ),
+        }
+
+    @classmethod
+    def _smugmug_photo_dict(
+        cls, image: Dict, expansions: Dict
+    ) -> Optional[SuggestionDict]:
+        image_key = image.get("ImageKey")
+        if not image_key:
+            logging.warning("SmugMug image response is missing an ImageKey")
+            return None
+
+        size_urls = cls._smugmug_size_urls(expansions)
+        return {
+            "media_type_enum": MediaType.SMUGMUG_PHOTO,
+            "is_social": False,
+            "foreign_key": image_key,
+            "site_name": TYPE_NAMES[MediaType.SMUGMUG_PHOTO],
+            "details_json": json.dumps(
+                {
+                    "title": image.get("Title", ""),
+                    "caption": image.get("Caption", ""),
+                    "web_uri": image.get("WebUri", ""),
+                    "image_url": size_urls["ImageSizeLarge"],
+                    "image_url_med": size_urls["ImageSizeMedium"],
+                    "image_url_sm": size_urls["ImageSizeSmall"],
+                }
+            ),
+        }

--- a/src/backend/common/suggestions/suggestion_creator.py
+++ b/src/backend/common/suggestions/suggestion_creator.py
@@ -7,7 +7,11 @@ from google.appengine.ext import ndb
 
 from backend.common.consts.auth_type import AuthType, WRITE_TYPE_NAMES
 from backend.common.consts.event_type import EventType, SEASON_EVENT_TYPES
-from backend.common.consts.media_type import MediaType, ROBOT_TYPES, SLUG_NAMES
+from backend.common.consts.media_type import (
+    EVENT_MEDIA_TYPES,
+    ROBOT_TYPES,
+    SLUG_NAMES,
+)
 from backend.common.consts.string_enum import StrEnum
 from backend.common.consts.suggestion_state import SuggestionState
 from backend.common.consts.webcast_type import WebcastType
@@ -128,7 +132,7 @@ class SuggestionCreator:
 
         media_dict = yield MediaParser.partial_media_dict_from_url(media_url)
         if media_dict is not None:
-            if media_dict["media_type_enum"] != MediaType.YOUTUBE_VIDEO:
+            if media_dict["media_type_enum"] not in EVENT_MEDIA_TYPES:
                 return SuggestionCreationStatus.BAD_URL, None
 
             existing_media = Media.get_by_id(

--- a/src/backend/common/suggestions/tests/media_url_parse_test.py
+++ b/src/backend/common/suggestions/tests/media_url_parse_test.py
@@ -1,5 +1,7 @@
+import copy
 import json
 import unittest
+from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +9,7 @@ import pytest
 from backend.common.consts.media_type import MediaType, TYPE_NAMES
 from backend.common.futures import InstantFuture
 from backend.common.helpers.webcast_helper import WebcastParser
+from backend.common.sitevars.smugmug_api_secret import ContentType, SmugmugApiSecret
 from backend.common.suggestions.media_parser import MediaParser
 from backend.common.urlfetch import URLFetchResult
 
@@ -437,3 +440,190 @@ class TestWebcastUrlParser(unittest.TestCase):
             "http://mywebsite.somewebcast"
         ).get_result()
         self.assertIsNone(bad)
+
+
+SMUGMUG_ALBUM_RESPONSE: Dict[str, Any] = {
+    "Response": {
+        "Locator": "Album",
+        "LocatorType": "Object",
+        "Album": {
+            "AlbumKey": "4RWMLM",
+            "Name": "2026 FIRST Championship - BAE Systems",
+            "Title": "2026 FIRST Championship - BAE Systems",
+            "ImageCount": 81,
+            "WebUri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+        },
+    },
+    # The cover image's sizes, from the AlbumHighlightImage expansion
+    "Expansions": {
+        "/api/v2/image/2F65K6P-0!sizedetails": {
+            "ImageSizeDetails": {
+                "ImageSizeSmall": {"Url": "https://photos.smugmug.com/S/cover-S.png"},
+                "ImageSizeMedium": {"Url": "https://photos.smugmug.com/M/cover-M.png"},
+                "ImageSizeLarge": {"Url": "https://photos.smugmug.com/L/cover-L.png"},
+            }
+        },
+        "/api/v2/album/4RWMLM!highlightimage": {"AlbumImage": {"ImageKey": "2F65K6P"}},
+    },
+}
+
+SMUGMUG_PHOTO_RESPONSE: Dict[str, Any] = {
+    "Response": {
+        "Locator": "AlbumImage",
+        "LocatorType": "Object",
+        "AlbumImage": {
+            "ImageKey": "xxrbgK6",
+            "Title": "",
+            "Caption": "A robot",
+            "WebUri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+        },
+    },
+    "Expansions": {
+        "/api/v2/image/xxrbgK6-0!sizedetails": {
+            "ImageSizeDetails": {
+                "ImageSizeSmall": {"Url": "https://photos.smugmug.com/S/x-S.jpg"},
+                "ImageSizeMedium": {"Url": "https://photos.smugmug.com/M/x-M.jpg"},
+                "ImageSizeLarge": {"Url": "https://photos.smugmug.com/L/x-L.jpg"},
+            }
+        }
+    },
+}
+
+
+class TestSmugmugParser(unittest.TestCase):
+    ALBUM_URL = "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+    PHOTO_URL = "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6/A"
+
+    def setUp(self) -> None:
+        SmugmugApiSecret.put(ContentType(api_key="abc", api_secret="def"))
+
+    def _parse(self, url: str, status_code: int, content: str):
+        mock_urlfetch_result = URLFetchResult.mock_urlfetch_result(
+            MediaParser.SMUGMUG_WEBURI_LOOKUP_URL, status_code, content
+        )
+        with patch(
+            "google.appengine.ext.ndb.Context.urlfetch",
+            return_value=InstantFuture(mock_urlfetch_result),
+        ):
+            return MediaParser.partial_media_dict_from_url(url).get_result()
+
+    def test_album_parse(self) -> None:
+        urls = [
+            self.ALBUM_URL,
+            self.ALBUM_URL + "/",
+            self.ALBUM_URL + "?utm_source=tba",
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                result = self._parse(url, 200, json.dumps(SMUGMUG_ALBUM_RESPONSE))
+                self.assertIsNotNone(result)
+                self.assertEqual(result["media_type_enum"], MediaType.SMUGMUG_ALBUM)
+                self.assertEqual(result["foreign_key"], "4RWMLM")
+                self.assertFalse(result["is_social"])
+                self.assertEqual(
+                    result["site_name"], TYPE_NAMES[MediaType.SMUGMUG_ALBUM]
+                )
+                self.assertEqual(
+                    json.loads(result["details_json"]),
+                    {
+                        "title": "2026 FIRST Championship - BAE Systems",
+                        "web_uri": self.ALBUM_URL,
+                        "image_count": 81,
+                        "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+                        "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+                        "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+                    },
+                )
+
+    def test_album_parse_falls_back_to_name(self) -> None:
+        response = copy.deepcopy(SMUGMUG_ALBUM_RESPONSE)
+        response["Response"]["Album"]["Title"] = ""
+        result = self._parse(self.ALBUM_URL, 200, json.dumps(response))
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            json.loads(result["details_json"])["title"],
+            "2026 FIRST Championship - BAE Systems",
+        )
+
+    def test_photo_parse(self) -> None:
+        urls = [
+            self.PHOTO_URL,
+            "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+            self.PHOTO_URL + "?utm_source=tba",
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                result = self._parse(url, 200, json.dumps(SMUGMUG_PHOTO_RESPONSE))
+                self.assertIsNotNone(result)
+                self.assertEqual(result["media_type_enum"], MediaType.SMUGMUG_PHOTO)
+                self.assertEqual(result["foreign_key"], "xxrbgK6")
+                self.assertFalse(result["is_social"])
+                self.assertEqual(
+                    result["site_name"], TYPE_NAMES[MediaType.SMUGMUG_PHOTO]
+                )
+                self.assertEqual(
+                    json.loads(result["details_json"]),
+                    {
+                        "title": "",
+                        "caption": "A robot",
+                        "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+                        "image_url": "https://photos.smugmug.com/L/x-L.jpg",
+                        "image_url_med": "https://photos.smugmug.com/M/x-M.jpg",
+                        "image_url_sm": "https://photos.smugmug.com/S/x-S.jpg",
+                    },
+                )
+
+    def test_album_parse_missing_cover(self) -> None:
+        response = copy.deepcopy(SMUGMUG_ALBUM_RESPONSE)
+        del response["Expansions"]
+        result = self._parse(self.ALBUM_URL, 200, json.dumps(response))
+        self.assertIsNotNone(result)
+        details = json.loads(result["details_json"])
+        self.assertEqual(details["cover_url"], "")
+        self.assertEqual(details["cover_url_med"], "")
+        self.assertEqual(details["cover_url_sm"], "")
+
+    def test_photo_parse_missing_size_details(self) -> None:
+        response = copy.deepcopy(SMUGMUG_PHOTO_RESPONSE)
+        del response["Expansions"]
+        result = self._parse(self.PHOTO_URL, 200, json.dumps(response))
+        self.assertIsNotNone(result)
+        details = json.loads(result["details_json"])
+        self.assertEqual(details["image_url"], "")
+        self.assertEqual(details["image_url_med"], "")
+        self.assertEqual(details["image_url_sm"], "")
+
+    def test_no_api_key(self) -> None:
+        SmugmugApiSecret.put(ContentType(api_key="", api_secret=""))
+        with patch("google.appengine.ext.ndb.Context.urlfetch") as mock_urlfetch:
+            result = MediaParser.partial_media_dict_from_url(
+                self.ALBUM_URL
+            ).get_result()
+        self.assertIsNone(result)
+        mock_urlfetch.assert_not_called()
+
+    def test_api_non_200(self) -> None:
+        self.assertIsNone(self._parse(self.ALBUM_URL, 500, ""))
+
+    def test_api_empty_response(self) -> None:
+        self.assertIsNone(self._parse(self.ALBUM_URL, 200, ""))
+
+    def test_url_is_not_an_album_or_photo(self) -> None:
+        # A folder page
+        response = {"Response": {"Locator": "Folder", "Folder": {"NodeID": "rSxh6r"}}}
+        self.assertIsNone(self._parse(self.ALBUM_URL, 200, json.dumps(response)))
+
+    def test_url_does_not_resolve(self) -> None:
+        # SmugMug answers 200 and names every type the url could have been
+        response = {"Response": {"Locator": "Folder,Album,Page,AlbumImage"}}
+        self.assertIsNone(self._parse(self.ALBUM_URL, 200, json.dumps(response)))
+
+    def test_album_missing_key(self) -> None:
+        response = copy.deepcopy(SMUGMUG_ALBUM_RESPONSE)
+        del response["Response"]["Album"]["AlbumKey"]
+        self.assertIsNone(self._parse(self.ALBUM_URL, 200, json.dumps(response)))
+
+    def test_photo_missing_key(self) -> None:
+        response = copy.deepcopy(SMUGMUG_PHOTO_RESPONSE)
+        del response["Response"]["AlbumImage"]["ImageKey"]
+        self.assertIsNone(self._parse(self.PHOTO_URL, 200, json.dumps(response)))

--- a/src/backend/common/suggestions/tests/suggestion_creator_test.py
+++ b/src/backend/common/suggestions/tests/suggestion_creator_test.py
@@ -283,6 +283,51 @@ class TestEventMediaSuggestionCreator(SuggestionCreatorTest):
         ).get_result()
         self.assertEqual(status, "bad_url")
 
+    def _patch_smugmug(self, response):
+        return patch.object(
+            MediaParser,
+            "_parse_smugmug",
+            return_value=InstantFuture(response),
+        )
+
+    def test_create_album_suggestion(self) -> None:
+        album_dict = {
+            "media_type_enum": MediaType.SMUGMUG_ALBUM,
+            "is_social": False,
+            "foreign_key": "4RWMLM",
+            "site_name": "SmugMug Album",
+        }
+        url = "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+        with self._patch_smugmug(album_dict):
+            status, _ = SuggestionCreator.createEventMediaSuggestion(
+                self.account.key, url, "2016nyny"
+            ).get_result()
+        self.assertEqual(status, "success")
+
+        suggestion = Suggestion.get_by_id(
+            Suggestion.render_media_key_name(
+                2016, "event", "2016nyny", "smugmug-album", "4RWMLM"
+            )
+        )
+        self.assertIsNotNone(suggestion)
+        self.assertEqual(suggestion.target_model, "event_media")
+        self.assertEqual(suggestion.contents["reference_type"], "event")
+        self.assertEqual(suggestion.contents["reference_key"], "2016nyny")
+
+    def test_create_photo_suggestion_rejected(self) -> None:
+        photo_dict = {
+            "media_type_enum": MediaType.SMUGMUG_PHOTO,
+            "is_social": False,
+            "foreign_key": "xxrbgK6",
+            "site_name": "SmugMug Photo",
+        }
+        url = "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6/A"
+        with self._patch_smugmug(photo_dict):
+            status, _ = SuggestionCreator.createEventMediaSuggestion(
+                self.account.key, url, "2016nyny"
+            ).get_result()
+        self.assertEqual(status, "bad_url")
+
 
 class TestOffseasonEventSuggestionCreator(SuggestionCreatorTest):
     def test_create_suggestion(self) -> None:

--- a/src/backend/web/handlers/suggestions/suggest_team_media_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_team_media_review_controller.py
@@ -98,6 +98,7 @@ class SuggestTeamMediaReviewController(SuggestionsReviewBase[Media]):
                 suggestions_and_references_and_preferred
             ),
             "max_preferred": Media.MAX_PREFERRED,
+            "image_types": IMAGE_TYPES,
         }
 
         return render_template(

--- a/src/backend/web/handlers/suggestions/tests/suggest_team_media_review_controller_test.py
+++ b/src/backend/web/handlers/suggestions/tests/suggest_team_media_review_controller_test.py
@@ -1,5 +1,7 @@
+import json
 import re
 from typing import List
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
@@ -10,9 +12,11 @@ from werkzeug.test import Client
 from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.media_type import MediaType
 from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.futures import InstantFuture
 from backend.common.models.media import Media
 from backend.common.models.suggestion import Suggestion
 from backend.common.models.team import Team
+from backend.common.suggestions.media_parser import MediaParser
 from backend.common.suggestions.suggestion_creator import (
     SuggestionCreationStatus,
     SuggestionCreator,
@@ -278,3 +282,176 @@ def test_instagram_suggestion_renders_embed(
     # Verify embed.js script is included
     embed_script = soup.find("script", attrs={"src": re.compile("instagram.com/embed")})
     assert embed_script is not None
+
+
+def createSmugmugSuggestion(logged_in_user, media_dict) -> None:
+    with patch.object(
+        MediaParser, "_parse_smugmug", return_value=InstantFuture(media_dict)
+    ):
+        status = SuggestionCreator.createTeamMediaSuggestion(
+            logged_in_user.account_key,
+            "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+            "frc1124",
+            "2026",
+        ).get_result()
+    assert status[0] == SuggestionCreationStatus.SUCCESS
+
+
+def test_smugmug_photo_suggestion_renders_image(
+    login_user_with_permission,
+    web_client: Client,
+) -> None:
+    createSmugmugSuggestion(
+        login_user_with_permission,
+        {
+            "media_type_enum": MediaType.SMUGMUG_PHOTO,
+            "is_social": False,
+            "foreign_key": "xxrbgK6",
+            "site_name": "SmugMug Photo",
+            "details_json": json.dumps(
+                {
+                    "title": "Robot on the field",
+                    "caption": "",
+                    "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+                    "image_url": "https://photos.smugmug.com/L/x-L.jpg",
+                    "image_url_med": "https://photos.smugmug.com/M/x-M.jpg",
+                    "image_url_sm": "https://photos.smugmug.com/S/x-S.jpg",
+                }
+            ),
+        },
+    )
+
+    response = web_client.get("/suggest/team/media/review")
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.data, "html.parser")
+
+    thumbnail = soup.find(
+        "a", class_="gallery", href="https://photos.smugmug.com/L/x-L.jpg"
+    )
+    assert thumbnail is not None
+    assert "https://photos.smugmug.com/M/x-M.jpg" in thumbnail.find("span")["style"]
+
+    caption = soup.find(
+        "a",
+        href="https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+    )
+    assert caption is not None
+    assert caption.text == "Robot on the field"
+
+    # A SmugMug photo is an image type, so it can be made the preferred image
+    assert soup.find("input", attrs={"name": "preferred_keys[]"}) is not None
+
+
+def test_accept_smugmug_photo_as_preferred(
+    login_user_with_permission,
+    ndb_stub,
+    web_client: Client,
+    taskqueue_stub,
+) -> None:
+    createSmugmugSuggestion(
+        login_user_with_permission,
+        {
+            "media_type_enum": MediaType.SMUGMUG_PHOTO,
+            "is_social": False,
+            "foreign_key": "xxrbgK6",
+            "site_name": "SmugMug Photo",
+            "details_json": json.dumps(
+                {
+                    "title": "Robot on the field",
+                    "caption": "",
+                    "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+                    "image_url": "https://photos.smugmug.com/L/x-L.jpg",
+                    "image_url_med": "https://photos.smugmug.com/M/x-M.jpg",
+                    "image_url_sm": "https://photos.smugmug.com/S/x-S.jpg",
+                }
+            ),
+        },
+    )
+    suggestion_id = Suggestion.render_media_key_name(
+        2026, "team", "frc1124", "smugmug-photo", "xxrbgK6"
+    )
+
+    response = web_client.post(
+        "/suggest/team/media/review",
+        data={
+            f"accept_reject-{suggestion_id}": f"accept::{suggestion_id}",
+            "preferred_keys[]": [f"preferred::{suggestion_id}"],
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    media = Media.get_by_id(Media.render_key_name(MediaType.SMUGMUG_PHOTO, "xxrbgK6"))
+    assert media is not None
+    assert media.is_image is True
+    assert ndb.Key(Team, "frc1124") in media.references
+    assert ndb.Key(Team, "frc1124") in media.preferred_references
+
+
+def test_smugmug_album_is_not_preferrable(
+    login_user_with_permission,
+    web_client: Client,
+) -> None:
+    createSmugmugSuggestion(
+        login_user_with_permission,
+        {
+            "media_type_enum": MediaType.SMUGMUG_ALBUM,
+            "is_social": False,
+            "foreign_key": "4RWMLM",
+            "site_name": "SmugMug Album",
+            "details_json": json.dumps(
+                {
+                    "title": "2026 FIRST Championship - BAE Systems",
+                    "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+                    "image_count": 81,
+                    "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+                    "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+                    "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+                }
+            ),
+        },
+    )
+
+    response = web_client.get("/suggest/team/media/review")
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert soup.find("input", attrs={"name": "preferred_keys[]"}) is None
+
+
+def test_smugmug_album_suggestion_renders_cover(
+    login_user_with_permission,
+    web_client: Client,
+) -> None:
+    createSmugmugSuggestion(
+        login_user_with_permission,
+        {
+            "media_type_enum": MediaType.SMUGMUG_ALBUM,
+            "is_social": False,
+            "foreign_key": "4RWMLM",
+            "site_name": "SmugMug Album",
+            "details_json": json.dumps(
+                {
+                    "title": "2026 FIRST Championship - BAE Systems",
+                    "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+                    "image_count": 81,
+                    "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+                    "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+                    "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+                }
+            ),
+        },
+    )
+
+    response = web_client.get("/suggest/team/media/review")
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.data, "html.parser")
+
+    links = soup.find_all(
+        "a", href="https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+    )
+    assert len(links) == 2
+
+    cover, caption = links
+    assert "https://photos.smugmug.com/M/cover-M.png" in cover.find("span")["style"]
+    assert caption.text == "2026 FIRST Championship - BAE Systems"
+    assert "81 photos" in caption.parent.text

--- a/src/backend/web/handlers/tests/event_detail_test.py
+++ b/src/backend/web/handlers/tests/event_detail_test.py
@@ -9,6 +9,7 @@ from werkzeug.test import Client
 from backend.common.consts.alliance_color import AllianceColor
 from backend.common.consts.comp_level import CompLevel
 from backend.common.consts.event_type import EventType
+from backend.common.consts.media_type import MediaType
 from backend.common.consts.webcast_status import WebcastStatus
 from backend.common.consts.webcast_type import WebcastType
 from backend.common.memcache_models.webcast_online_status_memcache import (
@@ -18,6 +19,7 @@ from backend.common.models.alliance import MatchAlliance
 from backend.common.models.event import Event
 from backend.common.models.event_details import EventDetails
 from backend.common.models.match import Match
+from backend.common.models.media import Media
 from backend.common.models.regional_champs_pool import RegionalChampsPool
 from backend.common.models.webcast import Webcast
 from backend.web.handlers.tests import helpers
@@ -464,3 +466,56 @@ def test_render_long_cache_event_without_divisions_beyond_a_day(
     resp = web_client.get("/event/2020nyny")
     assert resp.status_code == 200
     assert "max-age=21600" in resp.headers["Cache-Control"]
+
+
+@ndb.synctasklet
+def preseed_smugmug_album(event_key: str):
+    yield Media(
+        id="smugmug-album_4RWMLM",
+        media_type_enum=MediaType.SMUGMUG_ALBUM,
+        foreign_key="4RWMLM",
+        year=int(event_key[:4]),
+        details_json=json.dumps(
+            {
+                "title": "2026 FIRST Championship - BAE Systems",
+                "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+                "image_count": 81,
+                "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+                "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+                "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+            }
+        ),
+        references=[ndb.Key(Event, event_key)],
+    ).put_async()
+
+
+def test_render_event_smugmug_album(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_event("2020nyny")
+    preseed_smugmug_album("2020nyny")
+
+    resp = web_client.get("/event/2020nyny")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+
+    media_tab = soup.find(id="media")
+    assert media_tab is not None
+    assert media_tab.find(id="photo-galleries") is not None
+
+    links = media_tab.find_all(
+        "a", href="https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+    )
+    assert len(links) == 2
+
+    cover, caption = links
+    assert "https://photos.smugmug.com/M/cover-M.png" in cover.find("span")["style"]
+    assert caption.text == "2026 FIRST Championship - BAE Systems"
+    assert "81 photos" in caption.parent.text
+
+
+def test_render_event_no_smugmug_album(ndb_stub, web_client: Client) -> None:
+    helpers.preseed_event("2020nyny")
+
+    resp = web_client.get("/event/2020nyny")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+    assert soup.find(id="photo-galleries") is None

--- a/src/backend/web/handlers/tests/team_detail_test.py
+++ b/src/backend/web/handlers/tests/team_detail_test.py
@@ -1,14 +1,19 @@
 import json
+from typing import Generator
 
 from bs4 import BeautifulSoup
 from freezegun import freeze_time
+from google.appengine.ext import ndb
 from werkzeug.test import Client
 
+from backend.common.consts.media_type import MediaType
 from backend.common.consts.webcast_status import WebcastStatus
 from backend.common.consts.webcast_type import WebcastType
 from backend.common.memcache_models.webcast_online_status_memcache import (
     WebcastOnlineStatusMemcache,
 )
+from backend.common.models.media import Media
+from backend.common.models.team import Team
 from backend.common.models.webcast import Webcast
 from backend.web.handlers.tests import helpers
 
@@ -216,3 +221,103 @@ def test_schema_org_sports_team_full_data(web_client: Client, setup_full_team) -
     assert sports_team_schema["location"]["address"]["addressLocality"] == "Greenville"
     assert sports_team_schema["location"]["address"]["addressRegion"] == "Texas"
     assert sports_team_schema["location"]["address"]["addressCountry"] == "USA"
+
+
+@ndb.synctasklet
+def preseed_smugmug_photo(team_number: int, year: int) -> Generator:
+    yield Media(
+        id="smugmug-photo_xxrbgK6",
+        media_type_enum=MediaType.SMUGMUG_PHOTO,
+        foreign_key="xxrbgK6",
+        year=year,
+        details_json=json.dumps(
+            {
+                "title": "Robot on the field",
+                "caption": "",
+                "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+                "image_url": "https://photos.smugmug.com/L/x-L.jpg",
+                "image_url_med": "https://photos.smugmug.com/M/x-M.jpg",
+                "image_url_sm": "https://photos.smugmug.com/S/x-S.jpg",
+            }
+        ),
+        references=[ndb.Key(Team, f"frc{team_number}")],
+    ).put_async()
+
+
+def test_smugmug_photo_in_gallery(web_client: Client, ndb_stub) -> None:
+    helpers.preseed_team(254)
+    helpers.preseed_event_for_team(254, "2020test")
+    preseed_smugmug_photo(254, 2020)
+
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+
+    thumbnail = soup.find(
+        "a", class_="gallery", href="https://photos.smugmug.com/L/x-L.jpg"
+    )
+    assert thumbnail is not None
+    assert "https://photos.smugmug.com/M/x-M.jpg" in thumbnail.find("span")["style"]
+
+    caption = soup.find(
+        "a",
+        href="https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6",
+    )
+    assert caption is not None
+    assert caption.text == "Robot on the field"
+
+
+@ndb.synctasklet
+def preseed_smugmug_album(team_number: int, year: int) -> Generator:
+    yield Media(
+        id="smugmug-album_4RWMLM",
+        media_type_enum=MediaType.SMUGMUG_ALBUM,
+        foreign_key="4RWMLM",
+        year=year,
+        details_json=json.dumps(
+            {
+                "title": "2026 FIRST Championship - BAE Systems",
+                "web_uri": "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE",
+                "image_count": 81,
+                "cover_url": "https://photos.smugmug.com/L/cover-L.png",
+                "cover_url_med": "https://photos.smugmug.com/M/cover-M.png",
+                "cover_url_sm": "https://photos.smugmug.com/S/cover-S.png",
+            }
+        ),
+        references=[ndb.Key(Team, f"frc{team_number}")],
+    ).put_async()
+
+
+def test_smugmug_album_in_photo_galleries(web_client: Client, ndb_stub) -> None:
+    helpers.preseed_team(254)
+    helpers.preseed_event_for_team(254, "2020test")
+    preseed_smugmug_album(254, 2020)
+
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+
+    assert soup.find(id="photo-galleries") is not None
+
+    links = soup.find_all(
+        "a", href="https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE"
+    )
+    assert len(links) == 2
+
+    cover, caption = links
+    assert "https://photos.smugmug.com/M/cover-M.png" in cover.find("span")["style"]
+    assert caption.text == "2026 FIRST Championship - BAE Systems"
+    assert "81 photos" in caption.parent.text
+
+    # An album alone must not fall through to the empty-media message
+    assert "No photos or videos for team" not in resp.get_data(as_text=True)
+
+
+def test_no_smugmug_album(web_client: Client, ndb_stub) -> None:
+    helpers.preseed_team(254)
+    helpers.preseed_event_for_team(254, "2020test")
+
+    resp = web_client.get("/team/254/2020")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.data, "html.parser")
+    assert soup.find(id="photo-galleries") is None

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.23.0",
+    "version": "3.24.0",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.23.0: Add `cmp_qualification` to District_Advancement_Cutoffs on /district/{district_key}/advancement, a mapping of team key to CmpQualificationMethod. This is the same data already projected onto each entry in `teams`, surfaced under `cutoffs` as well because it is computed by TBA from rankings, events and awards rather than sourced from the per-team advancement feed, and so is available even when `teams` is empty. 3.22.1: Fix /district/{district_key}/advancement returning `teams: null` for a district whose advancement has been fetched but is empty; it now returns an empty object, and `null` is reserved for advancement that has never been fetched. 3.22.0: Adds CMP/DCMP qualification cutoffs and methods. 3.21.0: Add the `date` value to the InsightV2 timeseries `x_type` enum. When `x_type` is `date`, each data point's `x` is a Unix timestamp (seconds) at UTC midnight of that day. Adds the `cumulative_matches_by_day` timeseries insight (per-year, `x_type` `date`), tracking the running cumulative count of played matches over the course of a season. 3.20.0: Add the `clubs` InsightV2 category, returning cumulative all-time memberships of teams that reached a milestone. Each member has an `event_added_key` (where the team first qualified) and an optional club-specific `extra_context`. The first club is `hall_of_fame` - teams that won the Impact/Chairman's Award at Championship finals, with `extra_context` carrying the Chairman's video, presentation, and essay links. Adds InsightV2_Clubs, InsightV2_Clubs_Extras, InsightV2ClubsData, InsightV2ClubEntry, and InsightV2HallOfFameContext schemas, and adds `clubs` to the InsightV2 category path parameter enum. 3.19.0: Add `kickoff_datetime` to API_Status, an ISO 8601 UTC datetime for the upcoming season's FRC Kickoff. 3.18.0: Rename the InsightV2 `success_rate` category to `game_stats`, and add `qual_averages`/`playoff_averages` to each InsightV2GameStatsScope - non-binary average statistics (e.g. average score, average win margin) for a season overall, per competition week, and per event, alongside the existing count/opportunities statistics. Renames InsightV2_SuccessRate, InsightV2_SuccessRate_Extras, InsightV2SuccessRateData, InsightV2SuccessRateScope, and InsightV2SuccessRateEntry to InsightV2_GameStats, InsightV2_GameStats_Extras, InsightV2GameStatsData, InsightV2GameStatsScope, and InsightV2GameStat respectively, and adds the InsightV2AverageStat schema. 3.17.1: Add success_rate to the InsightV2 category path parameter enum, so /insights/{year}/{category} and its district variant document the category the API already serves. 3.17.0: Add the `success_rate` InsightV2 category, returning count/opportunities statistics (bonus ranking points and game-specific objectives) for a season overall, per competition week, and per event. Adds InsightV2_SuccessRate, InsightV2SuccessRateData, InsightV2SuccessRateScope, and InsightV2SuccessRate schemas. 3.16.0: Add /event/{event_key}/nexus_info endpoint, returning cached live match-queuing info sourced from Nexus (https://frc.nexus/) for an event, or null if unavailable. Adds Nexus_Event_Info, Nexus_Now_Queueing, Nexus_Match_Info, and Nexus_Match_Timing schemas. 3.15.0: Add InsightV2 endpoints and schemas. Introduces /insights/{year}, /insights/{year}/{category}, /insights/{year}/district/{district_abbreviation}, and /insights/{year}/{category}/district/{district_abbreviation} routes returning typed InsightV2 objects with leaderboard, streak, and timeseries categories. Use year=0 for all-time insights. 3.14.0: Introduce named string enum schemas (AllianceColor, WebcastStatus). Webcast.status now references the WebcastStatus schema. AllianceColor includes red, blue, and empty string for no winner or tie; Match.winning_alliance references AllianceColor. Wire values are unchanged; clients regenerated against the spec get correctly-named enum members. 3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.24.0: Add the `smugmug-photo` and `smugmug-album` media types, for SmugMug photos and galleries. A `smugmug-photo` may be attached to a team; a `smugmug-album` may be attached to a team or an event, but not both. A `smugmug-album`'s details carry `cover_url`/`cover_url_med`/`cover_url_sm` for the album's cover image. Adds the Media_SmugmugPhoto and Media_SmugmugAlbum schemas. 3.23.0: Add `cmp_qualification` to District_Advancement_Cutoffs on /district/{district_key}/advancement, a mapping of team key to CmpQualificationMethod. This is the same data already projected onto each entry in `teams`, surfaced under `cutoffs` as well because it is computed by TBA from rankings, events and awards rather than sourced from the per-team advancement feed, and so is available even when `teams` is empty. 3.22.1: Fix /district/{district_key}/advancement returning `teams: null` for a district whose advancement has been fetched but is empty; it now returns an empty object, and `null` is reserved for advancement that has never been fetched. 3.22.0: Adds CMP/DCMP qualification cutoffs and methods. 3.21.0: Add the `date` value to the InsightV2 timeseries `x_type` enum. When `x_type` is `date`, each data point's `x` is a Unix timestamp (seconds) at UTC midnight of that day. Adds the `cumulative_matches_by_day` timeseries insight (per-year, `x_type` `date`), tracking the running cumulative count of played matches over the course of a season. 3.20.0: Add the `clubs` InsightV2 category, returning cumulative all-time memberships of teams that reached a milestone. Each member has an `event_added_key` (where the team first qualified) and an optional club-specific `extra_context`. The first club is `hall_of_fame` - teams that won the Impact/Chairman's Award at Championship finals, with `extra_context` carrying the Chairman's video, presentation, and essay links. Adds InsightV2_Clubs, InsightV2_Clubs_Extras, InsightV2ClubsData, InsightV2ClubEntry, and InsightV2HallOfFameContext schemas, and adds `clubs` to the InsightV2 category path parameter enum. 3.19.0: Add `kickoff_datetime` to API_Status, an ISO 8601 UTC datetime for the upcoming season's FRC Kickoff. 3.18.0: Rename the InsightV2 `success_rate` category to `game_stats`, and add `qual_averages`/`playoff_averages` to each InsightV2GameStatsScope - non-binary average statistics (e.g. average score, average win margin) for a season overall, per competition week, and per event, alongside the existing count/opportunities statistics. Renames InsightV2_SuccessRate, InsightV2_SuccessRate_Extras, InsightV2SuccessRateData, InsightV2SuccessRateScope, and InsightV2SuccessRateEntry to InsightV2_GameStats, InsightV2_GameStats_Extras, InsightV2GameStatsData, InsightV2GameStatsScope, and InsightV2GameStat respectively, and adds the InsightV2AverageStat schema. 3.17.1: Add success_rate to the InsightV2 category path parameter enum, so /insights/{year}/{category} and its district variant document the category the API already serves. 3.17.0: Add the `success_rate` InsightV2 category, returning count/opportunities statistics (bonus ranking points and game-specific objectives) for a season overall, per competition week, and per event. Adds InsightV2_SuccessRate, InsightV2SuccessRateData, InsightV2SuccessRateScope, and InsightV2SuccessRate schemas. 3.16.0: Add /event/{event_key}/nexus_info endpoint, returning cached live match-queuing info sourced from Nexus (https://frc.nexus/) for an event, or null if unavailable. Adds Nexus_Event_Info, Nexus_Now_Queueing, Nexus_Match_Info, and Nexus_Match_Timing schemas. 3.15.0: Add InsightV2 endpoints and schemas. Introduces /insights/{year}, /insights/{year}/{category}, /insights/{year}/district/{district_abbreviation}, and /insights/{year}/{category}/district/{district_abbreviation} routes returning typed InsightV2 objects with leaderboard, streak, and timeseries categories. Use year=0 for all-time insights. 3.14.0: Introduce named string enum schemas (AllianceColor, WebcastStatus). Webcast.status now references the WebcastStatus schema. AllianceColor includes red, blue, and empty string for no winner or tie; Match.winning_alliance references AllianceColor. Wire values are unchanged; clients regenerated against the spec get correctly-named enum members. 3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -10153,6 +10153,12 @@
           },
           {
             "$ref": "#/components/schemas/Media_Onshape"
+          },
+          {
+            "$ref": "#/components/schemas/Media_SmugmugAlbum"
+          },
+          {
+            "$ref": "#/components/schemas/Media_SmugmugPhoto"
           }
         ],
         "discriminator": {
@@ -10173,7 +10179,9 @@
             "gitlab-profile": "#/components/schemas/Media_NoDetails",
             "instagram-image": "#/components/schemas/Media_NoDetails",
             "external-link": "#/components/schemas/Media_NoDetails",
-            "onshape": "#/components/schemas/Media_Onshape"
+            "onshape": "#/components/schemas/Media_Onshape",
+            "smugmug-album": "#/components/schemas/Media_SmugmugAlbum",
+            "smugmug-photo": "#/components/schemas/Media_SmugmugPhoto"
           }
         },
         "description": "The `Media` object contains a reference for most any media associated with a team or event on TBA."
@@ -10234,7 +10242,9 @@
               "external-link",
               "avatar",
               "onshape",
-              "cd-thread"
+              "cd-thread",
+              "smugmug-photo",
+              "smugmug-album"
             ]
           },
           "foreign_key": {
@@ -10434,6 +10444,106 @@
                   },
                   "model_name": {
                     "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_SmugmugAlbum": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "smugmug-album"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "cover_url",
+                  "cover_url_med",
+                  "cover_url_sm",
+                  "image_count",
+                  "title",
+                  "web_uri"
+                ],
+                "properties": {
+                  "cover_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "cover_url_med": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "cover_url_sm": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "image_count": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "web_uri": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_SmugmugPhoto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "smugmug-photo"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "caption",
+                  "image_url",
+                  "image_url_med",
+                  "image_url_sm",
+                  "title",
+                  "web_uri"
+                ],
+                "properties": {
+                  "caption": {
+                    "type": "string"
+                  },
+                  "image_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "image_url_med": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "image_url_sm": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "web_uri": {
+                    "type": "string",
+                    "format": "uri"
                   }
                 }
               }

--- a/src/backend/web/templates/event_details.html
+++ b/src/backend/web/templates/event_details.html
@@ -486,6 +486,19 @@
               {% endif %}
             </div>
           </div>
+
+          {% if medias_by_slugname['smugmug-album'] %}
+          <div class="row">
+            <div class="col-xs-12">
+              <h3 id="photo-galleries">Photo Galleries</h3>
+              {% for media in medias_by_slugname['smugmug-album'] %}
+                <div class="col-xs-6 col-sm-3">
+                  {% include "media_partials/media_display_partial.html" %}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+          {% endif %}
         </div>
       </div>
 

--- a/src/backend/web/templates/media_partials/media_display_partial.html
+++ b/src/backend/web/templates/media_partials/media_display_partial.html
@@ -15,4 +15,8 @@
     {% include "media_partials/onshape_partial.html" %}
 {% elif media.media_type_enum == 15 %}
     {% include "media_partials/cd_thread_partial.html" %}
+{% elif media.media_type_enum == 16 %}
+    {% include "media_partials/smugmug_photo_partial.html" %}
+{% elif media.media_type_enum == 17 %}
+    {% include "media_partials/smugmug_album_partial.html" %}
 {% endif %}

--- a/src/backend/web/templates/media_partials/smugmug_album_partial.html
+++ b/src/backend/web/templates/media_partials/smugmug_album_partial.html
@@ -1,0 +1,9 @@
+<div class="thumbnail cdphotothread-thumbnail">
+  <a href="{{media.view_image_url}}" target="_blank" rel="noopener noreferrer">
+    <span style="background-image:url('{{media.details.cover_url_med}}')"></span>
+  </a>
+  <div class="caption">
+    <a href="{{media.view_image_url}}" target="_blank" rel="noopener noreferrer">{{ media.details.title or "SmugMug Album" }}</a>
+    <span class="text-muted">({{ media.details.image_count }} photos)</span>
+  </div>
+</div>

--- a/src/backend/web/templates/media_partials/smugmug_photo_partial.html
+++ b/src/backend/web/templates/media_partials/smugmug_photo_partial.html
@@ -1,0 +1,8 @@
+<div class="thumbnail cdphotothread-thumbnail">
+  <a href="{{media.image_direct_url}}" class="gallery">
+    <span style="background-image:url('{{media.image_direct_url_med}}')"></span>
+  </a>
+  <div class="caption">
+    <a href="{{media.view_image_url}}" target="_blank" rel="noopener noreferrer">{{ media.details.title or "SmugMug Photo" }}</a>
+  </div>
+</div>

--- a/src/backend/web/templates/suggestions/suggest_team_media_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_team_media_review_list.html
@@ -99,7 +99,7 @@
                         {% include "media_partials/image_thumbnail_partial.html" %}
                       </div>
                     {% endfor %}
-                    {% if suggestion.contents.media_type_enum == 1 or suggestion.contents.media_type_enum == 2 or suggestion.contents.media_type_enum == 10 %}
+                    {% if suggestion.contents.media_type_enum in image_types %}
                       {% if preferred|length < max_preferred %}
                       <label class="checkbox text-info" for="preferred_{{suggestion.key.id()}}">
                         <input type="checkbox" name="preferred_keys[]" id="preferred_{{suggestion.key.id()}}" value="preferred::{{suggestion.key.id()}}" {% if suggestion.contents.default_preferred %}checked{% endif %}> Add as Preferred<br>(Doesn't do anything for non-images)

--- a/src/backend/web/templates/team_details.html
+++ b/src/backend/web/templates/team_details.html
@@ -293,7 +293,7 @@
           <hr>
           <a class="btn btn-success pull-right" href="/suggest/team/media?team_key={{team.key_name}}&year={{year}}" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-plus"></span> Add Media!</a>
           <h2 id="media">Photos &amp; Videos</h2>
-          {% if image_medias or medias_by_slugname.youtube %}
+          {% if image_medias or medias_by_slugname.youtube or medias_by_slugname['smugmug-album'] %}
             <div class="row">
               <div class="col-xs-12">
                 {% if image_medias %}
@@ -321,6 +321,19 @@
                 {% endif %}
               </div>
             </div>
+
+            {% if medias_by_slugname['smugmug-album'] %}
+            <div class="row">
+              <div class="col-xs-12">
+                <h3 id="photo-galleries">Photo Galleries</h3>
+                {% for media in medias_by_slugname['smugmug-album'] %}
+                  <div class="col-xs-6 col-sm-3">
+                    {% include "media_partials/media_display_partial.html" %}
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+            {% endif %}
           {% else %}
             <p>No photos or videos for team {{team.team_number}} from {{year}}... <a href="/suggest/team/media?team_key={{team.key_name}}&year={{year}}" target="_blank" rel="noopener noreferrer">Why not add one</a>?</p>
           {% endif %}


### PR DESCRIPTION
Supports both smugmug images and smugmug albums. An image can belong to a team. An album can belong to a team or an event (not both). 

<img width="1247" height="1181" alt="firefox_k6mb8GhEaH" src="https://github.com/user-attachments/assets/6695e9e0-653a-4c51-ad42-f158196c2747" />
<img width="1212" height="1229" alt="firefox_0Rq8iTxB9O" src="https://github.com/user-attachments/assets/1db73876-1e70-43ca-b3d5-574b7c00e4df" />
<img width="1251" height="1555" alt="firefox_9FrMEQKAZe" src="https://github.com/user-attachments/assets/150c471a-4672-4719-a46b-c8862d87fb5a" />
<img width="1204" height="818" alt="firefox_c7T6vdcPsy" src="https://github.com/user-attachments/assets/b2ff8ab5-e16d-4fad-905f-6e7360724b80" />
<img width="1315" height="1150" alt="firefox_II69AuyBYO" src="https://github.com/user-attachments/assets/b7a6a8f3-2073-4c0e-bf07-9922ae5c1e24" />
<img width="1369" height="1789" alt="firefox_yes69KpOLo" src="https://github.com/user-attachments/assets/30ef7c3f-842e-494b-95c1-df72864650f4" />
