### PR TITLE
[pwa] Speed up data loading: non-blocking Nexus + historical staleTime

### DIFF
--- a/pwa/app/routes/district.$districtAbbreviation.champs.$year.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.champs.$year.tsx
@@ -39,6 +39,7 @@ import {
 } from '~/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { sortMatchComparator } from '~/lib/matchUtils';
+import { staleTimeForYear } from '~/lib/queryClient';
 import { cn, publicCacheControlHeaders } from '~/lib/utils';
 
 const REFETCH_INTERVAL = 60_000;
@@ -644,6 +645,10 @@ function ChampsPage() {
     Route.useLoaderData();
   const districtKey = `${year}${abbreviation}`;
 
+  const isLivePolling = year >= currentSeason;
+  const pollInterval = isLivePolling ? REFETCH_INTERVAL : (false as const);
+  const yearStaleTime = staleTimeForYear(year);
+
   // Fetch district history to know which years this district existed
   const districtHistoryQuery = useQuery({
     ...getDistrictHistoryOptions({
@@ -680,22 +685,25 @@ function ChampsPage() {
   }, [runCountdownTimer]);
 
   useEffect(() => {
+    if (!isLivePolling) return;
     runCountdownTimer();
     return () => {
       if (countdownRef.current) clearInterval(countdownRef.current);
     };
-  }, [runCountdownTimer]);
+  }, [runCountdownTimer, isLivePolling]);
 
   // Fetch district team keys
   const districtTeamsQuery = useQuery({
     ...getDistrictTeamsKeysOptions({ path: { district_key: districtKey } }),
-    refetchInterval: REFETCH_INTERVAL,
+    staleTime: yearStaleTime,
+    refetchInterval: pollInterval,
   });
 
   // Fetch all events for the year and filter to CMP divisions
   const allEventsQuery = useQuery({
     ...getEventsByYearOptions({ path: { year } }),
-    refetchInterval: REFETCH_INTERVAL,
+    staleTime: yearStaleTime,
+    refetchInterval: pollInterval,
   });
 
   const cmpDivisions: Event[] = (allEventsQuery.data ?? []).filter(
@@ -708,21 +716,24 @@ function ChampsPage() {
   const matchesQueries = useQueries({
     queries: cmpDivisions.map((div) => ({
       ...getEventMatchesOptions({ path: { event_key: div.key } }),
-      refetchInterval: REFETCH_INTERVAL,
+      staleTime: yearStaleTime,
+      refetchInterval: pollInterval,
     })),
   });
 
   const rankingsQueries = useQueries({
     queries: cmpDivisions.map((div) => ({
       ...getEventRankingsOptions({ path: { event_key: div.key } }),
-      refetchInterval: REFETCH_INTERVAL,
+      staleTime: yearStaleTime,
+      refetchInterval: pollInterval,
     })),
   });
 
   const colorsQueries = useQueries({
     queries: cmpDivisions.map((div) => ({
       ...getEventColorsOptions({ path: { eventKey: div.key } }),
-      refetchInterval: REFETCH_INTERVAL,
+      staleTime: yearStaleTime,
+      refetchInterval: pollInterval,
     })),
   });
 
@@ -735,11 +746,12 @@ function ChampsPage() {
 
   const prevFetchingRef = useRef(false);
   useEffect(() => {
+    if (!isLivePolling) return;
     if (prevFetchingRef.current && !isFetchingAny) {
       resetCountdown();
     }
     prevFetchingRef.current = isFetchingAny;
-  }, [isFetchingAny, resetCountdown]);
+  }, [isFetchingAny, resetCountdown, isLivePolling]);
 
   // Build a map from eventKey -> colors query result
   const eventColorsMap = new Map<string, ColorsQueryResult>();
@@ -776,11 +788,13 @@ function ChampsPage() {
           {displayName} at FIRST Championship {year}
         </h1>
         <div className="flex items-center gap-2">
-          <span
-            className="rounded border px-2 py-1 text-xs text-muted-foreground"
-          >
-            {isFetchingAny ? 'Refreshing…' : `Auto-refresh in ${countdown}s`}
-          </span>
+          {isLivePolling && (
+            <span
+              className="rounded border px-2 py-1 text-xs text-muted-foreground"
+            >
+              {isFetchingAny ? 'Refreshing…' : `Auto-refresh in ${countdown}s`}
+            </span>
+          )}
           <YearSelector
             currentLabel={String(year)}
             triggerClassName="w-24"

--- a/pwa/app/routes/district.$districtAbbreviation.{-$year}.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.{-$year}.tsx
@@ -10,13 +10,15 @@ import {
   Event,
   EventType,
   Team,
-  getDistrictAdvancement,
-  getDistrictAwards,
-  getDistrictEvents,
-  getDistrictHistory,
-  getDistrictRankings,
-  getDistrictTeams,
 } from '~/api/tba/read';
+import {
+  getDistrictAdvancementOptions,
+  getDistrictAwardsOptions,
+  getDistrictEventsOptions,
+  getDistrictHistoryOptions,
+  getDistrictRankingsOptions,
+  getDistrictTeamsOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { TitledCard } from '~/components/tba/cards';
 import { DataTable } from '~/components/tba/dataTable';
 import {
@@ -44,9 +46,11 @@ import {
   getEventDateString,
   sortEvents,
 } from '~/lib/eventUtils';
+import { staleTimeForYear } from '~/lib/queryClient';
 import { sortTeams } from '~/lib/teamUtils';
 import {
   USA_STATE_ABBREVIATION_TO_FULL,
+  doThrowNotFound,
   joinComponents,
   parseParamsForYearElseDefault,
   publicCacheControlHeaders,
@@ -55,66 +59,79 @@ import {
 export const Route = createFileRoute(
   '/district/$districtAbbreviation/{-$year}',
 )({
-  loader: async ({ params, context: { currentSeason } }) => {
+  loader: async ({ params, context: { queryClient, currentSeason } }) => {
     const year = parseParamsForYearElseDefault(currentSeason, params);
     if (year === undefined) {
       throw notFound();
     }
 
+    const districtKey = `${year}${params.districtAbbreviation}`;
+    const yearStaleTime = staleTimeForYear(year);
+
     const [districtHistory, rankings, teams, events, awards, advancement] =
       await Promise.all([
-        getDistrictHistory({
-          path: {
-            district_abbreviation: params.districtAbbreviation,
-          },
-        }),
-        getDistrictRankings({
-          path: {
-            district_key: `${year}${params.districtAbbreviation}`,
-          },
-        }),
-        getDistrictTeams({
-          path: {
-            district_key: `${year}${params.districtAbbreviation}`,
-          },
-        }),
-        getDistrictEvents({
-          path: {
-            district_key: `${year}${params.districtAbbreviation}`,
-          },
-        }),
-        getDistrictAwards({
-          path: {
-            district_key: `${year}${params.districtAbbreviation}`,
-          },
-        }),
-        getDistrictAdvancement({
-          path: {
-            district_key: `${year}${params.districtAbbreviation}`,
-          },
-        }),
+        queryClient
+          .ensureQueryData({
+            ...getDistrictHistoryOptions({
+              path: { district_abbreviation: params.districtAbbreviation },
+            }),
+            staleTime: yearStaleTime,
+          })
+          .catch(doThrowNotFound),
+        queryClient
+          .ensureQueryData({
+            ...getDistrictRankingsOptions({
+              path: { district_key: districtKey },
+            }),
+            staleTime: yearStaleTime,
+          })
+          .catch(() => null),
+        queryClient
+          .ensureQueryData({
+            ...getDistrictTeamsOptions({ path: { district_key: districtKey } }),
+            staleTime: yearStaleTime,
+          })
+          .catch(() => []),
+        queryClient
+          .ensureQueryData({
+            ...getDistrictEventsOptions({
+              path: { district_key: districtKey },
+            }),
+            staleTime: yearStaleTime,
+          })
+          .catch(() => []),
+        queryClient
+          .ensureQueryData({
+            ...getDistrictAwardsOptions({
+              path: { district_key: districtKey },
+            }),
+            staleTime: yearStaleTime,
+          })
+          .catch(() => []),
+        queryClient
+          .ensureQueryData({
+            ...getDistrictAdvancementOptions({
+              path: { district_key: districtKey },
+            }),
+            staleTime: yearStaleTime,
+          })
+          .catch(() => null),
       ]);
 
-    if (
-      districtHistory.data === undefined ||
-      rankings.data === undefined ||
-      teams.data === undefined ||
-      events.data === undefined ||
-      awards.data === undefined
-    ) {
+    if (districtHistory.length === 0) {
       throw notFound();
     }
 
     // The api returns a lot of teams that previously played in the district but didn't in the given year
     const actuallyActiveRankings =
-      rankings.data === null
+      rankings === null
         ? null
-        : rankings.data.filter(
+        : rankings.filter(
             (r) => r.point_total > 0 && (r.event_points?.length ?? 0) > 0,
           );
 
     const today = Temporal.Now.plainDateISO();
-    const seasonIsComplete = events.data.every(
+    const seasonIsComplete = events.every(
       (e) =>
         Temporal.PlainDate.compare(Temporal.PlainDate.from(e.end_date), today) <
         0,
@@ -124,20 +141,20 @@ export const Route = createFileRoute(
     // Otherwise, show all teams (since it may be mid-season and some may not have played yet, thus have no ranking)
     const actuallyActiveTeams =
       actuallyActiveRankings === null || !seasonIsComplete
-        ? teams.data
-        : teams.data.filter((team) =>
+        ? teams
+        : teams.filter((team) =>
             actuallyActiveRankings.find((r) => r.team_key === team.key),
           );
 
     return {
       abbreviation: params.districtAbbreviation,
       year,
-      districtHistory: districtHistory.data,
+      districtHistory,
       rankings: actuallyActiveRankings,
       teams: actuallyActiveTeams,
-      events: events.data,
-      awards: awards.data,
-      advancementCutoffs: advancement.data?.cutoffs ?? null,
+      events,
+      awards,
+      advancementCutoffs: advancement?.cutoffs ?? null,
     };
   },
   headers: publicCacheControlHeaders(),

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -178,14 +178,6 @@ export const Route = createFileRoute('/event/$eventKey')({
         staleTime: eventStaleTime,
       })
       .catch(() => []);
-    const nexusQuery = queryClient
-      .ensureQueryData({
-        ...getEventNexusInfoOptions({
-          path: { event_key: params.eventKey },
-        }),
-        staleTime: 30_000,
-      })
-      .catch(() => null);
 
     const event = await queryClient
       .ensureQueryData({
@@ -226,7 +218,7 @@ export const Route = createFileRoute('/event/$eventKey')({
         .catch(() => undefined);
     }
 
-    await Promise.all([matchesQuery, alliancesQuery, nexusQuery]);
+    await Promise.all([matchesQuery, alliancesQuery]);
 
     // event needs to be returned so we can access it in meta
     return { eventKey: params.eventKey, event };

--- a/pwa/app/routes/events.{-$year}.tsx
+++ b/pwa/app/routes/events.{-$year}.tsx
@@ -30,6 +30,7 @@ import {
   groupEventsBySections,
   sortEventsComparator,
 } from '~/lib/eventUtils';
+import { staleTimeForYear } from '~/lib/queryClient';
 import {
   parseParamsForYearElseDefault,
   pluralize,
@@ -52,11 +53,16 @@ export const Route = createFileRoute('/events/{-$year}')({
       throw notFound();
     }
 
+    const yearStaleTime = staleTimeForYear(year);
     await Promise.all([
-      queryClient.ensureQueryData(getEventsByYearOptions({ path: { year } })),
-      queryClient.ensureQueryData(
-        getDistrictsByYearOptions({ path: { year } }),
-      ),
+      queryClient.ensureQueryData({
+        ...getEventsByYearOptions({ path: { year } }),
+        staleTime: yearStaleTime,
+      }),
+      queryClient.ensureQueryData({
+        ...getDistrictsByYearOptions({ path: { year } }),
+        staleTime: yearStaleTime,
+      }),
     ]);
 
     return { year };
@@ -92,11 +98,14 @@ export const Route = createFileRoute('/events/{-$year}')({
 
 function YearEventsPage() {
   const { year } = Route.useLoaderData();
+  const yearStaleTime = staleTimeForYear(year);
   const { data: events } = useSuspenseQuery({
     ...getEventsByYearOptions({ path: { year } }),
+    staleTime: yearStaleTime,
   });
   const { data: districts } = useSuspenseQuery({
     ...getDistrictsByYearOptions({ path: { year } }),
+    staleTime: yearStaleTime,
   });
   const validYears = useValidYears();
   const [inView, setInView] = useState<Set<string>>(new Set());

--- a/pwa/app/routes/insights.{-$year}.tsx
+++ b/pwa/app/routes/insights.{-$year}.tsx
@@ -5,17 +5,18 @@ import {
   type InsightV2Leaderboard,
   type InsightV2Streak,
   type InsightV2Timeseries,
-  getInsightsV2Year,
 } from '~/api/tba/read';
+import { getInsightsV2YearOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import { Leaderboard } from '~/components/tba/leaderboard';
 import { StreakInsight } from '~/components/tba/streakInsight';
 import { SuccessRateInsight } from '~/components/tba/successRateInsight';
 import { TimeseriesInsight } from '~/components/tba/timeseriesInsight';
 import { YearSelector } from '~/components/tba/yearSelector';
+import { STALE_TIME, staleTimeForYear } from '~/lib/queryClient';
 import { publicCacheControlHeaders, useValidYears } from '~/lib/utils';
 
 export const Route = createFileRoute('/insights/{-$year}')({
-  loader: async ({ params }) => {
+  loader: async ({ params, context: { queryClient } }) => {
     let numericYear = -1;
     if (params.year === undefined || params.year === '') {
       numericYear = 0;
@@ -30,15 +31,13 @@ export const Route = createFileRoute('/insights/{-$year}')({
       throw notFound();
     }
 
-    const insights = await getInsightsV2Year({
-      path: { year: numericYear },
+    const insights = await queryClient.ensureQueryData({
+      ...getInsightsV2YearOptions({ path: { year: numericYear } }),
+      staleTime:
+        numericYear === 0 ? STALE_TIME.DEFAULT : staleTimeForYear(numericYear),
     });
 
-    if (insights.data === undefined) {
-      throw new Error('Failed to load insights');
-    }
-
-    if (insights.data.length === 0) {
+    if (insights.length === 0) {
       throw notFound();
     }
 
@@ -47,7 +46,7 @@ export const Route = createFileRoute('/insights/{-$year}')({
     const timeseries: InsightV2Timeseries[] = [];
     const successRates: InsightV2GameStats[] = [];
 
-    for (const insight of insights.data) {
+    for (const insight of insights) {
       switch (insight.category) {
         case 'leaderboard':
           leaderboards.push(insight);

--- a/pwa/tests/data-caching.spec.ts
+++ b/pwa/tests/data-caching.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test('event page fetches Nexus from the browser, not the SSR loader', async ({
+  page,
+}) => {
+  const nexusRequests: string[] = [];
+  page.on('request', (r) => {
+    if (r.url().includes('/nexus_info')) nexusRequests.push(r.url());
+  });
+
+  await page.goto('/event/2024mil');
+  await page.locator('body[data-hydrated]').waitFor();
+
+  await expect.poll(() => nexusRequests.length).toBeGreaterThan(0);
+});
+
+test('past-year district championship page stops polling', async ({ page }) => {
+  await page.clock.install();
+
+  const eventsRequests: string[] = [];
+  page.on('request', (r) => {
+    if (r.url().includes('/api/v3/events/2019')) eventsRequests.push(r.url());
+  });
+
+  await page.goto('/district/fim/champs/2019');
+  await page.locator('body[data-hydrated]').waitFor();
+  await expect.poll(() => eventsRequests.length).toBeGreaterThan(0);
+
+  const afterLoad = eventsRequests.length;
+  await page.clock.fastForward('03:00');
+  await page.waitForTimeout(500);
+
+  expect(eventsRequests.length).toBe(afterLoad);
+});


### PR DESCRIPTION
## What

Two low-risk changes to the PWA data-fetching lifecycle.

### Nexus off the event-page critical path

`event.$eventKey.tsx`'s loader used to `await Promise.all([matchesQuery, alliancesQuery, nexusQuery])`. Nexus (live queue status) is a third-party dependency that misses the SSR cache often (30s staleTime) and is not needed for first paint. When it's slow or down, every event-page SSR render waits on it.

The loader prefetch is removed; the page component already has its own `useQuery` for Nexus, so it streams in client-side after hydration.

### `staleTimeForYear` for historical, year-scoped data

`team.$teamNumber.{-$year}.tsx` already threads `staleTimeForYear(year)` through its loader and component queries so past-season pages are served from cache for an hour. Several other year-scoped routes never opted in and refetched large immutable payloads every 60s and on every client back-navigation:

| Route | Change |
|---|---|
| `events.{-$year}.tsx` | `staleTimeForYear` on the loader (`getEventsByYear` + `getDistrictsByYear`) and both component `useSuspenseQuery` calls |
| `district.$districtAbbreviation.champs.$year.tsx` | `staleTimeForYear` on every query; `refetchInterval` gated to `year >= currentSeason` so past-year championship pages stop polling ~6 endpoints/division forever (the auto-refresh badge/timer are gated the same way) |
| `insights.{-$year}.tsx` | raw-SDK loader → `queryClient.ensureQueryData(getInsightsV2YearOptions…)` with `staleTimeForYear` (year 0 "Overall" stays at `DEFAULT`) |
| `district.$districtAbbreviation.{-$year}.tsx` | 6 raw-SDK loader calls → `queryClient.ensureQueryData(*Options…)` with `staleTimeForYear` |

**Behavior note (district year page):** a missing district still 404s (empty history), but a lone failure of the teams/events/awards/advancement fetch now degrades to a partial render instead of a full 404. These failures are rare and already Sentry-reported.

## Tests

- New `tests/data-caching.spec.ts`:
  1. Nexus is now fetched as a browser request on `/event/2024mil` (fails on the old prefetch-into-dehydrated-cache behavior).
  2. `/district/fim/champs/2019` makes no further requests after `page.clock.fastForward('03:00')` (fails on the old always-on `refetchInterval`).
- Existing coverage carries the rest: `routes.spec.ts` smoke-tests all touched routes; `district-rankings-advancement.spec.ts` deep-tests the district-year page through the new `queryClient` loader path; `queryClient.test.ts` covers `staleTimeForYear`.
- `pnpm run typecheck` + `pnpm run lint` clean.

## Screenshot Pages

- /event/2024mil
- /events/2015
- /insights/2015
- /district/fim/2015
- /district/fim/champs/2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)