### PR TITLE
Cache 404 responses for 61s in cached_public

### DIFF
--- a/src/backend/api/handlers/tests/district_test.py
+++ b/src/backend/api/handlers/tests/district_test.py
@@ -1,7 +1,8 @@
 import json
+from datetime import timedelta
 
 import pytest
-
+from freezegun import freeze_time
 from google.appengine.ext import ndb
 from werkzeug.test import Client
 
@@ -709,35 +710,37 @@ def test_district_advancement_empty(ndb_stub, api_client: Client) -> None:
     "endpoint", ["advancement", "awards", "rankings", "teams", "events"]
 )
 def test_district_endpoints_validate(endpoint, ndb_stub, api_client: Client) -> None:
-    ApiAuthAccess(
-        id="test_auth_key",
-        auth_types_enum=[AuthType.READ_API],
-    ).put()
+    with freeze_time("2024-01-01 00:00:00") as frozen_time:
+        ApiAuthAccess(
+            id="test_auth_key",
+            auth_types_enum=[AuthType.READ_API],
+        ).put()
 
-    # Invalid district endpoint
-    resp = api_client.get(
-        f"/api/v3/district/2024Minnesota/{endpoint}",
-        headers={"X-TBA-Auth-Key": "test_auth_key"},
-    )
-    assert resp.status_code == 404
-    assert resp.json == {"Error": "2024Minnesota is not a valid district key"}
+        # Invalid district endpoint
+        resp = api_client.get(
+            f"/api/v3/district/2024Minnesota/{endpoint}",
+            headers={"X-TBA-Auth-Key": "test_auth_key"},
+        )
+        assert resp.status_code == 404
+        assert resp.json == {"Error": "2024Minnesota is not a valid district key"}
 
-    # Missing district
-    resp = api_client.get(
-        f"/api/v3/district/2024ne/{endpoint}",
-        headers={"X-TBA-Auth-Key": "test_auth_key"},
-    )
-    assert resp.status_code == 404
-    assert resp.json == {"Error": "district key: 2024ne does not exist"}
+        # Missing district
+        resp = api_client.get(
+            f"/api/v3/district/2024ne/{endpoint}",
+            headers={"X-TBA-Auth-Key": "test_auth_key"},
+        )
+        assert resp.status_code == 404
+        assert resp.json == {"Error": "district key: 2024ne does not exist"}
 
-    District(
-        id="2024ne",
-        year=2024,
-        abbreviation="ne",
-    ).put()
+        District(
+            id="2024ne",
+            year=2024,
+            abbreviation="ne",
+        ).put()
+        frozen_time.tick(delta=timedelta(seconds=65))
 
-    resp = api_client.get(
-        f"/api/v3/district/2024ne/{endpoint}",
-        headers={"X-TBA-Auth-Key": "test_auth_key"},
-    )
-    assert resp.status_code == 200
+        resp = api_client.get(
+            f"/api/v3/district/2024ne/{endpoint}",
+            headers={"X-TBA-Auth-Key": "test_auth_key"},
+        )
+        assert resp.status_code == 200

--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -4,6 +4,7 @@ from typing import Callable, Optional, Union
 
 from flask import current_app, has_request_context, make_response, request, Response
 from flask_caching import CachedResponse
+from werkzeug.exceptions import NotFound
 
 from backend.common.environment import Environment
 
@@ -37,7 +38,19 @@ def cached_public(
 
     @wraps(func)
     def decorated_function(*args, **kwargs):
-        status_codes = [200, 301, 302] if cache_redirects else [200]
+        status_codes = [200, 301, 302, 404] if cache_redirects else [200, 404]
+
+        @wraps(func)
+        def func_wrapper(*func_args, **func_kwargs):
+            try:
+                rv = func(*func_args, **func_kwargs)
+            except NotFound as e:
+                rv = current_app.handle_user_exception(e)
+            resp = make_response(rv)
+            if resp.status_code == 404:
+                resp.freeze()
+                return CachedResponse(resp, 61)
+            return rv
 
         if hasattr(current_app, "cache") and Environment.flask_response_cache_enabled():
             cached = current_app.cache.cached(
@@ -46,17 +59,22 @@ def cached_public(
                 in status_codes,
                 query_string=query_string,
             )
-            resp = make_response(cached(func)(*args, **kwargs))
+            resp = make_response(cached(func_wrapper)(*args, **kwargs))
         else:
-            resp = make_response(func(*args, **kwargs))
+            try:
+                resp = make_response(func(*args, **kwargs))
+            except NotFound as e:
+                resp = make_response(current_app.handle_user_exception(e))
         if (
             resp.status_code in status_codes
             and Environment.cache_control_header_enabled()
         ):
-            # Only set cache headers for OK responses
+            # Only set cache headers for cacheable responses
             browser_timeout = timeout
             if isinstance(resp, CachedResponse):
                 browser_timeout = resp.timeout
+            if resp.status_code == 404:
+                browser_timeout = 61
             resp.headers["Cache-Control"] = "public, max-age={0}, s-maxage={0}".format(
                 max(
                     browser_timeout, 61

--- a/src/backend/common/tests/decorator_test.py
+++ b/src/backend/common/tests/decorator_test.py
@@ -2,7 +2,7 @@ import datetime
 import time
 from datetime import timedelta
 
-from flask import Flask, make_response, Response
+from flask import abort, Flask, make_response, Response
 from flask_caching import CachedResponse
 from freezegun import freeze_time
 from werkzeug.http import http_date
@@ -346,3 +346,85 @@ def test_memoize_with_memcache(app: Flask, memcache_stub) -> None:
     resp2 = app.test_client().get("/")
     assert resp2.status_code == 200
     assert resp2.data == b"1"
+
+
+def test_cached_public_404_cache_control(app: Flask) -> None:
+    @app.route("/")
+    @cached_public(ttl=3600)
+    def view():
+        return "Not Found", 404
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 404
+    assert resp.headers.get("Cache-Control") == "public, max-age=61, s-maxage=61"
+
+
+def test_cached_public_404_abort_cache_control(app: Flask) -> None:
+    @app.route("/")
+    @cached_public(ttl=3600)
+    def view():
+        abort(404)
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 404
+    assert resp.headers.get("Cache-Control") == "public, max-age=61, s-maxage=61"
+
+
+def test_flask_cache_with_memcache_404_overrides_ttl(app: Flask, memcache_stub) -> None:
+    configure_flask_cache(app)
+
+    calls = 0
+
+    @app.route("/")
+    @cached_public(ttl=3600)
+    def view():
+        nonlocal calls
+        calls += 1
+        return "Not Found", 404
+
+    assert hasattr(app, "cache")
+    assert isinstance(app.cache.cache, MemcacheFlaskResponseCache)  # pyre-ignore[16]
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 404
+    assert calls == 1
+
+    cached_entry = app.cache.get("/bcd8b0c2eb1fce714eab6cef0d771acc")
+    assert cached_entry is not None
+    assert isinstance(cached_entry, CachedResponse)
+    assert cached_entry.timeout == 61
+
+    resp2 = app.test_client().get("/")
+    assert resp2.status_code == 404
+    assert calls == 1
+
+
+def test_flask_cache_with_memcache_abort_404_overrides_ttl(
+    app: Flask, memcache_stub
+) -> None:
+    configure_flask_cache(app)
+
+    calls = 0
+
+    @app.route("/")
+    @cached_public(ttl=3600)
+    def view():
+        nonlocal calls
+        calls += 1
+        abort(404)
+
+    assert hasattr(app, "cache")
+    assert isinstance(app.cache.cache, MemcacheFlaskResponseCache)  # pyre-ignore[16]
+
+    resp = app.test_client().get("/")
+    assert resp.status_code == 404
+    assert calls == 1
+
+    cached_entry = app.cache.get("/bcd8b0c2eb1fce714eab6cef0d771acc")
+    assert cached_entry is not None
+    assert isinstance(cached_entry, CachedResponse)
+    assert cached_entry.timeout == 61
+
+    resp2 = app.test_client().get("/")
+    assert resp2.status_code == 404
+    assert calls == 1

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -1,3 +1,4 @@
+import time
 from concurrent import futures
 from typing import Generator
 
@@ -95,6 +96,7 @@ def memcache_stub(
 ) -> testbed.memcache_stub.MemcacheServiceStub:
     gae_testbed.init_memcache_stub()
     stub = gae_testbed.get_stub(testbed.MEMCACHE_SERVICE_NAME)
+    monkeypatch.setattr(stub, "_gettime", lambda: time.time())
     return stub
 
 


### PR DESCRIPTION
## Overview
Includes HTTP 404 status codes in `@cached_public` response caching, with the cache TTL and `Cache-Control` header pinned to 61 seconds for 404s (regardless of the route's primary TTL).

## Changes
- Updated `status_codes` in `cached_public` to include `404`.
- Wrapped `func` to catch `werkzeug.exceptions.NotFound` (raised by `abort(404)`) and dispatch through `current_app.handle_user_exception(e)` into the formatted 404 response.
- When `status_code == 404`, froze the response and returned `CachedResponse(resp, 61)` so Memcache/Redis stores it for 61 seconds even if the route specifies a longer TTL (e.g. `ttl=3600`).
- Set `browser_timeout = 61` for 404s so `Cache-Control: public, max-age=61, s-maxage=61` is emitted.
- Added unit tests in `decorator_test.py` covering both explicit 404 returns and `abort(404)` with Memcache caching and `Cache-Control` validation.