### PR TITLE
Move the PWA service from F1 to F2

### DIFF
--- a/pwa/pwa.yaml
+++ b/pwa/pwa.yaml
@@ -1,7 +1,7 @@
 service: pwa
 runtime: nodejs24
 
-instance_class: F1
+instance_class: F2
 automatic_scaling:
   max_idle_instances: 1
   target_cpu_utilization: 0.9


### PR DESCRIPTION
Evaluation plan, baseline numbers, and success criteria are pre-registered in #10608. Read that before merging; this PR is the mechanism, the issue is the experiment.

## Change

`pwa/pwa.yaml`: `instance_class: F1` → `F2`. Nothing else.

F2 gives 1.2 GHz and 768 MiB versus F1's 600 MHz and 384 MiB, at double the hourly rate. The pwa service billed 869 instance hours ($36.46) in August, so the expected steady-state cost at current traffic is about **+$36/month**, less if faster requests reduce concurrent instances.

## Why

Justin's report: SSR is intermittently slow and he suspects the F1 CPU. The last two weeks of production data agree with him more than not:

- Daily p50 latency 1.4 to 4.1 s, p95 3.3 to 8.8 s (the Jinja site on the same class runs p50 ≈ 1 s).
- 20 to 50 `MaxListenersExceededWarning … [BrotliCompress]` warnings per day: streamed SSR chunks queuing up faster than the compressor can drain them, a direct CPU-starvation signal.
- Only 2 hard-memory-limit kills in 30 days, so memory is not the main story.

## How the test runs

Merge this. The push workflow deploys and promotes F2. The 7 days after are compared against the 14-day F1 baseline using the metrics and thresholds in #10608. When it deploys, drop the timestamp and version id in a comment on the issue.

If the result misses the revert threshold, revert this PR; that's the whole rollback.

## Deliberately not included

`NODE_OPTIONS=--max-old-space-size` and dropping origin-side `compression()` are both worth trying, but bundling them here would make the latency result unattributable. They are listed as follow-ups in #10608.

## Test plan

- [x] `pwa.yaml` parses; only `instance_class` changed
- [ ] 7 days post-merge vs. the 14-day baseline, per #10608

🤖 Generated with [Claude Code](https://claude.com/claude-code)