### PR TITLE
Ignore URL query parameters for APIv3 response caching

### DIFF
--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -38,7 +38,7 @@ from backend.common.queries.team_query import DistrictTeamsQuery
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def district_history(
     district_abbreviation: DistrictAbbreviation,
@@ -56,7 +56,7 @@ def district_history(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def district_events(
@@ -76,7 +76,7 @@ def district_events(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def district_teams(
@@ -96,7 +96,7 @@ def district_teams(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def district_rankings(district_key: DistrictKey) -> TypedFlaskResponse[Any]:
@@ -112,7 +112,7 @@ def district_rankings(district_key: DistrictKey) -> TypedFlaskResponse[Any]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def district_list_year(year: int) -> TypedFlaskResponse[list[DistrictDict]]:
     """
@@ -125,7 +125,7 @@ def district_list_year(year: int) -> TypedFlaskResponse[list[DistrictDict]]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def district_awards(district_key: DistrictKey) -> TypedFlaskResponse[list[dict]]:
@@ -154,7 +154,7 @@ def district_awards(district_key: DistrictKey) -> TypedFlaskResponse[list[dict]]
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def district_advancement(district_key: DistrictKey) -> TypedFlaskResponse[dict]:
@@ -201,7 +201,7 @@ def district_advancement(district_key: DistrictKey) -> TypedFlaskResponse[dict]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def dcmp_history(
     district_abbreviation: DistrictAbbreviation,
@@ -255,7 +255,7 @@ def dcmp_history(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def district_insights(
     district_abbreviation: DistrictAbbreviation,

--- a/src/backend/api/handlers/event.py
+++ b/src/backend/api/handlers/event.py
@@ -53,7 +53,7 @@ from backend.common.queries.team_query import EventEventTeamsQuery, EventTeamsQu
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event(
@@ -71,7 +71,7 @@ def event(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def event_list_all(
     model_type: Optional[ModelType] = None,
@@ -98,7 +98,7 @@ def event_list_all(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def event_list_year(
     year: int, model_type: Optional[ModelType] = None
@@ -115,7 +115,7 @@ def event_list_year(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_detail(event_key: EventKey, detail_type: str) -> TypedFlaskResponse[Any]:
@@ -138,7 +138,7 @@ def event_detail(event_key: EventKey, detail_type: str) -> TypedFlaskResponse[An
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_advancement_points(event_key: EventKey) -> TypedFlaskResponse[Any]:
@@ -163,7 +163,7 @@ def event_advancement_points(event_key: EventKey) -> TypedFlaskResponse[Any]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_teams(
@@ -181,7 +181,7 @@ def event_teams(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
@@ -216,7 +216,7 @@ def event_teams_statuses(event_key: EventKey) -> TypedFlaskResponse[dict]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
@@ -225,7 +225,7 @@ def event_teams_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
@@ -234,7 +234,7 @@ def event_media(event_key: EventKey) -> TypedFlaskResponse[list[MediaDict]]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_matches(
@@ -252,7 +252,7 @@ def event_matches(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
@@ -266,7 +266,7 @@ def event_awards(event_key: EventKey) -> TypedFlaskResponse[list[AwardDict]]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_nexus_info(
@@ -286,7 +286,7 @@ def event_nexus_info(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def event_playoff_advancement(event_key: EventKey) -> TypedFlaskResponse[Any]:

--- a/src/backend/api/handlers/insights.py
+++ b/src/backend/api/handlers/insights.py
@@ -30,7 +30,7 @@ _VALID_INSIGHT_V2_CATEGORIES = frozenset(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def insights_leaderboards_year(year: int) -> Response:
     track_call_after_response("insights/leaderboards", str(year))
@@ -43,7 +43,7 @@ def insights_leaderboards_year(year: int) -> Response:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def insights_notables_year(year: int) -> Response:
     track_call_after_response("insights/notables", str(year))
@@ -53,7 +53,7 @@ def insights_notables_year(year: int) -> Response:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def insights_v2_year(year: int) -> Response:
     track_call_after_response("insights/v2", str(year))
@@ -63,7 +63,7 @@ def insights_v2_year(year: int) -> Response:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def insights_v2_year_category(year: int, category: str) -> Response:
     if category not in _VALID_INSIGHT_V2_CATEGORIES:
@@ -78,7 +78,7 @@ def insights_v2_year_category(year: int, category: str) -> Response:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def insights_v2_year_district(
     year: int, district_abbreviation: DistrictAbbreviation
@@ -92,7 +92,7 @@ def insights_v2_year_district(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def insights_v2_year_category_district(
     year: int, category: str, district_abbreviation: DistrictAbbreviation

--- a/src/backend/api/handlers/match.py
+++ b/src/backend/api/handlers/match.py
@@ -23,7 +23,7 @@ from backend.common.queries.match_query import MatchQuery
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def match(
@@ -41,7 +41,7 @@ def match(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def zebra_motionworks(match_key: MatchKey) -> TypedFlaskResponse[Any]:

--- a/src/backend/api/handlers/media.py
+++ b/src/backend/api/handlers/media.py
@@ -8,7 +8,7 @@ from backend.common.decorators import cached_public
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 def media_tags() -> Response:
     """
     Returns a list of media tag names and codes.

--- a/src/backend/api/handlers/regional_advancement.py
+++ b/src/backend/api/handlers/regional_advancement.py
@@ -10,7 +10,7 @@ from backend.common.models.regional_champs_pool import RegionalChampsPool
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def regional_rankings(year: Year) -> Response:
     """
@@ -30,7 +30,7 @@ def regional_rankings(year: Year) -> Response:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def regional_advancement(year: Year) -> Response:
     """

--- a/src/backend/api/handlers/search.py
+++ b/src/backend/api/handlers/search.py
@@ -19,7 +19,7 @@ from backend.common.queries.team_query import TeamListQuery
 
 # TODO: bump cache time to 1 day after testing/dev is complete
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def search_index() -> TypedFlaskResponse[dict]:
     track_call_after_response("search_index", "search_index")

--- a/src/backend/api/handlers/status.py
+++ b/src/backend/api/handlers/status.py
@@ -17,7 +17,7 @@ from backend.common.sitevars.apistatus_fmsapi_down import ApiStatusFMSApiDown
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 def status() -> TypedFlaskResponse[dict]:
     track_call_after_response("status", "status")
 

--- a/src/backend/api/handlers/team.py
+++ b/src/backend/api/handlers/team.py
@@ -66,7 +66,7 @@ from backend.common.queries.team_query import (
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team(
@@ -84,7 +84,7 @@ def team(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_history(team_key: TeamKey) -> TypedFlaskResponse[Any]:
@@ -105,7 +105,7 @@ def team_history(team_key: TeamKey) -> TypedFlaskResponse[Any]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_years_participated(team_key: TeamKey) -> TypedFlaskResponse[list[int]]:
@@ -120,7 +120,7 @@ def team_years_participated(team_key: TeamKey) -> TypedFlaskResponse[list[int]]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[DistrictDict]]:
@@ -134,7 +134,7 @@ def team_history_districts(team_key: TeamKey) -> TypedFlaskResponse[list[Distric
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]]:
@@ -148,7 +148,7 @@ def team_history_robots(team_key: TeamKey) -> TypedFlaskResponse[list[RobotDict]
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
@@ -162,7 +162,7 @@ def team_social_media(team_key: TeamKey) -> TypedFlaskResponse[list[MediaDict]]:
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_events(
@@ -192,7 +192,7 @@ def team_events(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_events_statuses_year(team_key: TeamKey, year: int) -> TypedFlaskResponse[dict]:
@@ -227,7 +227,7 @@ def team_events_statuses_year(team_key: TeamKey, year: int) -> TypedFlaskRespons
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_event_matches(
@@ -247,7 +247,7 @@ def team_event_matches(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_event_awards(
@@ -263,7 +263,7 @@ def team_event_awards(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_event_status(
@@ -297,7 +297,7 @@ def team_event_status(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_awards(
@@ -318,7 +318,7 @@ def team_awards(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_matches(
@@ -338,7 +338,7 @@ def team_matches(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_media_year(
@@ -352,7 +352,7 @@ def team_media_year(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 @validate_keys
 def team_media_tag(
@@ -380,7 +380,7 @@ def team_media_tag(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def team_list_all(
     model_type: Optional[ModelType] = None,
@@ -416,7 +416,7 @@ def team_list_all(
 
 
 @api_authenticated
-@cached_public
+@cached_public(query_string=False)
 @validate_etag
 def team_list(
     page_num: int, year: Optional[int] = None, model_type: Optional[ModelType] = None

--- a/src/backend/api/handlers/tests/decorator_order_test.py
+++ b/src/backend/api/handlers/tests/decorator_order_test.py
@@ -106,3 +106,54 @@ def test_decorator_order_invalid_keys_return_404_on_cache_miss(
         "/api/v3/team/frc9999999", headers={"X-TBA-Auth-Key": "test_auth_key"}
     )
     assert resp_nonexistent.status_code == 404
+
+
+def test_apiv3_query_params_ignored_for_caching(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Ensure that APIv3 memcache keys ignore URL query parameters so that
+    requests with query params (such as ?X-TBA-Auth-Key=... or ?foo=bar) hit
+    the same cached response.
+    """
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    # 1. Warm cache with header authentication
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Track calls to Team.get_by_id_async to ensure cache hits bypass handler/validate_keys
+    original_get_by_id_async = Team.get_by_id_async
+    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+
+    # 2. Request with query param auth: ?X-TBA-Auth-Key=test_auth_key
+    resp2 = api_client.get("/api/v3/team/frc254?X-TBA-Auth-Key=test_auth_key")
+    assert resp2.status_code == 200
+    assert resp2.json["key"] == "frc254"
+    mock_get_by_id_async.assert_not_called()
+
+    # 3. Request with arbitrary query parameters: ?foo=bar&baz=qux
+    resp3 = api_client.get(
+        "/api/v3/team/frc254?foo=bar&baz=qux",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp3.status_code == 200
+    assert resp3.json["key"] == "frc254"
+    mock_get_by_id_async.assert_not_called()
+
+    # 4. Request with query params and If-None-Match
+    resp4 = api_client.get(
+        "/api/v3/team/frc254?timestamp=123456789",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp4.status_code == 304
+    mock_get_by_id_async.assert_not_called()

--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -12,14 +12,15 @@ def cached_public(
     func: Optional[Callable] = None,
     ttl: Union[int, timedelta] = 61,
     cache_redirects: bool = False,
+    query_string: bool = True,
 ):
     """
     Caches the handler's response and marks it publicly cacheable.
 
-    The cache is keyed on path + query string only, with no user component, so
-    the response body is stored once and served to every visitor. Never render
-    anything session-specific - a CSRF token, account details, per-user state -
-    into a response wrapped in this decorator.
+    The cache is keyed on path (and query string by default unless query_string=False),
+    with no user component, so the response body is stored once and served to every
+    visitor. Never render anything session-specific - a CSRF token, account
+    details, per-user state - into a response wrapped in this decorator.
 
     See src/backend/web/tests/cached_public_csrf_test.py, which enforces this
     for CSRF tokens, and
@@ -27,7 +28,12 @@ def cached_public(
     """
     timeout = ttl if isinstance(ttl, int) else int(ttl.total_seconds())
     if func is None:  # Handle no-argument decorator
-        return partial(cached_public, ttl=ttl, cache_redirects=cache_redirects)
+        return partial(
+            cached_public,
+            ttl=ttl,
+            cache_redirects=cache_redirects,
+            query_string=query_string,
+        )
 
     @wraps(func)
     def decorated_function(*args, **kwargs):
@@ -38,7 +44,7 @@ def cached_public(
                 timeout=timeout,
                 response_filter=lambda resp: make_response(resp).status_code
                 in status_codes,
-                query_string=True,
+                query_string=query_string,
             )
             resp = make_response(cached(func)(*args, **kwargs))
         else:


### PR DESCRIPTION
### Description
APIv3 endpoints determine their responses purely from URL route parameters and do not use query parameters for data fetching. Previously, `@cached_public` included query string parameters in cache keys by default, resulting in cache fragmentation when clients pass auth keys or tracking parameters in query strings (e.g. `?X-TBA-Auth-Key=...` or `?timestamp=...`).

### Changes
- Updated `@cached_public` in `backend.common.decorators` to accept `query_string: bool = True` and pass it to Flask-Caching.
- Explicitly marked all APIv3 endpoints in `src/backend/api/handlers/` with `@cached_public(query_string=False)`.
- Added a unit test in `decorator_order_test.py` verifying that requests with varying query params hit the same cached response entry.