### PR TITLE
[pwa] Lazy-load the framer-motion tab indicator

### DIFF
--- a/pwa/app/components/ui/animated-tabs.tsx
+++ b/pwa/app/components/ui/animated-tabs.tsx
@@ -1,13 +1,18 @@
-import { LayoutGroup, motion } from 'motion/react';
 import {
   type ComponentProps,
+  Suspense,
   createContext,
+  lazy,
   useContext,
   useState,
 } from 'react';
 
 import { Tabs, TabsTrigger } from '~/components/ui/tabs';
 import { cn } from '~/lib/utils';
+
+const AnimatedTabIndicator = lazy(
+  () => import('~/components/ui/animatedTabIndicator'),
+);
 
 const AnimatedTabsContext = createContext<{ activeValue: string | undefined }>({
   activeValue: undefined,
@@ -37,18 +42,16 @@ function AnimatedTabs({
 
   return (
     <AnimatedTabsContext.Provider value={{ activeValue }}>
-      <LayoutGroup>
-        <Tabs
-          defaultValue={defaultValue}
-          value={value}
-          onValueChange={(v, eventDetails) => {
-            const stringValue = String(v);
-            setInternalValue(stringValue);
-            onValueChange?.(stringValue, eventDetails);
-          }}
-          {...props}
-        />
-      </LayoutGroup>
+      <Tabs
+        defaultValue={defaultValue}
+        value={value}
+        onValueChange={(v, eventDetails) => {
+          const stringValue = String(v);
+          setInternalValue(stringValue);
+          onValueChange?.(stringValue, eventDetails);
+        }}
+        {...props}
+      />
     </AnimatedTabsContext.Provider>
   );
 }
@@ -72,12 +75,15 @@ function AnimatedTabsTrigger({
       {...props}
     >
       {isActive && (
-        <motion.span
-          layoutId="tab-indicator"
-          initial={false}
-          className="absolute inset-0 rounded-sm bg-background shadow-xs"
-          transition={{ type: 'spring', bounce: 0.15, duration: 0.4 }}
-        />
+        <Suspense
+          fallback={
+            <span
+              className="absolute inset-0 rounded-sm bg-background shadow-xs"
+            />
+          }
+        >
+          <AnimatedTabIndicator />
+        </Suspense>
       )}
       <span className="relative z-10">{children}</span>
     </TabsTrigger>

--- a/pwa/app/components/ui/animatedTabIndicator.tsx
+++ b/pwa/app/components/ui/animatedTabIndicator.tsx
@@ -1,0 +1,12 @@
+import { motion } from 'motion/react';
+
+export default function AnimatedTabIndicator() {
+  return (
+    <motion.span
+      layoutId="tab-indicator"
+      initial={false}
+      className="absolute inset-0 rounded-sm bg-background shadow-xs"
+      transition={{ type: 'spring', bounce: 0.15, duration: 0.4 }}
+    />
+  );
+}

--- a/pwa/tests/lazy-chunks.spec.ts
+++ b/pwa/tests/lazy-chunks.spec.ts
@@ -53,3 +53,25 @@ test.describe('devtools gating', () => {
     await expect(page.locator('.tsqd-open-btn-container')).toHaveCount(0);
   });
 });
+
+test.describe('lazy animated tab indicator', () => {
+  test('defers the motion chunk but tabs still switch', async ({ page }) => {
+    const scriptUrls: string[] = [];
+    page.on('request', (req) => {
+      if (req.resourceType() === 'script') scriptUrls.push(req.url());
+    });
+
+    await page.goto('/event/2024mil');
+    await page.locator('body[data-hydrated]').waitFor();
+
+    expect(
+      scriptUrls.some((u) => u.includes('animatedTabIndicator')),
+    ).toBeFalsy();
+
+    await page.getByRole('tab', { name: /rankings/i }).click();
+    await expect(page.getByRole('tab', { name: /rankings/i })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+});


### PR DESCRIPTION
## Description

`AnimatedTabs` pulled framer-motion (~60 KB, flagged 65% unused by Lighthouse) into the event route chunk just for the sliding pill behind the active tab. The `motion.span` is now a `lazy()` component with a static CSS indicator as the Suspense fallback, so motion loads after hydration instead of on the critical path. The spring-slide animation still kicks in once the chunk arrives.

## Motivation and Context

Part of PWA performance stack #10560.

## How Has This Been Tested?

`pnpm run typecheck`, `pnpm run lint`, full unit suite. New regression test in `tests/lazy-chunks.spec.ts` asserts the `animatedTabIndicator` chunk is not requested on initial load and that tab switching still works. Verified motion is no longer in the `event.$eventKey` chunk.

## Screenshot Pages

- /event/2024mil Event page (tab bar)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
