### PR TITLE
[pwa] Serve stale SSR cache entries, fix edge stale-while-revalidate

### DIFF
--- a/docs/Architecture/Architecture-Caching-PWA.md
+++ b/docs/Architecture/Architecture-Caching-PWA.md
@@ -1,0 +1,268 @@
+# PWA Caching Lifecycle
+
+How a request for a PWA page is served, and which cache answers it at each hop.
+Everything here is derived from the code in `pwa/`; the API-side layers
+(Cloudflare on `www`, Memcache, the 304 fastpath) are shown only as the far end
+of the chain.
+
+The PWA is served at `beta.thebluealliance.com` (`src/dispatch.yaml`) and fetches
+data from `https://www.thebluealliance.com/api/v3`
+(`pwa/app/api/tba/read/client.gen.ts`), so **every API call — from the SSR server
+and from the browser alike — crosses the public internet and hits Cloudflare in
+front of `www`.**
+
+## The five caches
+
+| # | Cache | Where it lives | Scope | Lifetime | Code |
+|---|-------|----------------|-------|----------|------|
+| 1 | Workbox precache | Browser (service worker) | Per browser | Until next deploy | `pwa/scripts/generate-sw.ts` |
+| 2 | Browser HTTP cache | Browser | Per browser | `max-age=61` from the API | (implicit — plain `fetch`) |
+| 3 | Cloudflare edge | CDN in front of `beta` and `www` | Global | `CDN-Cache-Control: max-age=61` | `publicCacheControlHeaders()` in `pwa/app/lib/utils.tsx:330` |
+| 4 | SSR network LRU | GAE `pwa` Node process | Per instance, **all users** | Response `max-age`, default 61s | `pwa/app/lib/middleware/network-cache.ts` |
+| 5 | TanStack Query cache | Browser (hydrated from SSR) | Per tab | `staleTime` tier | `pwa/app/lib/queryClient.ts` |
+
+## Full lifecycle
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor B as Browser
+    participant SW as Service Worker<br/>(workbox precache)
+    participant CF as Cloudflare<br/>(beta.thebluealliance.com)
+    participant EX as Express<br/>(pwa/server.ts)
+    participant SSR as TanStack Start SSR<br/>(GAE F1, nodejs24)
+    participant LRU as SSR network LRU<br/>(300 entries, per process)
+    participant CFW as Cloudflare<br/>(www.thebluealliance.com)
+    participant API as APIv3 (py3-api)<br/>Memcache + 304 fastpath
+    participant RQ as React Query cache<br/>(browser)
+
+    rect rgb(245, 245, 250)
+        note over B,SW: Static assets only
+        B->>SW: GET /assets/app-abc123.js
+        SW-->>B: precache hit (no network)
+    end
+
+    B->>CF: GET /event/2024casj (document)
+    alt CDN HIT (within 61s, or stale-while-revalidate 122s)
+        CF-->>B: cached HTML
+    else MISS / EXPIRED
+        CF->>EX: forward
+        EX->>SSR: nodeHandler(req)
+
+        rect rgb(240, 245, 255)
+            note over SSR,LRU: Server render — loaders await data
+            SSR->>SSR: __root beforeLoad: ensureQueryData(/status)
+            SSR->>SSR: route loader: ensureQueryData(...)
+            SSR->>LRU: cachedFetch("GET:https://www.tba.com/api/v3/...")
+            alt LRU hit (TTL from upstream max-age)
+                LRU-->>SSR: cached JSON body
+            else LRU miss
+                LRU->>CFW: fetch (X-TBA-Auth-Key, no If-None-Match)
+                CFW->>API: on CDN miss
+                API-->>CFW: 200 + ETag + Cache-Control: max-age=61
+                CFW-->>LRU: 200 JSON
+                LRU->>LRU: cache.set(key, body, ttl = max-age)
+            end
+        end
+
+        SSR->>SSR: render HTML + dehydrate query cache
+        SSR-->>EX: HTML (Cache-Control: public, max-age=61,<br/>stale-while-revalidate=122)<br/>(CDN-Cache-Control: max-age=61)
+        EX-->>CF: response
+        CF->>CF: store at edge
+        CF-->>B: HTML
+    end
+
+    B->>RQ: hydrate dehydrated query cache
+    note over RQ: staleTime = 60s default, so freshly<br/>SSR'd data is NOT refetched on mount
+
+    rect rgb(245, 250, 245)
+        note over B,API: Client-side navigation (defaultPreload: 'intent')
+        B->>RQ: hover link → router runs loader<br/>(defaultPreloadStaleTime: 0)
+        alt Query data still fresh for its staleTime tier
+            RQ-->>B: served from memory, zero network
+        else Stale
+            RQ->>B: fetch() — SSR LRU is bypassed in the browser
+            B->>CFW: GET /api/v3/... (browser HTTP cache may serve<br/>or revalidate with If-None-Match)
+            CFW->>API: on CDN miss
+            API-->>B: 200 JSON, or 304 via the ETag fastpath
+        end
+    end
+```
+
+## Layer notes
+
+### 1. Service worker — static assets only
+
+`scripts/generate-sw.ts` runs Workbox `generateSW` at build time over
+`build/client`, precaching `js/css/html/png/jpg/svg/woff/woff2/ico` up to 2 MB
+each under cache id `tba-pwa`, with `skipWaiting`, `clientsClaim`, and
+`cleanupOutdatedCaches`.
+
+There is **no `runtimeCaching` config**. The service worker therefore never
+intercepts API calls or SSR documents — it is a precache for the build output and
+nothing more. There is also no `navigateFallback`, so there is no offline shell.
+Registration is PROD-only (`app/lib/serviceWorkerRegistration.ts`, called from
+`getRouter()`).
+
+### 2. Express static headers
+
+`pwa/server.ts` sets, before the SSR handler:
+
+- `/assets` → `immutable, max-age=1y` (Vite fingerprints these)
+- `/favicon.ico` → 1 week
+- `/sw.js` → `Cache-Control: no-cache`
+- everything else in `build/client` → 24 hours
+
+The SSR handler itself sets no cache headers; those come from the routes.
+
+### 3. Cloudflare / document caching
+
+`cacheControlHeadersForSeason(season)` (`app/lib/utils.tsx`) returns `{}` outside
+production, and in production picks one of two tiers:
+
+```
+current season:  Cache-Control:     public, max-age=61, stale-while-revalidate=600
+                 CDN-Cache-Control: max-age=61, stale-while-revalidate=600
+
+past season:     Cache-Control:     public, max-age=86400, stale-while-revalidate=604800
+                 CDN-Cache-Control: max-age=86400, stale-while-revalidate=604800
+```
+
+Routes that know their season call it inline so TanStack still infers `params`
+from the route itself:
+
+```ts
+headers: ({ params }) =>
+  cacheControlHeadersForSeason(seasonFromKey(params.matchKey)),
+```
+
+Routes with no season in the URL use `publicCacheControlHeaders()`, which is the
+current-season (short) tier. An unknown season always resolves to the short tier.
+
+**Why `stale-while-revalidate` appears in `CDN-Cache-Control` too:** Cloudflare
+prefers `CDN-Cache-Control` over `Cache-Control`, so while the directive was only
+on the latter, the edge did a *blocking* origin revalidation the moment `max-age`
+lapsed. Measured by polling one URL every 15s: `HIT` through age 60s, then
+`EXPIRED` at 61s — never a stale serve, at a cost of ~0.5s versus ~0.03s for a hit.
+
+Because the response is `public`, a rendered page is shared across all visitors at
+the edge — correct today because SSR renders no per-user content, and a constraint
+to remember if that ever changes.
+
+**Serving stale documents is only safe because of layer 5.** React Query keeps the
+server's original `dataUpdatedAt` through dehydration, so a page rendered from a
+stale edge copy refetches on mount. That correction only exists for data read via
+`useQuery`/`useSuspenseQuery`; a component reading `useLoaderData()` renders the
+snapshot forever. Every route on the long tier must read from the query cache.
+
+### 4. SSR network LRU — the layer most people are asking about
+
+Installed in `app/routes/__root.tsx:87`, guarded by `typeof window === 'undefined'`,
+onto the **read client only**. The mobile, colors, and moderation clients do not
+get it.
+
+```ts
+if (typeof window === 'undefined') {
+  client.setConfig({ fetch: createCachedFetch({ cacheableMethods: ['GET'] }) });
+}
+```
+
+`app/lib/middleware/network-cache.ts`:
+
+- A **module-global** `LRUCache`, so it is shared by every request and every user
+  handled by that GAE instance. Cold instance = cold cache; `max_idle_instances: 1`
+  and F1 instance class mean this happens often.
+- `max: 300` entries. The cap is deliberate — a heavy page (district stats) can
+  fan out 20–40 entries, but the whole LRU sits in the F1 instance's memory
+  (see #9984).
+- Freshness is computed **in the middleware**, not by the LRU: each entry stores
+  `fetchedAt` and `freshForMs` (the upstream `max-age`, falling back to 61s with a
+  warning). The `LRUCache` is constructed with no `ttl` at all, so an entry past
+  its freshness window stays reachable instead of being dropped at the boundary —
+  which is what makes serve-stale possible. The LRU's remaining job is bounding
+  memory.
+- Cache key is `METHOD:url` — **no auth identity**. Safe only because TBA read
+  data is public and there is a single shared `X-TBA-Auth-Key`. Per-user keys
+  would make this a cross-user leak.
+- A second `typeof window !== 'undefined'` guard inside `cachedFetch` makes the
+  browser path a plain `fetch` even if the config ever leaked to the client.
+- Counters go to Sentry as `network.cache.hit` / `network.cache.miss` with an
+  `outcome` attribute (`fresh`, `stale_served`, `miss`) plus
+  `network.cache.revalidation` (`not_modified`, `replaced`, `error`), and are
+  exposed at `/local/debug` via `getCacheStats()` / `getCacheEntries()`.
+
+**Serve-stale and revalidation.** A read resolves one of three ways:
+
+| Entry state | Behavior |
+|---|---|
+| Fresh (`age < freshForMs`) | Served immediately, no network |
+| Stale within ceiling | Served immediately, conditional revalidation fired **behind** the response |
+| Stale past ceiling, or absent | Blocks on the network |
+
+The stale ceiling is tiered like the edge headers, from the season parsed out of
+the API URL (`seasonFromPath`): **24h** for past seasons, **5min** for the current
+season.
+
+Revalidation re-issues the request with `If-None-Match` from the stored ETag, so
+the APIv3 304 fastpath (#10545) answers with no body and no Datastore read. It is
+deliberately **not awaited**: measured against the live API, a `304` (~0.03s) and
+a `200` (~0.03s, 287KB) are within noise of each other when Cloudflare has the
+response cached — the round trip, not the payload, is the cost. Putting
+revalidation on the critical path would buy bandwidth at the price of latency.
+Concurrent stale reads for one key are deduped through an in-flight map, so a hot
+key fires one revalidation rather than up to `max_concurrent_requests` (80).
+
+Historically this layer discarded the upstream `ETag` and never sent
+`If-None-Match`, so the APIv3 304 fastpath did **nothing** for SSR traffic — every
+miss was a full 200 with a full JSON body, and the measured hit rate sat at 21.4%
+(45,075 hits against 165,105 misses over 7 days).
+
+### 5. TanStack Query — the client's freshness authority
+
+`setupRouterSsrQueryIntegration` (`app/router.tsx:76`) dehydrates the server's
+query cache into the HTML and rehydrates it in the browser.
+
+`createQueryClient()` sets `staleTime: STALE_TIME.DEFAULT` globally. This is what
+prevents the hydration refetch storm: with the library default of `0`, every
+`useSuspenseQuery` would treat the data the server just embedded as instantly
+stale and refetch it on mount.
+
+Tiers in `app/lib/queryClient.ts`:
+
+| Tier | Value | Used for |
+|------|-------|----------|
+| `DEFAULT` | 60s | Anything current; matches the API's `max-age=61` |
+| `HISTORICAL` | 1h | Immutable past-season data; picked by `staleTimeForYear()` (pure calendar comparison, not `/status`) |
+| `STATUS` | 6h | `/status`, awaited once in the root `beforeLoad` |
+| `SEARCH_INDEX` | 24h | `/search_index`, prefetched client-only and deliberately not dehydrated (#10254) |
+
+Live data (in-progress matches, rankings) stays on a low `staleTime` and uses an
+explicit `refetchInterval`, which fires independently of `staleTime` — see the
+district champs route.
+
+Failure handling lives here too: `retry` skips 4xx (an `ApiError` with status
+400–499 will not be retried), and the `QueryCache.onError` hook is the single seam
+that logs and reports to Sentry, skipping 404s as "legitimately absent".
+
+### Router preloading
+
+`defaultPreload: 'intent'` with `defaultPreloadStaleTime: 0` means the router
+always invokes loaders on hover/touch and lets React Query's `staleTime` decide
+whether that turns into a network request. Preloading a page whose data is still
+fresh costs nothing.
+
+## Where a given request actually gets answered
+
+- **Repeat visitor, page inside its edge `max-age`** → Cloudflare edge, no GAE
+  instance involved (~0.03s vs ~0.5s for a miss). For past-season pages that
+  window is 24h, not 61s.
+- **Repeat visitor, page inside the edge stale window** → edge serves the stale
+  copy and revalidates behind it; the client corrects anything past its
+  `staleTime` on hydration.
+- **Cold page, warm instance** → SSR renders; API calls are served fresh from the
+  in-process LRU, or served stale with a background 304 revalidation.
+- **Cold page, cold instance** → SSR renders, every API call goes to Cloudflare
+  on `www` and possibly through to Datastore.
+- **Client-side navigation, data fresh** → React Query memory, zero network.
+- **Client-side navigation, data stale** → browser `fetch` → browser HTTP cache
+  or Cloudflare on `www` → APIv3 (where the ETag 304 fastpath applies).

--- a/pwa/app/lib/middleware/network-cache.test.ts
+++ b/pwa/app/lib/middleware/network-cache.test.ts
@@ -16,6 +16,10 @@ vi.mock('@sentry/tanstackstart-react', () => ({
   },
 }));
 
+function secondsToMs(seconds: number): number {
+  return seconds * 1000;
+}
+
 describe('Network Cache Middleware', () => {
   let originalWindow: typeof globalThis.window;
 
@@ -259,6 +263,192 @@ describe('Network Cache Middleware', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  describe('serve-stale and revalidation', () => {
+    const PAST_SEASON_URL = 'https://api.example.com/api/v3/event/2015casj';
+    const CURRENT_SEASON_URL = 'https://api.example.com/api/v3/event/2026casj';
+
+    function jsonResponse(body: string, headers: Record<string, string> = {}) {
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'public, max-age=61',
+          ...headers,
+        },
+      });
+    }
+
+    beforeEach(() => {
+      // lru-cache reads `performance.now()` for TTLs, so faking Date alone
+      // leaves entries permanently fresh.
+      // Freshness is computed from `Date.now()` in the middleware itself, so
+      // this is the only clock the cache depends on.
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-06-15T00:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** Lets the un-awaited revalidation promise settle. */
+    async function flushRevalidation() {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    it('serves a stale entry without waiting on the network', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockImplementation(
+          () =>
+            new Promise(() => {
+              // never settles: proves the stale read did not await it
+            }),
+        );
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(PAST_SEASON_URL);
+
+      vi.advanceTimersByTime(secondsToMs(120));
+
+      const stale = await cachedFetch(PAST_SEASON_URL);
+      expect(await stale.text()).toBe('{"v":1}');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(getCacheStats().staleServed).toBe(1);
+    });
+
+    it('sends If-None-Match when revalidating', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockResolvedValue(new Response(null, { status: 304 }));
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(PAST_SEASON_URL);
+      vi.advanceTimersByTime(secondsToMs(120));
+      await cachedFetch(PAST_SEASON_URL);
+      await flushRevalidation();
+
+      const revalidationInit = mockFetch.mock.calls[1]?.[1];
+      const headers = new Headers(revalidationInit?.headers);
+      expect(headers.get('If-None-Match')).toBe('"v1"');
+    });
+
+    it('keeps the cached body and refreshes freshness on a 304', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockResolvedValue(
+          new Response(null, {
+            status: 304,
+            headers: { 'Cache-Control': 'public, max-age=61' },
+          }),
+        );
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(PAST_SEASON_URL);
+      vi.advanceTimersByTime(secondsToMs(120));
+      await cachedFetch(PAST_SEASON_URL);
+      await flushRevalidation();
+
+      // Entry is fresh again, so this serves without another network call.
+      const afterRevalidation = await cachedFetch(PAST_SEASON_URL);
+      expect(await afterRevalidation.text()).toBe('{"v":1}');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('replaces the cached body when revalidation returns 200', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockResolvedValue(jsonResponse('{"v":2}', { ETag: '"v2"' }));
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(PAST_SEASON_URL);
+      vi.advanceTimersByTime(secondsToMs(120));
+      await cachedFetch(PAST_SEASON_URL);
+      await flushRevalidation();
+
+      const afterRevalidation = await cachedFetch(PAST_SEASON_URL);
+      expect(await afterRevalidation.text()).toBe('{"v":2}');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('fires a single revalidation for concurrent stale reads', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockResolvedValue(new Response(null, { status: 304 }));
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(PAST_SEASON_URL);
+      vi.advanceTimersByTime(secondsToMs(120));
+
+      await Promise.all([
+        cachedFetch(PAST_SEASON_URL),
+        cachedFetch(PAST_SEASON_URL),
+        cachedFetch(PAST_SEASON_URL),
+      ]);
+      await flushRevalidation();
+
+      // 1 initial + exactly 1 revalidation, not 3.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(getCacheStats().staleServed).toBe(3);
+    });
+
+    it('keeps serving a past-season entry well beyond the current-season window', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockResolvedValue(new Response(null, { status: 304 }));
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(PAST_SEASON_URL);
+
+      // 1h: past the 5min current-season ceiling, inside the 24h past-season one.
+      vi.advanceTimersByTime(secondsToMs(3600));
+
+      const stale = await cachedFetch(PAST_SEASON_URL);
+      expect(await stale.text()).toBe('{"v":1}');
+      expect(getCacheStats().staleServed).toBe(1);
+    });
+
+    it('blocks on the network for a current-season entry past its stale ceiling', async () => {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse('{"v":1}', { ETag: '"v1"' }))
+        .mockResolvedValue(jsonResponse('{"v":2}', { ETag: '"v2"' }));
+      global.fetch = mockFetch;
+      mockServerEnvironment();
+
+      const cachedFetch = createCachedFetch();
+      await cachedFetch(CURRENT_SEASON_URL);
+
+      // 1h is well past the 5min current-season ceiling.
+      vi.advanceTimersByTime(secondsToMs(3600));
+
+      const refetched = await cachedFetch(CURRENT_SEASON_URL);
+      expect(await refetched.text()).toBe('{"v":2}');
+      expect(getCacheStats().staleServed).toBe(0);
+      expect(getCacheStats().misses).toBe(2);
+    });
+  });
+
   describe('hit rate tracking', () => {
     function mockOkFetch() {
       const mockFetch = vi
@@ -391,14 +581,14 @@ describe('Network Cache Middleware', () => {
         'network.cache.miss',
         1,
         {
-          attributes: { client_platform: 'pwa' },
+          attributes: { client_platform: 'pwa', outcome: 'miss' },
         },
       );
       expect(Sentry.metrics.count).toHaveBeenCalledWith(
         'network.cache.hit',
         1,
         {
-          attributes: { client_platform: 'pwa' },
+          attributes: { client_platform: 'pwa', outcome: 'fresh' },
         },
       );
       expect(Sentry.metrics.count).toHaveBeenCalledTimes(2);

--- a/pwa/app/lib/middleware/network-cache.ts
+++ b/pwa/app/lib/middleware/network-cache.ts
@@ -10,14 +10,34 @@
  * Installed only on the server via `client.setConfig` in `__root.tsx`. Client
  * freshness is owned by React Query `staleTime`; this must not run in the
  * browser as a second TTL under Query.
+ *
+ * Entries past their freshness window are still served, immediately, while a
+ * conditional revalidation runs behind the response. A `304` against the API's
+ * ETag fastpath then costs no payload and no origin work. Revalidation is
+ * deliberately *not* awaited: a round trip to the API is ~30ms whether it
+ * returns 200 or 304, so putting it on the critical path would buy bandwidth
+ * at the cost of latency, which is backwards for SSR.
  */
 import * as Sentry from '@sentry/tanstackstart-react';
 import ccParser from 'cache-control-parser';
 import { LRUCache } from 'lru-cache';
 
-import { createLogger, secondsToMilliseconds } from '~/lib/utils';
+import {
+  createLogger,
+  hoursToMilliseconds,
+  isPastSeason,
+  minutesToMilliseconds,
+  seasonFromPath,
+  secondsToMilliseconds,
+} from '~/lib/utils';
 
-type CacheEntry = string;
+interface CacheEntry {
+  body: string;
+  etag: string | undefined;
+  fetchedAt: number;
+  /** Upstream `max-age`, in ms. Freshness is computed here, not by the LRU. */
+  freshForMs: number;
+}
 
 /**
  * Cap kept deliberately modest: heavy pages (e.g. district stats) can fan out
@@ -29,15 +49,48 @@ const CACHE_MAX_ENTRIES = 300;
 const CACHE_TTL = secondsToMilliseconds(61);
 
 /**
- * Global singleton LRU cache - shared across all SSR sessions on this process
+ * How far past its freshness window an entry may still be served.
+ *
+ * Past seasons are immutable, so a day-old body is the same body. Current-season
+ * data can still move, so the window stays short — a stale render is corrected
+ * on hydration by React Query, but only for routes whose components read from
+ * the query cache.
  */
-const cache = new LRUCache<string, CacheEntry>({
-  max: CACHE_MAX_ENTRIES,
-  ttl: CACHE_TTL,
-});
+const MAX_STALE_PAST_SEASON = hoursToMilliseconds(24);
+const MAX_STALE_CURRENT_SEASON = minutesToMilliseconds(5);
 
 let hits = 0;
 let misses = 0;
+let staleServed = 0;
+let revalidations = 0;
+let evictions = 0;
+
+/**
+ * Global singleton LRU cache - shared across all SSR sessions on this process.
+ *
+ * Deliberately configured without a `ttl`: entries age out via `fetchedAt`
+ * below, so that a stale-but-usable body stays reachable instead of being
+ * dropped at the freshness boundary. The LRU's job here is bounding memory.
+ */
+const cache = new LRUCache<string, CacheEntry>({
+  max: CACHE_MAX_ENTRIES,
+  dispose: (_value, _key, reason) => {
+    if (reason === 'evict') {
+      evictions++;
+    }
+  },
+});
+
+function ageOf(entry: CacheEntry): number {
+  return Date.now() - entry.fetchedAt;
+}
+
+function isFresh(entry: CacheEntry): boolean {
+  return ageOf(entry) < entry.freshForMs;
+}
+
+/** Dedupes revalidations so a hot stale key fires one request, not 80. */
+const inFlight = new Map<string, Promise<void>>();
 
 interface NetworkCacheConfig {
   /**
@@ -49,6 +102,14 @@ interface NetworkCacheConfig {
 
 const logger = createLogger('network-cache');
 
+function countAccess(outcome: string) {
+  Sentry.metrics.count(
+    outcome === 'miss' ? 'network.cache.miss' : 'network.cache.hit',
+    1,
+    { attributes: { client_platform: 'pwa', outcome } },
+  );
+}
+
 /**
  * Generate cache key from request.
  * Keyed on METHOD:url only — fine today with one shared read key; not safe
@@ -57,6 +118,121 @@ const logger = createLogger('network-cache');
 function generateCacheKey(url: string, options: RequestInit = {}): string {
   const method = options.method?.toUpperCase() || 'GET';
   return `${method}:${url}`;
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+  return input instanceof URL ? input.toString() : input.url;
+}
+
+function maxStaleForUrl(url: string): number {
+  return isPastSeason(seasonFromPath(url))
+    ? MAX_STALE_PAST_SEASON
+    : MAX_STALE_CURRENT_SEASON;
+}
+
+function ttlFromResponse(response: Response, url: string, method: string) {
+  const cacheControl = response.headers.get('cache-control');
+  if (!cacheControl) {
+    logger.warn(
+      { method, url },
+      'No Cache-Control header found; falling back to default TTL',
+    );
+    return CACHE_TTL;
+  }
+
+  const parsed = ccParser.parse(cacheControl);
+  if (!parsed['max-age']) {
+    logger.warn(
+      { method, url },
+      'No max-age found in Cache-Control header; falling back to default TTL',
+    );
+    return CACHE_TTL;
+  }
+
+  return secondsToMilliseconds(parsed['max-age']);
+}
+
+function cachedResponse(entry: CacheEntry, status = 200): Response {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (entry.etag) {
+    headers.ETag = entry.etag;
+  }
+  return new Response(entry.body, { status, headers });
+}
+
+/**
+ * Re-issues the request with `If-None-Match` so the API's 304 fastpath can
+ * answer without a body or a Datastore read. Never rejects: a failed
+ * revalidation leaves the stale entry in place to be served again.
+ */
+function revalidate(
+  cacheKey: string,
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  entry: CacheEntry,
+): Promise<void> {
+  const existing = inFlight.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+
+  const url = requestUrl(input);
+  const method = init?.method?.toUpperCase() || 'GET';
+
+  const pending = (async () => {
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    if (entry.etag) {
+      headers.set('If-None-Match', entry.etag);
+    }
+
+    const response = await fetch(input, { ...init, headers });
+    revalidations++;
+
+    if (response.status === 304) {
+      cache.set(cacheKey, {
+        ...entry,
+        fetchedAt: Date.now(),
+        freshForMs: ttlFromResponse(response, url, method),
+      });
+      Sentry.metrics.count('network.cache.revalidation', 1, {
+        attributes: { client_platform: 'pwa', outcome: 'not_modified' },
+      });
+      logger.debug({ method, url }, 'Revalidated 304');
+      return;
+    }
+
+    if (response.ok) {
+      cache.set(cacheKey, {
+        body: await response.text(),
+        etag: response.headers.get('etag') ?? undefined,
+        fetchedAt: Date.now(),
+        freshForMs: ttlFromResponse(response, url, method),
+      });
+      Sentry.metrics.count('network.cache.revalidation', 1, {
+        attributes: { client_platform: 'pwa', outcome: 'replaced' },
+      });
+      logger.debug({ method, url }, 'Revalidated with fresh body');
+    }
+  })()
+    .catch((error: unknown) => {
+      Sentry.metrics.count('network.cache.revalidation', 1, {
+        attributes: { client_platform: 'pwa', outcome: 'error' },
+      });
+      logger.error({ method, url, error }, 'Revalidation failed');
+    })
+    .finally(() => {
+      inFlight.delete(cacheKey);
+    });
+
+  inFlight.set(cacheKey, pending);
+  return pending;
 }
 
 /**
@@ -76,62 +252,48 @@ export function createCachedFetch(
       return fetch(input, init);
     }
 
-    const url =
-      typeof input === 'string'
-        ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url;
+    const url = requestUrl(input);
     const method = init?.method?.toUpperCase() || 'GET';
 
     // Only cache specified methods (default: GET)
     if (!cacheableMethods.includes(method)) {
-      logger.debug(
-        {
-          method,
-          url,
-        },
-        'Skipping cache for non-cacheable method',
-      );
+      logger.debug({ method, url }, 'Skipping cache for non-cacheable method');
 
       return fetch(input, init);
     }
 
     const cacheKey = generateCacheKey(url, init);
 
-    // Check cache
-    const cachedData = cache.get(cacheKey);
-    if (cachedData) {
-      hits++;
-      Sentry.metrics.count('network.cache.hit', 1, {
-        attributes: { client_platform: 'pwa' },
-      });
+    const cached = cache.get(cacheKey);
+
+    if (cached) {
+      if (isFresh(cached)) {
+        hits++;
+        countAccess('fresh');
+        logger.debug({ method, url }, 'Cache HIT');
+        return cachedResponse(cached);
+      }
+
+      const staleFor = ageOf(cached) - cached.freshForMs;
+      if (staleFor <= maxStaleForUrl(url)) {
+        hits++;
+        staleServed++;
+        countAccess('stale_served');
+        logger.debug({ method, url, staleFor }, 'Cache STALE served');
+        void revalidate(cacheKey, input, init, cached);
+        return cachedResponse(cached);
+      }
+
       logger.debug(
-        {
-          method,
-          url,
-        },
-        'Cache HIT',
+        { method, url, staleFor },
+        'Cache entry too stale to serve; fetching',
       );
-      return new Response(cachedData, {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
     }
 
     misses++;
-    Sentry.metrics.count('network.cache.miss', 1, {
-      attributes: { client_platform: 'pwa' },
-    });
+    countAccess('miss');
 
-    // Cache miss or expired - fetch from network
-    logger.debug(
-      {
-        method,
-        url,
-      },
-      'Outbound request',
-    );
+    logger.debug({ method, url }, 'Outbound request');
 
     try {
       const response = await fetch(input, init);
@@ -139,62 +301,24 @@ export function createCachedFetch(
       // Only cache successful responses
       if (response.ok && response.status >= 200 && response.status < 300) {
         // Read response body as text to avoid clone() issues
-        const data = await response.text();
+        const entry: CacheEntry = {
+          body: await response.text(),
+          etag: response.headers.get('etag') ?? undefined,
+          fetchedAt: Date.now(),
+          freshForMs: ttlFromResponse(response, url, method),
+        };
+        cache.set(cacheKey, entry);
+        logger.debug(
+          { method, url, freshForMs: entry.freshForMs },
+          'Cached response',
+        );
 
-        // Get TTL from Cache-Control header, fall back to default
-        const cacheControl = response.headers.get('cache-control');
-        if (!cacheControl) {
-          logger.warn(
-            {
-              method,
-              url,
-            },
-            'No Cache-Control header found; falling back to default TTL',
-          );
-          cache.set(cacheKey, data, { ttl: CACHE_TTL });
-        } else {
-          const ttl = ccParser.parse(cacheControl);
-
-          if (!ttl['max-age']) {
-            logger.warn(
-              {
-                method,
-                url,
-              },
-              'No max-age found in Cache-Control header; falling back to default TTL',
-            );
-            cache.set(cacheKey, data, { ttl: CACHE_TTL });
-          } else {
-            const ttlMs = secondsToMilliseconds(ttl['max-age']);
-            logger.debug(
-              {
-                method,
-                url,
-                ttlMs,
-              },
-              'Cached response with max-age',
-            );
-            cache.set(cacheKey, data, { ttl: ttlMs });
-          }
-        }
-
-        // Return a new Response with the cached data
-        return new Response(data, {
-          status: response.status,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        return cachedResponse(entry, response.status);
       }
 
       return response;
     } catch (error) {
-      logger.error(
-        {
-          method,
-          url,
-          error,
-        },
-        'Request failed',
-      );
+      logger.error({ method, url, error }, 'Request failed');
       throw error;
     }
   };
@@ -205,8 +329,12 @@ export function createCachedFetch(
  */
 export function clearCache(): void {
   cache.clear();
+  inFlight.clear();
   hits = 0;
   misses = 0;
+  staleServed = 0;
+  revalidations = 0;
+  evictions = 0;
   logger.debug('Cache cleared');
 }
 
@@ -220,6 +348,9 @@ export function getCacheStats(): {
   hits: number;
   misses: number;
   hitRate: number;
+  staleServed: number;
+  revalidations: number;
+  evictions: number;
 } {
   const total = hits + misses;
   return {
@@ -229,6 +360,9 @@ export function getCacheStats(): {
     hits,
     misses,
     hitRate: total === 0 ? 0 : hits / total,
+    staleServed,
+    revalidations,
+    evictions,
   };
 }
 
@@ -239,13 +373,25 @@ export function getCacheEntries(): Array<{
   key: string;
   data: string;
   remainingTTL: number;
+  etag: string | undefined;
+  fetchedAt: number;
 }> {
-  const entries: Array<{ key: string; data: string; remainingTTL: number }> =
-    [];
+  const entries: Array<{
+    key: string;
+    data: string;
+    remainingTTL: number;
+    etag: string | undefined;
+    fetchedAt: number;
+  }> = [];
 
   cache.forEach((value, key) => {
-    const remainingTTL = cache.getRemainingTTL(key);
-    entries.push({ key, data: value, remainingTTL });
+    entries.push({
+      key,
+      data: value.body,
+      remainingTTL: value.freshForMs - ageOf(value),
+      etag: value.etag,
+      fetchedAt: value.fetchedAt,
+    });
   });
 
   return entries;

--- a/pwa/app/lib/queryClient.ts
+++ b/pwa/app/lib/queryClient.ts
@@ -54,8 +54,8 @@ export const STALE_TIME = {
  * `app/routes/__root.tsx`). Reusing the same `Temporal.Now.plainDateISO().year`
  * pattern already used elsewhere in the app as the current-year fallback.
  */
-export function staleTimeForYear(year: number): number {
-  return year < Temporal.Now.plainDateISO().year
+export function staleTimeForYear(year: number | undefined): number {
+  return year !== undefined && year < Temporal.Now.plainDateISO().year
     ? STALE_TIME.HISTORICAL
     : STALE_TIME.DEFAULT;
 }

--- a/pwa/app/lib/utils.test.ts
+++ b/pwa/app/lib/utils.test.ts
@@ -9,6 +9,8 @@ import {
   parseParamsForYearElseDefault,
   queryFromAPI,
   removeNonNumeric,
+  seasonFromKey,
+  seasonFromPath,
   slugify,
   splitIntoNChunks,
 } from '~/lib/utils';
@@ -122,5 +124,46 @@ describe.concurrent('hasAnyMatches', () => {
 
   test('returns false for an empty record', () => {
     expect(hasAnyMatches({ wins: 0, losses: 0, ties: 0 })).toEqual(false);
+  });
+});
+
+describe.concurrent('seasonFromKey', () => {
+  test('reads the year prefix off event and match keys', () => {
+    expect(seasonFromKey('2024casj')).toEqual(2024);
+    expect(seasonFromKey('2024mil_f1m2')).toEqual(2024);
+    expect(seasonFromKey('1999flor')).toEqual(1999);
+    expect(seasonFromKey('2024')).toEqual(2024);
+  });
+
+  test('does not mistake a team key for a season', () => {
+    expect(seasonFromKey('frc2024')).toBeUndefined();
+    expect(seasonFromKey('frc254')).toBeUndefined();
+  });
+
+  test('returns undefined when there is no year', () => {
+    expect(seasonFromKey(undefined)).toBeUndefined();
+    expect(seasonFromKey('')).toBeUndefined();
+    expect(seasonFromKey('status')).toBeUndefined();
+    expect(seasonFromKey('3024casj')).toBeUndefined();
+  });
+});
+
+describe.concurrent('seasonFromPath', () => {
+  test('finds the season segment in API paths', () => {
+    expect(seasonFromPath('/api/v3/event/2024casj')).toEqual(2024);
+    expect(seasonFromPath('/api/v3/match/2024mil_f1m2')).toEqual(2024);
+    expect(seasonFromPath('/api/v3/team/frc254/2019')).toEqual(2019);
+    expect(seasonFromPath('/api/v3/events/2015')).toEqual(2015);
+    expect(seasonFromPath('/api/v3/district/2024fim/events')).toEqual(2024);
+  });
+
+  test('skips team numbers that look like years', () => {
+    expect(seasonFromPath('/api/v3/team/frc2024')).toBeUndefined();
+    expect(seasonFromPath('/api/v3/team/frc2024/2019')).toEqual(2019);
+  });
+
+  test('returns undefined for season-less paths', () => {
+    expect(seasonFromPath('/api/v3/status')).toBeUndefined();
+    expect(seasonFromPath('/api/v3/team/frc254/history')).toBeUndefined();
   });
 });

--- a/pwa/app/lib/utils.tsx
+++ b/pwa/app/lib/utils.tsx
@@ -325,17 +325,88 @@ export function doThrowNotFound(): never {
   throw notFound();
 }
 
-// TODO: Increase the default max age once we are confident things work.
-// The end goal is for this to be relatively large, since the client will re-fetch data on load.
-export function publicCacheControlHeaders(maxAge: number = 61) {
-  return (): Record<string, string> => {
-    const isProd = process.env.NODE_ENV === 'production';
-    if (!isProd) {
-      return {};
+const SEASON_PREFIX = /^(?:19|20)\d{2}/;
+
+/**
+ * Pulls the 4-digit FRC season out of a TBA key or path segment.
+ *
+ * Only matches segments that *begin* with the year, which is what keeps team
+ * keys out of the results — `frc2024` is team 2024, not season 2024.
+ */
+export function seasonFromKey(key: string | undefined): number | undefined {
+  if (key === undefined) {
+    return undefined;
+  }
+  const match = SEASON_PREFIX.exec(key);
+  return match ? Number(match[0]) : undefined;
+}
+
+/** First season-shaped segment in a path, e.g. `/api/v3/team/frc254/2024`. */
+export function seasonFromPath(path: string): number | undefined {
+  for (const segment of path.split('/')) {
+    const season = seasonFromKey(segment);
+    if (season !== undefined) {
+      return season;
     }
-    return {
-      'Cache-Control': `public, max-age=${maxAge}, stale-while-revalidate=${maxAge * 2}`,
-      'CDN-Cache-Control': `max-age=${maxAge}`, // Cloudflare-specific
-    };
+  }
+  return undefined;
+}
+
+/**
+ * Past calendar years are immutable regardless of where the current FRC season
+ * sits, so this is a pure calendar comparison — the same rule (and the same
+ * deliberate independence from `/status`) as `staleTimeForYear` in
+ * `~/lib/queryClient`. An unknown season is treated as current, which is the
+ * conservative direction: short TTLs, never long ones.
+ */
+export function isPastSeason(season: number | undefined): boolean {
+  return season !== undefined && season < Temporal.Now.plainDateISO().year;
+}
+
+/**
+ * Edge/browser cache tiers for SSR documents.
+ *
+ * `CDN-Cache-Control` carries its own `stale-while-revalidate`: Cloudflare
+ * prefers that header over `Cache-Control`, so omitting the directive there
+ * left the edge doing a *blocking* origin revalidation the moment `max-age`
+ * lapsed (observed as `cf-cache-status: EXPIRED`, never a stale HIT).
+ */
+const CACHE_TIER = {
+  CURRENT_SEASON: { maxAge: 61, staleWhileRevalidate: 600 },
+  PAST_SEASON: { maxAge: 86_400, staleWhileRevalidate: 604_800 },
+} as const;
+
+/**
+ * Serving a stale document is only safe because the client re-fetches on
+ * hydration: React Query keeps the server's original `dataUpdatedAt` through
+ * dehydration, so anything past its `staleTime` refetches on mount. Routes
+ * whose components read `useLoaderData()` instead of `useQuery` have no such
+ * correction — do not put those on the past-season tier.
+ *
+ * Call this inline from a route's `headers` so TanStack still infers `params`
+ * from the route itself:
+ *
+ *   headers: ({ params }) =>
+ *     cacheControlHeadersForSeason(seasonFromKey(params.matchKey)),
+ */
+export function cacheControlHeadersForSeason(
+  season: number | undefined,
+): Record<string, string> {
+  const isProd = process.env.NODE_ENV === 'production';
+  if (!isProd) {
+    return {};
+  }
+
+  const { maxAge, staleWhileRevalidate } = isPastSeason(season)
+    ? CACHE_TIER.PAST_SEASON
+    : CACHE_TIER.CURRENT_SEASON;
+
+  return {
+    'Cache-Control': `public, max-age=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`,
+    'CDN-Cache-Control': `max-age=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`,
   };
+}
+
+export function publicCacheControlHeaders() {
+  return (): Record<string, string> => cacheControlHeadersForSeason(undefined);
 }

--- a/pwa/app/routes/district.$districtAbbreviation.insights.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.insights.tsx
@@ -1,11 +1,12 @@
-import { createFileRoute, notFound } from '@tanstack/react-router';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 
+import { DistrictInsight } from '~/api/tba/read';
 import {
-  DistrictInsight,
-  getDistrictHistory,
-  getDistrictInsights,
-} from '~/api/tba/read';
+  getDistrictHistoryOptions,
+  getDistrictInsightsOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { DataTable, type TbaColumnDef } from '~/components/tba/dataTable';
 import { TeamLink } from '~/components/tba/links';
 import {
@@ -14,33 +15,36 @@ import {
   ChartTooltipContent,
 } from '~/components/ui/chart';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
-import { confidence, publicCacheControlHeaders } from '~/lib/utils';
+import {
+  confidence,
+  doThrowNotFound,
+  publicCacheControlHeaders,
+} from '~/lib/utils';
 
 export const Route = createFileRoute(
   '/district/$districtAbbreviation/insights',
 )({
-  loader: async ({ params }) => {
-    const [history, insights] = await Promise.all([
-      getDistrictHistory({
-        path: {
-          district_abbreviation: params.districtAbbreviation,
-        },
-      }),
-      getDistrictInsights({
-        path: {
-          district_abbreviation: params.districtAbbreviation,
-        },
-      }),
+  loader: async ({ params, context: { queryClient } }) => {
+    const districtAbbreviation = params.districtAbbreviation;
+
+    const [history] = await Promise.all([
+      queryClient
+        .ensureQueryData(
+          getDistrictHistoryOptions({
+            path: { district_abbreviation: districtAbbreviation },
+          }),
+        )
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData(
+          getDistrictInsightsOptions({
+            path: { district_abbreviation: districtAbbreviation },
+          }),
+        )
+        .catch(doThrowNotFound),
     ]);
 
-    if (history.data === undefined || insights.data === undefined) {
-      throw notFound();
-    }
-
-    return {
-      history: history.data,
-      insights: insights.data,
-    };
+    return { districtAbbreviation, history };
   },
   headers: publicCacheControlHeaders(),
   head: ({ loaderData }) => {
@@ -72,7 +76,18 @@ export const Route = createFileRoute(
 });
 
 function DistrictInsightsPage() {
-  const { history, insights } = Route.useLoaderData();
+  const { districtAbbreviation } = Route.useLoaderData();
+
+  const { data: history } = useSuspenseQuery(
+    getDistrictHistoryOptions({
+      path: { district_abbreviation: districtAbbreviation },
+    }),
+  );
+  const { data: insights } = useSuspenseQuery(
+    getDistrictInsightsOptions({
+      path: { district_abbreviation: districtAbbreviation },
+    }),
+  );
 
   return (
     <div>

--- a/pwa/app/routes/district.$districtAbbreviation.stats.tsx
+++ b/pwa/app/routes/district.$districtAbbreviation.stats.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, notFound } from '@tanstack/react-router';
+import { useQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
 import { type ReactNode, useMemo } from 'react';
 
 import {
@@ -7,61 +8,58 @@ import {
   Event,
   EventType,
   type LeaderboardInsight,
-  getDistrictAwards,
-  getDistrictEvents,
-  getDistrictHistory,
-  getDistrictInsights,
 } from '~/api/tba/read';
+import {
+  getDistrictAwardsOptions,
+  getDistrictEventsOptions,
+  getDistrictHistoryOptions,
+  getDistrictInsightsOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { Leaderboard } from '~/components/tba/leaderboard';
 import { EventLink, TeamLink } from '~/components/tba/links';
 import { YearSelector } from '~/components/tba/yearSelector';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { BLUE_BANNER_AWARDS } from '~/lib/api/AwardType';
-import { publicCacheControlHeaders } from '~/lib/utils';
+import { doThrowNotFound, publicCacheControlHeaders } from '~/lib/utils';
 
 export const Route = createFileRoute('/district/$districtAbbreviation/stats')({
-  loader: async ({ params }) => {
-    const [historyResult, insightsResult] = await Promise.all([
-      getDistrictHistory({
-        path: { district_abbreviation: params.districtAbbreviation },
-      }),
-      getDistrictInsights({
-        path: { district_abbreviation: params.districtAbbreviation },
-      }),
+  loader: async ({ params, context: { queryClient } }) => {
+    const abbreviation = params.districtAbbreviation;
+
+    const [history] = await Promise.all([
+      queryClient
+        .ensureQueryData(
+          getDistrictHistoryOptions({
+            path: { district_abbreviation: abbreviation },
+          }),
+        )
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData(
+          getDistrictInsightsOptions({
+            path: { district_abbreviation: abbreviation },
+          }),
+        )
+        .catch(doThrowNotFound),
     ]);
 
-    if (historyResult.data === undefined || insightsResult.data === undefined) {
-      throw notFound();
-    }
-
-    const history = historyResult.data;
-    const insights = insightsResult.data;
-
     // Fetch events and awards for each year in parallel
-    const yearResults = await Promise.all(
-      history.map(async (district) => {
-        const [eventsResult, awardsResult] = await Promise.all([
-          getDistrictEvents({
-            path: { district_key: district.key },
-          }),
-          getDistrictAwards({
-            path: { district_key: district.key },
-          }),
-        ]);
-        return {
-          year: district.year,
-          events: eventsResult.data ?? [],
-          awards: awardsResult.data ?? [],
-        };
-      }),
+    await Promise.all(
+      history.flatMap((district) => [
+        queryClient
+          .ensureQueryData(
+            getDistrictEventsOptions({ path: { district_key: district.key } }),
+          )
+          .catch(() => undefined),
+        queryClient
+          .ensureQueryData(
+            getDistrictAwardsOptions({ path: { district_key: district.key } }),
+          )
+          .catch(() => undefined),
+      ]),
     );
 
-    return {
-      abbreviation: params.districtAbbreviation,
-      history,
-      insights,
-      yearResults,
-    };
+    return { abbreviation, history };
   },
   headers: publicCacheControlHeaders(),
   head: ({ loaderData }) => {
@@ -750,8 +748,41 @@ function computeTeamupLeaderboard(
 }
 
 function DistrictStatsPage() {
-  const { abbreviation, history, insights, yearResults } =
-    Route.useLoaderData();
+  const { abbreviation } = Route.useLoaderData();
+
+  const { data: history } = useSuspenseQuery(
+    getDistrictHistoryOptions({
+      path: { district_abbreviation: abbreviation },
+    }),
+  );
+  const { data: insights } = useSuspenseQuery(
+    getDistrictInsightsOptions({
+      path: { district_abbreviation: abbreviation },
+    }),
+  );
+
+  const eventsByYear = useQueries({
+    queries: history.map((d) =>
+      getDistrictEventsOptions({ path: { district_key: d.key } }),
+    ),
+    combine: (results) => results.map((r) => r.data),
+  });
+  const awardsByYear = useQueries({
+    queries: history.map((d) =>
+      getDistrictAwardsOptions({ path: { district_key: d.key } }),
+    ),
+    combine: (results) => results.map((r) => r.data),
+  });
+
+  const yearResults = useMemo(
+    () =>
+      history.map((d, i) => ({
+        year: d.year,
+        events: eventsByYear[i] ?? [],
+        awards: awardsByYear[i] ?? [],
+      })),
+    [history, eventsByYear, awardsByYear],
+  );
 
   const validYears = history.map((d) => d.year).sort((a, b) => b - a);
 

--- a/pwa/app/routes/event.$eventKey.tsx
+++ b/pwa/app/routes/event.$eventKey.tsx
@@ -148,9 +148,10 @@ import { staleTimeForYear } from '~/lib/queryClient';
 import { sortTeamKeysComparator, sortTeamsComparator } from '~/lib/teamUtils';
 import {
   MODEL_TYPE,
+  cacheControlHeadersForSeason,
   cn,
   doThrowNotFound,
-  publicCacheControlHeaders,
+  seasonFromKey,
   splitIntoNChunks,
 } from '~/lib/utils';
 
@@ -229,7 +230,8 @@ export const Route = createFileRoute('/event/$eventKey')({
     // event needs to be returned so we can access it in meta
     return { eventKey: params.eventKey, event };
   },
-  headers: publicCacheControlHeaders(),
+  headers: ({ params }) =>
+    cacheControlHeadersForSeason(seasonFromKey(params.eventKey)),
   head: ({ loaderData }) => {
     if (!loaderData) {
       return {

--- a/pwa/app/routes/local.debug.tsx
+++ b/pwa/app/routes/local.debug.tsx
@@ -14,6 +14,8 @@ interface CacheInfo {
   dataPreview: string;
   remainingTTL: number;
   expiresAt: string;
+  etag: string | undefined;
+  fetchedAt: string;
 }
 
 const PREVIEW_JSON_LENGTH = 50;
@@ -26,7 +28,7 @@ export const Route = createFileRoute('/local/debug')({
 
     // Parse cache entries to extract useful information
     const cacheEntries: CacheInfo[] = entries.map(
-      ({ key, data, remainingTTL }) => {
+      ({ key, data, remainingTTL, etag, fetchedAt }) => {
         // Format: METHOD:URL
         const parts = key.split(':');
         const method = parts[0] || 'UNKNOWN';
@@ -50,6 +52,9 @@ export const Route = createFileRoute('/local/debug')({
           dataPreview: preview,
           remainingTTL,
           expiresAt,
+          etag,
+          fetchedAt:
+            Temporal.Instant.fromEpochMilliseconds(fetchedAt).toString(),
         };
       },
     );
@@ -193,6 +198,25 @@ function LocalDebug(): React.JSX.Element {
                 {Math.round(stats.hitRate * 100)}%
               </div>
               <div className="text-sm text-muted-foreground">all-time</div>
+            </div>
+            <div className="rounded-lg border p-4">
+              <div className="text-sm text-muted-foreground">Stale Served</div>
+              <div className="text-3xl font-bold">{stats.staleServed}</div>
+              <div className="text-sm text-muted-foreground">
+                served without blocking
+              </div>
+            </div>
+            <div className="rounded-lg border p-4">
+              <div className="text-sm text-muted-foreground">Revalidations</div>
+              <div className="text-3xl font-bold">{stats.revalidations}</div>
+              <div className="text-sm text-muted-foreground">background</div>
+            </div>
+            <div className="rounded-lg border p-4">
+              <div className="text-sm text-muted-foreground">Evictions</div>
+              <div className="text-3xl font-bold">{stats.evictions}</div>
+              <div className="text-sm text-muted-foreground">
+                pushed out by the cap
+              </div>
             </div>
           </div>
           <div className="mt-4 text-sm text-muted-foreground">

--- a/pwa/app/routes/match.$matchKey.tsx
+++ b/pwa/app/routes/match.$matchKey.tsx
@@ -1,35 +1,50 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import { Temporal } from 'temporal-polyfill';
 
-import { PlayoffType, getEvent, getMatch } from '~/api/tba/read';
+import { PlayoffType } from '~/api/tba/read';
+import {
+  getEventOptions,
+  getMatchOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { EventLink } from '~/components/tba/links';
 import MatchDetails from '~/components/tba/match/matchDetails';
 import { isValidMatchKey, matchTitleShort } from '~/lib/matchUtils';
-import { publicCacheControlHeaders } from '~/lib/utils';
+import { staleTimeForYear } from '~/lib/queryClient';
+import {
+  cacheControlHeadersForSeason,
+  doThrowNotFound,
+  seasonFromKey,
+} from '~/lib/utils';
 
 export const Route = createFileRoute('/match/$matchKey')({
-  loader: async ({ params }) => {
+  loader: async ({ params, context: { queryClient } }) => {
     if (!isValidMatchKey(params.matchKey)) {
       throw notFound();
     }
 
     const eventKey = params.matchKey.split('_')[0];
+    const staleTime = staleTimeForYear(seasonFromKey(params.matchKey));
 
     const [event, match] = await Promise.all([
-      getEvent({ path: { event_key: eventKey } }),
-      getMatch({ path: { match_key: params.matchKey } }),
+      queryClient
+        .ensureQueryData({
+          ...getEventOptions({ path: { event_key: eventKey } }),
+          staleTime,
+        })
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData({
+          ...getMatchOptions({ path: { match_key: params.matchKey } }),
+          staleTime,
+        })
+        .catch(doThrowNotFound),
     ]);
 
-    if (event.data === undefined || match.data === undefined) {
-      throw notFound();
-    }
-
-    return {
-      event: event.data,
-      match: match.data,
-    };
+    return { matchKey: params.matchKey, eventKey, event, match };
   },
-  headers: publicCacheControlHeaders(),
+  headers: ({ params }) =>
+    cacheControlHeadersForSeason(seasonFromKey(params.matchKey)),
   head: ({ loaderData }) => {
     if (!loaderData) {
       return {
@@ -124,7 +139,17 @@ export const Route = createFileRoute('/match/$matchKey')({
 });
 
 function MatchPage() {
-  const { event, match } = Route.useLoaderData();
+  const { matchKey, eventKey } = Route.useLoaderData();
+  const staleTime = staleTimeForYear(seasonFromKey(matchKey));
+
+  const { data: event } = useSuspenseQuery({
+    ...getEventOptions({ path: { event_key: eventKey } }),
+    staleTime,
+  });
+  const { data: match } = useSuspenseQuery({
+    ...getMatchOptions({ path: { match_key: matchKey } }),
+    staleTime,
+  });
 
   return (
     <div>

--- a/pwa/app/routes/match_suggestion.tsx
+++ b/pwa/app/routes/match_suggestion.tsx
@@ -1,7 +1,7 @@
 import { Progress as ProgressPrimitive } from '@base-ui/react/progress';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { type JSX, useState } from 'react';
+import { type JSX, useMemo, useState } from 'react';
 import { Temporal } from 'temporal-polyfill';
 
 import MedalIcon from '~icons/lucide/medal';
@@ -19,14 +19,13 @@ import {
   getEventOprs,
   getEventPredictions,
   getEventRankings,
-  getEventsByYear,
   getInsightsNotablesYear,
-  getStatus,
   getTeamEventsStatusesByYear,
 } from '~/api/tba/read';
 import {
   getDistrictRankingsOptions,
   getEventOptions,
+  getEventsByYearOptions,
   getTeamAwardsByYearOptions,
   getTeamDistrictsOptions,
   getTeamEventsByYearOptions,
@@ -45,25 +44,12 @@ import { matchTitleShort, sortMatchComparator } from '~/lib/matchUtils';
 import { cn, publicCacheControlHeaders, queryFromAPI } from '~/lib/utils';
 
 export const Route = createFileRoute('/match_suggestion')({
-  loader: async () => {
-    const status = await getStatus();
+  loader: async ({ context: { queryClient, currentSeason } }) => {
+    await queryClient.ensureQueryData(
+      getEventsByYearOptions({ path: { year: currentSeason } }),
+    );
 
-    if (status.data === undefined) {
-      throw new Error('Failed to load status');
-    }
-
-    const year = status.data.current_season;
-    const events = await getEventsByYear({ path: { year } });
-
-    if (events.data === undefined) {
-      throw new Error('Failed to load events');
-    }
-
-    const filteredEvents = getCurrentWeekEvents(events.data);
-
-    return {
-      events: filteredEvents,
-    };
+    return { year: currentSeason };
   },
   headers: publicCacheControlHeaders(),
   component: MatchSuggestion,
@@ -643,7 +629,12 @@ function MatchSuggestionRow({
 }
 
 function MatchSuggestion(): JSX.Element {
-  const { events } = Route.useLoaderData();
+  const { year } = Route.useLoaderData();
+
+  const { data: allEvents } = useSuspenseQuery(
+    getEventsByYearOptions({ path: { year } }),
+  );
+  const events = useMemo(() => getCurrentWeekEvents(allEvents), [allEvents]);
 
   const eventMatchesQuery = useQuery({
     queryKey: ['eventMatches', events],

--- a/pwa/app/routes/team.$teamNumber.history.tsx
+++ b/pwa/app/routes/team.$teamNumber.history.tsx
@@ -1,12 +1,13 @@
-import { createFileRoute, notFound } from '@tanstack/react-router';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
 import { Fragment } from 'react/jsx-runtime';
 
 import {
-  getTeam,
-  getTeamHistory,
-  getTeamSocialMedia,
-  getTeamYearsParticipated,
-} from '~/api/tba/read';
+  getTeamHistoryOptions,
+  getTeamOptions,
+  getTeamSocialMediaOptions,
+  getTeamYearsParticipatedOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { AwardBanner } from '~/components/tba/banner';
 import { EventLink, TeamLink } from '~/components/tba/links';
 import TeamPageTeamInfo from '~/components/tba/teamPageTeamInfo';
@@ -24,46 +25,32 @@ import { BLUE_BANNER_AWARDS } from '~/lib/api/AwardType';
 import { SEASON_EVENT_TYPES } from '~/lib/api/EventType';
 import { sortAwardsByEventDate } from '~/lib/awardUtils';
 import { sortEventsComparator } from '~/lib/eventUtils';
-import { joinComponents, publicCacheControlHeaders } from '~/lib/utils';
+import {
+  doThrowNotFound,
+  joinComponents,
+  publicCacheControlHeaders,
+} from '~/lib/utils';
 
 export const Route = createFileRoute('/team/$teamNumber/history')({
-  loader: async ({ params }) => {
+  loader: async ({ params, context: { queryClient } }) => {
     const teamKey = `frc${params.teamNumber}`;
 
-    const [team, history, yearsParticipated, socials] = await Promise.all([
-      getTeam({ path: { team_key: teamKey } }),
-      getTeamHistory({ path: { team_key: teamKey } }),
-      getTeamYearsParticipated({ path: { team_key: teamKey } }),
-      getTeamSocialMedia({ path: { team_key: teamKey } }),
+    const [team] = await Promise.all([
+      queryClient
+        .ensureQueryData(getTeamOptions({ path: { team_key: teamKey } }))
+        .catch(doThrowNotFound),
+      queryClient.ensureQueryData(
+        getTeamHistoryOptions({ path: { team_key: teamKey } }),
+      ),
+      queryClient.ensureQueryData(
+        getTeamYearsParticipatedOptions({ path: { team_key: teamKey } }),
+      ),
+      queryClient.ensureQueryData(
+        getTeamSocialMediaOptions({ path: { team_key: teamKey } }),
+      ),
     ]);
 
-    if (team.data === undefined) {
-      throw notFound();
-    }
-
-    if (
-      history.data === undefined ||
-      yearsParticipated.data === undefined ||
-      socials.data === undefined
-    ) {
-      throw new Error('Failed to load team history');
-    }
-
-    history.data.events
-      .sort(
-        (a, b) =>
-          a.year - b.year ||
-          (a.week ?? 100) - (b.week ?? 100) ||
-          Date.parse(a.start_date) - Date.parse(b.start_date),
-      )
-      .reverse();
-
-    return {
-      team: team.data,
-      history: history.data,
-      yearsParticipated: yearsParticipated.data,
-      socials: socials.data,
-    };
+    return { teamKey, team };
   },
   headers: publicCacheControlHeaders(),
   head: ({ loaderData }) => {
@@ -97,10 +84,28 @@ export const Route = createFileRoute('/team/$teamNumber/history')({
 });
 
 function TeamHistoryPage(): React.JSX.Element {
-  const { team, history, yearsParticipated, socials } = Route.useLoaderData();
+  const { teamKey } = Route.useLoaderData();
 
-  yearsParticipated.sort((a, b) => b - a);
-  history.events.sort(sortEventsComparator).reverse();
+  const { data: team } = useSuspenseQuery(
+    getTeamOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: rawHistory } = useSuspenseQuery(
+    getTeamHistoryOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: rawYearsParticipated } = useSuspenseQuery(
+    getTeamYearsParticipatedOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: socials } = useSuspenseQuery(
+    getTeamSocialMediaOptions({ path: { team_key: teamKey } }),
+  );
+
+  // These arrays are React Query cache objects now, so order them by copy.
+  const yearsParticipated = rawYearsParticipated.toSorted((a, b) => b - a);
+  const history = {
+    ...rawHistory,
+    events: rawHistory.events.toSorted(sortEventsComparator).toReversed(),
+  };
+
   const awardsSortedByEventDate = sortAwardsByEventDate(
     history.awards,
     history.events,

--- a/pwa/app/routes/team.$teamNumber.stats.tsx
+++ b/pwa/app/routes/team.$teamNumber.stats.tsx
@@ -1,5 +1,5 @@
-import { useQueries } from '@tanstack/react-query';
-import { createFileRoute, notFound } from '@tanstack/react-router';
+import { useQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
 import { uniq } from 'lodash-es';
 import { useMemo, useState } from 'react';
 import { Temporal } from 'temporal-polyfill';
@@ -8,14 +8,14 @@ import MdiCog from '~icons/mdi/cog';
 import MdiRobotExcited from '~icons/mdi/robot-excited';
 
 import { MediaAvatar } from '~/api/tba/read';
-import { getTeamMatchesByYearOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import {
-  getTeam,
-  getTeamAwards,
-  getTeamEvents,
-  getTeamMediaByYear,
-  getTeamSocialMedia,
-} from '~/api/tba/read/sdk.gen';
+  getTeamAwardsOptions,
+  getTeamEventsOptions,
+  getTeamMatchesByYearOptions,
+  getTeamMediaByYearOptions,
+  getTeamOptions,
+  getTeamSocialMediaOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { DoubleSlider } from '~/components/tba/doubleSlider';
 import TeamAwardsSummary from '~/components/tba/teamAwardsSummary';
 import TeamMatchStats from '~/components/tba/teamMatchStats';
@@ -27,39 +27,38 @@ import { SEASON_EVENT_TYPES } from '~/lib/api/EventType';
 import { sortAwardsByEventDate } from '~/lib/awardUtils';
 import { sortEventsComparator } from '~/lib/eventUtils';
 import { sortMultipleEventsMatches } from '~/lib/matchUtils';
-import { publicCacheControlHeaders } from '~/lib/utils';
+import { doThrowNotFound, publicCacheControlHeaders } from '~/lib/utils';
 
 export const Route = createFileRoute('/team/$teamNumber/stats')({
-  loader: async ({ params }) => {
-    const [team, events, awards, socials, media] = await Promise.all([
-      getTeam({ path: { team_key: `frc${params.teamNumber}` } }),
-      getTeamEvents({ path: { team_key: `frc${params.teamNumber}` } }),
-      getTeamAwards({ path: { team_key: `frc${params.teamNumber}` } }),
-      getTeamSocialMedia({ path: { team_key: `frc${params.teamNumber}` } }),
-      getTeamMediaByYear({
-        path: {
-          team_key: `frc${params.teamNumber}`,
-          year: Temporal.Now.plainDateISO().year,
-        },
-      }),
-    ]);
-    if (
-      team.data === undefined ||
-      events.data === undefined ||
-      awards.data === undefined ||
-      socials.data === undefined ||
-      media.data === undefined
-    ) {
-      throw notFound();
-    }
+  loader: async ({ params, context: { queryClient } }) => {
+    const teamKey = `frc${params.teamNumber}`;
+    const mediaYear = Temporal.Now.plainDateISO().year;
 
-    return {
-      team: team.data,
-      allAwards: awards.data,
-      allEvents: events.data,
-      socials: socials.data,
-      media: media.data,
-    };
+    const [team] = await Promise.all([
+      queryClient
+        .ensureQueryData(getTeamOptions({ path: { team_key: teamKey } }))
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData(getTeamEventsOptions({ path: { team_key: teamKey } }))
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData(getTeamAwardsOptions({ path: { team_key: teamKey } }))
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData(
+          getTeamSocialMediaOptions({ path: { team_key: teamKey } }),
+        )
+        .catch(doThrowNotFound),
+      queryClient
+        .ensureQueryData(
+          getTeamMediaByYearOptions({
+            path: { team_key: teamKey, year: mediaYear },
+          }),
+        )
+        .catch(doThrowNotFound),
+    ]);
+
+    return { teamKey, mediaYear, team };
   },
   headers: publicCacheControlHeaders(),
   head: ({ loaderData }) => {
@@ -118,7 +117,25 @@ function MatchStatsLoadingState({
 }
 
 function TeamStatsPage() {
-  const { team, allEvents, allAwards, socials, media } = Route.useLoaderData();
+  const { teamKey, mediaYear } = Route.useLoaderData();
+
+  const { data: team } = useSuspenseQuery(
+    getTeamOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: allEvents } = useSuspenseQuery(
+    getTeamEventsOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: allAwards } = useSuspenseQuery(
+    getTeamAwardsOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: socials } = useSuspenseQuery(
+    getTeamSocialMediaOptions({ path: { team_key: teamKey } }),
+  );
+  const { data: media } = useSuspenseQuery(
+    getTeamMediaByYearOptions({
+      path: { team_key: teamKey, year: mediaYear },
+    }),
+  );
 
   const [includeOffseasons, setIncludeOffseasons] = useState(false);
   const [minYear, setMinYear] = useState(allEvents[0].year);

--- a/pwa/app/routes/team.$teamNumber.{-$year}.tsx
+++ b/pwa/app/routes/team.$teamNumber.{-$year}.tsx
@@ -80,11 +80,12 @@ import { staleTimeForYear } from '~/lib/queryClient';
 import {
   MODEL_TYPE,
   addRecords,
+  cacheControlHeadersForSeason,
   doThrowNotFound,
   hasAnyMatches,
   parseParamsForYearElseDefault,
   pluralize,
-  publicCacheControlHeaders,
+  seasonFromKey,
   stringifyRecord,
   winrateFromRecord,
 } from '~/lib/utils';
@@ -197,7 +198,8 @@ export const Route = createFileRoute('/team/$teamNumber/{-$year}')({
       team,
     };
   },
-  headers: publicCacheControlHeaders(),
+  headers: ({ params }) =>
+    cacheControlHeadersForSeason(seasonFromKey(params.year)),
   head: ({ loaderData }) => {
     if (!loaderData) {
       return {

--- a/pwa/app/routes/teams.{-$pgNum}.tsx
+++ b/pwa/app/routes/teams.{-$pgNum}.tsx
@@ -1,6 +1,7 @@
+import { useSuspenseQueries } from '@tanstack/react-query';
 import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router';
 
-import { getTeamsSimple } from '~/api/tba/read';
+import { getTeamsSimpleOptions } from '~/api/tba/read/@tanstack/react-query.gen';
 import FavoriteTeamsSection from '~/components/tba/favoriteTeamsSection';
 import TeamListTable from '~/components/tba/teamListTable';
 import {
@@ -16,7 +17,7 @@ import {
 } from '~/lib/utils';
 
 export const Route = createFileRoute('/teams/{-$pgNum}')({
-  loader: async ({ params, context: { status } }) => {
+  loader: async ({ params, context: { status, queryClient } }) => {
     const maxPageNum = Math.floor(status.max_team_page / 2) + 1;
     const pageNum = parseParamsForTeamPgNumElseDefault(params, maxPageNum);
 
@@ -24,16 +25,16 @@ export const Route = createFileRoute('/teams/{-$pgNum}')({
       throw notFound();
     }
 
-    const [teamsSetOne, teamsSetTwo] = await Promise.all([
-      getTeamsSimple({ path: { page_num: 2 * (pageNum - 1) } }),
-      getTeamsSimple({ path: { page_num: 2 * (pageNum - 1) + 1 } }),
+    await Promise.all([
+      queryClient.ensureQueryData(
+        getTeamsSimpleOptions({ path: { page_num: 2 * (pageNum - 1) } }),
+      ),
+      queryClient.ensureQueryData(
+        getTeamsSimpleOptions({ path: { page_num: 2 * (pageNum - 1) + 1 } }),
+      ),
     ]);
-    if (teamsSetOne.data === undefined || teamsSetTwo.data === undefined) {
-      throw new Error('Failed to load teams');
-    }
-    const teams = teamsSetOne.data.concat(teamsSetTwo.data);
 
-    return { teams, pageNum, maxPageNum };
+    return { pageNum, maxPageNum };
   },
   headers: publicCacheControlHeaders(),
   head: () => {
@@ -60,8 +61,16 @@ function TeamPageNumberToRange(pageNum: number): string {
 }
 
 function TeamsPage() {
-  const { teams, pageNum, maxPageNum } = Route.useLoaderData();
+  const { pageNum, maxPageNum } = Route.useLoaderData();
   const navigate = useNavigate();
+
+  const [{ data: teamsSetOne }, { data: teamsSetTwo }] = useSuspenseQueries({
+    queries: [
+      getTeamsSimpleOptions({ path: { page_num: 2 * (pageNum - 1) } }),
+      getTeamsSimpleOptions({ path: { page_num: 2 * (pageNum - 1) + 1 } }),
+    ],
+  });
+  const teams = teamsSetOne.concat(teamsSetTwo);
 
   // Base UI's Select.Value renders the raw value unless the items are
   // registered on Select.Root, so provide value -> label pairs there too.


### PR DESCRIPTION
Two fixes to PWA caching, plus the route migration that makes the first one safe.

## Problems (measured)

| Finding | Evidence |
|---|---|
| SSR network LRU hit rate is **21.4%** | Sentry, 7d: `network.cache.hit` 45,075 vs `network.cache.miss` 165,105 |
| Cloudflare **never serves stale** documents | Polled one URL every 15s: `HIT` through age 60s → `EXPIRED` at 61s → re-cached. Twice, plus a `MISS`. Never a stale serve. |
| A CDN miss costs **17x** a CDN hit | Same URL: `cf-cache-status: MISS` 0.506s vs `HIT` 0.029s |
| The #10545 304 fastpath is **unused by SSR** | `network-cache.ts` discarded the upstream `ETag` and never sent `If-None-Match` |

Root cause of the stale-while-revalidate failure: we sent `stale-while-revalidate` only on `Cache-Control`. Cloudflare prefers `CDN-Cache-Control`, which carried no such directive, so the edge did a *blocking* origin revalidation the moment `max-age` lapsed.

## Changes

**Serve-stale + ETag revalidation** (`network-cache.ts`). A stale entry is returned synchronously while a conditional `If-None-Match` request runs behind the response. Revalidation is deliberately **not** awaited: against the live API a `304` (~0.03s) and a `200` (~0.03s, 287KB) are within noise of each other once Cloudflare has the response cached — the round trip, not the payload, is the cost. Concurrent stale reads for one key are deduped, so a hot key fires one revalidation rather than up to `max_concurrent_requests` (80).

**Season-tiered cache headers** (`utils.tsx`), reusing the `staleTimeForYear` immutability rule, with `stale-while-revalidate` now also in `CDN-Cache-Control`. Past season 24h/7d; current season 61s/600s. Unknown season resolves to the short tier.

**Seven loader-only routes migrated to React Query** — `match.$matchKey` (68% of SSR traffic), `team/*/history`, `team/*/stats`, `teams/*`, `district/*/stats`, `district/*/insights`, `match_suggestion` — following the existing `event.$eventKey.tsx` pattern. This is a prerequisite, not a nice-to-have: those routes read `useLoaderData()`, so stale HTML would **not** self-correct on hydration. Both halves are required — `ensureQueryData` in the loader only dehydrates; the components move to `useSuspenseQuery` too.

## Notable implementation detail

Freshness moved out of lru-cache and into the middleware (`fetchedAt`/`freshForMs`). lru-cache captures the `performance` object at import and debounces `perf.now()` behind a real `setTimeout`, so its TTL clock can't be faked and the behavior wasn't testable. The LRU now only bounds memory; the 300-entry cap is unchanged.

## Verification

Ran the production server locally against the live API and let entries age past 61s:

- Past-season match → `max-age=86400, stale-while-revalidate=604800` on both headers; current-season → `61/600`.
- After aging: **Stale Served 3, Revalidations 3, misses unchanged at 5.** Those three would previously have been three blocking fetches.
- A cached entry came back with `etag: W/"6e798f46…"` and `fetchedAt` advanced with full freshness restored — the 304 path working without counting a miss.

416 unit tests pass (7 new for serve-stale/revalidation, 6 for season parsing). Typecheck, lint, format, and production build all clean.

## Open question

Whether Cloudflare honors `stale-while-revalidate` once it's in `CDN-Cache-Control`. I confirmed it ignores the directive when *absent* from that header, but not that it obeys it when present. If a preview deploy still shows `EXPIRED` at TTL rather than a stale `HIT`, the raised `max-age` alone still captures most of the win for past-season content. Polling command is in `docs/Architecture/Architecture-Caching-PWA.md`.

## Screenshot Pages

- /match/2024mil_f1m2 Match page (migrated)
- /team/254/2024 Team year page
- /team/254/history Team history (migrated)
- /team/254/stats Team stats (migrated)
- /teams/2 Teams list (migrated)
- /district/fim/insights District insights (migrated)
- /district/fim/stats District stats (migrated)
- /event/2024mil Event page

