### PR TITLE
[api] Scope validate_etag trace span to validation only

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -278,22 +278,22 @@ def validate_etag(func: Callable) -> Callable:
                 except Exception as e:
                     logging.warning(f"Error during validate_etag fast-path: {e}")
 
-            with track_accessed_query_cache_keys() as accessed_keys:
-                resp = make_response(func(*args, **kwargs))
+        with track_accessed_query_cache_keys() as accessed_keys:
+            resp = make_response(func(*args, **kwargs))
 
-                if resp.status_code == 200:
-                    try:
+            if resp.status_code == 200:
+                try:
+                    etag_header = resp.headers.get("ETag")
+                    if not etag_header:
+                        resp.add_etag()
                         etag_header = resp.headers.get("ETag")
-                        if not etag_header:
-                            resp.add_etag()
-                            etag_header = resp.headers.get("ETag")
-                        if etag_header and accessed_keys:
-                            normalized = normalize_etag(etag_header)
-                            if normalized:
-                                save_etag_dependencies(normalized, accessed_keys)
-                    except Exception as e:
-                        logging.warning(f"Error saving validate_etag dependencies: {e}")
+                    if etag_header and accessed_keys:
+                        normalized = normalize_etag(etag_header)
+                        if normalized:
+                            save_etag_dependencies(normalized, accessed_keys)
+                except Exception as e:
+                    logging.warning(f"Error saving validate_etag dependencies: {e}")
 
-                return resp
+            return resp
 
     return decorated_function

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -580,3 +580,43 @@ def test_validate_etag_weak_etag_supported(
     assert resp2.status_code == 304
     assert resp2.headers.get("ETag") == etag
     mock_get_by_id_async.assert_not_called()
+
+
+def test_validate_etag_span_does_not_wrap_handler(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from backend.common.profiler import trace_context
+
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    spans_during_handler: list[str] = []
+    original_get_by_id_async = Team.get_by_id_async
+
+    def mock_get_by_id(*args, **kwargs):
+        if hasattr(trace_context, "request") and hasattr(
+            trace_context.request, "spans"
+        ):
+            spans_during_handler.extend(
+                [s["name"] for s in trace_context.request.spans]
+            )
+        return original_get_by_id_async(*args, **kwargs)
+
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id)
+
+    resp = api_client.get(
+        "/api/v3/team/frc254",
+        headers={
+            "X-TBA-Auth-Key": "test_auth_key",
+            "X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1",
+        },
+    )
+    assert resp.status_code == 200
+    assert "validate_etag" in spans_during_handler
+    assert "api_authenticated" in spans_during_handler
+    assert "validate_keys" in spans_during_handler


### PR DESCRIPTION
## Description
Unindents the query cache key tracking and endpoint handler execution out of the `with Span("validate_etag"):` block in `validate_etag`. Also adds a unit test verifying that `validate_etag`, `api_authenticated`, and `validate_keys` spans have all closed prior to handler execution.

## Motivation and Context
`validate_etag` was keeping its trace span open across the entire request handler execution and cache recording logic instead of closing once the `If-None-Match` validation check finished. Other decorators such as `api_authenticated` and `validate_keys` properly close their spans prior to calling the wrapped function. This caused the `validate_etag` span in Cloud Trace to include the duration of the entire endpoint rather than just the ETag validation check.

## How Has This Been Tested?
- Ran `make test ARGS='src/backend/api/handlers/tests/test_validate_etag.py'` (all 12 tests passed).
- Ran `make test ARGS='src/backend/api/handlers/tests/decorator_order_test.py'` (all 3 tests passed).
- Verified with `make lint`.
- Verified with `make typecheck`.

## Screenshots (if appropriate):

## Screenshot Pages

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)