### PR TITLE
Add x-enum-varnames to the moderation spec so the PWA client regenerates cleanly (unblocks PWA deploys)

### DIFF
--- a/src/backend/web/static/swagger/api_moderation_v1.json
+++ b/src/backend/web/static/swagger/api_moderation_v1.json
@@ -32,6 +32,16 @@
           "robot",
           "event_media"
         ],
+        "x-enum-varnames": [
+          "EVENT",
+          "MATCH",
+          "MEDIA",
+          "SOCIAL_MEDIA",
+          "OFFSEASON_EVENT",
+          "API_AUTH_ACCESS",
+          "ROBOT",
+          "EVENT_MEDIA"
+        ],
         "description": "The type of suggestion (event=Webcasts, match=Match Videos, media=Team Media, social-media=Social Media, offseason-event=Offseason Events, api_auth_access=API Key Requests, robot=CAD Models, event_media=Event Videos)"
       },
       "QueueResponse": {


### PR DESCRIPTION
## Why this is urgent

**PWA deploys to production are currently blocked.** Every push to `main` since #10187 merged (`b94478a86`, 20:30 UTC) fails `[pwa] Check API regeneration`, and `Deploy PWA Service` declares `needs: [..., check-pwa-api]`, so it's **skipped**. The `pwa` service is still serving the version deployed at 19:11 UTC — from before #10187 — which is why `beta.thebluealliance.com/suggest/review` **404s** (as bdaroz noted on #10524).

## What went wrong

A sequencing slip on my part. #10187 regenerated the moderation client with `enums: 'typescript'`, using a spec that carried `x-enum-varnames` for `SuggestionType`. That spec change was pushed to `moderation-api` at ~19:40 UTC — but #10150 had already been squash-merged at **19:26**. So `main` ended up with:

- `pwa/app/api/tba/moderation/types.gen.ts` — the **enum** client (from #10187) ✅
- `src/backend/web/static/swagger/api_moderation_v1.json` — **no** `x-enum-varnames` ❌

Regenerating from `main`'s spec yields member names derived from the values instead of the declared ones → the generated file differs → the check fails.

## Proof

Reproduced locally, mirroring the check:

| state | `./generate-api.sh` then `git status pwa/app/api` |
|---|---|
| `main` as-is | **1 file changed** (`types.gen.ts`) — the CI failure |
| `main` + this commit | **0 files changed** |

This PR is exactly the missing commit, cherry-picked (`0db9fd535` from `moderation-api`): eight `x-enum-varnames` entries mirroring `backend/common/consts/suggestion_type.py`. Spec-only; no Python or client changes.

## After merge

The next `push.yml` run's regeneration check passes, `Deploy PWA Service` runs, and beta gets the review UI. #10524 (the Jinja→PWA banner) should then be rebased so its own copy of this check goes green, and its link stops pointing at a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)