### PR TITLE
Upgrade the Firebase web SDK from 8.10.0 to the 10.14.1 compat build

### DIFF
--- a/src/backend/web/templates/account_login_required.html
+++ b/src/backend/web/templates/account_login_required.html
@@ -5,7 +5,7 @@
 {% block meta_description %}Login Required{% endblock %}
 
 {% block inline_javascript %}
-<script src="//www.gstatic.com/firebasejs/8.10.0/firebase-auth.js" integrity="sha384-p62xBRve8PdqGDGASZtZMuHgPsyPcT5VsFwgmz2p4zaFdEtt5ZzNqxK+CLzQS7xP" crossorigin="anonymous"></script>
+<script src="//www.gstatic.com/firebasejs/10.14.1/firebase-auth-compat.js" integrity="sha384-I1LYojsZ5RM1cOda44Z2h42Qa6YfsQ1XkXxREnhp4ueYBR/4d1pG1K+NZM537Vsj" crossorigin="anonymous"></script>
 <script src="/py3_javascript/tba_combined_js.firebase.min.js"></script>
 <script>
   // Setup auth emulator host if passed

--- a/src/backend/web/templates/base.html
+++ b/src/backend/web/templates/base.html
@@ -174,7 +174,7 @@
 <!-- Admin Bar -->
 {% endblock %}
 
-<script src="//www.gstatic.com/firebasejs/8.10.0/firebase-app.js" integrity="sha384-gNTK1b3nq+NMsDf1ASdhbVEwXj9tjBeobuvcjWGlmIffN9OP+Q0SU9Q10JKPZryT" crossorigin="anonymous"></script>
+<script src="//www.gstatic.com/firebasejs/10.14.1/firebase-app-compat.js" integrity="sha384-ZaR6mWzmJtrRibZ1Vm7SoHFr8OXjyAuGAXalGDKqbxFT18oi/z+oZLIRFkpeNor1" crossorigin="anonymous"></script>
 {% block main_javascript %}
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.3.1/jquery.cookie.min.js" integrity="sha384-4ub8UfB60O1GlzOr5uCNPBlf/dBByyme0yBsAhVasBJmdJ1hO4FjLkIkGgUgd7ak" crossorigin="anonymous"></script>


### PR DESCRIPTION
Stacked on #10601 → #10600 → #10599. Merge those first; this diff is then two `<script>` tags.

## Problem

The Jinja site loads Firebase JS **8.10.0** (June 2021), which is end-of-life and no longer receives security fixes. It backs the Google/Apple sign-in flow on `/account/login`.

## Change

- `base.html`: `firebase-app.js` 8.10.0 → `firebase-app-compat.js` 10.14.1
- `account_login_required.html`: `firebase-auth.js` 8.10.0 → `firebase-auth-compat.js` 10.14.1

The compat builds expose the same namespaced v8 API (`firebase.initializeApp`, `firebase.auth()`, `GoogleAuthProvider`, `OAuthProvider`, `Auth.Persistence.NONE`), so `tba_firebase.js` and `tba_auth.js` are untouched. Integrity hashes updated.

Not in scope: GameDay's bundled `firebase` 8.x from the root `package.json` (a webpack dependency, not a CDN tag) and `match_timeline.html`, which calls `firebase.database()` without ever loading the database SDK and is broken on `main` today.

## Verification

Rendered `/account/login` from this branch through the Flask test client, inlined the freshly built `tba_combined_js.firebase` bundle in place of the dev-server one, and loaded it in headless Chromium against the real gstatic CDN. Result: SDK reports `10.14.1`, `firebase.apps.length === 1` (initializeApp ran), `new GoogleAuthProvider()` and `new OAuthProvider('apple.com')` both construct, `Persistence.NONE` resolves, integrity hashes pass, zero console errors. Same check on `/` (app-compat only): clean.

`make test` on index and account handler tests passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)