### PR TITLE
[common] Fix run_after_response lifecycle, decorator support, and NDB toplevel drainage

### DIFF
--- a/src/backend/common/middleware.py
+++ b/src/backend/common/middleware.py
@@ -71,12 +71,26 @@ class AfterResponseMiddleware:
     @ndb.toplevel
     def __call__(self, environ: Any, start_response: Any):
         response_context.request = Request(environ)
-        return ClosingIterator(self.app(environ, start_response), self._run_after)
+        try:
+            app_iter = self.app(environ, start_response)
+        except Exception:
+            self._cleanup()
+            send_traces()
+            raise
+        return ClosingIterator(app_iter, self._run_after)
 
-    def _run_after(self):
-        with Span("Running AfterResponseMiddleware"):
-            execute_callbacks()
-        send_traces()
+    @ndb.toplevel
+    def _run_after(self) -> None:
+        try:
+            with Span("Running AfterResponseMiddleware"):
+                execute_callbacks()
+            send_traces()
+        finally:
+            self._cleanup()
+
+    def _cleanup(self) -> None:
+        if hasattr(response_context, "request"):
+            del response_context.request
 
 
 def install_middleware(

--- a/src/backend/common/run_after_response.py
+++ b/src/backend/common/run_after_response.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable
+from typing import Any, Callable, TypeVar
 
 from werkzeug.local import Local
 
@@ -9,11 +9,14 @@ from backend.common.profiler import Span
 response_context = Local()
 
 
-def run_after_response(callback: Callable[[], None]) -> None:
+TCallback = TypeVar("TCallback", bound=Callable[..., Any])
+
+
+def run_after_response(callback: TCallback) -> TCallback:
     """
     Enqueues a callback to be run after the request response.
     Usage examples:
-    1) As a lambda (Note that this will not log the function name because it is a lambda)
+    1) As a lambda
     run_after_response(lambda: ...)
 
     2) As a named function
@@ -25,11 +28,15 @@ def run_after_response(callback: Callable[[], None]) -> None:
         ...
     """
     if not hasattr(response_context, "request"):
-        return
+        logging.debug(
+            "run_after_response called outside active request context; dropping callback."
+        )
+        return callback
 
     if not hasattr(response_context.request, "after_response_callbacks"):
         response_context.request.after_response_callbacks = []
     response_context.request.after_response_callbacks.append(callback)
+    return callback
 
 
 def execute_callbacks() -> None:
@@ -37,12 +44,14 @@ def execute_callbacks() -> None:
         return
 
     callbacks = getattr(response_context.request, "after_response_callbacks", [])
+    response_context.request.after_response_callbacks = []
 
     for callback in callbacks:
-        with Span(
-            f"execute_callback:{callback.__name__ if hasattr(callback, "__name__") else None}"
-        ):
-            try:
+        name = getattr(callback, "__name__", None) or getattr(
+            getattr(callback, "func", None), "__name__", None
+        )
+        try:
+            with Span(f"execute_callback:{name}"):
                 callback()
-            except Exception as e:
-                logging.info(f"Callback failed: {e}")
+        except Exception:
+            logging.warning(f"Callback {name} failed after response", exc_info=True)

--- a/src/backend/common/tests/middleware_test.py
+++ b/src/backend/common/tests/middleware_test.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 from unittest.mock import Mock, patch
 from wsgiref.types import WSGIApplication
 
@@ -19,7 +19,7 @@ from backend.common.middleware import (
     TraceRequestMiddleware,
 )
 from backend.common.profiler import trace_context
-from backend.common.run_after_response import run_after_response
+from backend.common.run_after_response import response_context, run_after_response
 
 
 def test_AppspotRedirectMiddleware_init(app: Flask) -> None:
@@ -204,6 +204,95 @@ def test_AfterResponseMiddleware_callable(app: Flask) -> None:
     run_wsgi_app(middleware, environ, buffered=True)
     callback1.assert_called_once()
     callback2.assert_called_once()
+    assert not hasattr(response_context, "request")
+
+
+def test_AfterResponseMiddleware_exception_in_app() -> None:
+    failing_app = Mock(side_effect=RuntimeError("WSGI error"))
+    middleware_app = cast(WSGIApplication, AfterResponseMiddleware(failing_app))
+
+    environ = create_environ(path="/error", base_url="http://localhost")
+    with patch("backend.common.middleware.send_traces") as mock_send_traces:
+        with pytest.raises(RuntimeError, match="WSGI error"):
+            run_wsgi_app(middleware_app, environ, buffered=True)
+
+        mock_send_traces.assert_called_once()
+        assert not hasattr(response_context, "request")
+
+
+def test_AfterResponseMiddleware_cleans_up_on_flask_500(app: Flask) -> None:
+    middleware_app = cast(WSGIApplication, AfterResponseMiddleware(app))
+
+    @app.route("/flask_error")
+    def test_handler_error():
+        raise RuntimeError("Flask view crashed")
+
+    environ = create_environ(path="/flask_error", base_url="http://localhost")
+    _, status, _ = run_wsgi_app(middleware_app, environ, buffered=True)
+
+    assert status == "500 INTERNAL SERVER ERROR"
+    assert not hasattr(response_context, "request")
+
+
+def test_AfterResponseMiddleware_toplevel_awaits_async(app: Flask, ndb_stub) -> None:
+    from google.appengine.ext import ndb
+
+    middleware_app = cast(WSGIApplication, AfterResponseMiddleware(app))
+    tasklet_finished = False
+
+    @ndb.tasklet
+    def async_work():
+        nonlocal tasklet_finished
+        tasklet_finished = True
+
+    def callback():
+        async_work()
+
+    @app.route("/async")
+    def test_handler_async():
+        run_after_response(callback)
+        return "OK"
+
+    environ = create_environ(path="/async", base_url="http://localhost")
+    run_wsgi_app(middleware_app, environ, buffered=True)
+
+    assert tasklet_finished is True
+    assert not hasattr(response_context, "request")
+
+
+def test_AfterResponseMiddleware_ndb_context_access(app: Flask, ndb_stub) -> None:
+    from google.appengine.ext import ndb
+
+    middleware_app = cast(WSGIApplication, AfterResponseMiddleware(app))
+    contexts: dict[str, Any] = {}
+
+    class TestModel(ndb.Model):
+        val = ndb.StringProperty()
+
+    @app.route("/ndb_test")
+    def test_handler():
+        contexts["handler"] = ndb.get_context()
+        TestModel(id="test_key", val="initial").put()
+
+        @run_after_response
+        def callback():
+            contexts["callback"] = ndb.get_context()
+            entity = TestModel.get_by_id("test_key")
+            contexts["read_val"] = entity.val if entity else None
+            TestModel(id="test_key2", val="after_response").put()
+
+        return "OK"
+
+    environ = create_environ(path="/ndb_test", base_url="http://localhost")
+    run_wsgi_app(middleware_app, environ, buffered=True)
+
+    assert contexts["callback"] is not None
+    assert contexts["handler"] is not None
+    assert contexts["callback"] is not contexts["handler"]
+    assert contexts["read_val"] == "initial"
+    saved_entity = TestModel.get_by_id("test_key2")
+    assert saved_entity is not None
+    assert saved_entity.val == "after_response"
 
 
 @patch.object(middleware, "_set_secret_key")

--- a/src/backend/common/tests/run_after_response_test.py
+++ b/src/backend/common/tests/run_after_response_test.py
@@ -1,0 +1,109 @@
+import functools
+import logging
+from unittest.mock import Mock
+
+import pytest
+from werkzeug.test import create_environ
+from werkzeug.wrappers import Request
+
+from backend.common.run_after_response import (
+    execute_callbacks,
+    response_context,
+    run_after_response,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_response_context():
+    if hasattr(response_context, "request"):
+        del response_context.request
+    yield
+    if hasattr(response_context, "request"):
+        del response_context.request
+
+
+def test_run_after_response_outside_request_logs_debug_and_returns_callback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    callback = Mock()
+    with caplog.at_level(logging.DEBUG):
+        result = run_after_response(callback)
+
+    assert result is callback
+    assert "dropping callback" in caplog.text
+
+
+def test_run_after_response_as_decorator() -> None:
+    response_context.request = Request(create_environ(path="/"))
+
+    @run_after_response
+    def my_callback() -> str:
+        return "called"
+
+    # Decorator returns the original function so it remains callable
+    assert callable(my_callback)
+    assert my_callback() == "called"
+
+    # It was also enqueued in after_response_callbacks
+    callbacks = getattr(response_context.request, "after_response_callbacks", [])
+    assert len(callbacks) == 1
+    assert callbacks[0] is my_callback
+
+
+def test_execute_callbacks_clears_list() -> None:
+    response_context.request = Request(create_environ(path="/"))
+    callback = Mock()
+    run_after_response(callback)
+
+    execute_callbacks()
+    callback.assert_called_once()
+
+    # Callbacks list is cleared
+    assert getattr(response_context.request, "after_response_callbacks") == []
+
+    # Second execution does not call the callback again
+    execute_callbacks()
+    callback.assert_called_once()
+
+
+def test_execute_callbacks_handles_exceptions_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    response_context.request = Request(create_environ(path="/"))
+    failing_callback = Mock(side_effect=RuntimeError("something went wrong"))
+    failing_callback.__name__ = "failing_callback"
+
+    successful_callback = Mock()
+    successful_callback.__name__ = "successful_callback"
+
+    run_after_response(failing_callback)
+    run_after_response(successful_callback)
+
+    with caplog.at_level(logging.WARNING):
+        execute_callbacks()
+
+    failing_callback.assert_called_once()
+    successful_callback.assert_called_once()
+    assert "Callback failing_callback failed after response" in caplog.text
+
+
+def test_execute_callbacks_with_partial() -> None:
+    response_context.request = Request(create_environ(path="/"))
+
+    def target_func(arg: str) -> None:
+        pass
+
+    mock_func = Mock(side_effect=target_func)
+    mock_func.__name__ = "target_func"
+
+    partial_callback = functools.partial(mock_func, "value")
+    run_after_response(partial_callback)
+
+    execute_callbacks()
+    mock_func.assert_called_once_with("value")
+
+
+def test_execute_callbacks_without_request() -> None:
+    # Should safely return without error when no request is set
+    assert not hasattr(response_context, "request")
+    execute_callbacks()


### PR DESCRIPTION
### Summary
This PR addresses several correctness, lifecycle, and observability issues identified in `run_after_response` and `AfterResponseMiddleware`:

1. **Decorator Support**:
   - Updates `run_after_response` to return the original callback (`TCallback`) rather than `None`, allowing `@run_after_response` decorator usage without clearing the function definition.
   - Logs a debug message and gracefully returns the callback when invoked outside an active request context.

2. **Context Lifecycle & State Leak Prevention**:
   - Adds `_cleanup()` to `AfterResponseMiddleware` to explicitly delete `response_context.request` inside a `finally` block in `_run_after()`, preventing request objects and callbacks from leaking across persistent worker threads.
   - Catches unhandled synchronous WSGI exceptions in `AfterResponseMiddleware.__call__` to clean up context and flush telemetry traces (`send_traces()`) before re-raising.

3. **NDB Context & Async Tasklet Drainage**:
   - Decorates `AfterResponseMiddleware._run_after` with `@ndb.toplevel` so post-response callbacks run inside a scoped NDB context, and any asynchronous tasklets, queries, or URL fetches initiated inside callbacks are properly awaited before the request thread concludes.

4. **Observability & Error Isolation**:
   - Resets the callback list in `execute_callbacks()` to ensure idempotence.
   - Wraps the profiler `Span` inside a `try...except` block so span enter/exit errors do not abort subsequent callbacks.
   - Resolves underlying function names across `functools.partial` wrappers.
   - Logs callback failures at `logging.warning(..., exc_info=True)` to preserve full stack traces in Cloud Logging.

### Testing
- Added unit tests in `src/backend/common/tests/run_after_response_test.py` covering decorator usage, context fallback, queue reset/idempotence, exception handling, and partial support.
- Added test cases in `src/backend/common/tests/middleware_test.py` covering context cleanup, crash handling, Flask 500 responses, NDB context access/freshness, and `@ndb.toplevel` async drainage.
- All 39 related tests in `middleware_test.py`, `run_after_response_test.py`, `google_analytics_test.py`, and `profiler_test.py` pass.
- Verified with `make lint` and `make typecheck` (0 Pyre errors).