### PR TITLE
[pwa] Reduce Sentry client trace/profile sampling

### DIFF
--- a/pwa/app/router.tsx
+++ b/pwa/app/router.tsx
@@ -84,10 +84,10 @@ export function getRouter() {
       sendDefaultPii: false,
       enableLogs: true,
       enableMetrics: true,
-      tracesSampleRate: 1,
+      tracesSampleRate: 0.1,
       replaysSessionSampleRate: 0.1,
       replaysOnErrorSampleRate: 1,
-      profilesSampleRate: 1,
+      profilesSampleRate: 0.1,
 
       integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
       enabled: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Description

`tracesSampleRate` and `profilesSampleRate` were both `1.0`, so every page load recorded, serialized, and transmitted a full transaction (plus JS self-profiler overhead) on the main thread. Both dropped to `0.1`. Session replay sampling is unchanged.

Fully unbundling the Sentry SDK from the entry chunk is left as follow-up — it is statically imported by entry-critical modules (`queryClient`, `network-cache` middleware) and needs a broader refactor.

## Motivation and Context

Part of PWA performance stack #10560.

## How Has This Been Tested?

`pnpm run typecheck`, `pnpm run build`, full unit suite.

## Screenshot Pages

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
