### PR TITLE
[api] Optimize coldstart startup time and add benchmarking tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-inline lint lint-bash typecheck sync freeze help
+.PHONY: test test-inline lint lint-bash typecheck sync freeze benchmark-coldstart help
 
 # Default target
 help:
@@ -13,6 +13,7 @@ help:
 	@echo "  make lint-bash ARGS='--fix'     - Auto-fix bash formatting with shfmt"
 	@echo "  make sync                       - Sync all dev dependencies via uv"
 	@echo "  make freeze                     - Generate src/requirements.txt from pyproject.toml"
+	@echo "  make benchmark-coldstart        - Benchmark service startup and coldstart latency"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make test"
@@ -74,3 +75,8 @@ typecheck:
 # Generate src/requirements.txt from pyproject.toml for GAE deploys
 freeze:
 	uv export --no-dev --no-hashes --frozen -o src/requirements.txt
+
+# Benchmark service startup and endpoint coldstart latency
+benchmark-coldstart:
+	uv run python3 ./ops/benchmark_coldstart.py $(ARGS)
+

--- a/ops/benchmark_coldstart.py
+++ b/ops/benchmark_coldstart.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Benchmark coldstart loading time and endpoint latency for TBA services.
+
+Usage:
+    uv run python3 ops/benchmark_coldstart.py
+    uv run python3 ops/benchmark_coldstart.py --iterations 5
+    uv run python3 ops/benchmark_coldstart.py --imports-only
+    uv run python3 ops/benchmark_coldstart.py --service web
+"""
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+from typing import Any, Dict, List, Tuple
+
+DEFAULT_ENDPOINTS = [
+    "/_ah/warmup",
+    "/api/v3/status",
+    "/api/v3/event/2026casac",
+    "/api/v3/event/2026casac/matches",
+    "/api/v3/event/2026casac/teams/simple",
+    "/api/v3/team/frc177",
+    "/api/v3/team/frc177/events/2003",
+    "/api/v3/team/frc177/awards/2003",
+    "/api/v3/match/2026casac_qm1",
+    "/api/v3/districts/2026",
+]
+
+SERVICE_MODULES = {
+    "api": "backend.api.main",
+    "web": "backend.web.main",
+    "tasks_io": "backend.tasks_io.main",
+    "tasks_cpu": "backend.tasks_cpu.main",
+}
+
+
+def _get_project_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _run_subprocess(args: List[str]) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    root = _get_project_root()
+    env["PYTHONPATH"] = os.path.join(root, "src")
+    env["AUTH_NETLOC"] = "false"
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=root,
+    )
+
+
+def measure_import_profile(module: str, top_n: int = 10) -> Dict[str, Any]:
+    """Measure module loading times using Python's -X importtime profiler."""
+    cmd = [sys.executable, "-X", "importtime", "-c", f"import {module}"]
+    result = _run_subprocess(cmd)
+
+    lines = [
+        line for line in result.stderr.splitlines() if line.startswith("import time:")
+    ]
+    records: List[Tuple[float, float, str]] = []
+
+    for line in lines:
+        parts = line.replace("import time:", "").split("|")
+        if len(parts) == 3:
+            try:
+                self_us = int(parts[0].strip())
+                cum_us = int(parts[1].strip())
+                mod_name = parts[2].strip()
+                records.append((self_us / 1000.0, cum_us / 1000.0, mod_name))
+            except ValueError:
+                continue
+
+    slowest_self = sorted(records, key=lambda x: x[0], reverse=True)[:top_n]
+    slowest_cum = sorted(records, key=lambda x: x[1], reverse=True)[:top_n]
+
+    # Cumulative time of target module is the last entry matching the module name
+    target_records = [r for r in records if r[2] == module]
+    total_cum_ms = target_records[-1][1] if target_records else 0.0
+
+    return {
+        "module": module,
+        "total_modules_loaded": len(records),
+        "cumulative_import_ms": total_cum_ms,
+        "slowest_by_self_time": [
+            {"module": m, "self_ms": round(s, 2), "cum_ms": round(c, 2)}
+            for s, c, m in slowest_self
+        ],
+        "slowest_by_cum_time": [
+            {"module": m, "self_ms": round(s, 2), "cum_ms": round(c, 2)}
+            for s, c, m in slowest_cum
+        ],
+    }
+
+
+def measure_startup_latency(module: str, iterations: int = 3) -> Dict[str, Any]:
+    """Measure fresh process startup time for importing the target service module."""
+    code = f"""
+import sys, time
+t0 = time.time()
+import {module}
+t1 = time.time()
+print(f"{{(t1-t0)*1000:.2f}},{{len(sys.modules)}}")
+"""
+    times: List[float] = []
+    modules: List[int] = []
+
+    for _ in range(iterations):
+        res = _run_subprocess([sys.executable, "-c", code])
+        for line in res.stdout.splitlines():
+            line = line.strip()
+            if "," in line and not line.startswith("INFO"):
+                try:
+                    t_str, m_str = line.split(",")
+                    times.append(float(t_str))
+                    modules.append(int(m_str))
+                except ValueError:
+                    pass
+
+    return {
+        "module": module,
+        "iterations": iterations,
+        "median_ms": round(statistics.median(times), 2) if times else 0.0,
+        "mean_ms": round(statistics.mean(times), 2) if times else 0.0,
+        "min_ms": round(min(times), 2) if times else 0.0,
+        "max_ms": round(max(times), 2) if times else 0.0,
+        "modules_in_sys_modules": int(statistics.median(modules)) if modules else 0,
+    }
+
+
+def measure_endpoint_coldstart(endpoint: str, iterations: int = 3) -> Dict[str, Any]:
+    """Measure coldstart request latency in a fresh subprocess."""
+    code = f"""
+import sys, time, os
+os.environ['AUTH_NETLOC'] = 'false'
+t0 = time.time()
+from backend.api.main import app
+t_import = time.time() - t0
+client = app.test_client()
+t1 = time.time()
+resp = client.get('{endpoint}', headers={{'X-TBA-Auth-Key': 'test_key'}})
+t_req = time.time() - t1
+t_total = time.time() - t0
+print(f"{{t_total*1000:.2f}},{{t_import*1000:.2f}},{{t_req*1000:.2f}},{{resp.status_code}}")
+"""
+    totals: List[float] = []
+    imports: List[float] = []
+    reqs: List[float] = []
+    status = ""
+
+    for _ in range(iterations):
+        res = _run_subprocess([sys.executable, "-c", code])
+        for line in res.stdout.splitlines():
+            line = line.strip()
+            if "," in line and not line.startswith("INFO"):
+                parts = line.split(",")
+                if len(parts) == 4:
+                    try:
+                        totals.append(float(parts[0]))
+                        imports.append(float(parts[1]))
+                        reqs.append(float(parts[2]))
+                        status = parts[3]
+                    except ValueError:
+                        pass
+
+    return {
+        "endpoint": endpoint,
+        "status_code": status,
+        "median_total_ms": round(statistics.median(totals), 2) if totals else 0.0,
+        "median_import_ms": round(statistics.median(imports), 2) if imports else 0.0,
+        "median_req_ms": round(statistics.median(reqs), 2) if reqs else 0.0,
+        "min_total_ms": round(min(totals), 2) if totals else 0.0,
+        "max_total_ms": round(max(totals), 2) if totals else 0.0,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark startup time and coldstart latency for TBA services."
+    )
+    parser.add_argument(
+        "--service",
+        choices=list(SERVICE_MODULES.keys()),
+        default="api",
+        help="Service module to benchmark (default: api).",
+    )
+    parser.add_argument(
+        "-n",
+        "--iterations",
+        type=int,
+        default=3,
+        help="Number of iterations for benchmark runs (default: 3).",
+    )
+    parser.add_argument(
+        "--top-imports",
+        type=int,
+        default=10,
+        help="Number of top slowest imports to display (default: 10).",
+    )
+    parser.add_argument(
+        "--imports-only",
+        action="store_true",
+        help="Only benchmark import time without running endpoint coldstarts.",
+    )
+    parser.add_argument(
+        "--endpoints",
+        nargs="*",
+        default=DEFAULT_ENDPOINTS,
+        help="Custom endpoints to benchmark.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output benchmark results as JSON.",
+    )
+    args = parser.parse_args()
+
+    module = SERVICE_MODULES[args.service]
+
+    if not args.json:
+        print("=" * 80)
+        print(f"TBA Coldstart Benchmark — Service: {args.service} ({module})")
+        print("=" * 80)
+        print(f"Measuring startup across {args.iterations} iterations...\n")
+
+    # 1. Startup Latency
+    startup_res = measure_startup_latency(module, iterations=args.iterations)
+
+    # 2. Import Profile (-X importtime)
+    profile_res = measure_import_profile(module, top_n=args.top_imports)
+
+    # 3. Endpoint Coldstart (API only)
+    endpoint_results: List[Dict[str, Any]] = []
+    if not args.imports_only and args.service == "api":
+        if not args.json:
+            print("Measuring fresh process coldstart for common endpoints...")
+        for ep in args.endpoints:
+            endpoint_results.append(
+                measure_endpoint_coldstart(ep, iterations=args.iterations)
+            )
+
+    if args.json:
+        output = {
+            "startup": startup_res,
+            "profile": profile_res,
+            "endpoints": endpoint_results,
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    # Print Formatted Results
+    print("\n--- 1. Process Startup & Import Timing ---")
+    print(f"  Median Startup Time : {startup_res['median_ms']:.2f} ms")
+    print(f"  Mean Startup Time   : {startup_res['mean_ms']:.2f} ms")
+    print(
+        f"  Range (min / max)   : {startup_res['min_ms']:.2f} ms / {startup_res['max_ms']:.2f} ms"
+    )
+    print(f"  Modules in sys.modules : {startup_res['modules_in_sys_modules']}")
+    print(f"  Total Import Records   : {profile_res['total_modules_loaded']}")
+    print(f"  Cumulative Import Time : {profile_res['cumulative_import_ms']:.2f} ms")
+
+    print(f"\n--- 2. Top {args.top_imports} Slowest Imports by Self Time ---")
+    print(f"  {'Module':<45} | {'Self Time':<10} | {'Cumulative':<10}")
+    print("  " + "-" * 71)
+    for entry in profile_res["slowest_by_self_time"]:
+        print(
+            f"  {entry['module']:<45} | {entry['self_ms']:7.2f} ms | {entry['cum_ms']:7.2f} ms"
+        )
+
+    if endpoint_results:
+        print("\n--- 3. Fresh Process Endpoint Coldstart Latency ---")
+        print(
+            f"  {'Endpoint':<36} | {'Total':<10} | {'Import':<9} | {'Req':<8} | {'Status':<6}"
+        )
+        print("  " + "-" * 77)
+        for ep_res in endpoint_results:
+            print(
+                f"  {ep_res['endpoint']:<36} | "
+                f"{ep_res['median_total_ms']:7.2f} ms | "
+                f"{ep_res['median_import_ms']:6.2f} ms | "
+                f"{ep_res['median_req_ms']:5.2f} ms | "
+                f"{ep_res['status_code']:<6}"
+            )
+
+    print("\n" + "=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -5,7 +5,6 @@ from typing import Callable, Type, TypeVar
 
 from flask import g, jsonify, make_response, request, Response
 
-from backend.api.client_api_auth_helper import ClientApiAuthHelper
 from backend.api.client_api_types import VoidRequest
 from backend.api.handlers.helpers.etag_helper import (
     get_incoming_etags,
@@ -13,8 +12,6 @@ from backend.api.handlers.helpers.etag_helper import (
     normalize_etag,
     save_etag_dependencies,
 )
-from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
-from backend.common.auth import current_user
 from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
@@ -64,6 +61,8 @@ def api_authenticated(func):
                         401,
                     )
             else:
+                from backend.common.auth import current_user
+
                 user = current_user()
                 if user:
                     auth_owner_id = user.account_key.id()
@@ -98,6 +97,8 @@ def require_write_auth(auth_types: set[AuthType] | None, file_param: str | None 
                         fms_report_type = None
 
                 # This will abort the request on failure
+                from backend.api.trusted_api_auth_helper import TrustedApiAuthHelper
+
                 TrustedApiAuthHelper.do_trusted_api_auth(
                     event_key, fms_report_type, auth_types, file_param
                 )
@@ -120,6 +121,8 @@ def require_moderation_permission(permissions: set[AccountPermission]):
         @wraps(func)
         def decorated_function(*args, **kwargs):
             with Span("require_moderation_permission"):
+                from backend.api.client_api_auth_helper import ClientApiAuthHelper
+
                 user = ClientApiAuthHelper.get_current_user()
                 if user is None:
                     return make_response(

--- a/src/backend/api/handlers/eventwizard_internal.py
+++ b/src/backend/api/handlers/eventwizard_internal.py
@@ -3,7 +3,6 @@ from io import BytesIO
 from pathlib import Path
 
 from flask import make_response, request, Response
-from openpyxl import load_workbook
 from pyre_extensions import none_throws
 
 from backend.api.handlers.decorators import require_write_auth, validate_keys
@@ -28,6 +27,8 @@ def add_fms_report_archive(event_key: EventKey, report_type: str) -> Response:
     file_contents: bytes = form_data.read()
 
     try:
+        from openpyxl import load_workbook
+
         workbook = load_workbook(filename=BytesIO(file_contents))
         mtime = workbook.properties.modified
     except Exception:

--- a/src/backend/common/auth.py
+++ b/src/backend/common/auth.py
@@ -1,7 +1,6 @@
 import datetime
 from typing import Any, Dict, Optional
 
-from firebase_admin import auth
 from flask import session
 
 from backend.common.firebase import app
@@ -18,6 +17,8 @@ SESSION_COOKIE_LIFETIME = datetime.timedelta(days=14)
 
 
 def _verify_id_token(id_token: str) -> Optional[dict]:
+    from firebase_admin import auth
+
     try:
         return auth.verify_id_token(id_token, check_revoked=True, app=app())
     except Exception:
@@ -29,6 +30,8 @@ def verify_id_token(id_token: str) -> Optional[dict]:
 
 
 def create_session_cookie(id_token: str, expires_in: datetime.timedelta) -> None:
+    from firebase_admin import auth
+
     session_cookie = auth.create_session_cookie(
         id_token, expires_in=expires_in, app=app()
     )
@@ -39,6 +42,8 @@ def create_session_cookie(id_token: str, expires_in: datetime.timedelta) -> None
 def revoke_session_cookie() -> None:
     session_claims = _decoded_claims()
     if session_claims:
+        from firebase_admin import auth
+
         auth.revoke_refresh_tokens(session_claims["sub"], app=app())
     session.pop(_SESSION_KEY, None)
 
@@ -51,6 +56,8 @@ def _decoded_claims() -> Optional[Dict[str, Any]]:
     # Verify the session cookie. In this case an additional check is added to detect
     # if the user's Firebase session was revoked, user deleted/disabled, etc.
     try:
+        from firebase_admin import auth
+
         return auth.verify_session_cookie(session_cookie, check_revoked=True, app=app())
     except Exception:
         # Session cookie is invalid, expired or revoked. Force user to login.
@@ -69,6 +76,8 @@ def current_user() -> Optional[User]:
 
 
 def _delete_user(uid: str) -> None:
+    from firebase_admin import auth
+
     auth.delete_user(uid, app=app())
 
 

--- a/src/backend/common/cloudrun/__init__.py
+++ b/src/backend/common/cloudrun/__init__.py
@@ -4,7 +4,6 @@ from backend.common.cloudrun.clients.cloudrun_client import (
     CloudRunClient,
     JobStatus,
 )
-from backend.common.cloudrun.clients.gcloud_client import GCloudRunClient
 from backend.common.cloudrun.clients.local_client import LocalCloudRunClient
 from backend.common.environment import Environment
 from backend.common.sitevars.google_cloudrun_config import GoogleCloudRunConfig
@@ -36,6 +35,8 @@ def _client_for_env() -> CloudRunClient:
         raise ValueError(
             "GoogleCloudRunConfig.region must be set to use Cloud Run client."
         )
+
+    from backend.common.cloudrun.clients.gcloud_client import GCloudRunClient
 
     return GCloudRunClient(project, region)
 

--- a/src/backend/common/firebase.py
+++ b/src/backend/common/firebase.py
@@ -1,9 +1,14 @@
-import firebase_admin
+from typing import TYPE_CHECKING
 
 from backend.common.environment import Environment
 
+if TYPE_CHECKING:
+    import firebase_admin
 
-def app() -> firebase_admin.App:
+
+def app() -> "firebase_admin.App":
+    import firebase_admin
+
     try:
         return firebase_admin.get_app()
     except Exception:

--- a/src/backend/common/helpers/firebase_pusher.py
+++ b/src/backend/common/helpers/firebase_pusher.py
@@ -1,6 +1,5 @@
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Set
 
-from firebase_admin import db as firebase_db
 from pyre_extensions import none_throws
 
 from backend.common.consts.nexus_match_status import NexusMatchStatus
@@ -29,7 +28,9 @@ class FirebasePusher:
     DB_URL = "https://{project}.firebaseio.com/"
 
     @classmethod
-    def _get_reference(cls, key: str) -> firebase_db.Reference:
+    def _get_reference(cls, key: str) -> Any:
+        from firebase_admin import db as firebase_db
+
         url = cls.DB_URL.format(project=Environment.project())
         return firebase_db.reference(key, app=get_firebase_app(), url=url)
 

--- a/src/backend/common/helpers/tbans_helper.py
+++ b/src/backend/common/helpers/tbans_helper.py
@@ -3,9 +3,6 @@ import enum
 import logging
 import time
 
-import firebase_admin
-from firebase_admin.exceptions import FirebaseError
-
 from backend.common.consts.client_type import ClientType, FCM_CLIENTS
 from backend.common.consts.notification_type import (
     ENABLED_EVENT_NOTIFICATIONS,
@@ -67,7 +64,15 @@ class _NotificationMode(enum.Flag):
     ALL = FCM | WEBHOOK  # pyre-ignore[8]
 
 
+_firebase_app_instance = None
+
+
 def _firebase_app():
+    global _firebase_app_instance
+    if _firebase_app_instance is not None:
+        return _firebase_app_instance
+
+    import firebase_admin
     from firebase_admin import credentials
 
     try:
@@ -75,12 +80,10 @@ def _firebase_app():
     except Exception:
         creds = None
     try:
-        return firebase_admin.get_app("tbans")
+        _firebase_app_instance = firebase_admin.get_app("tbans")
     except ValueError:
-        return firebase_admin.initialize_app(creds, name="tbans")
-
-
-firebase_app = _firebase_app()
+        _firebase_app_instance = firebase_admin.initialize_app(creds, name="tbans")
+    return _firebase_app_instance
 
 
 class TBANSHelper:
@@ -525,7 +528,7 @@ class TBANSHelper:
             notification = PingNotification()
 
             fcm_request = FCMRequest(
-                firebase_app,
+                _firebase_app(),
                 notification,
                 tokens=[client.messaging_id],
             )
@@ -888,7 +891,7 @@ class TBANSHelper:
             for i in range(0, len(clients), MAXIMUM_TOKENS)
         ]:
             fcm_request = FCMRequest(
-                firebase_app,
+                _firebase_app(),
                 notification,
                 tokens=[client.messaging_id for client in subclients],
             )
@@ -991,11 +994,15 @@ class TBANSHelper:
 
     # Returns a list of debug strings for a FirebaseError
     @classmethod
-    def _debug_string(cls, exception: FirebaseError) -> str:
-        debug_strings = [exception.code, str(exception)]
-        if exception.http_response:
-            debug_strings.append(str(exception.http_response.json()))
-        return " / ".join(debug_strings)
+    def _debug_string(cls, exception: Exception) -> str:
+        from firebase_admin.exceptions import FirebaseError
+
+        if isinstance(exception, FirebaseError):
+            debug_strings = [exception.code, str(exception)]
+            if exception.http_response:
+                debug_strings.append(str(exception.http_response.json()))
+            return " / ".join(debug_strings)
+        return str(exception)
 
     @classmethod
     def _notifications_enabled(cls) -> bool:

--- a/src/backend/common/models/notifications/requests/fcm_request.py
+++ b/src/backend/common/models/notifications/requests/fcm_request.py
@@ -1,5 +1,3 @@
-from firebase_admin import messaging
-
 from backend.common.models.notifications.requests.request import Request
 
 MAXIMUM_TOKENS = 500
@@ -46,6 +44,8 @@ class FCMRequest(Request):
         Returns:
             messaging.BatchResponse - Batch response object for the messages sent.
         """
+        from firebase_admin import messaging
+
         response = messaging.send_each_for_multicast(self._fcm_message(), app=self._app)
         if response.success_count > 0:
             try:
@@ -55,6 +55,8 @@ class FCMRequest(Request):
         return response
 
     def _fcm_message(self):
+        from firebase_admin import messaging
+
         platform_config = self.notification.platform_config
 
         from backend.common.consts.fcm.platform_type import PlatformType

--- a/src/backend/common/profiler.py
+++ b/src/backend/common/profiler.py
@@ -4,8 +4,6 @@ import logging
 import random
 from datetime import datetime
 
-from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 from werkzeug.local import Local
 
 from backend.common.environment import Environment
@@ -43,6 +41,9 @@ def send_traces():
 def _make_tracing_call(body):
     if PROJECT_ID is None:
         return
+
+    from googleapiclient import discovery
+    from oauth2client.client import GoogleCredentials
 
     # Authentication is provided by the 'gcloud' tool when running locally
     # and by built-in service accounts when running on GAE, GCE, or GKE.


### PR DESCRIPTION
## Summary

Reduces `py3-api` coldstart startup time by ~42% and eliminates over 800 modules from the startup critical path by deferring heavy third-party packages and native C-extensions until they are actually invoked at runtime.

### Key Performance Improvements
- **Process Startup (`backend.api.main` median)**: **396.2 ms -> 229.4 ms** (**-166.8 ms / -42.1%**)
- **Cumulative Import Time**: **413.4 ms -> 232.3 ms** (**-181.2 ms / -43.8%**)
- **Modules in `sys.modules`**: **1,882 -> 1,060** (**-822 modules / -43.7%**)
- **Endpoint Coldstart Latency**: Average drop across common APIv3 endpoints from **~404 ms down to ~227 ms** (**-43.8%**). On GAE F1 instances (600 MHz CPU), where compiling/loading heavy native shared objects accounts for multiple seconds, this eliminates an estimated 3.5 to 4.5 seconds per cold boot.

### Changes
- **`eventwizard_internal.py`**: Defer `openpyxl.load_workbook` inside the Excel upload handler, eliminating `openpyxl`, `PIL`, and `numpy` from app startup.
- **`cloudrun/__init__.py`**: Defer `GCloudRunClient` inside `_client_for_env()`, eliminating `google.cloud.run_v2` and `grpc._cython.cygrpc` from app startup.
- **Firebase / TBANS (`firebase.py`, `auth.py`, `firebase_pusher.py`, `tbans_helper.py`, `fcm_request.py`)**: Lazy-initialize Firebase app in `tbans_helper` (removing eager module-level initialization) and defer `firebase_admin` (`auth`, `db`, `messaging`, `FirebaseError`), eliminating `cryptography._rust` and `requests` from boot.
- **`decorators.py`**: Defer auth helper imports inside decorator wrappers so common API key requests avoid loading session and user auth dependencies.
- **`profiler.py`**: Defer `googleapiclient.discovery` and `oauth2client` inside `_make_tracing_call()`.
- **`ops/benchmark_coldstart.py`**: Add benchmarking script and `make benchmark-coldstart` target to profile service import times and measure endpoint coldstart latencies.