### PR TITLE
[api] Optimize APIv3 cold start latency and configure pending latency thresholds

### DIFF
--- a/src/api.yaml
+++ b/src/api.yaml
@@ -6,6 +6,8 @@ app_engine_apis: true
 instance_class: F1
 automatic_scaling:
   max_idle_instances: 1
+  min_pending_latency: 300ms
+  max_pending_latency: 1000ms
   target_cpu_utilization: 0.9
   target_throughput_utilization: 0.9
   max_concurrent_requests: 20

--- a/src/backend/api/handlers/eventwizard_internal.py
+++ b/src/backend/api/handlers/eventwizard_internal.py
@@ -3,7 +3,6 @@ from io import BytesIO
 from pathlib import Path
 
 from flask import make_response, request, Response
-from openpyxl import load_workbook
 from pyre_extensions import none_throws
 
 from backend.api.handlers.decorators import require_write_auth, validate_keys
@@ -28,6 +27,8 @@ def add_fms_report_archive(event_key: EventKey, report_type: str) -> Response:
     file_contents: bytes = form_data.read()
 
     try:
+        from openpyxl import load_workbook
+
         workbook = load_workbook(filename=BytesIO(file_contents))
         mtime = workbook.properties.modified
     except Exception:

--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -1,7 +1,7 @@
 import datetime
+from types import ModuleType
 from typing import Any, Dict, Optional
 
-from firebase_admin import auth
 from flask import session
 
 from backend.common.firebase import app
@@ -14,12 +14,18 @@ _SESSION_KEY = "session"
 SESSION_COOKIE_LIFETIME = datetime.timedelta(days=14)
 
 
+def _get_auth() -> ModuleType:
+    from firebase_admin import auth
+
+    return auth
+
+
 # Code from https://firebase.google.com/docs/auth/admin/manage-cookies
 
 
 def _verify_id_token(id_token: str) -> Optional[dict]:
     try:
-        return auth.verify_id_token(id_token, check_revoked=True, app=app())
+        return _get_auth().verify_id_token(id_token, check_revoked=True, app=app())
     except Exception:
         return None
 
@@ -29,7 +35,7 @@ def verify_id_token(id_token: str) -> Optional[dict]:
 
 
 def create_session_cookie(id_token: str, expires_in: datetime.timedelta) -> None:
-    session_cookie = auth.create_session_cookie(
+    session_cookie = _get_auth().create_session_cookie(
         id_token, expires_in=expires_in, app=app()
     )
     session.permanent = True
@@ -39,7 +45,7 @@ def create_session_cookie(id_token: str, expires_in: datetime.timedelta) -> None
 def revoke_session_cookie() -> None:
     session_claims = _decoded_claims()
     if session_claims:
-        auth.revoke_refresh_tokens(session_claims["sub"], app=app())
+        _get_auth().revoke_refresh_tokens(session_claims["sub"], app=app())
     session.pop(_SESSION_KEY, None)
 
 
@@ -51,7 +57,9 @@ def _decoded_claims() -> Optional[Dict[str, Any]]:
     # Verify the session cookie. In this case an additional check is added to detect
     # if the user's Firebase session was revoked, user deleted/disabled, etc.
     try:
-        return auth.verify_session_cookie(session_cookie, check_revoked=True, app=app())
+        return _get_auth().verify_session_cookie(
+            session_cookie, check_revoked=True, app=app()
+        )
     except Exception:
         # Session cookie is invalid, expired or revoked. Force user to login.
         return None
@@ -69,7 +77,7 @@ def current_user() -> Optional[User]:
 
 
 def _delete_user(uid: str) -> None:
-    auth.delete_user(uid, app=app())
+    _get_auth().delete_user(uid, app=app())
 
 
 def delete_user(uid: str) -> None:

--- a/src/backend/common/cloudrun/__init__.py
+++ b/src/backend/common/cloudrun/__init__.py
@@ -4,7 +4,6 @@ from backend.common.cloudrun.clients.cloudrun_client import (
     CloudRunClient,
     JobStatus,
 )
-from backend.common.cloudrun.clients.gcloud_client import GCloudRunClient
 from backend.common.cloudrun.clients.local_client import LocalCloudRunClient
 from backend.common.environment import Environment
 from backend.common.sitevars.google_cloudrun_config import GoogleCloudRunConfig
@@ -36,6 +35,8 @@ def _client_for_env() -> CloudRunClient:
         raise ValueError(
             "GoogleCloudRunConfig.region must be set to use Cloud Run client."
         )
+
+    from backend.common.cloudrun.clients.gcloud_client import GCloudRunClient
 
     return GCloudRunClient(project, region)
 

--- a/src/backend/common/helpers/firebase_pusher.py
+++ b/src/backend/common/helpers/firebase_pusher.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Set
+from __future__ import annotations
 
-from firebase_admin import db as firebase_db
+from typing import Dict, List, Set, TYPE_CHECKING
+
 from pyre_extensions import none_throws
 
 from backend.common.consts.nexus_match_status import NexusMatchStatus
@@ -14,7 +15,6 @@ from backend.common.models.event import Event
 from backend.common.models.event_queue_status import EventQueueStatus
 from backend.common.models.keys import EventKey
 from backend.common.models.match import Match
-from backend.common.models.match_suggestion import MatchSuggestions
 from backend.common.queries.dict_converters.event_converter import EventConverter
 from backend.common.queries.dict_converters.match_converter import (
     MatchConverter,
@@ -24,12 +24,19 @@ from backend.common.sitevars.gameday_special_webcasts import (
     WebcastType as TSpecialWebcast,
 )
 
+if TYPE_CHECKING:
+    from firebase_admin import db as firebase_db
+
+    from backend.common.models.match_suggestion import MatchSuggestions
+
 
 class FirebasePusher:
     DB_URL = "https://{project}.firebaseio.com/"
 
     @classmethod
     def _get_reference(cls, key: str) -> firebase_db.Reference:
+        from firebase_admin import db as firebase_db
+
         url = cls.DB_URL.format(project=Environment.project())
         return firebase_db.reference(key, app=get_firebase_app(), url=url)
 

--- a/src/backend/common/helpers/season_helper.py
+++ b/src/backend/common/helpers/season_helper.py
@@ -7,7 +7,20 @@ from backend.common.models.keys import Year
 from backend.common.queries.event_query import EventListQuery, LastSeasonEventQuery
 from backend.common.sitevars.apistatus import ApiStatus
 
-EST = timezone("US/Eastern")
+_est_tz = None
+
+
+def _get_est():
+    global _est_tz
+    if _est_tz is None:
+        _est_tz = timezone("US/Eastern")
+    return _est_tz
+
+
+def __getattr__(name: str):
+    if name == "EST":
+        return _get_est()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class SeasonHelper(object):
@@ -87,7 +100,7 @@ class SeasonHelper(object):
         Kickoff is always the first Saturday in January after Jan 2nd.
         In 2026, it is the second Saturday in January after Jan 2nd.
         """
-        jan_2nd = EST.localize(
+        jan_2nd = _get_est().localize(
             datetime(year=year, month=1, day=2, hour=10, minute=30, second=0)
         )
         # Since 2021, Kickoff starts at 12:00am EST


### PR DESCRIPTION
## Overview

This PR addresses APIv3 cold start latency and excessive autoscaler instance churn based on an analysis of Google Cloud Trace and Cloud Logging data on `tbatv-prod-hrd`.

### 1. Autoscaler Pending Latency Tuning (`src/api.yaml`)
- Configured `min_pending_latency: 300ms` and `max_pending_latency: 1000ms` under `automatic_scaling`.
- **Problem:** Over the analyzed 12-hour period, `py3-api` logged **1,913 cold starts** (~159/hr). Analysis of request logs revealed that **60.1%** of cold starts were micro-bursts of conditional polling requests returning **HTTP 304 (Not Modified)**. Because `max_pending_latency` was omitted (defaulting to ~30ms), App Engine would prematurely provision new instances for bursts that could clear on existing warm threads in 50–100ms. In fact, **37.5% of newly spawned instances served exactly 1 request before being terminated**.
- **Solution:** Setting `min_pending_latency: 300ms` guarantees that requests waiting under 300ms do not trigger new instances. Since 95% of warm 304s finish in $\le$ 200ms, transient queues drain on warm instances without triggering 3-second cold starts. `max_pending_latency: 1000ms` ensures genuine backlogs still scale out promptly.

### 2. Defer Heavy Top-Level Imports (`src/backend/...`)
- Defers unnecessary eager imports along the application startup path:
  - Defer `GCloudRunClient` in `backend.common.cloudrun` (prevents loading `google.cloud.run_v2`).
  - Defer `openpyxl` in `eventwizard_internal` (avoids loading `openpyxl`, `numpy`, and `Pillow`).
  - Guard `MatchSuggestions` in `firebase_pusher` with `TYPE_CHECKING` and defer `firebase_admin.db` (avoids importing `pydantic` at startup).
  - Lazily load `firebase_admin.auth` in `backend.common.auth`.
  - Lazily load EST timezone in `season_helper` to avoid parsing tzdata files on import.

Together, these changes significantly reduce module import duration at boot and prevent unnecessary autoscaler spin-up / tear-down cycles.

## Verification
- Validated formatting with `make lint`.