### PR TITLE
Reorder @cached_public before @validate_keys in APIv3 handlers

### DIFF
--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -51,8 +51,8 @@ def district_history(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def district_events(
     district_key: DistrictKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[EventDict]]:
@@ -70,8 +70,8 @@ def district_events(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def district_teams(
     district_key: DistrictKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[TeamDict]]:
@@ -89,8 +89,8 @@ def district_teams(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def district_rankings(district_key: DistrictKey) -> TypedFlaskResponse[Any]:
     """
     Returns the rankings a given DistrictKey.
@@ -116,8 +116,8 @@ def district_list_year(year: int) -> TypedFlaskResponse[list[DistrictDict]]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def district_awards(district_key: DistrictKey) -> TypedFlaskResponse[list[dict]]:
     """
     Returns a list of awards for a given DistrictKey.
@@ -144,8 +144,8 @@ def district_awards(district_key: DistrictKey) -> TypedFlaskResponse[list[dict]]
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def district_advancement(district_key: DistrictKey) -> TypedFlaskResponse[dict]:
     """
     Returns DCMP/CMP advancement information for a given DistrictKey

--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -45,8 +45,8 @@ from backend.common.queries.team_query import EventEventTeamsQuery, EventTeamsQu
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event(
     event_key: EventKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[EventDict]:
@@ -107,8 +107,8 @@ def event_list_year(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_detail(event_key: EventKey, detail_type: str) -> TypedFlaskResponse[Any]:
     """
     Returns details about one event, specified by |event_key| and |detail_type|.
@@ -129,8 +129,8 @@ def event_detail(event_key: EventKey, detail_type: str) -> TypedFlaskResponse[An
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_advancement_points(event_key: EventKey) -> TypedFlaskResponse[Any]:
     """
     Returns details about one event, specified by |event_key| and |detail_type|.
@@ -153,8 +153,8 @@ def event_advancement_points(event_key: EventKey) -> TypedFlaskResponse[Any]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_teams(
     event_key: EventKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[TeamDict]]:
@@ -170,8 +170,8 @@ def event_teams(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
     """
     Returns a dict of team_key: status for teams at a given event.
@@ -204,8 +204,8 @@ def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
     track_call_after_response("event/teams/media", event_key)
 
@@ -217,8 +217,8 @@ def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
     track_call_after_response("event/media", event_key)
 
@@ -228,8 +228,8 @@ def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_matches(
     event_key: EventKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[MatchDict]]:
@@ -245,8 +245,8 @@ def event_matches(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
     """
     Returns a list of awards for a given event.
@@ -258,8 +258,8 @@ def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_nexus_info(
     event_key: EventKey,
 ) -> TypedFlaskResponse[Optional[NexusInfoDict]]:
@@ -277,8 +277,8 @@ def event_nexus_info(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def event_playoff_advancement(event_key: EventKey) -> TypedFlaskResponse[Any]:
     """
     Returns the playoff advancement for a given event.

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -21,8 +21,8 @@ from backend.common.queries.match_query import MatchQuery
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def match(
     match_key: MatchKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[MatchDict]:
@@ -40,8 +40,8 @@ def match(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def zebra_motionworks(match_key: MatchKey) -> TypedFlaskResponse[Any]:
     """
     Returns Zebra Motionworks data for a given match.

--- a/src/backend/api/handlers/team.py
+++ b/src/backend/api/handlers/team.py
@@ -63,8 +63,8 @@ from backend.common.queries.team_query import (
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team(
     team_key: TeamKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[TeamDict]:
@@ -82,8 +82,8 @@ def team(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_history(team_key: TeamKey) -> TypedFlaskResponse[Any]:
     track_call_after_response("team/history", team_key)
 
@@ -102,8 +102,8 @@ def team_history(team_key: TeamKey) -> TypedFlaskResponse[Any]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_years_participated(team_key: TeamKey) -> TypedFlaskResponse[list[int]]:
     """
     Returns a list of years the given Team participated in an event.
@@ -116,8 +116,8 @@ def team_years_participated(team_key: TeamKey) -> TypedFlaskResponse[list[int]]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[DistrictDict]]:
     """
     Returns a list of all DistrictTeam models associated with the given Team.
@@ -131,8 +131,8 @@ def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[Distric
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]]:
     """
     Returns a list of all Robot models associated with the given Team.
@@ -144,8 +144,8 @@ def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
     """
     Returns a list of all social media models associated with the given Team.
@@ -159,8 +159,8 @@ def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_events(
     team_key: TeamKey,
     year: Optional[int] = None,
@@ -190,8 +190,8 @@ def team_events(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_events_statuses_year(team_key: TeamKey, year: int) -> TypedFlaskResponse[dict]:
     """
     Returns a dict of { event_key: status_dict } for all events in the given year for the associated team.
@@ -224,8 +224,8 @@ def team_events_statuses_year(team_key: TeamKey, year: int) -> TypedFlaskRespons
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_event_matches(
     team_key: TeamKey, event_key: EventKey, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[MatchDict]]:
@@ -246,8 +246,8 @@ def team_event_matches(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_event_awards(
     team_key: TeamKey, event_key: EventKey
 ) -> TypedFlaskResponse[list[AwardDict]]:
@@ -263,8 +263,8 @@ def team_event_awards(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_event_status(
     team_key: TeamKey, event_key: EventKey
 ) -> TypedFlaskResponse[Any]:
@@ -296,8 +296,8 @@ def team_event_status(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_awards(
     team_key: TeamKey,
     year: Optional[int] = None,
@@ -318,8 +318,8 @@ def team_awards(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_matches(
     team_key: TeamKey,
     year: int,
@@ -340,8 +340,8 @@ def team_matches(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_media_year(
     team_key: TeamKey, year: int
 ) -> TypedFlaskResponse[list[MediaDict]]:
@@ -357,8 +357,8 @@ def team_media_year(
 
 
 @api_authenticated
-@validate_keys
 @cached_public
+@validate_keys
 def team_media_tag(
     team_key: TeamKey, media_tag: str, year: Optional[int] = None
 ) -> TypedFlaskResponse[list[MediaDict]]:

--- a/src/backend/api/handlers/tests/decorator_order_test.py
+++ b/src/backend/api/handlers/tests/decorator_order_test.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock
+
+import pytest
+from werkzeug.test import Client
+
+from backend.common.consts.auth_type import AuthType
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.team import Team
+
+
+def test_decorator_order_cache_hit_bypasses_validate_keys(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Ensure that when an endpoint response is cached, @cached_public serves it
+    without executing @validate_keys (preventing redundant Datastore/Memcache lookups).
+    """
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    # 1. First request: cache miss, executes validate_keys and handler, caches response
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    assert resp1.json["key"] == "frc254"
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Track calls to Team.get_by_id_async (which is called by validate_keys)
+    original_get_by_id_async = Team.get_by_id_async
+    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+
+    # 2. Second request: cache hit, should bypass validate_keys completely
+    resp2 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp2.status_code == 200
+    assert resp2.json["key"] == "frc254"
+    # Team.get_by_id_async should NOT have been called because validate_keys was bypassed
+    mock_get_by_id_async.assert_not_called()
+
+    # 3. Third request with If-None-Match: should return 304 directly from cache
+    resp3 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 304
+    mock_get_by_id_async.assert_not_called()
+
+
+def test_decorator_order_unauthenticated_request_rejected_first(
+    ndb_stub, api_client: Client
+) -> None:
+    """
+    Ensure that unauthenticated requests are rejected by @api_authenticated with 401
+    without serving cached responses.
+    """
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    # Seed the cache with a valid request
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+
+    # Request without auth key should return 401 despite cached data being present
+    resp_unauth = api_client.get("/api/v3/team/frc254")
+    assert resp_unauth.status_code == 401
+
+    # Request with invalid auth key should return 401
+    resp_invalid_key = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "invalid_key"}
+    )
+    assert resp_invalid_key.status_code == 401
+
+
+def test_decorator_order_invalid_keys_return_404_on_cache_miss(
+    ndb_stub, api_client: Client
+) -> None:
+    """
+    Ensure that @validate_keys still correctly rejects invalid format or non-existent keys.
+    """
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    # Invalid key format
+    resp_bad_format = api_client.get(
+        "/api/v3/team/not_a_valid_team_key",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp_bad_format.status_code == 404
+
+    # Non-existent team key
+    resp_nonexistent = api_client.get(
+        "/api/v3/team/frc9999999", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp_nonexistent.status_code == 404


### PR DESCRIPTION
Run @cached_public before @validate_keys across public APIv3 handlers so that cached responses (HTTP 200 and 304 Not Modified) are served directly from cache without querying Memcache/Datastore to validate entity existence. Add regression unit tests.