### PR TITLE
[ops] Parallelize and speed up unit tests with pytest-xdist

### DIFF
--- a/ops/test_py3.sh
+++ b/ops/test_py3.sh
@@ -51,7 +51,11 @@ run_inline_tests() {
         return 0
     fi
 
-    pytest "${test_targets[@]}" "${pytest_args[@]}"
+    if [[ ! " ${pytest_args[*]} " =~ " -n" ]]; then
+        pytest -n 0 "${test_targets[@]}" "${pytest_args[@]}"
+    else
+        pytest "${test_targets[@]}" "${pytest_args[@]}"
+    fi
 }
 
 if [ "${1:-}" == "--inline" ]; then
@@ -63,7 +67,7 @@ elif [ "${1:-}" == "--relevant" ]; then
 elif [ "$#" -ge 1 ]; then
     pytest "$@"
 else
-    if python -c "import pytest_cov" 2>/dev/null; then
+    if [ -n "${CI:-}" ] || [ "${COVERAGE:-}" = "1" ]; then
         pytest src --cov-report=xml --cov=src
     else
         pytest src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "pytest-custom_exit_code",
     "pytest-split",
     "pytest-testmon",
+    "pytest-xdist>=3.8.0",
     "requests-mock==1.12.1",
 ]
 ci = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ markers =
 # SyntaxWarning on Python 3.13+. The -W flag ensures these are treated as
 # warnings (not errors) during early conftest loading, before pytest's
 # filterwarnings take effect.
-addopts = -W default::SyntaxWarning
+addopts = -W default::SyntaxWarning -n auto
 filterwarnings =
     error
 

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -9,11 +9,30 @@ from google.appengine.api import datastore_types
 from google.appengine.ext import ndb, testbed
 
 from backend.common.context_cache import context_cache
+from backend.common.logging import logging_context
 from backend.common.models.cached_query_result import CachedQueryResult
+from backend.common.profiler import trace_context
+from backend.common.run_after_response import response_context
 from backend.common.storage.clients.cloudstorage.stub_dispatcher import (
     dispatch as dispatch_gcs_stub,
 )
 from backend.tests.json_data_importer import JsonDataImporter
+
+
+@pytest.fixture(autouse=True)
+def clear_request_contexts() -> Generator[None, None, None]:
+    _clear_request_contexts()
+    yield
+    _clear_request_contexts()
+
+
+def _clear_request_contexts() -> None:
+    if hasattr(logging_context, "request"):
+        del logging_context.request
+    if hasattr(trace_context, "request"):
+        del trace_context.request
+    if hasattr(response_context, "request"):
+        del response_context.request
 
 
 @pytest.fixture(autouse=True)
@@ -30,7 +49,7 @@ def drain_gae_rpc_thread_pool(
     # This thread pool can leave work dangling after the test session
     # is done, which can cause pytest to hang.
     # So we add this fixture to manually shut it down
-    thread_pool.shutdown()
+    thread_pool.shutdown(cancel_futures=True)
 
 
 @pytest.fixture(autouse=True)

--- a/src/backend/web/handlers/admin/tests/team_media_mod_test.py
+++ b/src/backend/web/handlers/admin/tests/team_media_mod_test.py
@@ -51,7 +51,7 @@ def test_add_team_media_mod_batched(
         "/admin/media/modcodes/add",
         data={
             "year": 2023,
-            "auth_codes_csv": "\n".join([f"{i},abc123" for i in range(1, 10000)]),
+            "auth_codes_csv": "\n".join([f"{i},abc123" for i in range(1, 251)]),
         },
     )
     assert resp.status_code == 302
@@ -62,7 +62,7 @@ def test_add_team_media_mod_batched(
             run_from_task(task)
 
     modcodes = TeamAdminAccess.query().fetch()
-    assert len(modcodes) == 9999
+    assert len(modcodes) == 250
 
 
 def test_edit_team_media_mod_doest_exist(login_gae_admin, web_client: Client) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -410,6 +410,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,12 +1351,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/cb/d7b78218a987eb8a8ce4eeae0286b1bb679333eb631ea0eeaf6371680bfc/orjson-3.12.0-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9a36ec60f1796f9a3f13e3b98390295e17a1c7c10155b448d264098bf9ee5900", size = 223397, upload-time = "2026-08-14T16:12:44.003Z" },
     { url = "https://files.pythonhosted.org/packages/f8/4a/bc87c45e7ec639d35ebefd62618e01939531ac8e171426606a01bda05914/orjson-3.12.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:ad0422b92d5195443a39f80c3bcf731cc2e00f153bd32063a47b73b057bd0f03", size = 123662, upload-time = "2026-08-14T16:12:45.433Z" },
     { url = "https://files.pythonhosted.org/packages/94/ee/c9a4ff3f2dbedbbe9e635d0fa72c8866adede09b6335ef9644f53752f0d8/orjson-3.12.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:5a0fdbc216388f653d3752ff310e710f59253bd4ed6a2bfb3f4f06b84714bbd8", size = 113374, upload-time = "2026-08-14T16:12:46.755Z" },
-    { url = "https://files.pythonhosted.org/packages/75/09/3f330a026a796c8b4c97a6f429652a5e912e7065039bf96ed25e42aa7b25/orjson-3.12.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2eb5c56e534127b2b8fa38d2363c8b1b8190367ee0d1d16c041517d880843b94", size = 130029, upload-time = "2026-08-14T16:12:48.060Z" },
+    { url = "https://files.pythonhosted.org/packages/75/09/3f330a026a796c8b4c97a6f429652a5e912e7065039bf96ed25e42aa7b25/orjson-3.12.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2eb5c56e534127b2b8fa38d2363c8b1b8190367ee0d1d16c041517d880843b94", size = 130029, upload-time = "2026-08-14T16:12:48.06Z" },
     { url = "https://files.pythonhosted.org/packages/7d/40/094cc53126a3d22f76cdf83b6ea67338bed01d774037621a785aa8e6e5ea/orjson-3.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:784106539f4b9d4b930e0b4eb8d45168507dae001945e71b4675a367f1e5e806", size = 130528, upload-time = "2026-08-14T16:12:49.362Z" },
     { url = "https://files.pythonhosted.org/packages/bc/74/89bb236deb9565f99434b13052bb40ddfcce4adf3afbfa3132ee7e421468/orjson-3.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c680706fc8396d95e7c4c1f9482563f552137aef91b57237a3ad5aaf64629df", size = 131075, upload-time = "2026-08-14T16:12:50.692Z" },
     { url = "https://files.pythonhosted.org/packages/0c/ac/1176360d762c01b5bd34acd56fc098e936c491363d8b6b397ad4aa475547/orjson-3.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:83445adc40cba26d6d621185a45128ce455b766af368cad2ab64b970603a7978", size = 135321, upload-time = "2026-08-14T16:12:52.114Z" },
     { url = "https://files.pythonhosted.org/packages/7a/02/bbd881c8b9276d50b998de38b4e97de8ace1aac940b0ee545aedbf65ed00/orjson-3.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:644d005bc82f917337a95ce270c9f6f92f9834c2bed7b1477572f8db00784222", size = 127472, upload-time = "2026-08-14T16:12:53.517Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/02/a0934d7503e6dcbedd6afac3e7f3f8597fd09389949ad94d0f7540e9dbca/orjson-3.12.0-cp313-cp313-win32.whl", hash = "sha256:d8e78d3d93705e3d27cc17cdb209e44d7a8ea203010cac6ce9c7ffc1ae1996f1", size = 128000, upload-time = "2026-08-14T16:12:55.140Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/02/a0934d7503e6dcbedd6afac3e7f3f8597fd09389949ad94d0f7540e9dbca/orjson-3.12.0-cp313-cp313-win32.whl", hash = "sha256:d8e78d3d93705e3d27cc17cdb209e44d7a8ea203010cac6ce9c7ffc1ae1996f1", size = 128000, upload-time = "2026-08-14T16:12:55.14Z" },
     { url = "https://files.pythonhosted.org/packages/52/87/69f98f8d40faff103a965a5fbb83f08241b01beaf92badb5413fbc9358cc/orjson-3.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b85931be5b6763c31283805c9bdaae1ca03ad9f6f12a15f1cbf6745b907932c2", size = 121841, upload-time = "2026-08-14T16:12:56.507Z" },
     { url = "https://files.pythonhosted.org/packages/e6/07/b83046a4e3cadcc0987d0f160696107c4af706a619b56e4ad01940cadadf/orjson-3.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:6a31348d7dfa64cd9c78bd1f510ff44c48fe64d71094e6b90e364dba3b55949e", size = 126765, upload-time = "2026-08-14T16:12:57.806Z" },
     { url = "https://files.pythonhosted.org/packages/12/9d/3931253e6f3148abf2cbe14830367042a4806b362ea520df2303db188fb9/orjson-3.12.0-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9e6fee342a48760e854d743e7a81534d8e2925a6f46e09f750cf56b50fd1de5d", size = 223391, upload-time = "2026-08-14T16:12:59.184Z" },
@@ -1355,9 +1364,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/f3/6782c6fa85e2702bc66be183c3b421486167dcf266ee4dc1403fe3824870/orjson-3.12.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:2bb3ce43203936072dd8b4917b01d3aecfc02329bfb42510cb7cfb24708adc9c", size = 113337, upload-time = "2026-08-14T16:13:02.009Z" },
     { url = "https://files.pythonhosted.org/packages/bf/79/b32ab64bacda9d0fa4942ef483bd03cabf0eaf2be819ca9fb7ff610c559d/orjson-3.12.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:6a2a79c89984dc719817d388c8709e0efc2a2795a934eaa746b4882eb6045adc", size = 130112, upload-time = "2026-08-14T16:13:03.404Z" },
     { url = "https://files.pythonhosted.org/packages/ee/49/6e6142999ca01509219be5e5a9c338a3e5ea011f63e91ff473fbbf3734ed/orjson-3.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f06dd838d1e07d9b1de0932ec0485ec92c4d5f5d1ad4817a656268c3e88be1e1", size = 130520, upload-time = "2026-08-14T16:13:04.798Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d0/3745af0a4cc9867784f29722929cec4d10bd1c877cd754b01ba6d96eb21a/orjson-3.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6b11be792c3d2c6a4be2af4ebf97a68d0bf5f580aca6e86a418a354f6cc846a", size = 131053, upload-time = "2026-08-14T16:13:06.140Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d0/3745af0a4cc9867784f29722929cec4d10bd1c877cd754b01ba6d96eb21a/orjson-3.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6b11be792c3d2c6a4be2af4ebf97a68d0bf5f580aca6e86a418a354f6cc846a", size = 131053, upload-time = "2026-08-14T16:13:06.14Z" },
     { url = "https://files.pythonhosted.org/packages/c3/f4/6fe5a22fa478fffb190e65c338c84df5c311ef597b363150a17cc57063c0/orjson-3.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:477ecaf6b9f88f873341b91fcc736119ca81b5e002a9f7f308ff5b4f2ce2a70e", size = 135321, upload-time = "2026-08-14T16:13:07.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/41/b1b0ec30289646a81a76e2dbaae2686b96fcccb7cb0323dc1dd78cbc7875/orjson-3.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f3c0683136acdc29afdf88a5bc2f7d3d0e34087788d1d63c0144b805a87a196f", size = 127485, upload-time = "2026-08-14T16:13:08.880Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/b1b0ec30289646a81a76e2dbaae2686b96fcccb7cb0323dc1dd78cbc7875/orjson-3.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f3c0683136acdc29afdf88a5bc2f7d3d0e34087788d1d63c0144b805a87a196f", size = 127485, upload-time = "2026-08-14T16:13:08.88Z" },
     { url = "https://files.pythonhosted.org/packages/bf/2b/277404bdcc21c93b112b963655b76443ebfe828f8a3ff1de7d90f8850eb3/orjson-3.12.0-cp314-cp314-win32.whl", hash = "sha256:d39f3f5c3927e2dc0913fe5bbc1a2f6b1b9d1bba1de6358340d0ad0d0c00ca92", size = 128048, upload-time = "2026-08-14T16:13:10.305Z" },
     { url = "https://files.pythonhosted.org/packages/41/2b/395b36fa2b4ce7af70b651d715e88f80d884b2c2b14a6b53e84d554fb5f0/orjson-3.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:0b1ac5bf6609b2716c7954011c5fef6254922df029f45d032ee4ebf5d363cbed", size = 121858, upload-time = "2026-08-14T16:13:11.634Z" },
     { url = "https://files.pythonhosted.org/packages/ea/a3/833e895ff452859eebe75093d26691fe9108f1a7a6a08435d7a5780ea652/orjson-3.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:50fae885cb073eac7556353ff3df93312b0d5137b0a5056b2bb63f97ed9a93c7", size = 126749, upload-time = "2026-08-14T16:13:13.117Z" },
@@ -1817,6 +1826,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2058,6 +2080,7 @@ ci = [
     { name = "pytest-custom-exit-code" },
     { name = "pytest-split" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist" },
     { name = "requests-mock" },
 ]
 dev = [
@@ -2072,6 +2095,7 @@ dev = [
     { name = "pytest-custom-exit-code" },
     { name = "pytest-split" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "watchdog" },
 ]
@@ -2087,6 +2111,7 @@ test = [
     { name = "pytest-custom-exit-code" },
     { name = "pytest-split" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist" },
     { name = "requests-mock" },
 ]
 typecheck = [
@@ -2136,6 +2161,7 @@ ci = [
     { name = "pytest-custom-exit-code" },
     { name = "pytest-split" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "requests-mock", specifier = "==1.12.1" },
 ]
 dev = [
@@ -2150,6 +2176,7 @@ dev = [
     { name = "pytest-custom-exit-code" },
     { name = "pytest-split" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "requests-mock", specifier = "==1.12.1" },
     { name = "watchdog", specifier = "==6.0.0" },
 ]
@@ -2165,6 +2192,7 @@ test = [
     { name = "pytest-custom-exit-code" },
     { name = "pytest-split" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "requests-mock", specifier = "==1.12.1" },
 ]
 typecheck = [


### PR DESCRIPTION
## Description
This PR parallelizes unit tests across CPU cores using `pytest-xdist` and eliminates test execution bottlenecks, reducing full `make test` run time from **~5m 16s down to ~1m 16s (~4.2x speedup)**.

### Key Changes
1. **Parallel Execution via `pytest-xdist`**:
   - Added `pytest-xdist>=3.8.0` to pyproject.toml test dependencies.
   - Configured `pytest.ini` with `-n auto` so pytest automatically distributes tests across available CPU cores.

2. **Test State Isolation**:
   - Added an autouse fixture `clear_request_contexts` in `src/backend/conftest.py` to clear request-local state (`logging_context`, `trace_context`, and `response_context`) before and after each test, preventing cross-test pollution across worker processes.
   - Added `cancel_futures=True` to `thread_pool.shutdown()` in `drain_gae_rpc_thread_pool` to avoid dangling RPC futures blocking worker teardown.

3. **Test Runner Optimizations (`ops/test_py3.sh`)**:
   - Configured `run_inline_tests` to default to `-n 0` when testing staged files, avoiding multi-worker spin-up overhead during pre-commit hooks.
   - Made coverage tracing opt-in for local `make test` runs unless `$CI` is present or `COVERAGE=1` is specified, removing the ~2x line tracing overhead during local development.

4. **Bottleneck Test Optimization**:
   - In `src/backend/web/handlers/admin/tests/team_media_mod_test.py`, reduced the test sample in `test_add_team_media_mod_batched` from 10,000 to 250 items. Since batching is performed in chunks of 100, 250 items exercises multi-batch queue execution identically while reducing test duration from **26.41s to 1.08s**.

---

### Benchmarks

| Metric | Before | After | Speedup |
| :--- | :--- | :--- | :--- |
| **All Unit Tests (`make test`)** | 316.42s (5m 16s) | **75.62s (1m 16s)** | **~4.2x faster** |
| **User CPU Work** | ~20m+ | **10m 24s** | **~2x less CPU** |

- **Unit tests**: 5,057 passed, 38 skipped, 0 failed
- **Lint**: `make lint` passed
- **Type check**: `make typecheck` passed