### PR TITLE
Add team nickname tooltips to Team CD Threads

### DIFF
--- a/src/backend/web/handlers/team_threads.py
+++ b/src/backend/web/handlers/team_threads.py
@@ -1,11 +1,13 @@
 import datetime
 
 from flask import abort
+from google.appengine.ext import ndb
 
 from backend.common.consts.media_type import MediaType
 from backend.common.decorators import cached_public
 from backend.common.helpers.season_helper import SeasonHelper
 from backend.common.models.keys import Year
+from backend.common.models.team import Team
 from backend.common.queries.media_query import MediaTypeYearQuery
 from backend.web.profiled_render import render_template
 
@@ -19,15 +21,24 @@ def team_threads(year: Year) -> str:
         MediaTypeYearQuery(MediaType.CD_THREAD, year).fetch_async().get_result()
     )
 
+    team_keys = {thread.references[0] for thread in all_cd_threads if thread.references}
+    teams_by_key = {
+        team.key: team for team in ndb.get_multi(team_keys) if isinstance(team, Team)
+    }
+
     rows = []
     for thread in all_cd_threads:
         if len(thread.references) == 0:
             continue
 
+        team_key = thread.references[0]
+        team = teams_by_key.get(team_key)
+
         rows.append(
             {
                 "year": thread.year,
-                "team_number": int(thread.references[0].id()[3:]),
+                "team_number": int(team_key.id()[3:]),
+                "team_nickname": team.nickname if team else None,
                 "thread_title": thread.details["thread_title"],
                 "thread_url": thread.view_image_url,
             }

--- a/src/backend/web/handlers/tests/team_threads_test.py
+++ b/src/backend/web/handlers/tests/team_threads_test.py
@@ -1,0 +1,54 @@
+import json
+
+from bs4 import BeautifulSoup
+from werkzeug.test import Client
+
+from backend.common.consts.media_type import MediaType
+from backend.common.models.media import Media
+from backend.common.models.team import Team
+
+
+def _preseed_thread(team_number: int, nickname: str | None) -> None:
+    team_key = Team(
+        id=f"frc{team_number}",
+        team_number=team_number,
+        nickname=nickname,
+    ).put()
+    Media(
+        id=f"cd-thread-team-{team_number}",
+        media_type_enum=MediaType.CD_THREAD,
+        foreign_key=f"team-{team_number}",
+        year=2020,
+        references=[team_key],
+        details_json=json.dumps({"thread_title": f"Team {team_number} thread"}),
+    ).put()
+
+
+def test_team_number_link_includes_nickname_tooltip(
+    ndb_stub, web_client: Client
+) -> None:
+    _preseed_thread(254, "The Cheesy Poofs")
+
+    response = web_client.get("/team-threads/2020")
+
+    assert response.status_code == 200
+    team_link = BeautifulSoup(response.data, "html.parser").find(
+        "a", href="/team/254/2020"
+    )
+    assert team_link is not None
+    assert team_link["rel"] == ["tooltip"]
+    assert team_link["title"] == "The Cheesy Poofs"
+
+
+def test_team_number_link_omits_empty_tooltip(ndb_stub, web_client: Client) -> None:
+    _preseed_thread(254, None)
+
+    response = web_client.get("/team-threads/2020")
+
+    assert response.status_code == 200
+    team_link = BeautifulSoup(response.data, "html.parser").find(
+        "a", href="/team/254/2020"
+    )
+    assert team_link is not None
+    assert "rel" not in team_link.attrs
+    assert "title" not in team_link.attrs

--- a/src/backend/web/templates/team_threads.html
+++ b/src/backend/web/templates/team_threads.html
@@ -21,7 +21,7 @@
           <tbody>
             {% for row in rows %}
               <tr>
-                <td><a href="/team/{{ row.team_number }}/{{ year }}">{{ row.team_number }}</a></td>
+                <td><a href="/team/{{ row.team_number }}/{{ year }}"{% if row.team_nickname %} rel="tooltip" title="{{ row.team_nickname }}"{% endif %}>{{ row.team_number }}</a></td>
                 <td><a href="{{ row.thread_url }}" target="_blank">{{ row.thread_title }}</a></td>
               </tr>
             {% endfor %}
@@ -34,4 +34,3 @@
   </div>
 </div>
 {% endblock %}
-


### PR DESCRIPTION
## Description
Adds each team's nickname as a tooltip on team-number links in the Team CD Threads table. Team records are loaded in one batch; links without a nickname remain unchanged.

## Motivation and Context
Fixes #5043.

## How Has This Been Tested?
- `uv run --group test pytest src/backend/web/handlers/tests/team_threads_test.py`
- `uv run --group typecheck pyre check`
- Black and flake8 on changed Python files

## Screenshots (if appropriate):
N/A (native browser tooltip only)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
