### PR TITLE
Support span hierarchy and nesting in profiler

### DIFF
--- a/src/backend/common/profiler.py
+++ b/src/backend/common/profiler.py
@@ -3,6 +3,7 @@
 import logging
 import random
 from datetime import datetime
+from typing import Optional
 
 from werkzeug.local import Local
 
@@ -63,6 +64,17 @@ def _make_tracing_call(body):
 
 
 class Span(object):
+    @staticmethod
+    def _get_span_stack() -> list["Span"]:
+        if hasattr(trace_context, "request") and trace_context.request:
+            if not hasattr(trace_context.request, "span_stack"):
+                trace_context.request.span_stack = []
+            return trace_context.request.span_stack
+        else:
+            if not hasattr(trace_context, "span_stack"):
+                trace_context.span_stack = []
+            return trace_context.span_stack
+
     def __init__(self, name: str):
         """
         Start a Span
@@ -71,6 +83,9 @@ class Span(object):
         """
         self._name = name
         self._labels = {}  # Cloud Trace spans support labels
+        self._span_id = str(random.getrandbits(64))
+        self._root_span_id: Optional[str] = None
+        self._parent_span_id: Optional[str] = None
 
         if hasattr(trace_context, "request") and trace_context.request:
             tcontext = trace_context.request.headers.get(
@@ -84,9 +99,22 @@ class Span(object):
             trace_id, root_span_id = tcontext.split(";")[0].split("/")
             trace_context.request.trace_id = trace_id
             self._root_span_id = root_span_id
+            self._parent_span_id = root_span_id
 
         else:
             self._do_trace = False
+
+        stack = self._get_span_stack()
+        if stack:
+            self._parent_span_id = stack[-1]._span_id
+
+    @property
+    def span_id(self) -> str:
+        return self._span_id
+
+    @property
+    def parent_span_id(self) -> Optional[str]:
+        return self._parent_span_id
 
     def set_label(self, key: str, value: str) -> None:
         """
@@ -102,11 +130,23 @@ class Span(object):
     def __enter__(self):
         if self._do_trace:
             logging.debug("CREATED SPAN: {}".format(self._name))
+        stack = self._get_span_stack()
+        if stack:
+            self._parent_span_id = stack[-1]._span_id
+        else:
+            self._parent_span_id = self._root_span_id
+        stack.append(self)
         self._startTime = datetime.now()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._endTime = datetime.now()
+        stack = self._get_span_stack()
+        if stack and stack[-1] is self:
+            stack.pop()
+        elif self in stack:
+            stack.remove(self)
+
         if self._do_trace:
             if not hasattr(trace_context.request, "spans"):
                 trace_context.request.spans = []
@@ -118,8 +158,8 @@ class Span(object):
         span_dict = {
             "kind": "SPAN_KIND_UNSPECIFIED",
             "name": self._name,
-            "parentSpanId": self._root_span_id,
-            "spanId": str(random.getrandbits(64)),
+            "parentSpanId": self._parent_span_id,
+            "spanId": self._span_id,
             "startTime": self._startTime.isoformat() + "Z",
             "endTime": self._endTime.isoformat() + "Z",
         }

--- a/src/backend/common/tests/profiler_test.py
+++ b/src/backend/common/tests/profiler_test.py
@@ -93,3 +93,128 @@ def test_multiple_spans(mock_send_traces) -> None:
         send_traces()
 
     mock_send_traces.assert_called()
+
+
+@patch("backend.common.profiler._make_tracing_call")
+def test_nested_spans(mock_send_traces) -> None:
+    app = setup_app()
+
+    @app.route("/")
+    def route():
+        with Span("parent") as parent:
+            with Span("child") as child:
+                with Span("grandchild") as grandchild:
+                    pass
+
+        spans = trace_context.request.spans
+        assert len(spans) == 3
+
+        grandchild_span = next(s for s in spans if s["name"] == "grandchild")
+        child_span = next(s for s in spans if s["name"] == "child")
+        parent_span = next(s for s in spans if s["name"] == "parent")
+
+        assert parent_span["parentSpanId"] == "SPAN_ID"
+        assert child_span["parentSpanId"] == parent.span_id
+        assert grandchild_span["parentSpanId"] == child.span_id
+        assert len({parent.span_id, child.span_id, grandchild.span_id}) == 3
+        return "Hi!"
+
+    mock_send_traces.assert_not_called()
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+    body = mock_send_traces.call_args[0][0]
+    trace_spans = body["traces"][0]["spans"]
+    assert len(trace_spans) == 3
+
+
+@patch("backend.common.profiler._make_tracing_call")
+def test_sibling_nested_spans(mock_send_traces) -> None:
+    app = setup_app()
+
+    @app.route("/")
+    def route():
+        with Span("parent") as parent:
+            with Span("child_1"):
+                pass
+            with Span("child_2"):
+                pass
+        with Span("top_level_2"):
+            pass
+
+        spans = trace_context.request.spans
+        assert len(spans) == 4
+
+        child1_span = next(s for s in spans if s["name"] == "child_1")
+        child2_span = next(s for s in spans if s["name"] == "child_2")
+        parent_span = next(s for s in spans if s["name"] == "parent")
+        top2_span = next(s for s in spans if s["name"] == "top_level_2")
+
+        assert parent_span["parentSpanId"] == "SPAN_ID"
+        assert child1_span["parentSpanId"] == parent.span_id
+        assert child2_span["parentSpanId"] == parent.span_id
+        assert top2_span["parentSpanId"] == "SPAN_ID"
+        return "Hi!"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+
+
+@patch("backend.common.profiler._make_tracing_call")
+def test_nested_span_exception_unwinds_stack(mock_send_traces) -> None:
+    app = setup_app()
+
+    @app.route("/")
+    def route():
+        try:
+            with Span("parent"):
+                with Span("failing_child"):
+                    raise RuntimeError("Something failed")
+        except RuntimeError:
+            pass
+
+        with Span("after_exception"):
+            pass
+
+        spans = trace_context.request.spans
+        assert len(spans) == 3
+
+        after_span = next(s for s in spans if s["name"] == "after_exception")
+        parent_span = next(s for s in spans if s["name"] == "parent")
+        failing_span = next(s for s in spans if s["name"] == "failing_child")
+
+        assert parent_span["parentSpanId"] == "SPAN_ID"
+        assert failing_span["parentSpanId"] == parent_span["spanId"]
+        assert after_span["parentSpanId"] == "SPAN_ID"
+        return "Hi!"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+
+
+def test_standalone_span_hierarchy() -> None:
+    trace_context.request = None
+    with Span("parent") as parent:
+        assert parent.parent_span_id is None
+        with Span("child") as child:
+            assert child.parent_span_id == parent.span_id
+            with Span("grandchild") as grandchild:
+                assert grandchild.parent_span_id == child.span_id
+    assert parent.span_id != child.span_id != grandchild.span_id
+
+    grandchild_dict = grandchild.dict()
+    child_dict = child.dict()
+    parent_dict = parent.dict()
+
+    assert grandchild_dict["parentSpanId"] == child.span_id
+    assert child_dict["parentSpanId"] == parent.span_id
+    assert parent_dict["parentSpanId"] is None


### PR DESCRIPTION
### Summary
Previously, custom Cloud Trace spans created using `with Span(...)` had their `parentSpanId` hardcoded to the incoming App Engine HTTP request root span (`self._root_span_id`). As a result, all application spans were rendered as flat siblings under the root span in the Google Cloud Trace console, even when nested in code (e.g. database query helpers, model serializers, auth decorators, and response handlers).

This PR introduces support for nested span hierarchies in [`profiler.py`](file:///usr/local/google/home/eugenefang/.gemini/antigravity-cli/worktrees/the-blue-alliance/support_span_hierarchy_profiler/src/backend/common/profiler.py):
1. **Stable Span ID Generation**: Pre-generates a unique 64-bit decimal string `span_id` during `Span.__init__` so child spans can reference their enclosing parent's span ID.
2. **Active Span Stack**: Maintains a request-scoped span stack on `trace_context.request.span_stack` (falling back to `trace_context.span_stack` outside active request contexts).
3. **Hierarchy & Parent Resolution**:
   - Outermost spans assign `parentSpanId = root_span_id` (the App Engine request root span).
   - Nested spans assign `parentSpanId = parent.span_id` (the active span on the stack).
   - Sibling spans under the same parent share the parent's `span_id`.
4. **Exception Safety**: Spans are popped cleanly in LIFO order upon exiting, ensuring proper stack unwinding even when exceptions are raised.

### Testing
- Added tests in [`profiler_test.py`](file:///usr/local/google/home/eugenefang/.gemini/antigravity-cli/worktrees/the-blue-alliance/support_span_hierarchy_profiler/src/backend/common/tests/profiler_test.py):
  - `test_nested_spans`: Verifies 3-level parent $\rightarrow$ child $\rightarrow$ grandchild span hierarchy and unique span IDs.
  - `test_sibling_nested_spans`: Verifies sibling spans under a common parent followed by top-level spans.
  - `test_nested_span_exception_unwinds_stack`: Verifies proper stack unwinding when exceptions bubble up through nested spans.
  - `test_standalone_span_hierarchy`: Verifies span hierarchy and `.dict()` generation outside a Flask request context.
- Verified test suite passes: `make test ARGS='src/backend/common/tests/profiler_test.py'` (8 passed).
- Verified linting & type checks: `make lint` and `make typecheck` pass with 0 errors.