### PR TITLE
Document how to get screenshots onto PRs (with a reusable capture script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,38 @@ FRC data has several quirks that are important to understand when working with h
 - **Reliability by year**: Data becomes more reliable around 2010. Prior to 2006, data is uncommon.
 - **Elimination format**: FIRST implemented Double Elimination brackets starting in the 2023 season. Prior seasons used a single-elimination best-of-three bracket.
 
+## Screenshots for PRs
+
+Two paths, depending on what the page is.
+
+**PWA pages** are screenshotted by CI. List them in the PR template's "Screenshot Pages" section
+(`- /path Display Name`) and the bot posts them on the PR.
+
+**Web-service (Jinja) pages**, including anything behind a login that CI cannot reach — account,
+admin, and suggestion-review pages — are rendered locally through the Flask test client and
+screenshotted against the running dev server's CSS:
+
+1. Have the dev server up (`docker compose up`); it serves the CSS/JS at `http://localhost:8080`.
+2. Render the page with a **throwaway** pytest in `src/backend/web/handlers/tests/`. Use the
+   fixtures the real tests use (`web_client`, `login_user`; set `login_user.permissions` and
+   `login_user.has_permission.return_value = True` for gated pages), seed whatever models the page
+   needs, `GET` it, and write `response.data` to a file after inserting
+   `<base href="http://localhost:8080/">` right after `<head>`. Run it with
+   `make test ARGS='src/backend/web/handlers/tests/<file> -q -s'`, then **delete the file** — it
+   is a tool, not a test. Redact secrets the page renders (API keys, tokens) in the seed data.
+3. Screenshot: `cd pwa && node ../ops/pr_screenshots/screenshot_html.mjs /tmp/page.html
+   /tmp/page.png '[data-testid=...]'`. Pass a selector for an element inside the content you want;
+   the script captures its surrounding content container. Do not target `div.container` — the
+   navbar is one too.
+4. Publish. GitHub has no API for attaching images to comments, so the repo keeps screenshots on
+   the `ci-screenshots` branch (the CI bot uses it too). In a worktree of that branch, copy the
+   PNGs in as `pr-<PR number>-<slug>-<unix timestamp>.png`, commit
+   (`Add screenshots for PR #<N>`), push, and reference them in a PR comment as
+   `![alt](https://github.com/the-blue-alliance/the-blue-alliance/raw/ci-screenshots/<file>)`.
+
+Look at every screenshot before posting it: an identical byte size across two supposedly different
+pages means the locator grabbed the wrong element.
+
 ## Notes
 - The PWA (Progressive Web App) is a separate project in `pwa/` with its own AGENTS.md
 - GAE deployment via `ops/deploy/` scripts (maintainers only)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,8 +218,9 @@ screenshotted against the running dev server's CSS:
    `<base href="http://localhost:8080/">` right after `<head>`. Run it with
    `make test ARGS='src/backend/web/handlers/tests/<file> -q -s'`, then **delete the file** — it
    is a tool, not a test. Redact secrets the page renders (API keys, tokens) in the seed data.
-3. Screenshot: `cd pwa && node ../ops/pr_screenshots/screenshot_html.mjs /tmp/page.html
-   /tmp/page.png '[data-testid=...]'`. Pass a selector for an element inside the content you want;
+3. Screenshot: `cd pwa && node scripts/screenshot_html.mjs /tmp/page.html /tmp/page.png
+   '[data-testid=...]'`. (The script lives in `pwa/` because Node resolves `@playwright/test`
+   from the script's own directory, not from where you run it.) Pass a selector for an element inside the content you want;
    the script captures its surrounding content container. Do not target `div.container` — the
    navbar is one too.
 4. Publish. GitHub has no API for attaching images to comments, so the repo keeps screenshots on

--- a/ops/pr_screenshots/screenshot_html.mjs
+++ b/ops/pr_screenshots/screenshot_html.mjs
@@ -1,0 +1,52 @@
+// Screenshot a saved HTML page (e.g. one rendered through the Flask test
+// client) using the running dev server for its CSS/JS.
+//
+//   cd pwa && node ../ops/pr_screenshots/screenshot_html.mjs <in.html> <out.png> [selector] [width]
+//
+// Run from pwa/ so `@playwright/test` resolves. The HTML should carry
+// `<base href="http://localhost:8080/">` so relative asset URLs hit the dev
+// server. With a selector, only that element's nearest `.container` (or the
+// element itself, if none) is captured; without one, the full page is.
+import { chromium } from "@playwright/test";
+import { readFileSync } from "fs";
+
+const [, , input, output, selector, widthArg] = process.argv;
+if (!input || !output) {
+  console.error(
+    "usage: screenshot_html.mjs <in.html> <out.png> [selector] [width]"
+  );
+  process.exit(2);
+}
+const width = Number(widthArg ?? 1180);
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width, height: 900 } });
+// Same origin as the <base href>, so relative asset requests resolve there.
+await page.goto("http://localhost:8080/", { waitUntil: "domcontentloaded" });
+await page.setContent(readFileSync(input, "utf8"), {
+  waitUntil: "networkidle",
+});
+
+if (selector) {
+  const target = page.locator(selector).first();
+  if ((await target.count()) === 0) {
+    console.error(`selector matched nothing: ${selector}`);
+    await browser.close();
+    process.exit(1);
+  }
+  // Prefer the content container around the element; base.html's navbar is
+  // also a .container, so never grab "the first .container" on the page.
+  const container = target.locator(
+    'xpath=ancestor::div[contains(@class,"container")][1]'
+  );
+  const box = await (
+    (await container.count()) ? container : target
+  ).boundingBox();
+  await page.screenshot({
+    path: output,
+    clip: { ...box, height: Math.min(box.height, 1400) },
+  });
+} else {
+  await page.screenshot({ path: output, fullPage: true });
+}
+await browser.close();
+console.log(`wrote ${output}`);

--- a/pwa/scripts/screenshot_html.mjs
+++ b/pwa/scripts/screenshot_html.mjs
@@ -1,19 +1,20 @@
 // Screenshot a saved HTML page (e.g. one rendered through the Flask test
 // client) using the running dev server for its CSS/JS.
 //
-//   cd pwa && node ../ops/pr_screenshots/screenshot_html.mjs <in.html> <out.png> [selector] [width]
+//   cd pwa && node scripts/screenshot_html.mjs <in.html> <out.png> [selector] [width]
 //
-// Run from pwa/ so `@playwright/test` resolves. The HTML should carry
+// Lives in pwa/ because Node resolves `@playwright/test` from the script's own
+// location, and only pwa/node_modules has it. The HTML should carry
 // `<base href="http://localhost:8080/">` so relative asset URLs hit the dev
 // server. With a selector, only that element's nearest `.container` (or the
 // element itself, if none) is captured; without one, the full page is.
-import { chromium } from "@playwright/test";
-import { readFileSync } from "fs";
+import { chromium } from '@playwright/test';
+import { readFileSync } from 'fs';
 
 const [, , input, output, selector, widthArg] = process.argv;
 if (!input || !output) {
   console.error(
-    "usage: screenshot_html.mjs <in.html> <out.png> [selector] [width]"
+    'usage: screenshot_html.mjs <in.html> <out.png> [selector] [width]',
   );
   process.exit(2);
 }
@@ -21,9 +22,9 @@ const width = Number(widthArg ?? 1180);
 const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width, height: 900 } });
 // Same origin as the <base href>, so relative asset requests resolve there.
-await page.goto("http://localhost:8080/", { waitUntil: "domcontentloaded" });
-await page.setContent(readFileSync(input, "utf8"), {
-  waitUntil: "networkidle",
+await page.goto('http://localhost:8080/', { waitUntil: 'domcontentloaded' });
+await page.setContent(readFileSync(input, 'utf8'), {
+  waitUntil: 'networkidle',
 });
 
 if (selector) {
@@ -36,7 +37,7 @@ if (selector) {
   // Prefer the content container around the element; base.html's navbar is
   // also a .container, so never grab "the first .container" on the page.
   const container = target.locator(
-    'xpath=ancestor::div[contains(@class,"container")][1]'
+    'xpath=ancestor::div[contains(@class,"container")][1]',
   );
   const box = await (
     (await container.count()) ? container : target


### PR DESCRIPTION
## Why

PWA pages get screenshots from CI. Web-service pages behind a login — account, admin, suggestion review — don't, and GitHub has no API for attaching images to PR comments. Three PRs this week (#10520, #10524, #10527) each needed the same workaround worked out by hand. This writes it down in `AGENTS.md` and turns the fiddly capture step into a script.

## The method

1. Render the page through the **Flask test client** with the usual fixtures (`web_client`, `login_user` with permissions set) in a throwaway pytest that writes the HTML with `<base href="http://localhost:8080/">` injected.
2. `ops/pr_screenshots/screenshot_html.mjs` loads that HTML on the dev server's origin (so CSS/JS resolve) and captures the content container around a selector.
3. Publish PNGs to the **`ci-screenshots` branch** — the same place the CI bot puts its screenshots — and link them by raw URL in a comment.

The doc calls out the two traps that bit me: `div.container` also matches the navbar, and identical byte sizes across two "different" screenshots mean the wrong element was captured.

## Proof

Per your ask, the instructions are exercised end-to-end below on a **throwaway template change** (a coloured background on the suggestion-review home) that is **not** in this diff — the diff is docs plus the script. The before/after screenshots in the comment were produced by following the steps exactly as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)