### PR TITLE
Mint API keys and trusted-API secrets with the secrets module

### DIFF
--- a/src/backend/common/models/api_auth_access.py
+++ b/src/backend/common/models/api_auth_access.py
@@ -1,4 +1,6 @@
 import datetime
+import secrets
+import string
 from typing import List, Optional
 
 from google.appengine.ext import ndb
@@ -48,6 +50,33 @@ class ApiAuthAccess(ndb.Model):
     # Allow access for all events marked official
     all_official_events: bool = ndb.BooleanProperty()
     expiration: Optional[datetime.datetime] = ndb.DateTimeProperty()
+
+    # Read keys and write secrets are bearer credentials, and write auth IDs
+    # are the lookup key for a secret. All of them must come from a
+    # cryptographically secure source, never from `random`.
+    TOKEN_ALPHABET = string.ascii_letters + string.digits
+    AUTH_ID_LENGTH = 16
+    READ_KEY_LENGTH = 64
+    SECRET_LENGTH = 64
+
+    @classmethod
+    def generate_auth_id(cls) -> str:
+        """The public identifier of a write key (X-TBA-Auth-Id)."""
+        return cls._generate_token(cls.AUTH_ID_LENGTH)
+
+    @classmethod
+    def generate_read_key(cls) -> str:
+        """The bearer token for the read API (X-TBA-Auth-Key); also the entity ID."""
+        return cls._generate_token(cls.READ_KEY_LENGTH)
+
+    @classmethod
+    def generate_secret(cls) -> str:
+        """The signing secret of a write key (used for X-TBA-Auth-Sig)."""
+        return cls._generate_token(cls.SECRET_LENGTH)
+
+    @classmethod
+    def _generate_token(cls, length: int) -> str:
+        return "".join(secrets.choice(cls.TOKEN_ALPHABET) for _ in range(length))
 
     def put(self, *args, **kwargs):
         # Validation for making sure that we never mix the READ_API and other write types together

--- a/src/backend/common/models/tests/api_auth_access_test.py
+++ b/src/backend/common/models/tests/api_auth_access_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from backend.common.consts.auth_type import AuthType
@@ -94,3 +96,38 @@ def test_is_write_key() -> None:
     assert auth.is_write_key
     auth.auth_types_enum = [AuthType.ZEBRA_MOTIONWORKS]
     assert auth.is_write_key
+
+
+def test_generate_auth_id() -> None:
+    auth_id = ApiAuthAccess.generate_auth_id()
+    assert len(auth_id) == 16
+    assert all(c in ApiAuthAccess.TOKEN_ALPHABET for c in auth_id)
+
+
+def test_generate_read_key() -> None:
+    key = ApiAuthAccess.generate_read_key()
+    assert len(key) == 64
+    assert all(c in ApiAuthAccess.TOKEN_ALPHABET for c in key)
+
+
+def test_generate_secret() -> None:
+    secret = ApiAuthAccess.generate_secret()
+    assert len(secret) == 64
+    assert all(c in ApiAuthAccess.TOKEN_ALPHABET for c in secret)
+
+
+def test_generated_tokens_are_unique() -> None:
+    assert len({ApiAuthAccess.generate_secret() for _ in range(100)}) == 100
+    assert len({ApiAuthAccess.generate_auth_id() for _ in range(100)}) == 100
+
+
+def test_tokens_come_from_secrets_module() -> None:
+    # `random` is a Mersenne Twister whose state can be recovered from its
+    # output; bearer credentials must be drawn from `secrets` instead.
+    with patch(
+        "backend.common.models.api_auth_access.secrets.choice", return_value="x"
+    ) as mock_choice:
+        assert ApiAuthAccess.generate_auth_id() == "x" * 16
+        assert ApiAuthAccess.generate_secret() == "x" * 64
+        assert ApiAuthAccess.generate_read_key() == "x" * 64
+    assert mock_choice.call_count == 16 + 64 + 64

--- a/src/backend/common/models/user.py
+++ b/src/backend/common/models/user.py
@@ -1,5 +1,3 @@
-import random
-import string
 from typing import Any, cast, Dict, List, Optional, Union
 
 from google.appengine.ext import ndb
@@ -246,12 +244,7 @@ class User:
 
     def add_api_read_key(self, description: str) -> ApiAuthAccess:
         api_key = ApiAuthAccess(
-            id="".join(
-                random.choice(
-                    string.ascii_lowercase + string.ascii_uppercase + string.digits
-                )
-                for _ in range(64)
-            ),
+            id=ApiAuthAccess.generate_read_key(),
             owner=none_throws(self.account_key),
             auth_types_enum=[AuthType.READ_API],
             description=description,

--- a/src/backend/common/suggestions/suggestion_reviewer.py
+++ b/src/backend/common/suggestions/suggestion_reviewer.py
@@ -1,8 +1,6 @@
 import datetime
 import enum
 import json
-import random
-import string
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from google.appengine.ext import ndb
@@ -457,21 +455,11 @@ class SuggestionReviewer:
         else:
             expiration = None
 
-        auth_id = "".join(
-            random.choice(
-                string.ascii_lowercase + string.ascii_uppercase + string.digits
-            )
-            for _ in range(16)
-        )
+        auth_id = ApiAuthAccess.generate_auth_id()
         auth = ApiAuthAccess(
             id=auth_id,
             description="{} @ {}".format(author.display_name, event_key),
-            secret="".join(
-                random.choice(
-                    string.ascii_lowercase + string.ascii_uppercase + string.digits
-                )
-                for _ in range(64)
-            ),
+            secret=ApiAuthAccess.generate_secret(),
             event_list=[ndb.Key(Event, event_key)],
             auth_types_enum=clean_auth_types,
             owner=suggestion.author,

--- a/src/backend/web/handlers/admin/api_auth.py
+++ b/src/backend/web/handlers/admin/api_auth.py
@@ -1,6 +1,4 @@
 import logging
-import random
-import string
 from datetime import datetime
 from typing import cast, Optional
 
@@ -20,12 +18,7 @@ from backend.web.profiled_render import render_template
 def api_auth_add() -> Response:
     event_key = request.args.get("event_key", "")
     template_values = {
-        "auth_id": "".join(
-            random.choice(
-                string.ascii_lowercase + string.ascii_uppercase + string.digits
-            )
-            for _ in range(16)
-        ),
+        "auth_id": ApiAuthAccess.generate_auth_id(),
         "event_key": event_key,
     }
 
@@ -142,12 +135,7 @@ def api_auth_edit_post(auth_id: str) -> Response:
             owner=owner_key,
             expiration=expiration,
             allow_admin=True if request.form.get("allow_admin") else False,
-            secret="".join(
-                random.choice(
-                    string.ascii_lowercase + string.ascii_uppercase + string.digits
-                )
-                for _ in range(64)
-            ),
+            secret=ApiAuthAccess.generate_secret(),
             district_list=district_list,
             event_list=event_list,
             offseason_webcast_channels=offseason_webcast_channels,

--- a/src/backend/web/handlers/suggestions/suggest_apiwrite_review_controller.py
+++ b/src/backend/web/handlers/suggestions/suggest_apiwrite_review_controller.py
@@ -1,5 +1,3 @@
-import random
-import string
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -50,12 +48,7 @@ class SuggestApiWriteReviewController(SuggestionsReviewBase[ApiWriteTargetModel]
         user = suggestion.author.get()
         event = none_throws(Event.get_by_id(event_key))
 
-        auth_id = "".join(
-            random.choice(
-                string.ascii_lowercase + string.ascii_uppercase + string.digits
-            )
-            for _ in range(16)
-        )
+        auth_id = ApiAuthAccess.generate_auth_id()
         auth_types = request.form.getlist("auth_types") or []
         expiration_offset = int(request.form.get("expiration_days", ""))
         if expiration_offset != -1:
@@ -71,12 +64,7 @@ class SuggestApiWriteReviewController(SuggestionsReviewBase[ApiWriteTargetModel]
             description="{} @ {}".format(
                 user.display_name, suggestion.contents["event_key"]
             ).encode("utf-8"),
-            secret="".join(
-                random.choice(
-                    string.ascii_lowercase + string.ascii_uppercase + string.digits
-                )
-                for _ in range(64)
-            ),
+            secret=ApiAuthAccess.generate_secret(),
             event_list=[ndb.Key(Event, event_key)],
             auth_types_enum=[AuthType(int(t)) for t in auth_types],
             owner=suggestion.author,


### PR DESCRIPTION
## Problem

Read API keys, write-key auth IDs, and write-key secrets were all built with `random.choice`, which draws from a Mersenne Twister. Its state can be reconstructed from observed output, and any registered user can mint unlimited read keys from their account page, giving them as many outputs of that generator as they want. Keys minted later on the same instance (including trusted write secrets) are then predictable in principle.

## Change

Generation is centralized on `ApiAuthAccess`:

- `generate_auth_id()` (16 chars, the public `X-TBA-Auth-Id`)
- `generate_read_key()` (64 chars, the `X-TBA-Auth-Key` bearer token and entity ID)
- `generate_secret()` (64 chars, the write-key signing secret)

All use `secrets.choice` over the same `[A-Za-z0-9]` alphabet and the same lengths as before, so existing keys, docs, and any client-side validation are unaffected.

Six call sites replaced: account read keys (`User.add_api_read_key`), the admin write-key form (`admin/api_auth.py`), the web apiwrite reviewer, and the moderation-API apiwrite reviewer (`SuggestionReviewer._accept_api_write`). Dev-only seeding in `local/` and `admin/suggestions_seed.py` is left on `random` since those values are not credentials.

## Tests

New tests in `api_auth_access_test.py` cover length, alphabet, uniqueness, and that the helpers actually draw from `secrets` (patched to verify). Existing tests for all six call sites pass unchanged.

## Test plan

- [x] `make lint`, `make typecheck`
- [x] `make test` on the model, user, admin api_auth, apiwrite review, suggestion reviewer, account, and moderation API tests (288 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)