### PR TITLE
Use SimilarEventHelper for similar events in the moderation API (PWA review parity with #10436)

### DIFF
--- a/src/backend/api/handlers/moderation.py
+++ b/src/backend/api/handlers/moderation.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import logging
 import re
-from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional
 
 from flask import g, jsonify, make_response, request, Response
@@ -12,13 +11,16 @@ from pyre_extensions import none_throws
 from backend.api.handlers.decorators import require_moderation_permission
 from backend.common.consts.account_permission import SUGGESTION_PERMISSIONS
 from backend.common.consts.auth_type import WRITE_TYPE_NAMES
-from backend.common.consts.event_type import EventType
 from backend.common.consts.media_type import IMAGE_TYPES
 from backend.common.consts.suggestion_state import SuggestionState
 from backend.common.consts.suggestion_type import SuggestionType, TYPE_NAMES
 from backend.common.datafeeds.datafeed_youtube import YoutubeVideoDetailsDatafeed
 from backend.common.helpers.outgoing_notification_helper import (
     OutgoingNotificationHelper,
+)
+from backend.common.helpers.similar_event_helper import (
+    MAX_SIMILAR_EVENTS,
+    SimilarEventHelper,
 )
 from backend.common.helpers.suggestion_fetcher import SuggestionFetcher
 from backend.common.memcache import MemcacheClient
@@ -31,6 +33,9 @@ from backend.common.models.user import User
 from backend.common.queries.event_query import EventListQuery
 from backend.common.sitevars.google_api_secret import GoogleApiSecret
 from backend.common.sitevars.slack_hook_urls import SlackHookUrls
+from backend.common.suggestions.offseason_event_candidate import (
+    candidate_event_from_suggestion,
+)
 from backend.common.suggestions.suggestion_reviewer import (
     REQUIRED_REVIEW_PERMISSIONS,
     SuggestionReviewer,
@@ -551,38 +556,18 @@ def _add_webcast_metadata(
         )
 
 
-def _normalized_event_name(name: str) -> str:
-    return " ".join(re.sub(r"[^a-z0-9]+", " ", name.lower()).split())
-
-
 def _find_similar_events(
-    name: str, events: List[Event], limit: int = 5
+    candidate: Event, events: List[Event], limit: int = MAX_SIMILAR_EVENTS
 ) -> List[Dict[str, str]]:
     """
-    Offseason events whose name or short name resembles the suggested name.
-    Comparison is case/punctuation-insensitive; containment (either direction)
-    counts as a strong match. Results are strongest-match first.
+    Existing events most likely to be the same event as the candidate, best
+    match first -- the same ranking the web review page shows, via
+    SimilarEventHelper (name, short name, acronyms, and location).
     """
-    normalized = _normalized_event_name(name)
-    if not normalized:
-        return []
-    scored = []
-    for event in events:
-        best = 0.0
-        for candidate in (event.name, event.short_name):
-            if not candidate:
-                continue
-            normalized_candidate = _normalized_event_name(candidate)
-            if not normalized_candidate:
-                continue
-            score = SequenceMatcher(a=normalized, b=normalized_candidate).ratio()
-            if normalized in normalized_candidate or normalized_candidate in normalized:
-                score = max(score, 0.9)
-            best = max(best, score)
-        if best > 0.5:
-            scored.append((best, event))
-    scored.sort(key=lambda pair: -pair[0])
-    return [{"key": e.key_name, "name": e.name} for _, e in scored[:limit]]
+    return [
+        {"key": e.key_name, "name": e.name}
+        for e in SimilarEventHelper.similar_events(candidate, events, limit=limit)
+    ]
 
 
 def _suggested_event_year(suggestion: Suggestion) -> int:
@@ -605,21 +590,22 @@ def _add_offseason_metadata(
         for y in (base_year, base_year - 1)
     }
     event_futures = {year: EventListQuery(year).fetch_async() for year in years}
+    # "Offseason" here means anything not in-season -- preseason and unlabeled
+    # events included -- matching the web review page. Returning events cross
+    # the offseason/preseason line often enough to matter.
     offseason_events_by_year = {
-        year: [
-            e for e in future.get_result() if e.event_type_enum == EventType.OFFSEASON
-        ]
+        year: [e for e in future.get_result() if e.is_offseason]
         for year, future in event_futures.items()
     }
 
     for i, suggestion in enumerate(suggestions):
-        name = suggestion.contents.get("name") or ""
+        candidate = candidate_event_from_suggestion(suggestion)
         year = _suggested_event_year(suggestion)
         serialized[i]["similar_events"] = _find_similar_events(
-            name, offseason_events_by_year[year]
+            candidate, offseason_events_by_year[year]
         )
         serialized[i]["similar_events_last_year"] = _find_similar_events(
-            name, offseason_events_by_year[year - 1]
+            candidate, offseason_events_by_year[year - 1]
         )
 
 

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -17,12 +17,12 @@ from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_type import EventType
 from backend.common.consts.media_type import MediaType
 from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.helpers.outgoing_notification_helper import (
+    OutgoingNotificationHelper,
+)
 from backend.common.helpers.similar_event_helper import (
     MAX_SIMILAR_EVENTS,
     SimilarEventHelper,
-)
-from backend.common.helpers.outgoing_notification_helper import (
-    OutgoingNotificationHelper,
 )
 from backend.common.memcache import MemcacheClient
 from backend.common.models.account import Account

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -17,6 +17,10 @@ from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_type import EventType
 from backend.common.consts.media_type import MediaType
 from backend.common.consts.suggestion_state import SuggestionState
+from backend.common.helpers.similar_event_helper import (
+    MAX_SIMILAR_EVENTS,
+    SimilarEventHelper,
+)
 from backend.common.helpers.outgoing_notification_helper import (
     OutgoingNotificationHelper,
 )
@@ -1213,44 +1217,67 @@ def _offseason_event(key: str, name: str, short_name: str = "") -> Event:
     )
 
 
+def _candidate(name: str) -> Event:
+    """An unsaved Event standing in for a suggested offseason event."""
+    return Event(name=name, year=2016, event_type_enum=EventType.OFFSEASON)
+
+
 def test_find_similar_events_case_insensitive(ndb_stub) -> None:
     events = [_offseason_event("2016cc", "CHEZY CHAMPS")]
-    assert _find_similar_events("chezy champs", events) == [
+    assert _find_similar_events(_candidate("chezy champs"), events) == [
         {"key": "2016cc", "name": "CHEZY CHAMPS"}
     ]
 
 
 def test_find_similar_events_matches_short_name(ndb_stub) -> None:
+    # Returning events are usually suggested under the name people call them,
+    # which is often the short name rather than the formal listing.
     events = [
         _offseason_event(
             "2016bb", "Southern California Robotics Invitational", "Beach Blitz"
         )
     ]
-    assert _find_similar_events("Beach Blitz", events) == [
+    assert _find_similar_events(_candidate("Beach Blitz"), events) == [
         {"key": "2016bb", "name": "Southern California Robotics Invitational"}
     ]
 
 
-def test_find_similar_events_containment(ndb_stub) -> None:
+def test_find_similar_events_acronym(ndb_stub) -> None:
     events = [_offseason_event("2016iri", "IROC - Indiana Robotics Off-Season")]
-    assert _find_similar_events("IROC", events) == [
+    assert _find_similar_events(_candidate("IROC"), events) == [
         {"key": "2016iri", "name": "IROC - Indiana Robotics Off-Season"}
     ]
 
 
 def test_find_similar_events_excludes_dissimilar(ndb_stub) -> None:
     events = [_offseason_event("2016cc", "Chezy Champs")]
-    assert _find_similar_events("Ranger Rumble", events) == []
+    assert _find_similar_events(_candidate("Ranger Rumble"), events) == []
 
 
 def test_find_similar_events_strongest_first_and_capped(ndb_stub) -> None:
     events = [
-        _offseason_event(f"2016ev{i}", f"Chezy Champs Qualifier {i}") for i in range(6)
+        _offseason_event(f"2016ev{i}", f"Chezy Champs Qualifier {i}") for i in range(10)
     ]
     events.append(_offseason_event("2016cc", "Chezy Champs"))
-    results = _find_similar_events("Chezy Champs", events)
-    assert len(results) == 5
+    results = _find_similar_events(_candidate("Chezy Champs"), events)
+    assert len(results) == MAX_SIMILAR_EVENTS
     assert results[0] == {"key": "2016cc", "name": "Chezy Champs"}
+
+
+def test_find_similar_events_matches_the_web_review_page(ndb_stub) -> None:
+    """Both review surfaces must rank the same way: they share the helper."""
+    events = [
+        _offseason_event(
+            "2016grits", "Georgia Robotics Invitational Tournament & Showcase"
+        ),
+        _offseason_event("2016cc", "Chezy Champs"),
+    ]
+    candidate = _candidate("GRITS")
+    from_api = [e["key"] for e in _find_similar_events(candidate, events)]
+    from_helper = [
+        e.key_name for e in SimilarEventHelper.similar_events(candidate, events)
+    ]
+    assert from_api == from_helper == ["2016grits"]
 
 
 def test_suggested_event_year(ndb_stub) -> None:

--- a/src/backend/common/helpers/similar_event_helper.py
+++ b/src/backend/common/helpers/similar_event_helper.py
@@ -282,8 +282,16 @@ def location_similarity(a: Event, b: Event) -> float:
 def event_similarity(a: Event, b: Event) -> float:
     """
     How likely two events are to be the same event, name plus location.
+
+    An existing event is matched on either its name or its short name -- a
+    returning "Beach Blitz" is usually suggested under that name, not as the
+    "Southern California Robotics Invitational" it is formally listed as.
     """
-    return name_similarity(a.name, b.name) + location_similarity(a, b)
+    candidate_names = [name for name in (b.name, b.short_name) if name]
+    name_score = max(
+        (name_similarity(a.name, name) for name in candidate_names), default=0.0
+    )
+    return name_score + location_similarity(a, b)
 
 
 class SimilarEventHelper:

--- a/src/backend/common/helpers/tests/similar_event_helper_test.py
+++ b/src/backend/common/helpers/tests/similar_event_helper_test.py
@@ -308,3 +308,27 @@ def test_name_similarity_of_only_generic_names() -> None:
     # names as written rather than comparing two empty strings.
     assert name_similarity("Off-Season Event", "Offseason Event") > SIMILARITY_THRESHOLD
     assert name_similarity("Robotics Competition", "Beach Blitz") < SIMILARITY_THRESHOLD
+
+
+def test_matches_an_existing_event_by_its_short_name() -> None:
+    """The formal listing and the name people use for an event can differ
+    completely; a returning event is usually suggested under the latter."""
+    candidate = Event(
+        name="Beach Blitz", year=2026, event_type_enum=EventType.OFFSEASON
+    )
+    formal = Event(
+        id="2025bb",
+        event_short="bb",
+        year=2025,
+        event_type_enum=EventType.OFFSEASON,
+        name="Southern California Robotics Invitational",
+        short_name="Beach Blitz",
+    )
+    unrelated = Event(
+        id="2025cc",
+        event_short="cc",
+        year=2025,
+        event_type_enum=EventType.OFFSEASON,
+        name="Chezy Champs",
+    )
+    assert SimilarEventHelper.similar_events(candidate, [unrelated, formal]) == [formal]

--- a/src/backend/common/suggestions/offseason_event_candidate.py
+++ b/src/backend/common/suggestions/offseason_event_candidate.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import Optional
+
+from backend.common.consts.event_type import EventType
+from backend.common.models.event import Event
+from backend.common.models.suggestion import Suggestion
+
+
+def _parse_date(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def candidate_event_from_suggestion(suggestion: Suggestion) -> Event:
+    """
+    The Event an offseason-event suggestion describes, as an unsaved model.
+
+    Both review surfaces -- the Jinja review page and the moderation API behind
+    the PWA -- compare this candidate against existing events to surface
+    returning events under new names, so they must build it the same way.
+    """
+    contents = suggestion.contents
+    start_date = _parse_date(contents.get("start_date"))
+    end_date = _parse_date(contents.get("end_date"))
+    venue = contents.get("venue_name")
+    city = contents.get("city")
+    state = contents.get("state")
+    country = contents.get("country")
+    event_type = contents.get("event_type", EventType.OFFSEASON)
+    return Event(
+        end_date=end_date,
+        event_type_enum=event_type or EventType.OFFSEASON,
+        district_key=None,
+        venue=venue,
+        city=city,
+        state_prov=state,
+        country=country,
+        venue_address="{}\n{}\n{}, {}, {}".format(
+            venue, contents.get("address"), city, state, country
+        ),
+        name=contents.get("name"),
+        start_date=start_date,
+        website=contents.get("website"),
+        year=start_date.year if start_date else None,
+        first_code=contents.get("first_code", None),
+        official=False,
+    )

--- a/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
@@ -15,6 +15,9 @@ from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, Year
 from backend.common.models.suggestion import Suggestion
+from backend.common.suggestions.offseason_event_candidate import (
+    candidate_event_from_suggestion,
+)
 from backend.common.queries.event_query import EventListQuery
 from backend.web.handlers.suggestions.suggestion_review_base import (
     SuggestionsReviewBase,
@@ -194,38 +197,8 @@ The Blue Alliance Admins\
     def _create_candidate_event(
         cls, suggestion: Suggestion
     ) -> Tuple[Union[int, str], Event]:
-        start_date = None
-        end_date = None
-        try:
-            start_date = datetime.strptime(
-                suggestion.contents["start_date"], "%Y-%m-%d"
-            )
-            end_date = datetime.strptime(suggestion.contents["end_date"], "%Y-%m-%d")
-        except ValueError:
-            pass
-
-        venue = suggestion.contents["venue_name"]
-        address = suggestion.contents["address"]
-        city = suggestion.contents["city"]
-        state = suggestion.contents["state"]
-        country = suggestion.contents["country"]
-        address = "{}\n{}\n{}, {}, {}".format(venue, address, city, state, country)
-        event_type = suggestion.contents.get("event_type", EventType.OFFSEASON)
-        return none_throws(suggestion.key.id()), Event(
-            end_date=end_date,
-            event_type_enum=event_type or EventType.OFFSEASON,
-            district_key=None,
-            venue=venue,
-            city=city,
-            state_prov=state,
-            country=country,
-            venue_address=address,
-            name=suggestion.contents["name"],
-            start_date=start_date,
-            website=suggestion.contents["website"],
-            year=start_date.year if start_date else None,
-            first_code=suggestion.contents.get("first_code", None),
-            official=False,
+        return none_throws(suggestion.key.id()), candidate_event_from_suggestion(
+            suggestion
         )
 
     @classmethod

--- a/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_offseason_event_review_controller.py
@@ -15,10 +15,10 @@ from backend.common.manipulators.event_manipulator import EventManipulator
 from backend.common.models.event import Event
 from backend.common.models.keys import EventKey, Year
 from backend.common.models.suggestion import Suggestion
+from backend.common.queries.event_query import EventListQuery
 from backend.common.suggestions.offseason_event_candidate import (
     candidate_event_from_suggestion,
 )
-from backend.common.queries.event_query import EventListQuery
 from backend.web.handlers.suggestions.suggestion_review_base import (
     SuggestionsReviewBase,
 )


### PR DESCRIPTION
Follow-up to #10436. That PR replaced the web review page's similar-events scoring with `SimilarEventHelper`, but the **PWA's** offseason queue gets its list from the moderation API, which still ran the old `SequenceMatcher` + containment rule against `OFFSEASON`-typed events only. Same suggestion, two review surfaces, different matches.

## What changes

- **`moderation.py` delegates to `SimilarEventHelper`** and fetches the same event set the web page now does — everything `is_offseason` (not in-season), so preseason and unlabeled events count. Output shape is unchanged (`[{key, name}]`), so no OpenAPI or client change.
- **One shared candidate builder.** The web controller built the suggestion's candidate `Event` inline; that's now `candidate_event_from_suggestion()` in `backend/common/suggestions/`, used by both the web controller and the API, so the two can't drift on location fields either (the helper's location bonuses depend on them).
- **Helper extension: match on `short_name` too.** The merged helper scored `name` only. The moderation API already matched short names, and dropping that would have been a regression there — a returning "Beach Blitz" is suggested as *Beach Blitz*, not as the "Southern California Robotics Invitational" it's formally listed under. Existing events are now scored on the better of name / short name. The web page benefits from this as well.

## Testing

105 tests across the helper, moderation, and offseason-controller suites. The moderation similar-events tests now build a real candidate `Event`, cover short-name and acronym matches, the dissimilar case, the `MAX_SIMILAR_EVENTS` cap, and — the point of the PR — assert that the API ranks **identically** to `SimilarEventHelper` for the same inputs. The helper gains a short-name test. `make lint` and `make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)