### PR TITLE
Point moderators at the PWA suggestion review queue

### DIFF
--- a/src/backend/web/handlers/tests/suggest_review_pwa_banner_test.py
+++ b/src/backend/web/handlers/tests/suggest_review_pwa_banner_test.py
@@ -1,0 +1,47 @@
+"""The Jinja suggestion-review pages point moderators at the PWA queue.
+
+Suggestion review shipped in the PWA (/suggest/review). These pages remain
+functional, but each one now carries a banner linking to the equivalent PWA
+queue so moderators try the new tooling instead.
+"""
+
+from werkzeug.test import Client
+
+from backend.common.consts.account_permission import AccountPermission
+
+BANNER = b'data-testid="pwa-review-banner"'
+PWA = b"https://beta.thebluealliance.com"
+
+
+def _as_reviewer(login_user, *permissions: AccountPermission) -> None:
+    login_user.has_permission.return_value = True
+    login_user.permissions = list(permissions)
+
+
+def test_review_home_links_to_pwa_queue_index(login_user, web_client: Client) -> None:
+    _as_reviewer(login_user, AccountPermission.REVIEW_MEDIA)
+
+    resp = web_client.get("/suggest/review")
+
+    assert resp.status_code == 200
+    assert BANNER in resp.data
+    assert PWA + b"/suggest/review" in resp.data
+
+
+def test_apiwrite_review_links_to_its_pwa_queue(login_user, web_client: Client) -> None:
+    _as_reviewer(login_user, AccountPermission.REVIEW_APIWRITE)
+
+    resp = web_client.get("/suggest/apiwrite/review")
+
+    assert resp.status_code == 200
+    assert BANNER in resp.data
+    # The link targets the matching queue, not just the index.
+    assert PWA + b"/suggest/review/api_auth_access" in resp.data
+
+
+def test_banner_is_not_on_public_suggest_forms(web_client: Client) -> None:
+    """Only reviewer pages get the banner; the public submission forms do not."""
+    resp = web_client.get("/suggest/event/webcast?event_key=2026casj")
+
+    # Whatever the form's own status, it must not carry the moderator banner.
+    assert BANNER not in resp.data

--- a/src/backend/web/templates/suggestions/partials/pwa_review_banner.html
+++ b/src/backend/web/templates/suggestions/partials/pwa_review_banner.html
@@ -1,0 +1,16 @@
+{# Points moderators at the PWA's review queue, which now supersedes these
+   pages. `pwa_review_path` is the PWA route for the queue being viewed;
+   omit it to link to the queue index. #}
+<div class="row">
+  <div class="col-xs-12">
+    <div class="alert alert-info" role="status" data-testid="pwa-review-banner">
+      <strong>Suggestion review has moved to the new web app.</strong>
+      Please review these in the PWA instead — same queue, with bulk accept/reject, keyboard shortcuts, and better previews:
+      <a href="https://beta.thebluealliance.com{{ pwa_review_path | default('/suggest/review') }}" class="alert-link">
+        beta.thebluealliance.com{{ pwa_review_path | default('/suggest/review') }} &raquo;
+      </a>
+      <br>
+      <small>These pages still work, but the PWA is where fixes and new review tooling land now. If something is missing there, please let us know.</small>
+    </div>
+  </div>
+</div>

--- a/src/backend/web/templates/suggestions/suggest_apiwrite_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_apiwrite_review_list.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/api_auth_access" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Trusted API Requests</li>

--- a/src/backend/web/templates/suggestions/suggest_designs_review.html
+++ b/src/backend/web/templates/suggestions/suggest_designs_review.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/robot" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Team CAD Models & Discussion Threads</li>

--- a/src/backend/web/templates/suggestions/suggest_event_media_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_event_media_review_list.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/event_media" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Event Medias</li>

--- a/src/backend/web/templates/suggestions/suggest_event_webcast_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_event_webcast_review_list.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/event" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
     <ol class="breadcrumb">
         <li><a href="/suggest/review">Suggestions</a></li>
         <li class="active">Webcasts</li>

--- a/src/backend/web/templates/suggestions/suggest_match_video_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_match_video_review_list.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/match" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
     <ol class="breadcrumb">
         <li><a href="/suggest/review">Suggestions</a></li>
         <li class="active">Match Videos</li>

--- a/src/backend/web/templates/suggestions/suggest_offseason_event_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_offseason_event_review_list.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/offseason-event" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Offseason Events</li>

--- a/src/backend/web/templates/suggestions/suggest_review_home.html
+++ b/src/backend/web/templates/suggestions/suggest_review_home.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <div class="container">
+  {% with pwa_review_path = "/suggest/review" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   {% if status %}
   <div class="row">
     <div class="col-xs-12 col-lg-6 col-lg-offset-3">

--- a/src/backend/web/templates/suggestions/suggest_team_media_review_list.html
+++ b/src/backend/web/templates/suggestions/suggest_team_media_review_list.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/media" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Team Medias</li>

--- a/src/backend/web/templates/suggestions/suggest_team_social_review.html
+++ b/src/backend/web/templates/suggestions/suggest_team_social_review.html
@@ -6,6 +6,7 @@
 {% block content %}
 <div class="container">
 
+  {% with pwa_review_path = "/suggest/review/social-media" %}{% include "suggestions/partials/pwa_review_banner.html" %}{% endwith %}
   <ol class="breadcrumb">
     <li><a href="/suggest/review">Suggestions</a></li>
     <li class="active">Team Social Media</li>


### PR DESCRIPTION
## What

Suggestion review now lives in the PWA — `/suggest/review`, shipped in #10187 on the moderation API from #10150. This adds a banner to the top of **every Jinja review page** (the review home plus the eight per-type queues) linking to the equivalent PWA queue, so moderators try the new tooling instead of the pages it supersedes.

One partial, `suggestions/partials/pwa_review_banner.html`, included per page with the matching PWA route:

| Jinja page | PWA queue |
|---|---|
| `/suggest/review` | `/suggest/review` |
| apiwrite | `/suggest/review/api_auth_access` |
| designs | `/suggest/review/robot` |
| event media | `/suggest/review/event_media` |
| event webcast | `/suggest/review/event` |
| match video | `/suggest/review/match` |
| offseason event | `/suggest/review/offseason-event` |
| team media | `/suggest/review/media` |
| team social | `/suggest/review/social-media` |

The route segments are the `SuggestionType` wire values, the same ones the PWA's `$suggestionType` route validates against.

## Copy

> **Suggestion review has moved to the new web app.** Please review these in the PWA instead — same queue, with bulk accept/reject, keyboard shortcuts, and better previews: **beta.thebluealliance.com/suggest/review »**
> *These pages still work, but the PWA is where fixes and new review tooling land now. If something is missing there, please let us know.*

Bootstrap `alert alert-info`, matching the existing alerts on these pages. The Jinja pages are left fully functional — this is a nudge, not a redirect — and the copy invites reports of anything the PWA is missing, which is the feedback we want while it's the beta.

## Notes

- The `beta.thebluealliance.com` host is hard-coded; that's where the PWA is served per `dispatch.yaml`. If it ever moves to `www`, this is one string in one partial.
- Only the reviewer pages get the banner; the public submission forms don't (tested).

## Testing

New `suggest_review_pwa_banner_test.py`: banner present with the correct link on the review home and on the apiwrite queue; absent from a public submit form. Ran every suggestion/review handler test (36) so all nine includes are exercised. `make lint` and `make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)