### PR TITLE
[api] Configure min and max pending latency

### DIFF
--- a/src/api.yaml
+++ b/src/api.yaml
@@ -5,6 +5,8 @@ app_engine_apis: true
 
 instance_class: F1
 automatic_scaling:
+  min_pending_latency: 300ms
+  max_pending_latency: 800ms
   max_idle_instances: 1
   target_cpu_utilization: 0.9
   target_throughput_utilization: 0.9


### PR DESCRIPTION
## Description
Configures `min_pending_latency: 300ms` and `max_pending_latency: 800ms` under `automatic_scaling` in `src/api.yaml`.

## Motivation and Context
Configuring pending latency parameters allows App Engine to manage instance scaling and pending request queueing behavior for the API service.

Currently there is a lot of instance churn from bursts of incoming requests. 

## How Has This Been Tested?
Ran `make lint` locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)