### PR TITLE
[pwa] Defer Firebase Analytics off the hydration critical path

### DIFF
--- a/pwa/app/firebase/firebaseConfig.tsx
+++ b/pwa/app/firebase/firebaseConfig.tsx
@@ -1,8 +1,8 @@
 import { isServer } from '@tanstack/react-query';
-import { initializeAnalytics } from 'firebase/analytics';
-import { getApps, initializeApp } from 'firebase/app';
+import type { Analytics } from 'firebase/analytics';
+import { type FirebaseApp, getApps, initializeApp } from 'firebase/app';
 import { connectAuthEmulator, getAuth } from 'firebase/auth';
-import { getDatabase } from 'firebase/database';
+import type { Database } from 'firebase/database';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,7 +13,7 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
-let app;
+let app: FirebaseApp;
 if (!getApps().length) {
   app = initializeApp(firebaseConfig);
 } else {
@@ -28,9 +28,23 @@ if (auth && import.meta.env.VITE_FIREBASE_AUTH_EMULATOR_HOST) {
   });
 }
 
-const database = getDatabase(app);
-const analytics =
-  !isServer && typeof window !== 'undefined'
-    ? initializeAnalytics(app, { config: { send_page_view: false } })
-    : null;
-export { auth, analytics, database };
+let cachedDatabase: Database | null = null;
+export async function getDatabaseInstance(): Promise<Database> {
+  if (cachedDatabase) return cachedDatabase;
+  const { getDatabase } = await import('firebase/database');
+  cachedDatabase = getDatabase(app);
+  return cachedDatabase;
+}
+
+let cachedAnalytics: Analytics | null = null;
+export async function getAnalyticsInstance(): Promise<Analytics | null> {
+  if (isServer || typeof window === 'undefined') return null;
+  if (cachedAnalytics) return cachedAnalytics;
+  const { initializeAnalytics } = await import('firebase/analytics');
+  cachedAnalytics = initializeAnalytics(app, {
+    config: { send_page_view: false },
+  });
+  return cachedAnalytics;
+}
+
+export { auth };

--- a/pwa/app/lib/gameday/useFirebaseWebcasts.ts
+++ b/pwa/app/lib/gameday/useFirebaseWebcasts.ts
@@ -1,22 +1,14 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { type Database, onValue, ref } from 'firebase/database';
+import { onValue, ref } from 'firebase/database';
 import { useEffect, useMemo } from 'react';
 
+import { getDatabaseInstance } from '~/firebase/firebaseConfig';
 import {
   type FirebaseLiveEvent,
   type FirebaseSpecialWebcast,
   type WebcastWithMeta,
   getWebcastId,
 } from '~/lib/gameday/types';
-
-// Lazy load database to avoid SSR issues
-let cachedDatabase: Database | null = null;
-async function getDatabase(): Promise<Database> {
-  if (cachedDatabase) return cachedDatabase;
-  const { database } = await import('~/firebase/firebaseConfig');
-  cachedDatabase = database;
-  return database;
-}
 
 export const FIREBASE_LIVE_EVENTS_QUERY_KEY = [
   'firebase',
@@ -51,7 +43,7 @@ export function useFirebaseWebcasts(): UseFirebaseWebcastsResult {
     let unsubscribeSpecialWebcasts: (() => void) | null = null;
 
     // Initialize Firebase subscriptions
-    void getDatabase().then((database) => {
+    void getDatabaseInstance().then((database) => {
       // Subscribe to live_events
       const liveEventsRef = ref(database, 'live_events');
       unsubscribeLiveEvents = onValue(liveEventsRef, (snapshot) => {

--- a/pwa/app/router.tsx
+++ b/pwa/app/router.tsx
@@ -102,22 +102,29 @@ export function getRouter() {
     );
 
     // onResolved doesn't fire for the initial hydration, so log it manually.
-    void logPageView(window.location.pathname, window.location.href);
+    // Defer to idle so Firebase Analytics (gtag.js) stays off the hydration
+    // critical path.
+    const logInitialPageView = () =>
+      void logPageView(window.location.pathname, window.location.href);
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(logInitialPageView);
+    } else {
+      setTimeout(logInitialPageView, 1);
+    }
   }
 
   return router;
 }
 
-// Firebase is dynamically imported here (mirroring the pattern in
-// useFirebaseWebcasts.ts) so `firebase/analytics` and firebaseConfig.tsx
-// (which also pulls in firebase/app and firebase/auth) stay out of the
-// entry chunk and only load once a client-side navigation actually happens.
+// `firebase/analytics` and the gtag.js network request it triggers are loaded
+// lazily here so they stay out of the hydration critical path.
 async function logPageView(pagePath: string, pageLocation: string) {
-  const [{ logEvent }, { analytics }] = await Promise.all([
+  const [{ logEvent }, { getAnalyticsInstance }] = await Promise.all([
     import('firebase/analytics'),
     import('~/firebase/firebaseConfig'),
   ]);
 
+  const analytics = await getAnalyticsInstance();
   if (analytics === null) {
     return;
   }


### PR DESCRIPTION
## Description

`initializeAnalytics` ran at module scope in `firebaseConfig.tsx` and the initial `page_view` was logged synchronously during hydration, pulling `gtag.js` (~90 KB) onto the critical path. Analytics and the Realtime Database are now lazily initialized via `getAnalyticsInstance` / `getDatabaseInstance`, and the initial `page_view` fires in `requestIdleCallback`.

## Motivation and Context

Part of PWA performance stack #10560. `gtag.js` was flagged 63% unused on first load in Lighthouse.

## How Has This Been Tested?

`pnpm run typecheck`, `pnpm run lint`, full unit suite, Playwright (`navigation`, `lazy-chunks`, `event-media`). Verified `gtag.js` / `apis.google.com` no longer appear on the initial `/event/2024mil` request; TBT down ~15% in a 10-run Lighthouse median.

## Screenshot Pages

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
