### PR TITLE
[pwa] Quick perf wins: size the footer logo, split temporal-polyfill

### DIFF
--- a/pwa/app/components/tba/navigation/footer.tsx
+++ b/pwa/app/components/tba/navigation/footer.tsx
@@ -164,7 +164,9 @@ export const Footer = () => {
               <img
                 src={andymarkLogo}
                 alt="AndyMark"
-                className="ml-2 inline h-4"
+                width={450}
+                height={81}
+                className="ml-2 inline h-4 w-auto"
               />
             </a>
           </span>

--- a/pwa/vite.config.ts
+++ b/pwa/vite.config.ts
@@ -86,6 +86,13 @@ export default defineConfig({
   build: {
     outDir: 'build',
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('/temporal-polyfill/')) return 'temporal-polyfill';
+        },
+      },
+    },
   },
   define: {
     __COMMIT_HASH__: JSON.stringify(getCommitHash()),


### PR DESCRIPTION
## Description

- Give the AndyMark footer logo explicit `width`/`height` (450×81) so the browser reserves layout space (Lighthouse `unsized-images`).
- Pin `temporal-polyfill` to its own `manualChunk` so it no longer rides in the `queryClient` chunk and stays cacheable across unrelated app changes.

## Motivation and Context

Top of PWA performance stack #10560.

## How Has This Been Tested?

`pnpm run typecheck`, `pnpm run lint`, `pnpm run build` (verified `temporal-polyfill` emits as its own chunk), full unit suite.

## Screenshot Pages

- /event/2024mil Footer

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
