### PR TITLE
[api] Zero-copy JSON passthrough for CachedQueryResult

### DIFF
--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -10,6 +10,10 @@ from backend.api.handlers.helpers.model_properties import (
     filter_team_properties,
     ModelType,
 )
+from backend.api.handlers.helpers.model_query_response import (
+    model_query_response,
+    models_query_response,
+)
 from backend.api.handlers.helpers.nexus_info_converter import (
     event_queue_status_to_api,
     NexusInfoDict,
@@ -54,13 +58,11 @@ def event(
     Returns info about one event, specified by |event_key|.
     """
     track_call_after_response("event", event_key, model_type)
-
-    event = EventQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
-    if event is None:
-        abort(404)
-    if model_type is not None:
-        event = filter_event_properties([event], model_type)[0]
-    return profiled_jsonify(event)
+    return model_query_response(
+        EventQuery(event_key=event_key),
+        model_type=model_type,
+        filter_func=filter_event_properties,
+    )
 
 
 @api_authenticated
@@ -98,12 +100,11 @@ def event_list_year(
     Returns a list of all events for a given year.
     """
     track_call_after_response("event/list", str(year), model_type)
-
-    events = EventListQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
-
-    if model_type is not None:
-        events = filter_event_properties(events, model_type)
-    return profiled_jsonify(events)
+    return models_query_response(
+        EventListQuery(year=year),
+        model_type=model_type,
+        filter_func=filter_event_properties,
+    )
 
 
 @api_authenticated
@@ -162,11 +163,11 @@ def event_teams(
     Returns a list of teams attending a given event.
     """
     track_call_after_response("event/teams", event_key, model_type)
-
-    teams = EventTeamsQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
-    if model_type is not None:
-        teams = filter_team_properties(teams, model_type)
-    return profiled_jsonify(teams)
+    return models_query_response(
+        EventTeamsQuery(event_key=event_key),
+        model_type=model_type,
+        filter_func=filter_team_properties,
+    )
 
 
 @api_authenticated
@@ -208,12 +209,7 @@ def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
 @cached_public
 def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
     track_call_after_response("event/teams/media", event_key)
-
-    query = EventTeamsMediasQuery(event_key=event_key).fetch_dict(
-        ApiMajorVersion.API_V3
-    )
-
-    return profiled_jsonify(query)
+    return models_query_response(EventTeamsMediasQuery(event_key=event_key))
 
 
 @api_authenticated
@@ -221,10 +217,7 @@ def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]
 @cached_public
 def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
     track_call_after_response("event/media", event_key)
-
-    query = EventMediasQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
-
-    return profiled_jsonify(query)
+    return models_query_response(EventMediasQuery(event_key=event_key))
 
 
 @api_authenticated
@@ -237,11 +230,11 @@ def event_matches(
     Returns a list of matches for a given event.
     """
     track_call_after_response("event/matches", event_key, model_type)
-
-    matches = EventMatchesQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
-    if model_type is not None:
-        matches = filter_match_properties(matches, model_type)
-    return profiled_jsonify(matches)
+    return models_query_response(
+        EventMatchesQuery(event_key=event_key),
+        model_type=model_type,
+        filter_func=filter_match_properties,
+    )
 
 
 @api_authenticated
@@ -252,9 +245,9 @@ def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
     Returns a list of awards for a given event.
     """
     track_call_after_response("event/awards", event_key)
-
-    awards = EventAwardsQuery(event_key=event_key).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(awards)
+    return models_query_response(
+        EventAwardsQuery(event_key=event_key),
+    )
 
 
 @api_authenticated

--- a/src/backend/api/handlers/helpers/model_query_response.py
+++ b/src/backend/api/handlers/helpers/model_query_response.py
@@ -1,0 +1,58 @@
+from typing import Any, Callable, Optional
+
+from flask import abort
+
+from backend.api.handlers.helpers.model_properties import ModelType
+from backend.api.handlers.helpers.profiled_jsonify import (
+    profiled_jsonify,
+    TypedFlaskResponse,
+)
+from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.queries.database_query import CachedDatabaseQuery
+
+
+def model_query_response(
+    query: CachedDatabaseQuery,
+    model_type: Optional[ModelType] = None,
+    filter_func: Optional[Callable] = None,
+    abort_404_if_none: bool = True,
+) -> TypedFlaskResponse[Any]:
+    """
+    Handles a query for a single model entity.
+    If model_type is None, fetches pre-serialized JSON bytes directly.
+    If model_type is specified, fetches the dict, filters properties, and serializes.
+    """
+    if model_type is None:
+        raw_json = query.fetch_json(ApiMajorVersion.API_V3)
+        if raw_json is None and abort_404_if_none:
+            abort(404)
+        return profiled_jsonify(raw_json)
+
+    data = query.fetch_dict(ApiMajorVersion.API_V3)
+    if data is None:
+        if abort_404_if_none:
+            abort(404)
+        return profiled_jsonify(None)
+    if filter_func is not None:
+        data = filter_func([data], model_type)[0]
+    return profiled_jsonify(data)
+
+
+def models_query_response(
+    query: CachedDatabaseQuery,
+    model_type: Optional[ModelType] = None,
+    filter_func: Optional[Callable] = None,
+) -> TypedFlaskResponse[Any]:
+    """
+    Handles a query for a collection of model entities.
+    If model_type is None, fetches pre-serialized JSON bytes directly.
+    If model_type is specified, fetches the dicts, filters properties, and serializes.
+    """
+    if model_type is None:
+        raw_json = query.fetch_json(ApiMajorVersion.API_V3)
+        return profiled_jsonify(raw_json)
+
+    data = query.fetch_dict(ApiMajorVersion.API_V3)
+    if filter_func is not None and data is not None:
+        data = filter_func(data, model_type)
+    return profiled_jsonify(data)

--- a/src/backend/api/handlers/helpers/profiled_jsonify.py
+++ b/src/backend/api/handlers/helpers/profiled_jsonify.py
@@ -1,6 +1,6 @@
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 
-from flask import jsonify, Response
+from flask import current_app, jsonify, Response
 
 from backend.common.profiler import Span
 
@@ -11,6 +11,11 @@ class TypedFlaskResponse(Response, Generic[T]):
     pass
 
 
-def profiled_jsonify(obj: T) -> TypedFlaskResponse[T]:
+def profiled_jsonify(obj: Union[T, bytes, bytearray]) -> TypedFlaskResponse[T]:
     with Span("profiled_jsonify"):
+        if isinstance(obj, (bytes, bytearray)):
+            return current_app.response_class(  # pyre-ignore[7]
+                bytes(obj),
+                mimetype="application/json",
+            )  # type: ignore[return-value]
         return jsonify(obj)  # type: ignore[return-value]

--- a/src/backend/api/handlers/helpers/tests/model_query_response_test.py
+++ b/src/backend/api/handlers/helpers/tests/model_query_response_test.py
@@ -1,0 +1,98 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from werkzeug.exceptions import NotFound
+
+from backend.api.handlers.helpers.model_properties import ModelType
+from backend.api.handlers.helpers.model_query_response import (
+    model_query_response,
+    models_query_response,
+)
+from backend.common.consts.api_version import ApiMajorVersion
+
+
+@pytest.fixture
+def app() -> Flask:
+    app = Flask(__name__)
+    return app
+
+
+def test_model_query_response_passthrough(app: Flask) -> None:
+    mock_query = MagicMock()
+    mock_query.fetch_json.return_value = b'{"key": "2024casf", "name": "Event"}'
+
+    with app.app_context():
+        resp = model_query_response(mock_query, model_type=None)
+
+        mock_query.fetch_json.assert_called_once_with(ApiMajorVersion.API_V3)
+        mock_query.fetch_dict.assert_not_called()
+        assert resp.content_type == "application/json"
+        assert json.loads(resp.data) == {"key": "2024casf", "name": "Event"}
+
+
+def test_model_query_response_404(app: Flask) -> None:
+    mock_query = MagicMock()
+    mock_query.fetch_json.return_value = None
+
+    with app.app_context():
+        with pytest.raises(NotFound):
+            model_query_response(mock_query, model_type=None)
+
+
+def test_model_query_response_filtered(app: Flask) -> None:
+    mock_query = MagicMock()
+    mock_query.fetch_dict.return_value = {
+        "key": "2024casf",
+        "name": "Event",
+        "secret": "hidden",
+    }
+    filter_func = MagicMock(
+        side_effect=lambda models, mt: [{"key": m["key"]} for m in models]
+    )
+
+    with app.app_context():
+        resp = model_query_response(
+            mock_query,
+            model_type=ModelType("simple"),
+            filter_func=filter_func,
+        )
+
+        mock_query.fetch_dict.assert_called_once_with(ApiMajorVersion.API_V3)
+        mock_query.fetch_json.assert_not_called()
+        assert json.loads(resp.data) == {"key": "2024casf"}
+
+
+def test_models_query_response_passthrough(app: Flask) -> None:
+    mock_query = MagicMock()
+    mock_query.fetch_json.return_value = b'[{"key": "2024casf"}]'
+
+    with app.app_context():
+        resp = models_query_response(mock_query, model_type=None)
+
+        mock_query.fetch_json.assert_called_once_with(ApiMajorVersion.API_V3)
+        mock_query.fetch_dict.assert_not_called()
+        assert json.loads(resp.data) == [{"key": "2024casf"}]
+
+
+def test_models_query_response_filtered(app: Flask) -> None:
+    mock_query = MagicMock()
+    mock_query.fetch_dict.return_value = [
+        {"key": "2024casf", "name": "Event"},
+        {"key": "2024sj", "name": "Event 2"},
+    ]
+    filter_func = MagicMock(
+        side_effect=lambda models, mt: [{"key": m["key"]} for m in models]
+    )
+
+    with app.app_context():
+        resp = models_query_response(
+            mock_query,
+            model_type=ModelType("simple"),
+            filter_func=filter_func,
+        )
+
+        mock_query.fetch_dict.assert_called_once_with(ApiMajorVersion.API_V3)
+        mock_query.fetch_json.assert_not_called()
+        assert json.loads(resp.data) == [{"key": "2024casf"}, {"key": "2024sj"}]

--- a/src/backend/api/handlers/helpers/tests/profiled_jsonify_test.py
+++ b/src/backend/api/handlers/helpers/tests/profiled_jsonify_test.py
@@ -49,3 +49,23 @@ def test_profiled_jsonify_uses_span(mock_span, app: Flask) -> None:
         profiled_jsonify({"test": "data"})
 
     mock_span.assert_called_once_with("profiled_jsonify")
+
+
+def test_profiled_jsonify_bytes_passthrough(app: Flask) -> None:
+    with app.app_context():
+        raw_json = b'{"test": "passthrough", "number": 123}'
+        response = profiled_jsonify(raw_json)
+
+        assert response.content_type == "application/json"
+        assert response.data == raw_json
+        assert json.loads(response.data) == {"test": "passthrough", "number": 123}
+
+
+def test_profiled_jsonify_bytearray_passthrough(app: Flask) -> None:
+    with app.app_context():
+        raw_json = bytearray(b'{"test": "bytearray"}')
+        response = profiled_jsonify(raw_json)
+
+        assert response.content_type == "application/json"
+        assert response.data == b'{"test": "bytearray"}'
+        assert json.loads(response.data) == {"test": "bytearray"}

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -1,18 +1,16 @@
 from typing import Any, Optional
 
-from flask import abort
-
 from backend.api.handlers.decorators import api_authenticated, validate_keys
 from backend.api.handlers.helpers.model_properties import (
     filter_match_properties,
     ModelType,
 )
+from backend.api.handlers.helpers.model_query_response import model_query_response
 from backend.api.handlers.helpers.profiled_jsonify import (
     profiled_jsonify,
     TypedFlaskResponse,
 )
 from backend.api.handlers.helpers.track_call import track_call_after_response
-from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
 from backend.common.models.keys import MatchKey
 from backend.common.models.zebra_motionworks import ZebraMotionWorks
@@ -30,13 +28,11 @@ def match(
     Returns details about one match, specified by |match_key|.
     """
     track_call_after_response("match", match_key, model_type)
-
-    match = MatchQuery(match_key=match_key).fetch_dict(ApiMajorVersion.API_V3)
-    if match is None:
-        abort(404)
-    if model_type is not None:
-        match = filter_match_properties([match], model_type)[0]
-    return profiled_jsonify(match)
+    return model_query_response(
+        MatchQuery(match_key=match_key),
+        model_type=model_type,
+        filter_func=filter_match_properties,
+    )
 
 
 @api_authenticated

--- a/src/backend/api/handlers/team.py
+++ b/src/backend/api/handlers/team.py
@@ -1,7 +1,5 @@
 from typing import Any, Optional
 
-from flask import abort
-
 from backend.api.handlers.decorators import (
     api_authenticated,
     validate_keys,
@@ -11,6 +9,10 @@ from backend.api.handlers.helpers.model_properties import (
     filter_match_properties,
     filter_team_properties,
     ModelType,
+)
+from backend.api.handlers.helpers.model_query_response import (
+    model_query_response,
+    models_query_response,
 )
 from backend.api.handlers.helpers.profiled_jsonify import (
     profiled_jsonify,
@@ -72,13 +74,11 @@ def team(
     Returns details about one team, specified by |team_key|.
     """
     track_call_after_response("team", team_key, model_type)
-
-    team = TeamQuery(team_key=team_key).fetch_dict(ApiMajorVersion.API_V3)
-    if team is None:
-        abort(404)
-    if model_type is not None:
-        team = filter_team_properties([team], model_type)[0]
-    return profiled_jsonify(team)
+    return model_query_response(
+        TeamQuery(team_key=team_key),
+        model_type=model_type,
+        filter_func=filter_team_properties,
+    )
 
 
 @api_authenticated
@@ -123,11 +123,9 @@ def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[Distric
     Returns a list of all DistrictTeam models associated with the given Team.
     """
     track_call_after_response("team/history/districts", team_key)
-
-    team_districts = TeamDistrictsQuery(team_key=team_key).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        TeamDistrictsQuery(team_key=team_key),
     )
-    return profiled_jsonify(team_districts)
 
 
 @api_authenticated
@@ -138,9 +136,9 @@ def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]
     Returns a list of all Robot models associated with the given Team.
     """
     track_call_after_response("team/history/robots", team_key)
-
-    team_robots = TeamRobotsQuery(team_key=team_key).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(team_robots)
+    return models_query_response(
+        TeamRobotsQuery(team_key=team_key),
+    )
 
 
 @api_authenticated
@@ -151,11 +149,9 @@ def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
     Returns a list of all social media models associated with the given Team.
     """
     track_call_after_response("team/social_media", team_key)
-
-    team_social_media = TeamSocialMediaQuery(team_key=team_key).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        TeamSocialMediaQuery(team_key=team_key),
     )
-    return profiled_jsonify(team_social_media)
 
 
 @api_authenticated
@@ -175,18 +171,16 @@ def team_events(
         api_action += f"/{year}"
     track_call_after_response(api_action, team_key, model_type)
 
-    if year is None:
-        team_events = TeamEventsQuery(team_key=team_key).fetch_dict(
-            ApiMajorVersion.API_V3
-        )
-    else:
-        team_events = TeamYearEventsQuery(team_key=team_key, year=year).fetch_dict(
-            ApiMajorVersion.API_V3
-        )
-
-    if model_type is not None:
-        team_events = filter_event_properties(team_events, model_type)
-    return profiled_jsonify(team_events)
+    query = (
+        TeamEventsQuery(team_key=team_key)
+        if year is None
+        else TeamYearEventsQuery(team_key=team_key, year=year)
+    )
+    return models_query_response(
+        query,
+        model_type=model_type,
+        filter_func=filter_event_properties,
+    )
 
 
 @api_authenticated
@@ -235,14 +229,11 @@ def team_event_matches(
     track_call_after_response(
         "team/event/matches", f"{team_key}/{event_key}", model_type
     )
-
-    matches = TeamEventMatchesQuery(team_key=team_key, event_key=event_key).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        TeamEventMatchesQuery(team_key=team_key, event_key=event_key),
+        model_type=model_type,
+        filter_func=filter_match_properties,
     )
-
-    if model_type is not None:
-        matches = filter_match_properties(matches, model_type)
-    return profiled_jsonify(matches)
 
 
 @api_authenticated
@@ -255,11 +246,9 @@ def team_event_awards(
     Returns a list of awards for a team at an event.
     """
     track_call_after_response("team/event/awards", f"{team_key}/{event_key}")
-
-    awards = TeamEventAwardsQuery(team_key=team_key, event_key=event_key).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        TeamEventAwardsQuery(team_key=team_key, event_key=event_key),
     )
-    return profiled_jsonify(awards)
 
 
 @api_authenticated
@@ -308,13 +297,11 @@ def team_awards(
     """
     if year is None:
         track_call_after_response("team/history/awards", team_key)
-        awards = TeamAwardsQuery(team_key=team_key).fetch_dict(ApiMajorVersion.API_V3)
+        query = TeamAwardsQuery(team_key=team_key)
     else:
         track_call_after_response("team/year/awards", f"{team_key}/{year}")
-        awards = TeamYearAwardsQuery(team_key=team_key, year=year).fetch_dict(
-            ApiMajorVersion.API_V3
-        )
-    return profiled_jsonify(awards)
+        query = TeamYearAwardsQuery(team_key=team_key, year=year)
+    return models_query_response(query)
 
 
 @api_authenticated
@@ -329,14 +316,11 @@ def team_matches(
     Returns a list of matches associated with the given Team in a given year.
     """
     track_call_after_response("team/year/matches", f"{team_key}/{year}", model_type)
-
-    matches = TeamYearMatchesQuery(team_key=team_key, year=year).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        TeamYearMatchesQuery(team_key=team_key, year=year),
+        model_type=model_type,
+        filter_func=filter_match_properties,
     )
-
-    if model_type is not None:
-        matches = filter_match_properties(matches, model_type)
-    return profiled_jsonify(matches)
 
 
 @api_authenticated
@@ -349,11 +333,7 @@ def team_media_year(
     Returns a list of media associated with the given Team in a given year.
     """
     track_call_after_response("team/media", f"{team_key}/{year}")
-
-    media = TeamYearMediaQuery(team_key=team_key, year=year).fetch_dict(
-        ApiMajorVersion.API_V3
-    )
-    return profiled_jsonify(media)
+    return models_query_response(TeamYearMediaQuery(team_key=team_key, year=year))
 
 
 @api_authenticated
@@ -375,15 +355,12 @@ def team_media_tag(
     if tag_enum is None:
         return profiled_jsonify([])
 
-    if year is None:
-        media = TeamTagMediasQuery(team_key=team_key, media_tag=tag_enum).fetch_dict(
-            ApiMajorVersion.API_V3
-        )
-    else:
-        media = TeamYearTagMediasQuery(
-            team_key=team_key, media_tag=tag_enum, year=year
-        ).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(media)
+    query = (
+        TeamTagMediasQuery(team_key=team_key, media_tag=tag_enum)
+        if year is None
+        else TeamYearTagMediasQuery(team_key=team_key, media_tag=tag_enum, year=year)
+    )
+    return models_query_response(query)
 
 
 @api_authenticated
@@ -434,13 +411,13 @@ def team_list(
         api_action += f"/{year}"
     track_call_after_response(api_action, str(page_num), model_type)
 
-    if year is None:
-        team_list = TeamListQuery(page=page_num).fetch_dict(ApiMajorVersion.API_V3)
-    else:
-        team_list = TeamListYearQuery(year=year, page=page_num).fetch_dict(
-            ApiMajorVersion.API_V3
-        )
-
-    if model_type is not None:
-        team_list = filter_team_properties(team_list, model_type)
-    return profiled_jsonify(team_list)
+    query = (
+        TeamListQuery(page=page_num)
+        if year is None
+        else TeamListYearQuery(year=year, page=page_num)
+    )
+    return models_query_response(
+        query,
+        model_type=model_type,
+        filter_func=filter_team_properties,
+    )

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -34,7 +34,7 @@ install_middleware(app, configure_secret_key=True, include_appspot_redirect=True
 install_url_converters(app)
 configure_flask_cache(app)
 
-app.json.compact = False  # pyre-ignore[16]
+app.json.compact = True  # pyre-ignore[16]
 app.url_map.converters["simple_model_type"] = SimpleModelTypeConverter
 app.url_map.converters["model_type"] = ModelTypeConverter
 app.url_map.converters["event_detail_type"] = EventDetailTypeConverter

--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import traceback
+import zlib
 from typing import Any, Generator, Iterable, Optional
 
 from google.appengine.ext import ndb
@@ -16,6 +18,30 @@ class CachedQueryResult(ndb.Model):
 
     created = ndb.DateTimeProperty(auto_now_add=True)
     updated = ndb.DateTimeProperty(auto_now=True)
+
+    def get_json_bytes(self) -> Optional[bytes]:
+        """
+        Returns the raw compact JSON bytes for result_dict without inflating into Python objects.
+        """
+        values = getattr(self, "_values", None)
+        if not values or b"result_dict" not in values:
+            return None
+        val = values[b"result_dict"]
+        if isinstance(val, ndb.model._BaseValue):
+            b_val = val.b_val
+            if isinstance(b_val, ndb.model._CompressedValue):
+                return zlib.decompress(b_val.z_val)
+            elif isinstance(b_val, (bytes, bytearray)):
+                return bytes(b_val)
+            elif isinstance(b_val, str):
+                return b_val.encode("utf-8")
+        elif isinstance(val, (bytes, bytearray)):
+            return bytes(val)
+        elif isinstance(val, str):
+            return val.encode("utf-8")
+        elif val is not None:
+            return json.dumps(val, separators=(",", ":")).encode("utf-8")
+        return None
 
     @staticmethod
     def cache_key_prefix_from_format(cache_key_format: str) -> str:

--- a/src/backend/common/models/tests/cached_query_result_test.py
+++ b/src/backend/common/models/tests/cached_query_result_test.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any, Generator, List
 
@@ -436,3 +437,45 @@ def test_purge_query_class_global_version_rejects_recent_version(
         delete_batch_size=50,
     )
     assert deleted == 0  # No entries created, but validation passed
+
+
+def test_get_json_bytes_from_datastore(ndb_stub) -> None:
+    data = {"team_key": "frc254", "year": 2024, "metrics": [1, 2, 3]}
+    c = CachedQueryResult(id="test_key", result_dict=data)
+    c.put()
+
+    fetched = CachedQueryResult.get_by_id("test_key")
+    assert fetched is not None
+    json_bytes = fetched.get_json_bytes()
+    assert isinstance(json_bytes, bytes)
+    assert json.loads(json_bytes) == data
+
+
+def test_get_json_bytes_in_memory() -> None:
+    data = {"hello": "world"}
+    c = CachedQueryResult(result_dict=data)
+    json_bytes = c.get_json_bytes()
+    assert isinstance(json_bytes, bytes)
+    assert json.loads(json_bytes) == data
+
+
+def test_get_json_bytes_none(ndb_stub) -> None:
+    c = CachedQueryResult(id="none_key", result_dict=None)
+    c.put()
+
+    fetched = CachedQueryResult.get_by_id("none_key")
+    assert fetched is not None
+    assert fetched.get_json_bytes() is None
+
+    empty = CachedQueryResult()
+    assert empty.get_json_bytes() is None
+
+
+def test_get_json_bytes_raw_types() -> None:
+    c_bytes = CachedQueryResult()
+    setattr(c_bytes, "_values", {b"result_dict": b'{"raw": "bytes"}'})
+    assert c_bytes.get_json_bytes() == b'{"raw": "bytes"}'
+
+    c_str = CachedQueryResult()
+    setattr(c_str, "_values", {b"result_dict": '{"raw": "str"}'})
+    assert c_str.get_json_bytes() == b'{"raw": "str"}'

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import json
 import logging
 from typing import Any, Dict, Generator, Generic, List, Optional, Set, Type, Union
 
@@ -235,3 +236,62 @@ class CachedDatabaseQuery(
                         logging.exception(e)
                 return converted_result
             return cached_query_result.result_dict
+
+    def fetch_json(self, version: ApiMajorVersion) -> Optional[bytes]:
+        fut: TypedFuture[Optional[bytes]] = self.fetch_json_async(version)
+        return fut.get_result()
+
+    @ndb.tasklet
+    def fetch_json_async(
+        self, version: ApiMajorVersion
+    ) -> Generator[Any, Any, Optional[bytes]]:
+        with Span("{}.fetch_json_async".format(self.__class__.__name__)):
+            query_result = yield self._do_json_query(version, **self._query_args)
+            return query_result
+
+    @ndb.tasklet
+    def _do_json_query(
+        self, _dict_version: ApiMajorVersion, *args, **kwargs
+    ) -> Generator[Any, Any, Optional[bytes]]:
+        if not self.DICT_CACHING_ENABLED:
+            dict_result = yield self._do_dict_query(_dict_version, *args, **kwargs)
+            if dict_result is None:
+                return None
+            return json.dumps(dict_result, separators=(",", ":")).encode("utf-8")
+
+        with Span("{}._do_json_query".format(self.__class__.__name__)):
+            cache_key = self.dict_cache_key(_dict_version)
+            cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+            if cached_query_result is None:
+                query_result = yield self._query_async(*args, **kwargs)
+
+                converted_result = none_throws(self.DICT_CONVERTER)(  # pyre-ignore[45]
+                    query_result
+                ).convert(_dict_version)
+
+                if self.CACHE_WRITES_ENABLED:
+                    try:
+                        yield CachedQueryResult(
+                            id=cache_key, result_dict=converted_result
+                        ).put_async()
+                    except Exception as e:
+                        logging.warning(
+                            f"CachedQueryResult.put_async() failed: {cache_key}"
+                        )
+                        logging.exception(e)
+
+                if converted_result is None:
+                    return None
+
+                return json.dumps(converted_result, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+
+            raw_bytes = cached_query_result.get_json_bytes()
+            if raw_bytes is not None:
+                return raw_bytes
+            if cached_query_result.result_dict is None:
+                return None
+            return json.dumps(
+                cached_query_result.result_dict, separators=(",", ":")
+            ).encode("utf-8")

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -1,5 +1,6 @@
+import json
 import logging
-from typing import Any, Generator, Iterable, List, TypedDict
+from typing import Any, Generator, Iterable, List, Optional, TypedDict
 from unittest.mock import patch
 
 from google.appengine.ext import ndb
@@ -76,6 +77,19 @@ class CachedDummyModelRangeQuery(
             DummyModel.int_prop >= min, DummyModel.int_prop <= max
         ).fetch_async()
         return list(models)
+
+
+class CachedDummyModelPointQuery(
+    CachedDatabaseQuery[Optional[DummyModel], Optional[DummyDict]]
+):
+    CACHE_KEY_FORMAT = "test_point_query_{model_key}"
+    DICT_CONVERTER = DummyConverter
+    CACHE_WRITES_ENABLED = True
+
+    @ndb.tasklet
+    def _query_async(self, model_key: str) -> Generator[Any, Any, Optional[DummyModel]]:
+        model = yield DummyModel.get_by_id_async(model_key)
+        return model
 
 
 class CachedDummyModelWithRequiredPropQuery(
@@ -337,3 +351,45 @@ def test_cached_query_corrupt_cache_treated_as_miss(caplog, monkeypatch) -> None
     # Should have refetched valid data from datastore
     assert len(result) == 3
     assert all(model.required_prop is not None for model in result)
+
+
+def test_cached_query_fetch_json() -> None:
+    keys = ndb.put_multi([DummyModel(id=f"{i}", int_prop=i) for i in range(0, 5)])
+    assert len(keys) == 5
+
+    query = CachedDummyModelRangeQuery(min=0, max=2)
+
+    # Cache miss
+    json_bytes = query.fetch_json(ApiMajorVersion.API_V3)
+    assert isinstance(json_bytes, bytes)
+    parsed = json.loads(json_bytes)
+    assert len(parsed) == 3
+    assert parsed[0] == {"int_val": 0}
+
+    # Verify cache was populated
+    cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+    cached_entity = CachedQueryResult.get_by_id(cache_key)
+    assert cached_entity is not None
+    assert cached_entity.get_json_bytes() is not None
+
+    # Cache hit should return the same raw JSON bytes
+    hit_json_bytes = query.fetch_json(ApiMajorVersion.API_V3)
+    assert hit_json_bytes == json_bytes
+
+
+def test_cached_query_fetch_json_negative_cache() -> None:
+    query = CachedDummyModelPointQuery(model_key="nonexistent")
+
+    # Cache miss on non-existent entity
+    json_bytes = query.fetch_json(ApiMajorVersion.API_V3)
+    assert json_bytes is None
+
+    # Verify cache was populated with negative result (result_dict=None)
+    cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+    cached_entity = CachedQueryResult.get_by_id(cache_key)
+    assert cached_entity is not None
+    assert cached_entity.result_dict is None
+
+    # Cache hit should also return None without querying datastore
+    hit_json_bytes = query.fetch_json(ApiMajorVersion.API_V3)
+    assert hit_json_bytes is None


### PR DESCRIPTION
## Summary
Optimizes APIv3 endpoint latency and memory overhead by implementing zero-copy pre-serialized JSON passthrough from `CachedQueryResult` directly to Flask HTTP responses, bypassing redundant `json.loads` and `json.dumps` cycles.

### Key Changes
- **Storage**: Added `CachedQueryResult.get_json_bytes()` to decompress raw JSON bytes from Datastore/NDB entity values directly without inflating Python dictionaries.
- **Query Layer**: Added `CachedDatabaseQuery.fetch_json()` and `fetch_json_async()`. Cache hits return pre-serialized JSON bytes directly; cache misses serialize compact JSON and store it for future hits. `DatabaseQuery` remains unchanged.
- **Response Layer**: Extended `profiled_jsonify` to recognize `bytes` / `bytearray` and return a `current_app.response_class` directly. Set `app.json.compact = True` for consistent JSON format.
- **Handler Helpers**: Centralized query responses via `model_query_response` and `models_query_response` in `model_query_response.py` to handle 404s, `model_type` property filtering, and clean up repetitive endpoint boilerplate across `match.py`, `event.py`, and `team.py`.

## Testing
- Added unit tests in `cached_query_result_test.py` covering Datastore-fetched compressed entities, in-memory uncommitted dicts, nulls, and raw bytes/strings.
- Added unit tests in `database_query_test.py` for `fetch_json` / `fetch_json_async` cache hit and miss flows.
- Added unit tests in `profiled_jsonify_test.py` for `bytes` and `bytearray` passthrough.
- Added unit tests in `model_query_response_test.py` for `model_query_response` and `models_query_response`.
- Full test suite verified: `687 passed in 6.76s`.
- Type checking: `pyre check` passed with 0 errors.
- Linting: `make lint` passed cleanly.