### PR TITLE
Remove dead RTDB emulator wiring from the login-page Firebase bundle

### DIFF
--- a/ops/build/run_buildweb.sh
+++ b/ops/build/run_buildweb.sh
@@ -15,7 +15,6 @@ var firebaseDatabaseURL = "https://${GCLOUD_PROJECT_ID}.firebaseio.com";
 var firebaseStorageBucket = "${GCLOUD_PROJECT_ID}.appspot.com";
 var firebaseMessagingSenderId = "${FIREBASE_MESSAGING_SENDER_ID}";
 var firebaseProjectId = "${GCLOUD_PROJECT_ID}";
-var firebaseDatabaseEmulatorHost = "";
 EOF
         shift
         ;;

--- a/ops/build/run_buildweb.sh
+++ b/ops/build/run_buildweb.sh
@@ -15,6 +15,7 @@ var firebaseDatabaseURL = "https://${GCLOUD_PROJECT_ID}.firebaseio.com";
 var firebaseStorageBucket = "${GCLOUD_PROJECT_ID}.appspot.com";
 var firebaseMessagingSenderId = "${FIREBASE_MESSAGING_SENDER_ID}";
 var firebaseProjectId = "${GCLOUD_PROJECT_ID}";
+var firebaseDatabaseEmulatorHost = "";
 EOF
         shift
         ;;

--- a/src/backend/web/static/javascript/tba_js/tba_firebase.js
+++ b/src/backend/web/static/javascript/tba_js/tba_firebase.js
@@ -12,12 +12,3 @@ firebase.initializeApp(config);
 
 const auth = firebase.auth();
 auth.setPersistence(firebase.auth.Auth.Persistence.NONE);
-
-// Connect to database emulator if available
-// Set firebaseDatabaseEmulatorHost in tba_keys.js (e.g., "localhost:9000")
-if (typeof firebaseDatabaseEmulatorHost !== "undefined" && firebaseDatabaseEmulatorHost) {
-  var parts = firebaseDatabaseEmulatorHost.split(':');
-  var host = parts[0];
-  var port = parseInt(parts[1], 10);
-  firebase.database().useEmulator(host, port);
-}

--- a/src/backend/web/static/javascript/tba_js/tba_firebase.js
+++ b/src/backend/web/static/javascript/tba_js/tba_firebase.js
@@ -15,7 +15,7 @@ auth.setPersistence(firebase.auth.Auth.Persistence.NONE);
 
 // Connect to database emulator if available
 // Set firebaseDatabaseEmulatorHost in tba_keys.js (e.g., "localhost:9000")
-if (firebaseDatabaseEmulatorHost) {
+if (typeof firebaseDatabaseEmulatorHost !== "undefined" && firebaseDatabaseEmulatorHost) {
   var parts = firebaseDatabaseEmulatorHost.split(':');
   var host = parts[0];
   var port = parseInt(parts[1], 10);


### PR DESCRIPTION
## Problem

Open the browser console on https://www.thebluealliance.com/account/login (or any suggestion form) and you get:

```
Uncaught ReferenceError: firebaseDatabaseEmulatorHost is not defined
```

The block in `tba_firebase.js` that reads that variable was added in #9733 alongside the live-event page's emulator support. But `tba_firebase.js` is only loaded by the login page (through the `tba_combined_js.firebase` bundle), which never touches the Realtime Database and never loads the database SDK. So the block cannot work anywhere:

- **prod**: `run_buildweb.sh --env` generates a `tba_keys.js` without the variable → ReferenceError on every login page. Sign-in still works only because the throw happens after `initializeApp` and `setPersistence`.
- **dev with the emulator var set**: `firebase.database` is undefined on that page → a different TypeError.

## Change

Delete the block. Nothing else changes:

- The live-event page keeps its own emulator wiring in `src/frontend/liveevent/firebaseapp.js`, which reads `window.firebaseDatabaseEmulatorHost || ""` safely and is the only real consumer. `tba_keys_template.js` still defines the variable for dev.
- The **auth** emulator for the login page is wired separately, server-side, via `auth_emulator_host` in `account_login_required.html`, and is untouched.

(First revision of this PR guarded the read with `typeof` and defined the variable in the prod build. Deleting dead code is the better fix; that's what's here now.)

## Verification

Built the `tba_combined_js.firebase` bundle (uglify, same as `do_compress.py`) from `main` and from this branch, inlined each into a rendered `/account/login` with prod-shaped keys, and loaded both in headless Chromium:

| bundle | console |
|---|---|
| `main` | `pageerror: firebaseDatabaseEmulatorHost is not defined` |
| this branch | clean |

In both, `firebase.apps.length === 1` and the Google and Apple providers construct, so sign-in behavior is unchanged.

Independent of the CDN/SRI PR stack (#10599 → #10600 → #10601 → #10602); can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)