### PR TITLE
Fix data oddity with onshape model_created timestamps

### DIFF
--- a/pwa/app/api/tba/read/types.gen.ts
+++ b/pwa/app/api/tba/read/types.gen.ts
@@ -2763,7 +2763,7 @@ export type MediaCdThread = MediaBase & {
 export type MediaGrabCad = MediaBase & {
   type?: 'grabcad';
   details?: {
-    model_created: string;
+    model_created: string | null;
     model_description: string | null;
     model_image: string;
     model_name: string;
@@ -2789,7 +2789,7 @@ export type MediaNoDetails = MediaBase & {
 export type MediaOnshape = MediaBase & {
   type?: 'onshape';
   details?: {
-    model_created: string;
+    model_created: string | null;
     model_description: string | null;
     model_image: string;
     model_name: string;

--- a/pwa/app/api/tba/read/zod.gen.ts
+++ b/pwa/app/api/tba/read/zod.gen.ts
@@ -905,7 +905,7 @@ export const zMediaGrabCad = zMediaBase.and(
     type: z.literal('grabcad').optional(),
     details: z
       .object({
-        model_created: z.string(),
+        model_created: z.iso.datetime({ offset: true }).nullable(),
         model_description: z.string().nullable(),
         model_image: z.url(),
         model_name: z.string(),
@@ -940,7 +940,7 @@ export const zMediaOnshape = zMediaBase.and(
     type: z.literal('onshape').optional(),
     details: z
       .object({
-        model_created: z.string(),
+        model_created: z.iso.datetime({ offset: true }).nullable(),
         model_description: z.string().nullable(),
         model_image: z.url(),
         model_name: z.string(),

--- a/src/backend/common/queries/dict_converters/media_converter.py
+++ b/src/backend/common/queries/dict_converters/media_converter.py
@@ -1,4 +1,6 @@
+import datetime
 import json
+import re
 from typing import Dict, List, NewType, Optional
 
 from google.appengine.ext import ndb
@@ -12,10 +14,26 @@ from backend.common.queries.dict_converters.converter_base import ConverterBase
 
 MediaDict = NewType("MediaDict", Dict)
 
+CAD_MEDIA_SLUGS = frozenset({"grabcad", "onshape"})
+_COLONLESS_OFFSET_RE = re.compile(r"([+-]\d{2})(\d{2})$")
+
+
+# Onshape/GrabCAD timestamps are passed through from third parties and some use a
+# colon-less UTC offset (e.g. "+0000") that violates the spec's date-time format and
+# breaks strongly-typed API clients. Coerce to RFC 3339, or null if unparseable.
+def _normalize_model_created(value: object) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    try:
+        datetime.datetime.fromisoformat(_COLONLESS_OFFSET_RE.sub(r"\1:\2", value))
+    except (TypeError, ValueError):
+        return None
+    return _COLONLESS_OFFSET_RE.sub(r"\1:\2", value)
+
 
 class MediaConverter(ConverterBase):
     SUBVERSIONS = {  # Increment every time a change to the dict is made
-        ApiMajorVersion.API_V3: 8,
+        ApiMajorVersion.API_V3: 9,
     }
 
     @classmethod
@@ -33,10 +51,15 @@ class MediaConverter(ConverterBase):
 
     @classmethod
     def mediaConverter_v3(cls, media: Media) -> MediaDict:
+        details = media.details.copy() if media.details else {}
+        if media.slug_name in CAD_MEDIA_SLUGS and "model_created" in details:
+            details["model_created"] = _normalize_model_created(
+                details["model_created"]
+            )
         dict = {
             "type": media.slug_name,
             "foreign_key": media.foreign_key,
-            "details": media.details if media.details else {},
+            "details": details,
             "preferred": True if media.preferred_references != [] else False,
             "view_url": None,
             "direct_url": None,

--- a/src/backend/common/queries/dict_converters/tests/media_converter_test.py
+++ b/src/backend/common/queries/dict_converters/tests/media_converter_test.py
@@ -1,6 +1,7 @@
 import json
 
 from google.appengine.ext import ndb
+from pyre_extensions import none_throws
 
 from backend.common.consts.media_type import MediaType
 from backend.common.models.media import Media
@@ -103,6 +104,56 @@ def test_mediaConverter_v3_smugmug_photo(ndb_context) -> None:
         == "https://nefirst.smugmug.com/2026-FIRST-AGE/2026-CMP-BAE/i-xxrbgK6"
     )
     assert result["direct_url"] == "https://photos.smugmug.com/L/x-L.jpg"
+
+
+def _cad_media(media_type: MediaType, model_created: str) -> Media:
+    return Media(
+        id="onshape_abc123",
+        media_type_enum=media_type,
+        foreign_key="abc123",
+        details_json=json.dumps(
+            {
+                "model_name": "Robot",
+                "model_description": "",
+                "model_image": "https://cad.onshape.com/api/thumbnails/d/abc123/s/300x300",
+                "model_created": model_created,
+            }
+        ),
+        references=[ndb.Key("Team", "frc4")],
+    )
+
+
+def test_mediaConverter_v3_onshape_colonless_offset_normalized(ndb_context) -> None:
+    media = _cad_media(MediaType.ONSHAPE, "2019-09-25T00:12:49.122+0000")
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["details"]["model_created"] == "2019-09-25T00:12:49.122+00:00"
+
+
+def test_mediaConverter_v3_onshape_valid_offset_unchanged(ndb_context) -> None:
+    media = _cad_media(MediaType.ONSHAPE, "2019-09-25T00:12:49.122+00:00")
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["details"]["model_created"] == "2019-09-25T00:12:49.122+00:00"
+
+
+def test_mediaConverter_v3_grabcad_zulu_unchanged(ndb_context) -> None:
+    media = _cad_media(MediaType.GRABCAD, "2016-09-19T11:52:23Z")
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["details"]["model_created"] == "2016-09-19T11:52:23Z"
+
+
+def test_mediaConverter_v3_onshape_unparseable_model_created_is_none(
+    ndb_context,
+) -> None:
+    media = _cad_media(MediaType.ONSHAPE, "")
+    result = MediaConverter.mediaConverter_v3(media)
+    assert result["details"]["model_created"] is None
+
+
+def test_mediaConverter_v3_does_not_mutate_model_details(ndb_context) -> None:
+    media = _cad_media(MediaType.ONSHAPE, "2019-09-25T00:12:49.122+0000")
+    MediaConverter.mediaConverter_v3(media)
+    details = none_throws(media.details)
+    assert details["model_created"] == "2019-09-25T00:12:49.122+0000"
 
 
 def test_mediaConverter_v3_smugmug_album(ndb_context) -> None:

--- a/src/backend/web/static/swagger/api_v3.json
+++ b/src/backend/web/static/swagger/api_v3.json
@@ -10473,7 +10473,11 @@
                 ],
                 "properties": {
                   "model_created": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
                   },
                   "model_description": {
                     "type": [
@@ -10548,7 +10552,11 @@
                 ],
                 "properties": {
                   "model_created": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
                   },
                   "model_description": {
                     "type": [


### PR DESCRIPTION
Fixes #10580. This is only a problem affecting a very small subset of onshape models. Basically they have timestamps as `2019-09-25T00:12:49.122+0000` instead of `2019-09-25T00:12:49.122+00:00` (lack of colon). This just fixes it in the api return layer since its an easy modification.