### PR TITLE
[api] Drop date-time format on media model_created

### DIFF
--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -905,7 +905,7 @@ export const zMediaGrabCad = zMediaBase.and(
     type: z.literal('grabcad').optional(),
     details: z
       .object({
-        model_created: z.iso.datetime({ offset: true }),
+        model_created: z.string(),
         model_description: z.string().nullable(),
         model_image: z.url(),
         model_name: z.string(),
@@ -940,7 +940,7 @@ export const zMediaOnshape = zMediaBase.and(
     type: z.literal('onshape').optional(),
     details: z
       .object({
-        model_created: z.iso.datetime({ offset: true }),
+        model_created: z.string(),
         model_description: z.string().nullable(),
         model_image: z.url(),
         model_name: z.string(),

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -10413,8 +10413,7 @@
                 ],
                 "properties": {
                   "model_created": {
-                    "type": "string",
-                    "format": "date-time"
+                    "type": "string"
                   },
                   "model_description": {
                     "type": [
@@ -10489,8 +10488,7 @@
                 ],
                 "properties": {
                   "model_created": {
-                    "type": "string",
-                    "format": "date-time"
+                    "type": "string"
                   },
                   "model_description": {
                     "type": [


### PR DESCRIPTION
**Problem**: PWA server throws `ZodError` validating `getTeamMediaByYear` responses (Sentry THE-BLUE-ALLIANCE-PWA-N2, 241 hits). Onshape media store `model_created` as `2019-09-25T00:12:49.122+0000` — a colon-less ISO 8601 basic offset that the generated `z.iso.datetime({ offset: true })` validator rejects. TBA passes the third-party string through untouched, so the spec's `format: date-time` is a guarantee the data does not keep.

**Fix**: Drop `format: date-time` from `model_created` in `Media_GrabCad` / `Media_Onshape` in `api_v3.json`; regenerate the PWA read client.

**Alternatives considered**:
- *Removing `dates: { offset: true }` in `read.config.ts`* — no: generates the stricter `z.iso.datetime()` (only `Z`), still rejects `+0000`, and globally affects every `date-time` field.
- *Normalizing `model_created` to RFC 3339 on API output* — risks unparseable historical values and changes output for existing consumers.
- *Disabling the generated `responseValidator`* — hides real schema drift everywhere.

Fixes THE-BLUE-ALLIANCE-PWA-N2

🤖 Generated with [Claude Code](https://claude.com/claude-code)