### PR TITLE
[api] Add in-memory cache for API key authentication

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from dataclasses import dataclass
 from functools import wraps
-from typing import Callable, Type, TypeVar
+from typing import Callable, Optional, Type, TypeVar
 
 from flask import g, jsonify, make_response, request, Response
 
@@ -12,6 +13,7 @@ from backend.api.handlers.helpers.etag_helper import (
     normalize_etag,
     save_etag_dependencies,
 )
+from backend.common.cache.instance_cache import InstanceCache
 from backend.common.consts.account_permission import AccountPermission
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.event_code_exceptions import EventCodeExceptions
@@ -28,6 +30,19 @@ from backend.common.profiler import Span
 from backend.common.queries.database_query import track_accessed_query_cache_keys
 
 
+@dataclass(frozen=True)
+class CachedAuth:
+    owner_id: Optional[str]
+    description: Optional[str]
+
+
+AUTH_KEY_CACHE_TTL: float = 600.0  # 10 minutes
+AUTH_KEY_CACHE_MAX_SIZE: int = 1000
+auth_key_cache: InstanceCache[str, CachedAuth] = InstanceCache(
+    ttl_seconds=AUTH_KEY_CACHE_TTL, max_size=AUTH_KEY_CACHE_MAX_SIZE
+)
+
+
 def api_authenticated(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
@@ -39,27 +54,36 @@ def api_authenticated(func):
             auth_owner_id = None
 
             if auth_key:
-                auth = ApiAuthAccess.get_by_id(auth_key)
-                if auth:
-                    auth_owner_id = auth.owner.id() if auth.owner else None
-                    # Set for our GA event tracking in `track_call_after_response`
-                    g.auth_description = auth.description
-                    # Add API key to logging context for searchability in logs
-                    set_logging_context("api_auth_key", auth_key)
-                    # Add to trace span for visibility in Cloud Trace
-                    span.set_label("api_auth_key", auth_key)
-                    span.set_label("auth_owner_id", str(auth_owner_id))
-                    # Log API key usage for visibility in GCP Console
-                    logging.info(
-                        f"API request authenticated with key: {auth_key[:16]}... (owner: {auth_owner_id})"
+                cached_auth = auth_key_cache.get(auth_key)
+                if cached_auth is None:
+                    auth = ApiAuthAccess.get_by_id(auth_key)
+                    if not auth:
+                        return (
+                            {
+                                "Error": "X-TBA-Auth-Key is invalid. Please get an access key at http://www.thebluealliance.com/account."
+                            },
+                            401,
+                        )
+                    cached_auth = CachedAuth(
+                        owner_id=auth.owner.id() if auth.owner else None,
+                        description=auth.description,
                     )
+                    auth_key_cache.set(auth_key, cached_auth)
                 else:
-                    return (
-                        {
-                            "Error": "X-TBA-Auth-Key is invalid. Please get an access key at http://www.thebluealliance.com/account."
-                        },
-                        401,
-                    )
+                    span.set_label("auth_cached", "true")
+
+                auth_owner_id = cached_auth.owner_id
+                # Set for our GA event tracking in `track_call_after_response`
+                g.auth_description = cached_auth.description
+                # Add API key to logging context for searchability in logs
+                set_logging_context("api_auth_key", auth_key)
+                # Add to trace span for visibility in Cloud Trace
+                span.set_label("api_auth_key", auth_key)
+                span.set_label("auth_owner_id", str(auth_owner_id))
+                # Log API key usage for visibility in GCP Console
+                logging.info(
+                    f"API request authenticated with key: {auth_key[:16]}... (owner: {auth_owner_id})"
+                )
             else:
                 from backend.common.auth import current_user
 

--- a/src/backend/api/handlers/tests/apiv3_auth_test.py
+++ b/src/backend/api/handlers/tests/apiv3_auth_test.py
@@ -423,3 +423,55 @@ def test_district_key_does_not_exist(ndb_stub, api_client: Client) -> None:
     )
     assert resp.status_code == 404
     assert resp.json["Error"] == "district key: 2020tx does not exist"
+
+
+def test_auth_key_cache_hit_on_subsequent_read(ndb_stub, api_client: Client) -> None:
+    from backend.api.handlers.decorators import auth_key_cache
+
+    account = Account()
+    account.put()
+    ApiAuthAccess(
+        id="cached_auth_key",
+        description="Test Key Description",
+        auth_types_enum=[AuthType.READ_API],
+        owner=account.key,
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    # 1. First request should query Datastore/NDB and populate in-memory cache
+    assert auth_key_cache.get("cached_auth_key") is None
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "cached_auth_key"}
+    )
+    assert resp1.status_code == 200
+
+    cached = auth_key_cache.get("cached_auth_key")
+    assert cached is not None
+    assert cached.owner_id == account.key.id()
+    assert cached.description == "Test Key Description"
+
+    # 2. Second request should hit in-memory cache without calling ApiAuthAccess.get_by_id
+    with patch.object(
+        ApiAuthAccess,
+        "get_by_id",
+        side_effect=AssertionError("Should not call get_by_id"),
+    ):
+        with api_client.application.test_request_context():  # pyre-ignore[16]
+            resp2 = api_client.get(
+                "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "cached_auth_key"}
+            )
+            assert resp2.status_code == 200
+            assert g.auth_owner_id == account.key.id()
+            assert g.auth_description == "Test Key Description"
+
+
+def test_auth_key_cache_does_not_cache_bad_keys(ndb_stub, api_client: Client) -> None:
+    from backend.api.handlers.decorators import auth_key_cache
+
+    Team(id="frc254", team_number=254).put()
+
+    resp = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "invalid_key_123"}
+    )
+    assert resp.status_code == 401
+    assert auth_key_cache.get("invalid_key_123") is None

--- a/src/backend/common/cache/instance_cache.py
+++ b/src/backend/common/cache/instance_cache.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from threading import Lock
+from typing import Generic, Optional, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+@dataclass(frozen=True)
+class _CacheEntry(Generic[V]):
+    value: V
+    expires_at: float
+
+
+class InstanceCache(Generic[K, V]):
+    """
+    A thread-safe, in-memory LRU cache with per-item TTL expiration.
+
+    Design & Concurrency Guarantees:
+    - Deadlock-free: The lock is held exclusively during internal dictionary
+      read/write operations. No callbacks, external functions, I/O operations,
+      or coroutine yields occur within the critical section.
+    - O(1) LRU eviction via OrderedDict.
+    - System clock skew resilient via time.monotonic().
+    """
+
+    def __init__(self, ttl_seconds: float = 3600.0, max_size: int = 1000) -> None:
+        self._ttl_seconds: float = ttl_seconds
+        self._max_size: int = max_size
+        self._cache: OrderedDict[K, _CacheEntry[V]] = OrderedDict()
+        self._lock: Lock = Lock()
+
+    @property
+    def ttl_seconds(self) -> float:
+        return self._ttl_seconds
+
+    @property
+    def max_size(self) -> int:
+        return self._max_size
+
+    def get(self, key: K) -> Optional[V]:
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            if entry.expires_at <= now:
+                del self._cache[key]
+                return None
+            self._cache.move_to_end(key)
+            return entry.value
+
+    def set(self, key: K, value: V, ttl_seconds: Optional[float] = None) -> None:
+        ttl = self._ttl_seconds if ttl_seconds is None else ttl_seconds
+        expires_at = time.monotonic() + ttl
+        entry = _CacheEntry(value=value, expires_at=expires_at)
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+            self._cache[key] = entry
+            while len(self._cache) > self._max_size:
+                self._cache.popitem(last=False)
+
+    def delete(self, key: K) -> bool:
+        with self._lock:
+            return self._cache.pop(key, None) is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._cache)
+
+    def __contains__(self, key: K) -> bool:
+        return self.get(key) is not None

--- a/src/backend/common/cache/tests/instance_cache_test.py
+++ b/src/backend/common/cache/tests/instance_cache_test.py
@@ -1,0 +1,89 @@
+import concurrent.futures
+import time
+
+from backend.common.cache.instance_cache import InstanceCache
+
+
+def test_basic_get_set() -> None:
+    cache: InstanceCache[str, str] = InstanceCache(ttl_seconds=10, max_size=5)
+    assert cache.get("k1") is None
+    cache.set("k1", "v1")
+    assert cache.get("k1") == "v1"
+    assert "k1" in cache
+    assert len(cache) == 1
+
+
+def test_delete() -> None:
+    cache: InstanceCache[str, int] = InstanceCache(ttl_seconds=10, max_size=5)
+    cache.set("k1", 100)
+    assert cache.delete("k1") is True
+    assert cache.get("k1") is None
+    assert cache.delete("k1") is False
+    assert len(cache) == 0
+
+
+def test_clear() -> None:
+    cache: InstanceCache[str, int] = InstanceCache(ttl_seconds=10, max_size=5)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    assert len(cache) == 2
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.get("a") is None
+    assert cache.get("b") is None
+
+
+def test_expiration() -> None:
+    cache: InstanceCache[str, str] = InstanceCache(ttl_seconds=0.05, max_size=5)
+    cache.set("fast", "val")
+    assert cache.get("fast") == "val"
+    time.sleep(0.06)
+    assert cache.get("fast") is None
+    assert "fast" not in cache
+    assert len(cache) == 0
+
+
+def test_custom_ttl_per_item() -> None:
+    cache: InstanceCache[str, str] = InstanceCache(ttl_seconds=10.0, max_size=5)
+    cache.set("short", "v1", ttl_seconds=0.05)
+    cache.set("long", "v2", ttl_seconds=10.0)
+    time.sleep(0.06)
+    assert cache.get("short") is None
+    assert cache.get("long") == "v2"
+
+
+def test_lru_eviction() -> None:
+    cache: InstanceCache[str, int] = InstanceCache(ttl_seconds=10, max_size=3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    # Access 'a' so 'b' becomes the oldest
+    assert cache.get("a") == 1
+
+    # Adding 'd' should evict 'b'
+    cache.set("d", 4)
+    assert len(cache) == 3
+    assert cache.get("b") is None
+    assert cache.get("a") == 1
+    assert cache.get("c") == 3
+    assert cache.get("d") == 4
+
+
+def test_concurrent_access_deadlock_free() -> None:
+    cache: InstanceCache[int, str] = InstanceCache(ttl_seconds=5, max_size=50)
+
+    def worker(worker_id: int) -> None:
+        for i in range(100):
+            key = (worker_id * 10 + i) % 100
+            cache.set(key, f"val-{worker_id}-{i}")
+            _ = cache.get(key)
+            if i % 10 == 0:
+                cache.delete(key)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(worker, i) for i in range(8)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()  # will raise if deadlock or exception occurred
+
+    assert len(cache) <= 50

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -43,6 +43,13 @@ def clear_context_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(context_cache, "CACHE_DATA", {})
 
 
+@pytest.fixture(autouse=True)
+def clear_auth_key_cache() -> None:
+    from backend.api.handlers.decorators import auth_key_cache
+
+    auth_key_cache.clear()
+
+
 @pytest.fixture()
 def gae_testbed() -> Generator[testbed.Testbed, None, None]:
     tb = testbed.Testbed()


### PR DESCRIPTION
## Overview
Production trace analysis across 30 million APIv3 requests revealed that over 86% of all API requests are driven by the top 5 API keys. Currently, every request queries Datastore/NDB or Memcache for `ApiAuthAccess`, adding 2-5ms of latency and Memcache roundtrip overhead.

## Changes
- Introduce `InstanceCache[K, V]` in `src/backend/common/cache/instance_cache.py`: a thread-safe, monotonic in-memory LRU cache with per-item TTL expiration and deadlock-free critical sections.
- Add `auth_key_cache` in `decorators.py` with a 10-minute TTL and 1,000 entry limit.
- Cache auth metadata (`owner_id` and `description`) in `@api_authenticated` without duplicating logging, trace annotations, or context setup.
- Add unit tests for `InstanceCache` (concurrency, TTL expiration, custom TTL, LRU eviction).
- Add unit tests for API key cache hits, non-caching of invalid keys, and test isolation.

## Testing
- Unit tests: `pytest src/backend/common/cache/tests/` (7 passed)
- Auth tests: `pytest src/backend/api/handlers/tests/apiv3_auth_test.py` (21 passed)
- Full API suite: `pytest src/backend/api/` (723 passed)
- Linters: `make lint` clean
- Type checking: `make typecheck` clean