### PR TITLE
[api] Implement 304 fastpath

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -7,6 +7,12 @@ from flask import g, jsonify, make_response, request, Response
 
 from backend.api.client_api_auth_helper import ClientApiAuthHelper
 from backend.api.client_api_types import VoidRequest
+from backend.api.handlers.helpers.etag_helper import (
+    get_incoming_etags,
+    is_etag_valid,
+    normalize_etag,
+    save_etag_dependencies,
+)
 from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
 from backend.common.auth import current_user
 from backend.common.consts.account_permission import AccountPermission
@@ -14,6 +20,7 @@ from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
 from backend.common.consts.fms_report_type import FMSReportType
 from backend.common.consts.renamed_districts import RenamedDistricts
+from backend.common.environment import Environment
 from backend.common.logging import set_logging_context
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.district import District
@@ -21,6 +28,7 @@ from backend.common.models.event import Event
 from backend.common.models.match import Match
 from backend.common.models.team import Team
 from backend.common.profiler import Span
+from backend.common.queries.database_query import track_accessed_query_cache_keys
 
 
 def api_authenticated(func):
@@ -242,5 +250,50 @@ def validate_keys(func):
                 return {"Error": f"district key: {district_key} does not exist"}, 404
 
         return func(*args, **kwargs)
+
+    return decorated_function
+
+
+def validate_etag(func: Callable) -> Callable:
+    """
+    Decorator for APIv3 endpoints to short-circuit 304 responses when query dependencies haven't changed.
+    """
+
+    @wraps(func)
+    def decorated_function(*args, **kwargs):
+        with Span("validate_etag"):
+            if_none_match = request.headers.get("If-None-Match")
+            if if_none_match:
+                try:
+                    incoming_etags = get_incoming_etags()
+                    for etag in incoming_etags:
+                        if etag and is_etag_valid(etag):
+                            response = Response(status=304)
+                            response.headers["ETag"] = f'"{etag}"'
+                            if Environment.cache_control_header_enabled():
+                                response.headers["Cache-Control"] = (
+                                    "public, max-age=61, s-maxage=61"
+                                )
+                            return response
+                except Exception as e:
+                    logging.warning(f"Error during validate_etag fast-path: {e}")
+
+            with track_accessed_query_cache_keys() as accessed_keys:
+                resp = make_response(func(*args, **kwargs))
+
+                if resp.status_code == 200:
+                    try:
+                        etag_header = resp.headers.get("ETag")
+                        if not etag_header:
+                            resp.add_etag()
+                            etag_header = resp.headers.get("ETag")
+                        if etag_header and accessed_keys:
+                            normalized = normalize_etag(etag_header)
+                            if normalized:
+                                save_etag_dependencies(normalized, accessed_keys)
+                    except Exception as e:
+                        logging.warning(f"Error saving validate_etag dependencies: {e}")
+
+                return resp
 
     return decorated_function

--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -2,7 +2,11 @@ from typing import Any, Optional
 
 from flask import abort
 
-from backend.api.handlers.decorators import api_authenticated, validate_keys
+from backend.api.handlers.decorators import (
+    api_authenticated,
+    validate_etag,
+    validate_keys,
+)
 from backend.api.handlers.helpers.model_properties import (
     filter_event_properties,
     filter_team_properties,
@@ -35,6 +39,7 @@ from backend.common.queries.team_query import DistrictTeamsQuery
 
 @api_authenticated
 @cached_public
+@validate_etag
 def district_history(
     district_abbreviation: DistrictAbbreviation,
 ) -> TypedFlaskResponse[list[DistrictDict]]:
@@ -52,6 +57,7 @@ def district_history(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def district_events(
     district_key: DistrictKey, model_type: Optional[ModelType] = None
@@ -71,6 +77,7 @@ def district_events(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def district_teams(
     district_key: DistrictKey, model_type: Optional[ModelType] = None
@@ -90,6 +97,7 @@ def district_teams(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def district_rankings(district_key: DistrictKey) -> TypedFlaskResponse[Any]:
     """
@@ -105,6 +113,7 @@ def district_rankings(district_key: DistrictKey) -> TypedFlaskResponse[Any]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def district_list_year(year: int) -> TypedFlaskResponse[list[DistrictDict]]:
     """
     Returns a list of all districts for a given year.
@@ -117,6 +126,7 @@ def district_list_year(year: int) -> TypedFlaskResponse[list[DistrictDict]]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def district_awards(district_key: DistrictKey) -> TypedFlaskResponse[list[dict]]:
     """
@@ -145,6 +155,7 @@ def district_awards(district_key: DistrictKey) -> TypedFlaskResponse[list[dict]]
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def district_advancement(district_key: DistrictKey) -> TypedFlaskResponse[dict]:
     """
@@ -191,6 +202,7 @@ def district_advancement(district_key: DistrictKey) -> TypedFlaskResponse[dict]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def dcmp_history(
     district_abbreviation: DistrictAbbreviation,
 ) -> TypedFlaskResponse[list[dict]]:
@@ -244,6 +256,7 @@ def dcmp_history(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def district_insights(
     district_abbreviation: DistrictAbbreviation,
 ) -> TypedFlaskResponse[dict]:

--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -2,7 +2,11 @@ from typing import Any, Optional
 
 from flask import abort
 
-from backend.api.handlers.decorators import api_authenticated, validate_keys
+from backend.api.handlers.decorators import (
+    api_authenticated,
+    validate_etag,
+    validate_keys,
+)
 from backend.api.handlers.helpers.add_alliance_status import add_alliance_status
 from backend.api.handlers.helpers.model_properties import (
     filter_event_properties,
@@ -50,6 +54,7 @@ from backend.common.queries.team_query import EventEventTeamsQuery, EventTeamsQu
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event(
     event_key: EventKey, model_type: Optional[ModelType] = None
@@ -67,6 +72,7 @@ def event(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def event_list_all(
     model_type: Optional[ModelType] = None,
 ) -> TypedFlaskResponse[list[EventDict]]:
@@ -93,6 +99,7 @@ def event_list_all(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def event_list_year(
     year: int, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[EventDict]]:
@@ -109,6 +116,7 @@ def event_list_year(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_detail(event_key: EventKey, detail_type: str) -> TypedFlaskResponse[Any]:
     """
@@ -131,6 +139,7 @@ def event_detail(event_key: EventKey, detail_type: str) -> TypedFlaskResponse[An
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_advancement_points(event_key: EventKey) -> TypedFlaskResponse[Any]:
     """
@@ -155,6 +164,7 @@ def event_advancement_points(event_key: EventKey) -> TypedFlaskResponse[Any]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_teams(
     event_key: EventKey, model_type: Optional[ModelType] = None
@@ -172,6 +182,7 @@ def event_teams(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
     """
@@ -206,6 +217,7 @@ def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
     track_call_after_response("event/teams/media", event_key)
@@ -214,6 +226,7 @@ def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
     track_call_after_response("event/media", event_key)
@@ -222,6 +235,7 @@ def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_matches(
     event_key: EventKey, model_type: Optional[ModelType] = None
@@ -239,6 +253,7 @@ def event_matches(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
     """
@@ -252,6 +267,7 @@ def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_nexus_info(
     event_key: EventKey,
@@ -271,6 +287,7 @@ def event_nexus_info(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def event_playoff_advancement(event_key: EventKey) -> TypedFlaskResponse[Any]:
     """

--- a/src/backend/api/handlers/helpers/add_alliance_status.py
+++ b/src/backend/api/handlers/helpers/add_alliance_status.py
@@ -1,33 +1,32 @@
-from google.appengine.ext import ndb
-
 from backend.common.models.alliance import EventAlliance
-from backend.common.models.event_team import EventTeam
+from backend.common.models.keys import EventKey
+from backend.common.queries.team_query import EventEventTeamsQuery
 
 
 # Adds the alliance captain's EventTeamStatusPlayoff to the alliance status.
 def add_alliance_status(
     event_key: str, alliances: list[EventAlliance]
 ) -> list[EventAlliance]:
-    captain_team_keys = []
-    for alliance in alliances:
-        if alliance["picks"]:
-            captain_team_keys.append(alliance["picks"][0])
-
-    event_team_keys = [
-        ndb.Key(EventTeam, "{}_{}".format(event_key, team_key))
-        for team_key in captain_team_keys
-    ]
-    captain_eventteams_future = ndb.get_multi_async(event_team_keys)
+    event_teams = EventEventTeamsQuery(event_key=EventKey(event_key)).fetch()
+    event_teams_by_key = {
+        event_team.team.id(): event_team
+        for event_team in event_teams
+        if event_team.team is not None
+    }
     with_status = []
-    for captain_future, alliance in zip(captain_eventteams_future, alliances):
-        captain = captain_future.get_result()
-        if (
-            captain
-            and captain.status
-            and captain.status.get("alliance")
-            and captain.status.get("playoff")
-        ):
-            alliance["status"] = captain.status.get("playoff")
+    for alliance in alliances:
+        if alliance.get("picks"):
+            captain_team_key = alliance["picks"][0]
+            captain = event_teams_by_key.get(captain_team_key)
+            if (
+                captain
+                and captain.status
+                and captain.status.get("alliance")
+                and captain.status.get("playoff")
+            ):
+                playoff_status = captain.status.get("playoff")
+                if playoff_status is not None:
+                    alliance["status"] = playoff_status
 
         with_status.append(alliance)
 

--- a/src/backend/api/handlers/helpers/etag_helper.py
+++ b/src/backend/api/handlers/helpers/etag_helper.py
@@ -1,0 +1,135 @@
+import logging
+import uuid
+from typing import Any, Dict, List, Optional, Set
+
+from flask import request
+
+from backend.common.memcache import MemcacheClient
+
+ETAG_CACHE_TTL: int = 7 * 24 * 3600  # 7 days in seconds
+
+
+def normalize_etag(etag: Optional[str]) -> Optional[str]:
+    """
+    Normalizes an ETag string by stripping weak indicators (W/) and quotes.
+    """
+    if not etag:
+        return None
+    etag = etag.strip()
+    if etag.startswith("W/") or etag.startswith("w/"):
+        etag = etag[2:].strip()
+    if (etag.startswith('"') and etag.endswith('"')) or (
+        etag.startswith("'") and etag.endswith("'")
+    ):
+        etag = etag[1:-1].strip()
+    return etag if etag else None
+
+
+def get_incoming_etags() -> List[str]:
+    """
+    Extracts and normalizes all ETags passed in the If-None-Match header.
+    """
+    etags: List[str] = []
+    if_none_match = request.if_none_match
+    if if_none_match:
+        for e in if_none_match.as_set(include_weak=True):
+            norm = normalize_etag(e)
+            if norm:
+                etags.append(norm)
+    if not etags:
+        raw_header = request.headers.get("If-None-Match")
+        if raw_header:
+            for part in raw_header.split(","):
+                norm = normalize_etag(part)
+                if norm:
+                    etags.append(norm)
+    return etags
+
+
+def get_request_path(path: Optional[str] = None) -> str:
+    """
+    Returns the request path used to scope ETag dependencies in Memcache.
+    """
+    if path is not None:
+        return path.split("?")[0]
+    return request.path
+
+
+def get_etag_dependencies(
+    normalized_etag: str, path: Optional[str] = None
+) -> Optional[Dict[str, str]]:
+    """
+    Fetches the query key -> version mapping for an ETag scoped by endpoint path from Memcache.
+    """
+    try:
+        memcache = MemcacheClient.get()
+        endpoint_path = get_request_path(path)
+        deps = memcache.get(
+            f"etag_deps:{endpoint_path}:{normalized_etag}".encode("utf-8")
+        )
+        if isinstance(deps, dict):
+            return deps
+    except Exception as e:
+        logging.warning(f"Error fetching ETag dependencies from Memcache: {e}")
+    return None
+
+
+def is_etag_valid(normalized_etag: str, path: Optional[str] = None) -> bool:
+    """
+    Verifies whether all dependent query cache keys for a given ETag match their current versions.
+    """
+    deps = get_etag_dependencies(normalized_etag, path=path)
+    if deps is None or not isinstance(deps, dict) or not deps:
+        return False
+    try:
+        memcache = MemcacheClient.get()
+        query_keys = list(deps.keys())
+        q_ver_keys = [f"q_ver:{k}".encode("utf-8") for k in query_keys]
+        current_versions = memcache.get_multi(q_ver_keys)
+        for k, expected_ver in deps.items():
+            actual_ver = current_versions.get(f"q_ver:{k}".encode("utf-8"))
+            if actual_ver is None or actual_ver != expected_ver:
+                return False
+        return True
+    except Exception as e:
+        logging.warning(f"Error validating ETag query versions in Memcache: {e}")
+        return False
+
+
+def save_etag_dependencies(
+    normalized_etag: str,
+    query_cache_keys: Set[str],
+    path: Optional[str] = None,
+    ttl: int = ETAG_CACHE_TTL,
+) -> None:
+    """
+    Stores the mapping between an ETag and its dependent query cache keys with their current versions.
+    """
+    if not query_cache_keys:
+        return
+    try:
+        memcache = MemcacheClient.get()
+        endpoint_path = get_request_path(path)
+        q_ver_keys = [f"q_ver:{k}".encode("utf-8") for k in query_cache_keys]
+        existing_versions = memcache.get_multi(q_ver_keys)
+        versions_to_set: Dict[bytes, Any] = {}
+        deps: Dict[str, str] = {}
+        for k in query_cache_keys:
+            q_key = f"q_ver:{k}".encode("utf-8")
+            ver = existing_versions.get(q_key)
+            if ver is None:
+                ver = uuid.uuid4().hex
+            # Refresh TTL for existing and new query versions
+            versions_to_set[q_key] = ver
+            deps[k] = str(ver)
+
+        if versions_to_set:
+            memcache.set_multi(versions_to_set, time=ttl)
+
+        memcache.set(
+            f"etag_deps:{endpoint_path}:{normalized_etag}".encode("utf-8"),
+            deps,
+            time=ttl,
+        )
+    except Exception as e:
+        logging.warning(f"Error saving ETag dependencies to Memcache: {e}")

--- a/src/backend/api/handlers/insights.py
+++ b/src/backend/api/handlers/insights.py
@@ -1,6 +1,6 @@
 from flask import abort, Response
 
-from backend.api.handlers.decorators import api_authenticated
+from backend.api.handlers.decorators import api_authenticated, validate_etag
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.consts.api_version import ApiMajorVersion
@@ -31,6 +31,7 @@ _VALID_INSIGHT_V2_CATEGORIES = frozenset(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def insights_leaderboards_year(year: int) -> Response:
     track_call_after_response("insights/leaderboards", str(year))
 
@@ -43,6 +44,7 @@ def insights_leaderboards_year(year: int) -> Response:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def insights_notables_year(year: int) -> Response:
     track_call_after_response("insights/notables", str(year))
 
@@ -52,6 +54,7 @@ def insights_notables_year(year: int) -> Response:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def insights_v2_year(year: int) -> Response:
     track_call_after_response("insights/v2", str(year))
 
@@ -61,6 +64,7 @@ def insights_v2_year(year: int) -> Response:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def insights_v2_year_category(year: int, category: str) -> Response:
     if category not in _VALID_INSIGHT_V2_CATEGORIES:
         abort(404)
@@ -75,6 +79,7 @@ def insights_v2_year_category(year: int, category: str) -> Response:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def insights_v2_year_district(
     year: int, district_abbreviation: DistrictAbbreviation
 ) -> Response:
@@ -88,6 +93,7 @@ def insights_v2_year_district(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def insights_v2_year_category_district(
     year: int, category: str, district_abbreviation: DistrictAbbreviation
 ) -> Response:

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -1,6 +1,10 @@
 from typing import Any, Optional
 
-from backend.api.handlers.decorators import api_authenticated, validate_keys
+from backend.api.handlers.decorators import (
+    api_authenticated,
+    validate_etag,
+    validate_keys,
+)
 from backend.api.handlers.helpers.model_properties import (
     filter_match_properties,
     ModelType,
@@ -20,6 +24,7 @@ from backend.common.queries.match_query import MatchQuery
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def match(
     match_key: MatchKey, model_type: Optional[ModelType] = None
@@ -37,6 +42,7 @@ def match(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def zebra_motionworks(match_key: MatchKey) -> TypedFlaskResponse[Any]:
     """

--- a/src/backend/api/handlers/regional_advancement.py
+++ b/src/backend/api/handlers/regional_advancement.py
@@ -1,6 +1,6 @@
 from flask import make_response, Response
 
-from backend.api.handlers.decorators import api_authenticated
+from backend.api.handlers.decorators import api_authenticated, validate_etag
 from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
 from backend.api.handlers.helpers.track_call import track_call_after_response
 from backend.common.decorators import cached_public
@@ -11,6 +11,7 @@ from backend.common.models.regional_champs_pool import RegionalChampsPool
 
 @api_authenticated
 @cached_public
+@validate_etag
 def regional_rankings(year: Year) -> Response:
     """
     Returns the regional advancement rankings
@@ -30,6 +31,7 @@ def regional_rankings(year: Year) -> Response:
 
 @api_authenticated
 @cached_public
+@validate_etag
 def regional_advancement(year: Year) -> Response:
     """
     Returns the regional advancement qualification info

--- a/src/backend/api/handlers/search.py
+++ b/src/backend/api/handlers/search.py
@@ -1,4 +1,4 @@
-from backend.api.handlers.decorators import api_authenticated
+from backend.api.handlers.decorators import api_authenticated, validate_etag
 from backend.api.handlers.helpers.model_properties import (
     filter_event_properties,
     filter_team_properties,
@@ -20,6 +20,7 @@ from backend.common.queries.team_query import TeamListQuery
 # TODO: bump cache time to 1 day after testing/dev is complete
 @api_authenticated
 @cached_public
+@validate_etag
 def search_index() -> TypedFlaskResponse[dict]:
     track_call_after_response("search_index", "search_index")
 
@@ -28,7 +29,12 @@ def search_index() -> TypedFlaskResponse[dict]:
     max_team_page = int(max_team_num / 500)
 
     team_futures = []
-    for page_num in range(max_team_page + 1):
+    # Query up to max_team_page + 1 (i.e. range(max_team_page + 2)).
+    # Page max_team_page + 1 is currently empty ([]), but querying it registers its
+    # cache key in @validate_etag's accessed_keys. When a new team is created that starts
+    # this next page, TeamManipulator invalidates TeamListQuery(max_team_page + 1),
+    # which invalidates the ETag and ensures clients receive the new team.
+    for page_num in range(max_team_page + 2):
         team_futures.append(
             TeamListQuery(page=page_num).fetch_dict_async(ApiMajorVersion.API_V3)
         )

--- a/src/backend/api/handlers/team.py
+++ b/src/backend/api/handlers/team.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 
 from backend.api.handlers.decorators import (
     api_authenticated,
+    validate_etag,
     validate_keys,
 )
 from backend.api.handlers.helpers.model_properties import (
@@ -66,6 +67,7 @@ from backend.common.queries.team_query import (
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team(
     team_key: TeamKey, model_type: Optional[ModelType] = None
@@ -83,6 +85,7 @@ def team(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_history(team_key: TeamKey) -> TypedFlaskResponse[Any]:
     track_call_after_response("team/history", team_key)
@@ -103,6 +106,7 @@ def team_history(team_key: TeamKey) -> TypedFlaskResponse[Any]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_years_participated(team_key: TeamKey) -> TypedFlaskResponse[list[int]]:
     """
@@ -117,6 +121,7 @@ def team_years_participated(team_key: TeamKey) -> TypedFlaskResponse[list[int]]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[DistrictDict]]:
     """
@@ -130,6 +135,7 @@ def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[Distric
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]]:
     """
@@ -143,6 +149,7 @@ def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
     """
@@ -156,6 +163,7 @@ def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_events(
     team_key: TeamKey,
@@ -185,6 +193,7 @@ def team_events(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_events_statuses_year(team_key: TeamKey, year: int) -> TypedFlaskResponse[dict]:
     """
@@ -219,6 +228,7 @@ def team_events_statuses_year(team_key: TeamKey, year: int) -> TypedFlaskRespons
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_event_matches(
     team_key: TeamKey, event_key: EventKey, model_type: Optional[ModelType] = None
@@ -238,6 +248,7 @@ def team_event_matches(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_event_awards(
     team_key: TeamKey, event_key: EventKey
@@ -253,6 +264,7 @@ def team_event_awards(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_event_status(
     team_key: TeamKey, event_key: EventKey
@@ -286,6 +298,7 @@ def team_event_status(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_awards(
     team_key: TeamKey,
@@ -306,6 +319,7 @@ def team_awards(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_matches(
     team_key: TeamKey,
@@ -325,6 +339,7 @@ def team_matches(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_media_year(
     team_key: TeamKey, year: int
@@ -338,6 +353,7 @@ def team_media_year(
 
 @api_authenticated
 @cached_public
+@validate_etag
 @validate_keys
 def team_media_tag(
     team_key: TeamKey, media_tag: str, year: Optional[int] = None
@@ -365,6 +381,7 @@ def team_media_tag(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def team_list_all(
     model_type: Optional[ModelType] = None,
 ) -> TypedFlaskResponse[list[TeamDict]]:
@@ -378,7 +395,12 @@ def team_list_all(
     max_team_page = int(max_team_num / TEAM_PAGE_SIZE)
 
     futures = []
-    for page_num in range(max_team_page + 1):
+    # Query up to max_team_page + 1 (i.e. range(max_team_page + 2)).
+    # Page max_team_page + 1 is currently empty ([]), but querying it registers its
+    # cache key in @validate_etag's accessed_keys. When a new team is created that starts
+    # this next page, TeamManipulator invalidates TeamListQuery(max_team_page + 1),
+    # which invalidates the ETag and ensures clients receive the new team.
+    for page_num in range(max_team_page + 2):
         futures.append(
             TeamListQuery(page=page_num).fetch_dict_async(ApiMajorVersion.API_V3)
         )
@@ -395,6 +417,7 @@ def team_list_all(
 
 @api_authenticated
 @cached_public
+@validate_etag
 def team_list(
     page_num: int, year: Optional[int] = None, model_type: Optional[ModelType] = None
 ) -> TypedFlaskResponse[list[TeamDict]]:

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -1,0 +1,582 @@
+from unittest.mock import MagicMock
+
+import pytest
+from google.appengine.ext import ndb
+from pyre_extensions import none_throws
+from werkzeug.test import Client
+
+from backend.api.handlers.helpers.etag_helper import (
+    get_etag_dependencies,
+    normalize_etag,
+)
+from backend.common.consts.auth_type import AuthType
+from backend.common.environment import Environment
+from backend.common.memcache import MemcacheClient
+from backend.common.models.api_auth_access import ApiAuthAccess
+from backend.common.models.award import Award
+from backend.common.models.event import Event
+from backend.common.models.event_team import EventTeam
+from backend.common.models.team import Team
+from backend.common.queries.award_query import TeamAwardsQuery
+from backend.common.queries.team_query import TeamQuery
+
+
+def test_validate_etag_records_and_short_circuits_304(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Disable flask_response_cache to specifically test the @validate_etag fast path
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    # 1. First request: cache miss, executes validate_keys and handler, records query in Memcache
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    assert resp1.json["key"] == "frc254"
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    normalized_etag = normalize_etag(etag)
+    assert normalized_etag is not None
+    deps = get_etag_dependencies(normalized_etag, path="/api/v3/team/frc254")
+    assert deps is not None
+    assert any("frc254" in k for k in deps.keys())
+
+    # Mock Team.get_by_id_async to verify handler and validate_keys are completely bypassed
+    original_get_by_id_async = Team.get_by_id_async
+    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+
+    # 2. Second request with If-None-Match: should return 304 via @validate_etag fast path
+    resp2 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+    assert resp2.headers.get("ETag") == etag
+    mock_get_by_id_async.assert_not_called()
+
+
+def test_delete_cache_multi_invalidates_etag_304(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    team_obj = Team(id="frc254", team_number=254, nickname="The Cheesy Poofs")
+    team_obj.put()
+
+    # Initial request
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Verify 304 works
+    resp2 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+
+    # Update team and invalidate cache
+    team_obj.nickname = "Updated Poofs"
+    team_obj.put()
+    TeamQuery.delete_cache_multi({TeamQuery(team_key="frc254").cache_key})
+
+    # Next request with old ETag should NOT return 304, but fresh 200 with new data
+    resp3 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 200
+    assert resp3.json["nickname"] == "Updated Poofs"
+    new_etag = resp3.headers.get("ETag")
+    assert new_etag != etag
+
+
+def test_validate_etag_multi_query_endpoint(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+    Event(id="2020casj", year=2020, event_short="casj", event_type_enum=0).put()
+    event_key = none_throws(Event.get_by_id("2020casj")).key
+    team_key = none_throws(Team.get_by_id("frc254")).key
+    EventTeam(
+        id="2020casj_frc254",
+        event=event_key,
+        team=team_key,
+        year=2020,
+    ).put()
+    award = Award(
+        id="2020casj_1",
+        year=2020,
+        award_type_enum=1,
+        event_type_enum=0,
+        event=event_key,
+        name_str="Winner",
+        team_list=[team_key],
+        recipient_json_list=[],
+    )
+    award.put()
+
+    # First request to team history (fetches TeamEventsQuery and TeamAwardsQuery)
+    resp1 = api_client.get(
+        "/api/v3/team/frc254/history", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    normalized_etag = normalize_etag(etag)
+    assert normalized_etag is not None
+    deps = get_etag_dependencies(normalized_etag, path="/api/v3/team/frc254/history")
+    assert deps is not None
+    assert len(deps) >= 2  # Must contain events and awards query keys
+
+    # Verify 304 returns
+    resp2 = api_client.get(
+        "/api/v3/team/frc254/history",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+
+    # Update award data and invalidate ONLY TeamAwardsQuery
+    award.name_str = "Finalist"
+    award.put()
+    TeamAwardsQuery.delete_cache_multi({TeamAwardsQuery(team_key="frc254").cache_key})
+
+    # Next request with old ETag must return 200 because one dependent query was invalidated
+    resp3 = api_client.get(
+        "/api/v3/team/frc254/history",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 200
+    assert resp3.json["awards"][0]["name"] == "Finalist"
+
+
+def test_scoped_etag_deps_prevent_cross_endpoint_collision(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Ensure that when two different endpoints return identical responses (e.g. empty lists []),
+    their ETag dependency mappings are scoped by endpoint path and do not overwrite each other.
+    """
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+    Team(id="frc9999", team_number=9999).put()
+    Event(id="2020casj", year=2020, event_short="casj", event_type_enum=0).put()
+
+    # 1. Both endpoints return [] and generate the exact same ETag
+    resp_254 = api_client.get(
+        "/api/v3/team/frc254/awards", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    resp_9999 = api_client.get(
+        "/api/v3/team/frc9999/awards", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp_254.status_code == 200
+    assert resp_9999.status_code == 200
+    assert resp_254.json == []
+    assert resp_9999.json == []
+
+    etag_254 = resp_254.headers.get("ETag")
+    etag_9999 = resp_9999.headers.get("ETag")
+    assert etag_254 == etag_9999  # Identical payload produces identical ETag hash
+
+    # Both endpoints should have separate dependency records in Memcache
+    norm_etag = normalize_etag(etag_254)
+    assert norm_etag is not None
+    deps_254 = get_etag_dependencies(norm_etag, path="/api/v3/team/frc254/awards")
+    deps_9999 = get_etag_dependencies(norm_etag, path="/api/v3/team/frc9999/awards")
+    assert deps_254 is not None
+    assert deps_9999 is not None
+    assert any("frc254" in k for k in deps_254.keys())
+    assert any("frc9999" in k for k in deps_9999.keys())
+
+    # 2. Add an award to frc254 and invalidate only frc254's awards query
+    Award(
+        id="2020casj_1",
+        year=2020,
+        award_type_enum=1,
+        event_type_enum=0,
+        event=none_throws(Event.get_by_id("2020casj")).key,
+        name_str="Winner",
+        team_list=[none_throws(Team.get_by_id("frc254")).key],
+        recipient_json_list=[],
+    ).put()
+    TeamAwardsQuery.delete_cache_multi({TeamAwardsQuery(team_key="frc254").cache_key})
+
+    # 3. frc254 request with old ETag must return 200 with new data
+    resp_254_updated = api_client.get(
+        "/api/v3/team/frc254/awards",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag_254},
+    )
+    assert resp_254_updated.status_code == 200
+    assert len(resp_254_updated.json) == 1
+
+    # 4. frc9999 request with the same empty-list ETag must STILL return 304!
+    resp_9999_fresh = api_client.get(
+        "/api/v3/team/frc9999/awards",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag_9999},
+    )
+    assert resp_9999_fresh.status_code == 304
+
+
+def test_validate_etag_unauthenticated_request_rejected(
+    ndb_stub, api_client: Client
+) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    etag = resp1.headers.get("ETag")
+
+    # Request without auth must return 401 even with If-None-Match
+    resp_unauth = api_client.get("/api/v3/team/frc254", headers={"If-None-Match": etag})
+    assert resp_unauth.status_code == 401
+
+
+def test_validate_etag_fallback_on_memcache_error(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    # Initial request
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    etag = resp1.headers.get("ETag")
+
+    # Track handler execution via Team.get_by_id_async
+    original_get_by_id_async = Team.get_by_id_async
+    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+
+    # Simulate Memcache failure during validation
+    monkeypatch.setattr(
+        MemcacheClient.get(),
+        "get",
+        MagicMock(side_effect=Exception("Memcache timeout")),
+    )
+
+    # Request should gracefully execute the handler without crashing
+    resp2 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code in (200, 304)
+    # Handler must have run (not fast-path short-circuited)
+    mock_get_by_id_async.assert_called()
+
+
+def test_event_alliances_etag_invalidated_on_event_team_update(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    from backend.common.consts.comp_level import CompLevel
+    from backend.common.models.alliance import PlayoffAllianceStatus, PlayoffOutcome
+    from backend.common.models.event_details import EventDetails
+    from backend.common.models.event_team_status import (
+        EventTeamStatus,
+        EventTeamStatusAlliance,
+    )
+    from backend.common.queries.team_query import EventEventTeamsQuery
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Event(id="2020casj", year=2020, event_short="casj", event_type_enum=0).put()
+    Team(id="frc254", team_number=254).put()
+    Team(id="frc971", team_number=971).put()
+
+    EventDetails(
+        id="2020casj",
+        alliance_selections=[{"picks": ["frc254", "frc971"], "declines": []}],
+    ).put()
+
+    event_team = EventTeam(
+        id="2020casj_frc254",
+        event=ndb.Key(Event, "2020casj"),
+        team=ndb.Key(Team, "frc254"),
+        year=2020,
+        status=EventTeamStatus(
+            qual=None,
+            playoff=PlayoffAllianceStatus(
+                level=CompLevel.QF,
+                status=PlayoffOutcome.PLAYING,
+                current_level_record=None,
+                record=None,
+            ),
+            alliance=EventTeamStatusAlliance(name=None, number=1, pick=0, backup=None),
+            last_match_key=None,
+            next_match_key=None,
+        ),
+    )
+    event_team.put()
+
+    # Initial request
+    resp1 = api_client.get(
+        "/api/v3/event/2020casj/alliances",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp1.status_code == 200
+    assert resp1.json[0]["status"]["status"] == "playing"
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Should 304 with unchanged ETag
+    resp2 = api_client.get(
+        "/api/v3/event/2020casj/alliances",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+
+    # Update event team playoff status and invalidate EventEventTeamsQuery
+    status = none_throws(event_team.status)
+    none_throws(status["playoff"])["status"] = PlayoffOutcome.WON
+    event_team.put()
+
+    EventEventTeamsQuery.delete_cache_multi(
+        {EventEventTeamsQuery(event_key="2020casj").cache_key}
+    )
+
+    # Should NOT 304 anymore, should return fresh 200 with new status
+    resp3 = api_client.get(
+        "/api/v3/event/2020casj/alliances",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 200
+    assert resp3.json[0]["status"]["status"] == "won"
+    assert resp3.headers.get("ETag") != etag
+
+
+def test_event_playoff_advancement_etag_invalidated_on_event_details_update(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    from backend.common.helpers.playoff_advancement_helper import (
+        PlayoffAdvancementHelper,
+    )
+    from backend.common.models.event_details import EventDetails
+    from backend.common.queries.event_details_query import EventDetailsQuery
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Event(
+        id="2020casj",
+        year=2020,
+        event_short="casj",
+        event_type_enum=0,
+        playoff_type=0,
+    ).put()
+    event_details = EventDetails(
+        id="2020casj",
+        playoff_advancement={"bracket": {}, "advancement": {}},
+    )
+    event_details.put()
+
+    # Initial request
+    resp1 = api_client.get(
+        "/api/v3/event/2020casj/playoff_advancement",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Verify that point queries with MODEL_CACHING_ENABLED = False are tracked
+    deps = get_etag_dependencies(
+        none_throws(normalize_etag(etag)),
+        path="/api/v3/event/2020casj/playoff_advancement",
+    )
+    assert deps is not None
+    assert any("event_details_2020casj" in k for k in deps.keys())
+    assert any("event_2020casj" in k for k in deps.keys())
+
+    # Should 304 with unchanged ETag
+    resp2 = api_client.get(
+        "/api/v3/event/2020casj/playoff_advancement",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+
+    # Update EventDetails (which has MODEL_CACHING_ENABLED = False)
+    # and invalidate EventDetailsQuery
+    monkeypatch.setattr(
+        PlayoffAdvancementHelper,
+        "create_playoff_advancement_response_for_apiv3",
+        lambda *args, **kwargs: [{"mock_advancement": "updated"}],
+    )
+    EventDetailsQuery.delete_cache_multi(
+        {EventDetailsQuery(event_key="2020casj").cache_key}
+    )
+
+    # Should NOT 304 anymore, should return fresh 200 with new playoff advancement
+    resp3 = api_client.get(
+        "/api/v3/event/2020casj/playoff_advancement",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 200
+    assert resp3.json == [{"mock_advancement": "updated"}]
+    assert resp3.headers.get("ETag") != etag
+
+
+def test_search_index_etag_invalidated_on_new_team_page(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    from backend.common.queries.team_query import TeamListQuery
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    # Initial request (max team is 254 -> max_team_page = 0, watches page 0 and 1)
+    resp1 = api_client.get(
+        "/api/v3/search_index",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+    assert len(resp1.json["teams"]) == 1
+
+    # Should 304 with unchanged ETag
+    resp2 = api_client.get(
+        "/api/v3/search_index",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+
+    # Create team on page 1 (team 600) and invalidate TeamListQuery(page=1)
+    Team(id="frc600", team_number=600, nickname="Team 600").put()
+    TeamListQuery.delete_cache_multi({TeamListQuery(page=1).cache_key})
+
+    # Should NOT 304, should return fresh 200 with team 600
+    resp3 = api_client.get(
+        "/api/v3/search_index",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 200
+    assert len(resp3.json["teams"]) == 2
+    assert resp3.headers.get("ETag") != etag
+
+
+def test_team_list_all_etag_invalidated_on_new_team_page(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    from backend.common.queries.team_query import TeamListQuery
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    # Initial request (max team is 254 -> max_team_page = 0, watches page 0 and 1)
+    resp1 = api_client.get(
+        "/api/v3/teams/all",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+    assert len(resp1.json) == 1
+
+    # Should 304 with unchanged ETag
+    resp2 = api_client.get(
+        "/api/v3/teams/all",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+
+    # Create team on page 1 (team 600) and invalidate TeamListQuery(page=1)
+    Team(id="frc600", team_number=600, nickname="Team 600").put()
+    TeamListQuery.delete_cache_multi({TeamListQuery(page=1).cache_key})
+
+    # Should NOT 304, should return fresh 200 with team 600
+    resp3 = api_client.get(
+        "/api/v3/teams/all",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 200
+    assert len(resp3.json) == 2
+    assert resp3.headers.get("ETag") != etag
+
+
+def test_validate_etag_weak_etag_supported(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    # Initial request
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Track handler calls via Team.get_by_id_async
+    original_get_by_id_async = Team.get_by_id_async
+    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+
+    # Sending weak ETag (e.g. W/"<hash>") should short-circuit to 304
+    weak_etag = f"W/{etag}"
+    resp2 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": weak_etag},
+    )
+    assert resp2.status_code == 304
+    assert resp2.headers.get("ETag") == etag
+    mock_get_by_id_async.assert_not_called()

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import abc
 import json
 import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, Dict, Generator, Generic, List, Optional, Set, Type, Union
 
 import orjson
@@ -11,15 +13,34 @@ from pyre_extensions import none_throws
 
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.futures import TypedFuture
+from backend.common.memcache import MemcacheClient
 from backend.common.models.cached_query_result import CachedQueryResult
 from backend.common.profiler import Span
 from backend.common.queries.dict_converters.converter_base import ConverterBase
 from backend.common.queries.types import DictQueryReturn, QueryReturn
 
+accessed_query_cache_keys_ctx: ContextVar[Optional[Set[str]]] = ContextVar[
+    Optional[Set[str]]
+]("accessed_query_cache_keys_ctx", default=None)
+
+
+@contextmanager
+def track_accessed_query_cache_keys() -> Generator[Set[str], None, None]:
+    """
+    Context manager to collect cache keys of all CachedDatabaseQuery instances
+    accessed during the block execution.
+    """
+    keys: Set[str] = set()
+    token = accessed_query_cache_keys_ctx.set(keys)
+    try:
+        yield keys
+    finally:
+        accessed_query_cache_keys_ctx.reset(token)
+
 
 class DatabaseQuery(abc.ABC, Generic[QueryReturn, DictQueryReturn]):
     _query_args: Dict[str, Any]
-    DICT_CONVERTER: Optional[Type[ConverterBase[QueryReturn, DictQueryReturn]]]
+    DICT_CONVERTER: Optional[Type[ConverterBase[QueryReturn, DictQueryReturn]]] = None
 
     def __init__(self, *args, **kwargs) -> None:
         self._query_args = kwargs
@@ -108,11 +129,17 @@ class CachedDatabaseQuery(
         return f"{cache_key}~dictv{dict_version}.{subvserion}"
 
     @classmethod
+    def _record_accessed_cache_key(cls, cache_key: str) -> None:
+        accessed_keys = accessed_query_cache_keys_ctx.get()
+        if accessed_keys is not None:
+            accessed_keys.add(cache_key)
+
+    @classmethod
     def delete_cache_multi(cls, cache_keys: Set[str]) -> None:
         all_cache_keys = []
         for cache_key in cache_keys:
             all_cache_keys.append(cache_key)
-            if cls.DICT_CONVERTER is not None:
+            if getattr(cls, "DICT_CONVERTER", None) is not None:
                 all_cache_keys += [
                     cls._dict_cache_key(cache_key, valid_dict_version)
                     for valid_dict_version in set(ApiMajorVersion)
@@ -121,6 +148,13 @@ class CachedDatabaseQuery(
         ndb.delete_multi(
             [ndb.Key(CachedQueryResult, cache_key) for cache_key in all_cache_keys]
         )
+        try:
+            memcache_client = MemcacheClient.get()
+            memcache_client.delete_multi(
+                [f"q_ver:{k}".encode("utf-8") for k in all_cache_keys]
+            )
+        except Exception as e:
+            logging.warning(f"Failed to delete Memcache query version keys: {e}")
 
     @classmethod
     def get_query_class_by_name(
@@ -170,12 +204,14 @@ class CachedDatabaseQuery(
 
     @ndb.tasklet
     def _do_query(self, *args, **kwargs) -> Generator[Any, Any, QueryReturn]:
+        cache_key = self.cache_key
+        self._record_accessed_cache_key(cache_key)
+
         if not self.MODEL_CACHING_ENABLED:
             result = yield self._query_async(*args, **kwargs)
             return result
 
         with Span("{}._do_query".format(self.__class__.__name__)):
-            cache_key = self.cache_key
             cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
 
             # Validate cached result for corruption and treat as cache miss if corrupted
@@ -210,6 +246,10 @@ class CachedDatabaseQuery(
     def _do_dict_query(
         self, _dict_version: ApiMajorVersion, *args, **kwargs
     ) -> Generator[Any, Any, Union[None, DictQueryReturn, List[DictQueryReturn]]]:
+        if self.DICT_CONVERTER is not None:
+            cache_key = self.dict_cache_key(_dict_version)
+            self._record_accessed_cache_key(cache_key)
+
         if not self.DICT_CACHING_ENABLED:
             result = yield self._query_async(*args, **kwargs)
             return result
@@ -270,6 +310,10 @@ class CachedDatabaseQuery(
     def _do_json_query(
         self, _dict_version: ApiMajorVersion, *args, **kwargs
     ) -> Generator[Any, Any, Optional[bytes]]:
+        if self.DICT_CONVERTER is not None:
+            cache_key = self.dict_cache_key(_dict_version)
+            self._record_accessed_cache_key(cache_key)
+
         if not self.DICT_CACHING_ENABLED:
             dict_result = yield self._do_dict_query(_dict_version, *args, **kwargs)
             if dict_result is None:


### PR DESCRIPTION
This PR adds a 304 fastpath for APIv3 endpoints. Instead of executing route parameter validation (which makes Datastore existence queries) and running the handler (which performs Datastore queries and JSON serialization), the API short-circuits to an HTTP `304 Not Modified` using Memcache to verify whether any underlying query dependencies have changed.

---

### Architecture Diagram

```mermaid
sequenceDiagram
    autonumber
    actor Client
    participant Auth as api_authenticated
    participant VE as validate_etag
    participant MC as Memcache
    participant VK as validate_keys
    participant Handler as API Handler
    participant NDB as Cloud Datastore

    Client->>Auth: GET /api/v3/... (If-None-Match: "etag123")
    Auth->>Auth: Validate API Key
    Auth->>VE: Proceed to ETag check
    
    rect rgb(240, 245, 255)
        note over VE,MC: Fastpath Check
        VE->>MC: get(etag_deps:path:etag123)
        MC-->>VE: Return dependent query keys and expected versions
        VE->>MC: get_multi(q_ver:key1, q_ver:key2, ...)
        MC-->>VE: Return current query versions
    end

    alt All query versions match
        VE-->>Client: 304 Not Modified (Bypasses Handler and Datastore)
    else Version mismatch, missing, or no ETag
        VE->>VK: Execute route validation
        VK->>NDB: Check key existence
        VK->>Handler: Execute handler
        activate Handler
        Handler->>NDB: Query models
        Handler-->>VE: 200 OK + JSON Payload
        deactivate Handler
        VE->>MC: save_etag_dependencies(etag, accessed_keys)
        VE-->>Client: 200 OK + ETag Header
    end
```

---

### Key Generation Documentation

The system generates and tracks three types of keys:

#### 1. Query Cache Keys ([database_query.py](file:///Users/eugene/git/the-blue-alliance/src/backend/common/queries/database_query.py))
Every subclass of [`CachedDatabaseQuery`](file:///Users/eugene/git/the-blue-alliance/src/backend/common/queries/database_query.py#L48) produces deterministic cache keys based on query arguments:
- **Model Cache Key**: Built using [`CachedDatabaseQuery.cache_key`](file:///Users/eugene/git/the-blue-alliance/src/backend/common/queries/database_query.py#L90) with format `{prefix}_{params}`.
  - *Example*: `team_frc254` or `event_teams_2024casj`
- **Dictionary Cache Key**: Built via [`CachedDatabaseQuery._dict_cache_key`](file:///Users/eugene/git/the-blue-alliance/src/backend/common/queries/database_query.py#L125) appending the API major version and converter subversion:
  - Format: `{cache_key}~dictv{ApiMajorVersion}.{subversion}`
  - *Example*: `team_frc254~dictv3.1`

#### 2. Query Version Keys (`q_ver:*`)
- **Key Format**: `q_ver:<query_cache_key>` encoded as UTF-8 bytes.
  - *Example*: `q_ver:team_frc254~dictv3.1`
- **Value**: A 32-character hexadecimal UUID string (`uuid.uuid4().hex`).
- **Generation**: Generated lazily in [`save_etag_dependencies`](file:///Users/eugene/git/the-blue-alliance/src/backend/api/handlers/helpers/etag_helper.py#L99) when an entity is first requested or after an invalidation.
- **TTL**: 7 days (`ETAG_CACHE_TTL = 604800` seconds), refreshed on each read access.
- **Invalidation**: In [`CachedDatabaseQuery.delete_cache_multi`](file:///Users/eugene/git/the-blue-alliance/src/backend/common/queries/database_query.py#L138), every associated `q_ver:*` key (both model and dictionary variants) is batch-deleted from Memcache via [`MemcacheClient.delete_multi`](file:///Users/eugene/git/the-blue-alliance/src/backend/common/cache/gae_builtin_cache.py#L59) whenever the database record is updated.

#### 3. ETag Dependency Keys (`etag_deps:*`)
- **Key Format**: `etag_deps:<endpoint_path>:<normalized_etag>` encoded as UTF-8 bytes.
  - `<endpoint_path>`: Extracted via [`get_request_path`](file:///Users/eugene/git/the-blue-alliance/src/backend/api/handlers/helpers/etag_helper.py#L49) from `request.path` (excluding query parameters). Scoping by path prevents collisions between different endpoints that produce identical responses (such as empty arrays `[]`).
  - `<normalized_etag>`: Derived by [`normalize_etag`](file:///Users/eugene/git/the-blue-alliance/src/backend/api/handlers/helpers/etag_helper.py#L12) by stripping quotes (`"`, `'`) and weak prefixes (`W/`, `w/`).
  - *Example*: `etag_deps:/api/v3/team/frc254:d41d8cd98f00b204e9800998ecf8427e`
- **Value**: A serialized Python dictionary mapping each accessed query cache key to its expected UUID version at response time:
  ```json
  {
    "team_frc254~dictv3.1": "f47ac10b58cc4372a5670e02b2c3d479"
  }
  ```
- **TTL**: 7 days (`ETAG_CACHE_TTL`), refreshed on subsequent saves.
- **Validation**: When an `If-None-Match` request arrives, [`is_etag_valid`](file:///Users/eugene/git/the-blue-alliance/src/backend/api/handlers/helpers/etag_helper.py#L77) fetches the dependency map and compares each entry against current `q_ver:*` keys in Memcache. If any key is missing or has a different UUID, validation fails and the request falls through to the handler.