### PR TITLE
Upgrade admin and tasks-service pages to jQuery 3.7.1 and Bootstrap 3.4.1

### DIFF
--- a/src/backend/tasks_io/templates/datafeeds/base.html
+++ b/src/backend/tasks_io/templates/datafeeds/base.html
@@ -14,9 +14,8 @@
 
     <!-- Le javascript
     ================================================== -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" integrity="sha384-npxfGiG5C/F5X72RqcKFYSfzr1AXsDiu1YC/ydsOrS+jL554Jh4zFAx9GpQi4lXQ" crossorigin="anonymous"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js" integrity="sha384-Zzs5x1/YUvlxpCu06c197tRCubLCMA7pCoHbZeoZuz/oEgYD6NVmvLzDSKYBoc3J" crossorigin="anonymous"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/fancybox/2.0.6/jquery.fancybox.pack.js" integrity="sha384-+ShC4binnPZqwwobFIyQCG2D3VfyxiKXTI9YQgEDeMGEnx3izh9WVhhGbFW0uxmo" crossorigin="anonymous"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/fitvids/1.0.1/jquery.fitvids.min.js" integrity="sha384-MzH5htynxPJ6Y6bGpUfL9hWU4a0zzhQyJU7kI1tmEtnFzy2/DQbm8XnZE1OlhCtF" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.5.2/jquery.tablesorter.min.js" integrity="sha384-8SYdUNuAPMLcoXkfx/UTEOOFz2lPITH5Im3cODT8t9Sk8dAgRk53loXo6ZK5wp5L" crossorigin="anonymous"></script>
     <script src="/javascript/tba_combined_js.main.min.js"></script>

--- a/src/backend/web/templates/admin/base.html
+++ b/src/backend/web/templates/admin/base.html
@@ -16,11 +16,10 @@
 
     <!-- Le javascript
     ================================================== -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" integrity="sha384-npxfGiG5C/F5X72RqcKFYSfzr1AXsDiu1YC/ydsOrS+jL554Jh4zFAx9GpQi4lXQ" crossorigin="anonymous"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js" integrity="sha384-4ub8UfB60O1GlzOr5uCNPBlf/dBByyme0yBsAhVasBJmdJ1hO4FjLkIkGgUgd7ak" crossorigin="anonymous"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js" integrity="sha384-Zzs5x1/YUvlxpCu06c197tRCubLCMA7pCoHbZeoZuz/oEgYD6NVmvLzDSKYBoc3J" crossorigin="anonymous"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.9.3/typeahead.min.js" integrity="sha384-3IAJO6AKe2iKDZuPZAi9+OLk/2FTjtKFjP9iF8gTz9p+qKKUVZrEJRMV8fqi1ILJ" crossorigin="anonymous"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/fancybox/2.0.6/jquery.fancybox.pack.js" integrity="sha384-+ShC4binnPZqwwobFIyQCG2D3VfyxiKXTI9YQgEDeMGEnx3izh9WVhhGbFW0uxmo" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/fitvids/1.0.1/jquery.fitvids.min.js" integrity="sha384-MzH5htynxPJ6Y6bGpUfL9hWU4a0zzhQyJU7kI1tmEtnFzy2/DQbm8XnZE1OlhCtF" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.5.2/jquery.tablesorter.min.js" integrity="sha384-8SYdUNuAPMLcoXkfx/UTEOOFz2lPITH5Im3cODT8t9Sk8dAgRk53loXo6ZK5wp5L" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highcharts/3.0.2/highcharts.js" integrity="sha384-0EwOwjEEIByl6tT1mgDW6STwDAvAFYXBV313fl5SzxTikjBCi155DDcxBqBiHDuU" crossorigin="anonymous"></script>


### PR DESCRIPTION
Stacked on #10600 → #10599. Merge those first; this PR's diff will shrink to `admin/base.html` and `tasks_io/templates/datafeeds/base.html`.

## Problem

The admin pages and the tasks-service datafeeds pages load **jQuery 1.7.1** and **Bootstrap 3.0.0**, older than the public site was. jQuery 1.7.1 predates every jQuery XSS fix (CVE-2012-6708 through CVE-2020-11023); Bootstrap 3.0.0 has the tooltip/popover/`data-target` XSS issues fixed in 3.4.1. Both templates also load fancybox 2.0.6, which no admin template uses.

Exposure is admin-only (these pages need a Google admin login), so this is hygiene rather than an outsider-reachable hole, but it also removes the last reason the admin needs a different jQuery than the rest of the site.

## Change

- `admin/base.html` and `tasks_io/templates/datafeeds/base.html`: jQuery 1.7.1 → 3.7.1, Bootstrap 3.0.0 → 3.4.1, hashes updated, fancybox 2.0.6 removed.
- Highcharts 3.0.2 on the admin home page is left alone; see verification.

## Verification

- Rendered `/admin/` and `/admin/tasks` through the Flask test client as an admin and loaded them in headless Chromium against the real CDNs: all integrity hashes pass, pages report jQuery 3.7.1 and Bootstrap 3.4.1, `tablesorter`/`typeahead`/`fitVids`/`featherlight` plugins are all attached, and a Highcharts 3.0.2 chart is created successfully under jQuery 3 (the admin home page draws memcache stats with it). No new console errors versus the same pages rendered from `main`.
- A grep of the admin and tasks templates for jQuery-3-removed APIs (`.live()`, `.die()`, `.size()`, `.andSelf()`, `$.browser`, jqXHR `.success()`) finds none.
- `make test` on all admin handler tests (212 passed) and the FRC API tasks handler tests that render the datafeeds templates (46 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)