### PR TITLE
[api] Ensure 404 responses return 404 instead of 304 on matching ETag

### DIFF
--- a/src/backend/api/handlers/tests/decorator_order_test.py
+++ b/src/backend/api/handlers/tests/decorator_order_test.py
@@ -108,6 +108,61 @@ def test_decorator_order_invalid_keys_return_404_on_cache_miss(
     assert resp_nonexistent.status_code == 404
 
 
+@pytest.mark.parametrize("cache_enabled", [True, False])
+def test_apiv3_404_returns_404_not_304_when_etag_matches(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch, cache_enabled: bool
+) -> None:
+    """
+    Ensure that 404 responses in APIv3 always return 404, not 304,
+    even when the client sends an If-None-Match header matching the 404 ETag.
+    Tests both with flask_response_cache enabled and disabled.
+    """
+    from backend.common.environment import Environment
+
+    monkeypatch.setattr(
+        Environment, "flask_response_cache_enabled", lambda: cache_enabled
+    )
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    # 1. Non-existent team key: returns 404 with ETag
+    resp1 = api_client.get(
+        "/api/v3/team/frc9999999", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 404
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Subsequent request with matching If-None-Match must STILL return 404, not 304
+    resp2 = api_client.get(
+        "/api/v3/team/frc9999999",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 404
+    assert resp2.headers.get("ETag") == etag
+    assert "Error" in resp2.json
+
+    # 2. Invalid key format: returns 404 with ETag
+    resp3 = api_client.get(
+        "/api/v3/team/not_a_valid_team_key",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp3.status_code == 404
+    bad_format_etag = resp3.headers.get("ETag")
+    assert bad_format_etag is not None
+
+    resp4 = api_client.get(
+        "/api/v3/team/not_a_valid_team_key",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": bad_format_etag},
+    )
+    assert resp4.status_code == 404
+    assert resp4.headers.get("ETag") == bad_format_etag
+    assert "Error" in resp4.json
+
+
 def test_apiv3_query_params_ignored_for_caching(
     ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/src/backend/common/decorators.py
+++ b/src/backend/common/decorators.py
@@ -83,12 +83,16 @@ def cached_public(
             resp.add_etag()
 
             # Return 304 Not Modified if ETag matches
-            if resp.headers.get("ETag", None) in str(request.if_none_match):
-                return Response(status=304)
-
-            if request.if_modified_since is not None and resp.last_modified is not None:
-                if request.if_modified_since >= resp.last_modified:
+            if resp.status_code == 200:
+                if resp.headers.get("ETag", None) in str(request.if_none_match):
                     return Response(status=304)
+
+                if (
+                    request.if_modified_since is not None
+                    and resp.last_modified is not None
+                ):
+                    if request.if_modified_since >= resp.last_modified:
+                        return Response(status=304)
 
         return resp
 

--- a/src/backend/common/tests/decorator_test.py
+++ b/src/backend/common/tests/decorator_test.py
@@ -357,6 +357,13 @@ def test_cached_public_404_cache_control(app: Flask) -> None:
     resp = app.test_client().get("/")
     assert resp.status_code == 404
     assert resp.headers.get("Cache-Control") == "public, max-age=61, s-maxage=61"
+    etag = resp.headers.get("ETag")
+    assert etag is not None
+
+    # ETag match must still return 404, not 304
+    resp2 = app.test_client().get("/", headers={"If-None-Match": etag})
+    assert resp2.status_code == 404
+    assert resp2.get_data(as_text=True) == "Not Found"
 
 
 def test_cached_public_404_abort_cache_control(app: Flask) -> None:
@@ -368,6 +375,12 @@ def test_cached_public_404_abort_cache_control(app: Flask) -> None:
     resp = app.test_client().get("/")
     assert resp.status_code == 404
     assert resp.headers.get("Cache-Control") == "public, max-age=61, s-maxage=61"
+    etag = resp.headers.get("ETag")
+    assert etag is not None
+
+    # ETag match must still return 404, not 304
+    resp2 = app.test_client().get("/", headers={"If-None-Match": etag})
+    assert resp2.status_code == 404
 
 
 def test_flask_cache_with_memcache_404_overrides_ttl(app: Flask, memcache_stub) -> None:


### PR DESCRIPTION
### Summary

In `cached_public`, responses with status code `404` were receiving `ETag` headers, but conditional `If-None-Match` and `If-Modified-Since` checks were running without ensuring `resp.status_code == 200`. As a result, when a client repeated a request to a nonexistent or invalid endpoint with `If-None-Match: <404_etag>`, the server returned `304 Not Modified`.

Per RFC 9110 / RFC 7232, a `304 Not Modified` status code is only valid for conditional requests that would have otherwise resulted in a `200 OK`.

### Changes

- Guarded the conditional `304 Not Modified` evaluation in `cached_public` (`src/backend/common/decorators.py`) with `if resp.status_code == 200:`.
- Added unit test coverage in `src/backend/common/tests/decorator_test.py` verifying that conditional requests matching a 404 ETag still return `404 Not Found`.
- Added parametrized test coverage in `src/backend/api/handlers/tests/decorator_order_test.py` confirming `404` status is maintained on matching ETags across both cache-enabled and cache-disabled environments in APIv3.

### Verification

- `make test ARGS='src/backend/common/tests/decorator_test.py src/backend/api/handlers/tests/decorator_order_test.py'` (28 passed)
- `make test ARGS='src/backend/api/handlers/tests/'` (477 passed)
- `make test ARGS='src/backend/common/tests/'` (89 passed)
- `make lint` and `make typecheck` (all passed with 0 errors)