### PR TITLE
[pwa] Render SmugMug galleries and event videos in the event Media tab

### DIFF
--- a/pwa/app/components/tba/smugmugAlbumGallery.tsx
+++ b/pwa/app/components/tba/smugmugAlbumGallery.tsx
@@ -1,0 +1,60 @@
+import { Media } from '~/api/tba/read';
+import { getMediaLinkUrl } from '~/lib/mediaUtils';
+
+export default function SmugmugAlbumGallery({
+  albums,
+}: {
+  albums: Media[];
+}): React.JSX.Element | null {
+  if (albums.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+      data-testid="smugmug-album-gallery"
+    >
+      {albums.map((album, index) => (
+        <SmugmugAlbumCard key={index} album={album} />
+      ))}
+    </div>
+  );
+}
+
+function SmugmugAlbumCard({
+  album,
+}: {
+  album: Media;
+}): React.JSX.Element | null {
+  if (album.type !== 'smugmug-album') {
+    return null;
+  }
+
+  const linkUrl = getMediaLinkUrl(album);
+  const coverUrl = album.details?.cover_url_med;
+  const title = album.details?.title || 'SmugMug Album';
+  const imageCount = album.details?.image_count ?? 0;
+
+  if (!linkUrl || !coverUrl) {
+    return null;
+  }
+
+  return (
+    <a
+      href={linkUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="block overflow-hidden rounded-lg border-2 border-neutral-300
+        hover:border-neutral-400"
+    >
+      <img src={coverUrl} alt={title} className="h-40 w-full object-cover" />
+      <div className="px-2 py-1">
+        <div className="truncate text-sm font-medium">{title}</div>
+        <div className="text-xs text-muted-foreground">
+          {imageCount} {imageCount === 1 ? 'photo' : 'photos'}
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/pwa/app/lib/mediaUtils.test.ts
+++ b/pwa/app/lib/mediaUtils.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Media } from '~/api/tba/read';
+import {
+  getEventVideos,
+  getMediaLinkUrl,
+  getSmugmugAlbums,
+} from '~/lib/mediaUtils';
+
+function smugmugAlbum(overrides: Partial<Media> = {}): Media {
+  return {
+    type: 'smugmug-album',
+    foreign_key: 'RRGxMR',
+    team_keys: [],
+    preferred: false,
+    view_url: 'https://nefirst.smugmug.com/2026-INGENUITY-Awards',
+    direct_url: 'https://photos.smugmug.com/i-57rxPBW-L.png',
+    details: {
+      cover_url: 'https://photos.smugmug.com/i-57rxPBW-L.png',
+      cover_url_med: 'https://photos.smugmug.com/i-57rxPBW-M.png',
+      cover_url_sm: 'https://photos.smugmug.com/i-57rxPBW-S.png',
+      image_count: 1626,
+      title: '2026 New England District Championship',
+      web_uri: 'https://nefirst.smugmug.com/2026-INGENUITY-Awards',
+    },
+    ...overrides,
+  } as Media;
+}
+
+function smugmugPhoto(overrides: Partial<Media> = {}): Media {
+  return {
+    type: 'smugmug-photo',
+    foreign_key: 'xxrbgK6',
+    team_keys: ['frc254'],
+    preferred: false,
+    view_url: 'https://nefirst.smugmug.com/i-xxrbgK6',
+    direct_url: 'https://photos.smugmug.com/x-L.jpg',
+    details: {
+      caption: '',
+      image_url: 'https://photos.smugmug.com/x-L.jpg',
+      image_url_med: 'https://photos.smugmug.com/x-M.jpg',
+      image_url_sm: 'https://photos.smugmug.com/x-S.jpg',
+      title: 'Robot',
+      web_uri: 'https://nefirst.smugmug.com/i-xxrbgK6',
+    },
+    ...overrides,
+  } as Media;
+}
+
+function youtubeMedia(foreignKey: string): Media {
+  return {
+    type: 'youtube',
+    foreign_key: foreignKey,
+    team_keys: [],
+    preferred: false,
+    view_url: `https://youtu.be/${foreignKey}`,
+    direct_url: `https://img.youtube.com/vi/${foreignKey}/hqdefault.jpg`,
+    details: {},
+  } as Media;
+}
+
+describe.concurrent('getMediaLinkUrl', () => {
+  test('smugmug-album links to its web_uri', () => {
+    expect(getMediaLinkUrl(smugmugAlbum())).toBe(
+      'https://nefirst.smugmug.com/2026-INGENUITY-Awards',
+    );
+  });
+
+  test('smugmug-photo links to its web_uri', () => {
+    expect(getMediaLinkUrl(smugmugPhoto())).toBe(
+      'https://nefirst.smugmug.com/i-xxrbgK6',
+    );
+  });
+
+  test('smugmug falls back to view_url when details are missing', () => {
+    const album = smugmugAlbum({ details: undefined });
+    expect(getMediaLinkUrl(album)).toBe(
+      'https://nefirst.smugmug.com/2026-INGENUITY-Awards',
+    );
+  });
+});
+
+describe.concurrent('getSmugmugAlbums', () => {
+  test('keeps only smugmug-album media', () => {
+    const media = [smugmugAlbum(), smugmugPhoto(), youtubeMedia('abc')];
+    expect(getSmugmugAlbums(media)).toEqual([smugmugAlbum()]);
+  });
+
+  test('returns an empty array when there are no albums', () => {
+    expect(getSmugmugAlbums([youtubeMedia('abc')])).toEqual([]);
+  });
+});
+
+describe.concurrent('getEventVideos', () => {
+  test('keeps only youtube media', () => {
+    const media = [youtubeMedia('abc'), youtubeMedia('def'), smugmugAlbum()];
+    expect(getEventVideos(media).map((m) => m.foreign_key)).toEqual([
+      'abc',
+      'def',
+    ]);
+  });
+});

--- a/pwa/app/lib/mediaUtils.ts
+++ b/pwa/app/lib/mediaUtils.ts
@@ -55,9 +55,22 @@ export function getMediaLinkUrl(media: Media): string | undefined {
       return `https://cad.onshape.com/documents/${media.foreign_key}`;
     case 'external-link':
       return media.foreign_key;
+    case 'smugmug-album':
+    case 'smugmug-photo':
+      return media.details?.web_uri || media.view_url || undefined;
     default:
       return undefined;
   }
+}
+
+/** Returns all SmugMug album media. */
+export function getSmugmugAlbums(media: Media[]): Media[] {
+  return media.filter((m) => m.type === 'smugmug-album');
+}
+
+/** Returns all YouTube video media (as attached to an event, not webcasts). */
+export function getEventVideos(media: Media[]): Media[] {
+  return media.filter((m) => m.type === 'youtube');
 }
 
 /** Returns the display name for a CAD model media item. */

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -6,6 +6,7 @@ import ParentEventIcon from '~icons/lucide/arrow-up-right';
 import SourceIcon from '~icons/lucide/badge-check';
 import TeamsIcon from '~icons/lucide/bot';
 import DateIcon from '~icons/lucide/calendar-days';
+import MediaIcon from '~icons/lucide/camera';
 import StatbotIcon from '~icons/lucide/chart-spline';
 import ScoutingIcon from '~icons/lucide/clipboard-list';
 import GlobeIcon from '~icons/lucide/globe';
@@ -17,7 +18,6 @@ import InsightsIcon from '~icons/lucide/scatter-chart';
 import ChampsQualPointsIcon from '~icons/lucide/star';
 import AwardsIcon from '~icons/lucide/trophy';
 import LiveWebcastIcon from '~icons/lucide/video';
-import MediaIcon from '~icons/mdi/folder-media-outline';
 import ResultsIcon from '~icons/mdi/tournament';
 
 import { getEventColorsOptions } from '~/api/colors/@tanstack/react-query.gen';
@@ -41,6 +41,7 @@ import {
   getEventCoprsOptions,
   getEventDistrictPointsOptions,
   getEventMatchesOptions,
+  getEventMediaOptions,
   getEventNexusInfoOptions,
   getEventOptions,
   getEventRankingsOptions,
@@ -80,6 +81,7 @@ import {
 import SimpleMatchRowsWithBreaks from '~/components/tba/match/matchRows';
 import RankingsTable from '~/components/tba/rankingsTable';
 import ScoutingTab from '~/components/tba/scoutingTab';
+import SmugmugAlbumGallery from '~/components/tba/smugmugAlbumGallery';
 import { WebcastIcon } from '~/components/tba/socialBadges';
 import {
   TableOfContents,
@@ -132,7 +134,11 @@ import {
   stripParentPrefix,
 } from '~/lib/eventUtils';
 import { sortMatchComparator } from '~/lib/matchUtils';
-import { getTeamPreferredRobotPicMedium } from '~/lib/mediaUtils';
+import {
+  getEventVideos,
+  getSmugmugAlbums,
+  getTeamPreferredRobotPicMedium,
+} from '~/lib/mediaUtils';
 import { type NexusMatchStatus, buildNexusStatusMap } from '~/lib/nexus';
 import {
   getDefaultAutoComponentName,
@@ -343,6 +349,11 @@ function EventPage() {
 
   const teamMediaQuery = useQuery({
     ...getEventTeamMediaOptions({ path: { event_key: eventKey } }),
+    staleTime: eventStaleTime,
+  });
+
+  const eventMediaQuery = useQuery({
+    ...getEventMediaOptions({ path: { event_key: eventKey } }),
     staleTime: eventStaleTime,
   });
 
@@ -755,7 +766,11 @@ function EventPage() {
           )}
 
         <TabsContent value="media">
-          <MediaTab webcasts={event.webcasts} eventKey={event.key} />
+          <MediaTab
+            webcasts={event.webcasts}
+            media={eventMediaQuery.data ?? []}
+            eventKey={event.key}
+          />
         </TabsContent>
 
         <TabsContent value="scouting">
@@ -1278,49 +1293,77 @@ function ChampsQualPointsTab({
 
 function MediaTab({
   webcasts,
+  media,
   eventKey,
 }: {
   webcasts: Webcast[];
+  media: Media[];
   eventKey: string;
 }) {
   const youtubeWebcasts = webcasts.filter((w) => w.type === 'youtube');
   const otherWebcasts = webcasts.filter((w) => w.type !== 'youtube');
+  const videos = getEventVideos(media);
+  const albums = getSmugmugAlbums(media);
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Webcasts</h1>
-      {webcasts.length > 0 ? (
-        <>
-          {youtubeWebcasts.length > 0 && (
-            <div className="grid gap-4 sm:grid-cols-2">
-              {youtubeWebcasts.map((w) => (
-                <YoutubeEmbed
-                  videoId={w.channel}
-                  title={w.channel}
-                  key={w.channel}
-                />
-              ))}
-            </div>
-          )}
-          {otherWebcasts.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {otherWebcasts.map((w) => (
-                <WebcastIcon webcast={w} key={w.channel} />
-              ))}
-            </div>
-          )}
-        </>
-      ) : (
-        <Button
-          variant="secondary"
-          render={
-            <a
-              href={`https://www.thebluealliance.com/suggest/event/webcast?event_key=${eventKey}`}
-            >
-              Add Webcast
-            </a>
-          }
-        />
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Webcasts</h1>
+        {webcasts.length > 0 ? (
+          <>
+            {youtubeWebcasts.length > 0 && (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {youtubeWebcasts.map((w) => (
+                  <YoutubeEmbed
+                    videoId={w.channel}
+                    title={w.channel}
+                    key={w.channel}
+                  />
+                ))}
+              </div>
+            )}
+            {otherWebcasts.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {otherWebcasts.map((w) => (
+                  <WebcastIcon webcast={w} key={w.channel} />
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <Button
+            variant="secondary"
+            render={
+              <a
+                href={`https://www.thebluealliance.com/suggest/event/webcast?event_key=${eventKey}`}
+              >
+                Add Webcast
+              </a>
+            }
+          />
+        )}
+      </div>
+
+      {videos.length > 0 && (
+        <div className="space-y-4">
+          <h1 className="text-2xl font-bold">Videos</h1>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {videos.map((m) => (
+              <YoutubeEmbed
+                videoId={m.foreign_key}
+                title={m.foreign_key}
+                key={m.foreign_key}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {albums.length > 0 && (
+        <div className="space-y-4">
+          <h1 className="text-2xl font-bold">Photo Galleries</h1>
+          <SmugmugAlbumGallery albums={albums} />
+        </div>
       )}
     </div>
   );

--- a/pwa/tests/event-media.spec.ts
+++ b/pwa/tests/event-media.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+// 2026necmp is a completed event with a SmugMug photo gallery attached to the
+// event itself (served by /event/{key}/media, not /team_media).
+test('event Media tab renders SmugMug photo galleries', async ({ page }) => {
+  await page.goto('/event/2026necmp');
+
+  await page.getByRole('tab', { name: /Media/ }).click();
+
+  const gallery = page.getByTestId('smugmug-album-gallery');
+  await expect(gallery).toBeVisible();
+  await expect(
+    gallery.locator('a[href*="nefirst.smugmug.com"]').first(),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Photo Galleries' }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

PR 2 of 2. Builds on #10533 (the `/event/{event_key}/media` endpoint, now deployed).

The event page **Media** tab previously showed only webcasts. It now also renders the event's own media:

- **Photo Galleries** — a responsive grid of SmugMug album covers, each linking to the album on SmugMug (new `SmugmugAlbumGallery` component, ported from the legacy `smugmug_album_partial.html`).
- **Videos** — the event's YouTube videos (event-attached media, distinct from webcasts).

Both sections only render when the event has that media. The webcasts section and its "Add Webcast" empty state are unchanged.

Also:
- Swaps the Media tab icon from `mdi/folder-media-outline` → `lucide/camera`.
- `mediaUtils`: `getMediaLinkUrl` now handles `smugmug-album` / `smugmug-photo` (→ `details.web_uri`); adds `getSmugmugAlbums` and `getEventVideos` helpers.

## Tests

- `app/lib/mediaUtils.test.ts` (new): `getMediaLinkUrl` for smugmug, `getSmugmugAlbums`, `getEventVideos`.
- `tests/event-media.spec.ts` (new): loads `/event/2026necmp`, opens the Media tab, asserts the SmugMug gallery and "Photo Galleries" heading render.
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format`, `pnpm test`, and the new Playwright spec all pass locally.

## Screenshot Pages

- /event/2026necmp 2026 New England DCMP (has SmugMug galleries)
- /event/2025micmp 2025 Michigan DCMP (has event videos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)