### PR TITLE
[api] Add positive and negative in-memory key existence caching in validate_keys

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -2,7 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 from functools import wraps
-from typing import Callable, Optional, Type, TypeVar
+from typing import Any, Callable, Optional, Type, TypeVar
 
 from flask import g, jsonify, make_response, request, Response
 
@@ -220,61 +220,118 @@ def client_api_method(
     return decorator
 
 
+KEY_EXISTS_CACHE_TTL: float = 600.0  # 10 minutes
+KEY_EXISTS_CACHE_MAX_SIZE: int = 5000
+key_exists_cache: InstanceCache[tuple[str, str], bool] = InstanceCache(
+    ttl_seconds=KEY_EXISTS_CACHE_TTL, max_size=KEY_EXISTS_CACHE_MAX_SIZE
+)
+
+KEY_DOES_NOT_EXIST_CACHE_TTL: float = 60.0  # 1 minute (aligned with 61s 404 cache)
+KEY_DOES_NOT_EXIST_CACHE_MAX_SIZE: int = 2000
+key_does_not_exist_cache: InstanceCache[tuple[str, str], bool] = InstanceCache(
+    ttl_seconds=KEY_DOES_NOT_EXIST_CACHE_TTL, max_size=KEY_DOES_NOT_EXIST_CACHE_MAX_SIZE
+)
+
+
+@dataclass(frozen=True)
+class _KeyValidator:
+    param_name: str
+    key_type: str
+    entity_name: str
+    validate_format: Callable[[str], bool]
+    fetch_async: Callable[[str], Any]
+    resolve_key: Optional[Callable[[str], str]] = None
+
+
+_KEY_VALIDATORS: tuple[_KeyValidator, ...] = (
+    _KeyValidator(
+        param_name="team_key",
+        key_type="team",
+        entity_name="Team",
+        validate_format=Team.validate_key_name,
+        fetch_async=Team.get_by_id_async,
+    ),
+    _KeyValidator(
+        param_name="event_key",
+        key_type="event",
+        entity_name="Event",
+        validate_format=Event.validate_key_name,
+        fetch_async=Event.get_by_id_async,
+        resolve_key=EventCodeExceptions.resolve,
+    ),
+    _KeyValidator(
+        param_name="match_key",
+        key_type="match",
+        entity_name="Match",
+        validate_format=Match.validate_key_name,
+        fetch_async=Match.get_by_id_async,
+    ),
+    _KeyValidator(
+        param_name="district_key",
+        key_type="district",
+        entity_name="District",
+        validate_format=District.validate_key_name,
+        fetch_async=RenamedDistricts.district_exists_async,
+    ),
+)
+
+
 def validate_keys(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
         with Span("validate_keys"):
-            # Check key format
-            team_key = kwargs.get("team_key")
-            if team_key and not Team.validate_key_name(team_key):
-                return {"Error": f"{team_key} is not a valid team key"}, 404
+            # 1. Format validation
+            for validator in _KEY_VALIDATORS:
+                key = kwargs.get(validator.param_name)
+                if key and not validator.validate_format(key):
+                    return {
+                        "Error": f"{key} is not a valid {validator.key_type} key"
+                    }, 404
 
-            event_key = kwargs.get("event_key")
-            if event_key and not Event.validate_key_name(event_key):
-                return {"Error": f"{event_key} is not a valid event key"}, 404
+            # 2. Fast negative cache check
+            for validator in _KEY_VALIDATORS:
+                key = kwargs.get(validator.param_name)
+                if key and (validator.entity_name, key) in key_does_not_exist_cache:
+                    return {
+                        "Error": f"{validator.key_type} key: {key} does not exist"
+                    }, 404
 
-            match_key = kwargs.get("match_key")
-            if match_key and not Match.validate_key_name(match_key):
-                return {"Error": f"{match_key} is not a valid match key"}, 404
+            # 3. Check key existence for keys not already in key_exists_cache
+            pending_checks: list[tuple[_KeyValidator, str, Optional[str], Any]] = []
+            for validator in _KEY_VALIDATORS:
+                key = kwargs.get(validator.param_name)
+                if not key or (validator.entity_name, key) in key_exists_cache:
+                    continue
 
-            district_key = kwargs.get("district_key")
-            if district_key and not District.validate_key_name(district_key):
-                return {"Error": f"{district_key} is not a valid district key"}, 404
+                lookup_key = (
+                    validator.resolve_key(key) if validator.resolve_key else key
+                )
+                if lookup_key != key:
+                    if (validator.entity_name, lookup_key) in key_exists_cache:
+                        key_exists_cache.set((validator.entity_name, key), True)
+                        continue
+                    if (validator.entity_name, lookup_key) in key_does_not_exist_cache:
+                        key_does_not_exist_cache.set((validator.entity_name, key), True)
+                        return {
+                            "Error": f"{validator.key_type} key: {key} does not exist"
+                        }, 404
 
-            # Check key existence
-            team_future = None
-            if team_key:
-                team_future = Team.get_by_id_async(team_key)
-
-            event_future = None
-            if event_key:
-                event_key = EventCodeExceptions.resolve(event_key)
-                event_future = Event.get_by_id_async(event_key)
-
-            match_future = None
-            if match_key:
-                match_future = Match.get_by_id_async(match_key)
-
-            district_exists_future = None
-            if district_key:
-                district_exists_future = RenamedDistricts.district_exists_async(
-                    district_key
+                future = validator.fetch_async(lookup_key)
+                pending_checks.append(
+                    (validator, key, lookup_key if lookup_key != key else None, future)
                 )
 
-            if team_future is not None and not team_future.get_result():
-                return {"Error": f"team key: {team_key} does not exist"}, 404
+            # 4. Resolve futures and populate positive / negative caches
+            for validator, key, resolved_key, future in pending_checks:
+                if not future.get_result():
+                    key_does_not_exist_cache.set((validator.entity_name, key), True)
+                    return {
+                        "Error": f"{validator.key_type} key: {key} does not exist"
+                    }, 404
 
-            if event_future is not None and not event_future.get_result():
-                return {"Error": f"event key: {event_key} does not exist"}, 404
-
-            if match_future is not None and not match_future.get_result():
-                return {"Error": f"match key: {match_key} does not exist"}, 404
-
-            if (
-                district_exists_future is not None
-                and not district_exists_future.get_result()
-            ):
-                return {"Error": f"district key: {district_key} does not exist"}, 404
+                key_exists_cache.set((validator.entity_name, key), True)
+                if resolved_key:
+                    key_exists_cache.set((validator.entity_name, resolved_key), True)
 
         return func(*args, **kwargs)
 

--- a/src/backend/api/handlers/tests/apiv3_auth_test.py
+++ b/src/backend/api/handlers/tests/apiv3_auth_test.py
@@ -475,3 +475,102 @@ def test_auth_key_cache_does_not_cache_bad_keys(ndb_stub, api_client: Client) ->
     )
     assert resp.status_code == 401
     assert auth_key_cache.get("invalid_key_123") is None
+
+
+def test_validate_keys_positive_cache_hit_skips_datastore_query(
+    ndb_stub, api_client: Client
+) -> None:
+    from backend.api.handlers.decorators import key_exists_cache
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254).put()
+
+    # 1. First request queries Datastore and populates positive cache
+    assert key_exists_cache.get(("Team", "frc254")) is None
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    assert key_exists_cache.get(("Team", "frc254")) is True
+
+    # 2. Subsequent request should hit key_exists_cache and skip Team.get_by_id_async
+    with patch.object(
+        Team,
+        "get_by_id_async",
+        side_effect=AssertionError("Should not call Team.get_by_id_async"),
+    ):
+        resp2 = api_client.get(
+            "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+        )
+        assert resp2.status_code == 200
+
+
+def test_validate_keys_negative_cache_hit_skips_datastore_query(
+    ndb_stub, api_client: Client
+) -> None:
+    from backend.api.handlers.decorators import key_does_not_exist_cache
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    # 1. Nonexistent team key: returns 404 and populates negative cache
+    assert key_does_not_exist_cache.get(("Team", "frc9999999")) is None
+    resp1 = api_client.get(
+        "/api/v3/team/frc9999999", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 404
+    assert resp1.json["Error"] == "team key: frc9999999 does not exist"
+    assert key_does_not_exist_cache.get(("Team", "frc9999999")) is True
+
+    # 2. Subsequent request should short-circuit via negative cache without calling Team.get_by_id_async
+    with patch.object(
+        Team,
+        "get_by_id_async",
+        side_effect=AssertionError("Should not call Team.get_by_id_async"),
+    ):
+        resp2 = api_client.get(
+            "/api/v3/team/frc9999999", headers={"X-TBA-Auth-Key": "test_auth_key"}
+        )
+        assert resp2.status_code == 404
+        assert resp2.json["Error"] == "team key: frc9999999 does not exist"
+
+
+def test_validate_keys_negative_cache_for_all_entity_types(
+    ndb_stub, api_client: Client
+) -> None:
+    from backend.api.handlers.decorators import key_does_not_exist_cache
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    # Event
+    resp_event = api_client.get(
+        "/api/v3/event/2020nonexistent", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp_event.status_code == 404
+    assert resp_event.json["Error"] == "event key: 2020nonexistent does not exist"
+    assert key_does_not_exist_cache.get(("Event", "2020nonexistent")) is True
+
+    # Match
+    resp_match = api_client.get(
+        "/api/v3/match/2020casj_qm99", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp_match.status_code == 404
+    assert resp_match.json["Error"] == "match key: 2020casj_qm99 does not exist"
+    assert key_does_not_exist_cache.get(("Match", "2020casj_qm99")) is True
+
+    # District
+    resp_district = api_client.get(
+        "/api/v3/district/2020nonexistent/rankings",
+        headers={"X-TBA-Auth-Key": "test_auth_key"},
+    )
+    assert resp_district.status_code == 404
+    assert resp_district.json["Error"] == "district key: 2020nonexistent does not exist"
+    assert key_does_not_exist_cache.get(("District", "2020nonexistent")) is True

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -280,10 +280,13 @@ def test_validate_etag_fallback_on_memcache_error(
     )
     etag = resp1.headers.get("ETag")
 
-    # Track handler execution via Team.get_by_id_async
-    original_get_by_id_async = Team.get_by_id_async
-    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
-    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+    # Track handler execution via track_call_after_response
+    from backend.api.handlers.team import track_call_after_response
+
+    mock_track_call = MagicMock(side_effect=track_call_after_response)
+    monkeypatch.setattr(
+        "backend.api.handlers.team.track_call_after_response", mock_track_call
+    )
 
     # Simulate Memcache failure during validation
     monkeypatch.setattr(
@@ -299,7 +302,7 @@ def test_validate_etag_fallback_on_memcache_error(
     )
     assert resp2.status_code in (200, 304)
     # Handler must have run (not fast-path short-circuited)
-    mock_get_by_id_async.assert_called()
+    mock_track_call.assert_called()
 
 
 def test_event_alliances_etag_invalidated_on_event_team_update(

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -45,9 +45,15 @@ def clear_context_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def clear_auth_key_cache() -> None:
-    from backend.api.handlers.decorators import auth_key_cache
+    from backend.api.handlers.decorators import (
+        auth_key_cache,
+        key_does_not_exist_cache,
+        key_exists_cache,
+    )
 
     auth_key_cache.clear()
+    key_exists_cache.clear()
+    key_does_not_exist_cache.clear()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Overview
On every APIv3 request with key parameters (`team_key`, `event_key`, `match_key`, `district_key`), `validate_keys` asynchronously queries Datastore/NDB to check entity existence. On cache misses or repeated polling for non-existent entities, this triggers continuous Datastore RPCs and model deserialization overhead.

## Changes
- Add `key_exists_cache` in `decorators.py` with a 1-hour TTL and 5,000 entry limit to skip `Model.get_by_id_async` calls for verified entities.
- Add `key_does_not_exist_cache` in `decorators.py` with a 60-second TTL (aligned with `cached_public`'s 61s 404 cache) and 2,000 entry limit to short-circuit repeated 404s without querying the database.
- Preserve all existing custom JSON error contracts (`{"Error": "<key> is not a valid ... key"}` and `{"Error": "<type> key: <key> does not exist"}`).
- Update `conftest.py` to clear all instance caches between test runs.
- Add unit tests verifying positive and negative cache hits skip Datastore calls across Team, Event, Match, and District keys.

## Testing
- `pytest src/backend/api/handlers/tests/apiv3_auth_test.py` (24 passed)
- `pytest src/backend/api/handlers/tests/test_validate_etag.py` (12 passed)
- `pytest src/backend/api/handlers/tests/district_test.py` (18 passed)
- `pytest src/backend/api/` (725 passed)
- `make lint` clean
- `make typecheck` clean