### PR TITLE
[api] Implement warmup requests for API service

### DIFF
--- a/src/api.yaml
+++ b/src/api.yaml
@@ -3,6 +3,9 @@ runtime: python313
 entrypoint: gunicorn -t 0 -b :$PORT --workers 1 --threads 8 backend.api.main:app
 app_engine_apis: true
 
+inbound_services:
+  - warmup
+
 instance_class: F1
 automatic_scaling:
   max_idle_instances: 1

--- a/src/backend/api/handlers/tests/warmup_test.py
+++ b/src/backend/api/handlers/tests/warmup_test.py
@@ -1,0 +1,13 @@
+from werkzeug.test import Client
+
+from backend.api.handlers.warmup import warmup
+
+
+def test_warmup_endpoint(api_client: Client) -> None:
+    resp = api_client.get("/_ah/warmup")
+    assert resp.status_code == 200
+
+
+def test_warmup_direct() -> None:
+    resp = warmup()
+    assert resp.status_code == 200

--- a/src/backend/api/handlers/warmup.py
+++ b/src/backend/api/handlers/warmup.py
@@ -1,0 +1,5 @@
+from flask import Response
+
+
+def warmup() -> Response:
+    return Response(status=200)

--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -6,6 +6,7 @@ from backend.api.apiv3_main import api_v3
 from backend.api.client_api_main import client_api
 from backend.api.eventwizard_api_main import eventwizard_api
 from backend.api.handlers.error import handle_404
+from backend.api.handlers.warmup import warmup
 from backend.api.moderation_api_main import moderation_api
 from backend.api.trusted_api_main import trusted_api
 from backend.common.flask_cache import configure_flask_cache
@@ -46,3 +47,5 @@ app.register_blueprint(trusted_api)
 app.register_blueprint(client_api)
 app.register_blueprint(moderation_api)
 app.register_error_handler(404, handle_404)
+
+app.add_url_rule("/_ah/warmup", view_func=warmup)

--- a/src/backend/common/middleware.py
+++ b/src/backend/common/middleware.py
@@ -25,7 +25,10 @@ class AppspotRedirectMiddleware:
         request = Request(environ)
         host = request.host.lower()
 
-        if host in ("tbatv-prod-hrd.appspot.com", "www.tbatv-prod-hrd.appspot.com"):
+        if not request.path.startswith("/_ah/") and host in (
+            "tbatv-prod-hrd.appspot.com",
+            "www.tbatv-prod-hrd.appspot.com",
+        ):
             redirect_url = f"https://www.thebluealliance.com{request.full_path}"
 
             # Create a 301 (permanent) redirect response

--- a/src/backend/common/tests/middleware_test.py
+++ b/src/backend/common/tests/middleware_test.py
@@ -119,6 +119,24 @@ def test_AppspotRedirectMiddleware_no_redirect_localhost(app: Flask) -> None:
     assert location_header is None
 
 
+def test_AppspotRedirectMiddleware_no_redirect_ah_path(app: Flask) -> None:
+    middleware = cast(WSGIApplication, AppspotRedirectMiddleware(app))
+
+    @app.route("/_ah/warmup")
+    def warmup_handler():
+        return "warmup ok"
+
+    # Test no redirect for /_ah/ paths on appspot host
+    environ = create_environ(
+        path="/_ah/warmup", base_url="https://tbatv-prod-hrd.appspot.com"
+    )
+    _, status, headers = run_wsgi_app(middleware, environ, buffered=True)
+
+    assert status == "200 OK"
+    location_header = next((v for k, v in headers if k == "Location"), None)
+    assert location_header is None
+
+
 def test_TraceRequestMiddleware_init(app: Flask) -> None:
     middleware = TraceRequestMiddleware(app)
     assert middleware.app is app


### PR DESCRIPTION
## Description
- Enable `inbound_services: - warmup` in `src/api.yaml` so App Engine automatically issues warmup requests (`GET /_ah/warmup`) before routing user traffic to newly provisioned instances.
- Register `/_ah/warmup` handler in `backend.api.main` returning a basic 200 OK response.
- Update `AppspotRedirectMiddleware` in `src/backend/common/middleware.py` to bypass paths starting with `/_ah/`, ensuring internal App Engine requests are not 301-redirected.
- Add unit tests for the warmup handler, endpoint, and middleware path bypass.

## Motivation and Context
This enables App Engine warmup requests to reduce cold start latency on newly provisioned API service instances.

## How Has This Been Tested?
- Ran targeted unit tests:
  ```
  make test ARGS='src/backend/api/handlers/tests/warmup_test.py src/backend/common/tests/middleware_test.py'
  ```
  (19 passed)
- Ran all API unit tests:
  ```
  make test ARGS='src/backend/api/'
  ```
  (719 passed)
- Ran code formatting and lint checks:
  ```
  make lint
  ```
- Ran pyre type checker:
  ```
  make typecheck
  ```
  (no errors found)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)