### PR TITLE
[common] Fix cascading query span nesting with tasklet context propagation

### DIFF
--- a/src/backend/common/profiler.py
+++ b/src/backend/common/profiler.py
@@ -2,25 +2,31 @@
 
 import logging
 import random
+from contextvars import ContextVar, Token
 from datetime import datetime
-from typing import Optional
+from typing import Any, cast, Dict, Optional
 
 from werkzeug.local import Local
 
 from backend.common.environment import Environment
+from backend.common.tasklets import enable_tasklet_context_propagation
+
+enable_tasklet_context_propagation()
 
 # create a request-local global context
 trace_context = Local()
+_active_span_var: ContextVar[Optional["Span"]] = ContextVar(
+    "active_span", default=cast(Optional["Span"], None)
+)
 
 PROJECT_ID = Environment.project()
 
 
-def send_traces():
+def send_traces() -> None:
     try:
-        if (
-            not hasattr(trace_context.request, "spans")
-            or len(trace_context.request.spans) == 0
-        ):
+        request = getattr(trace_context, "request", None)
+        spans = getattr(request, "spans", None)
+        if not spans:
             return
 
         _make_tracing_call(
@@ -28,8 +34,8 @@ def send_traces():
                 "traces": [
                     {
                         "projectId": PROJECT_ID,
-                        "traceId": trace_context.request.trace_id,
-                        "spans": trace_context.request.spans,
+                        "traceId": request.trace_id,
+                        "spans": spans,
                     }
                 ]
             }
@@ -39,7 +45,7 @@ def send_traces():
         logging.exception(e)
 
 
-def _make_tracing_call(body):
+def _make_tracing_call(body: Dict[str, Any]) -> None:
     if PROJECT_ID is None:
         return
 
@@ -63,29 +69,21 @@ def _make_tracing_call(body):
     request.execute()
 
 
-class Span(object):
-    @staticmethod
-    def _get_span_stack() -> list["Span"]:
-        if hasattr(trace_context, "request") and trace_context.request:
-            if not hasattr(trace_context.request, "span_stack"):
-                trace_context.request.span_stack = []
-            return trace_context.request.span_stack
-        else:
-            if not hasattr(trace_context, "span_stack"):
-                trace_context.span_stack = []
-            return trace_context.span_stack
-
-    def __init__(self, name: str):
+class Span:
+    def __init__(self, name: str) -> None:
         """
         Start a Span
         Spans are saved in trace_context.request.spans on exit
         Spans are sent by send_traces() which is called when the request context ends
         """
         self._name = name
-        self._labels = {}  # Cloud Trace spans support labels
+        self._labels: Dict[str, str] = {}  # Cloud Trace spans support labels
         self._span_id = str(random.getrandbits(64))
         self._root_span_id: Optional[str] = None
         self._parent_span_id: Optional[str] = None
+        self._token: Optional[Token[Optional["Span"]]] = None
+        self._startTime: Optional[datetime] = None
+        self._endTime: Optional[datetime] = None
 
         if hasattr(trace_context, "request") and trace_context.request:
             tcontext = trace_context.request.headers.get(
@@ -99,14 +97,12 @@ class Span(object):
             trace_id, root_span_id = tcontext.split(";")[0].split("/")
             trace_context.request.trace_id = trace_id
             self._root_span_id = root_span_id
-            self._parent_span_id = root_span_id
 
         else:
             self._do_trace = False
 
-        stack = self._get_span_stack()
-        if stack:
-            self._parent_span_id = stack[-1]._span_id
+        parent = _active_span_var.get()
+        self._parent_span_id = parent._span_id if parent else self._root_span_id
 
     @property
     def span_id(self) -> str:
@@ -127,32 +123,32 @@ class Span(object):
         """
         self._labels[key] = str(value)
 
-    def __enter__(self):
+    def __enter__(self) -> "Span":
         if self._do_trace:
             logging.debug("CREATED SPAN: {}".format(self._name))
-        stack = self._get_span_stack()
-        if stack:
-            self._parent_span_id = stack[-1]._span_id
-        else:
-            self._parent_span_id = self._root_span_id
-        stack.append(self)
+        parent = _active_span_var.get()
+        self._parent_span_id = parent._span_id if parent else self._root_span_id
+        self._token = _active_span_var.set(self)
         self._startTime = datetime.now()
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         self._endTime = datetime.now()
-        stack = self._get_span_stack()
-        if stack and stack[-1] is self:
-            stack.pop()
-        elif self in stack:
-            stack.remove(self)
+        if self._token is not None:
+            try:
+                _active_span_var.reset(self._token)
+            except ValueError:
+                pass
+            self._token = None
 
-        if self._do_trace:
-            if not hasattr(trace_context.request, "spans"):
-                trace_context.request.spans = []
-            trace_context.request.spans.append(self.dict())
+        if self._do_trace and exc_type is not GeneratorExit:
+            request = getattr(trace_context, "request", None)
+            if request is not None:
+                if not hasattr(request, "spans"):
+                    request.spans = []
+                request.spans.append(self.dict())
 
-    def dict(self):
+    def dict(self) -> Dict[str, Any]:
         """Format as a dictionary of the correct shape for sending to the Cloud
         Trace REST API as a JSON object"""
         span_dict = {
@@ -160,8 +156,8 @@ class Span(object):
             "name": self._name,
             "parentSpanId": self._parent_span_id,
             "spanId": self._span_id,
-            "startTime": self._startTime.isoformat() + "Z",
-            "endTime": self._endTime.isoformat() + "Z",
+            "startTime": (self._startTime.isoformat() + "Z") if self._startTime else "",
+            "endTime": (self._endTime.isoformat() + "Z") if self._endTime else "",
         }
 
         # Add labels if any were set

--- a/src/backend/common/tasklets.py
+++ b/src/backend/common/tasklets.py
@@ -1,11 +1,53 @@
+import contextvars
 from typing import Any, Callable, cast, Generator, Iterable, ParamSpec, TypeVar, Union
 
 from google.appengine.ext import ndb
+from google.appengine.ext.ndb import tasklets as ndb_tasklets
 
 from backend.common.futures import TypedFuture
 
 TParams = ParamSpec("TParams")
 TReturn = TypeVar("TReturn")
+
+_tasklet_context_propagation_enabled: bool = False
+
+
+def enable_tasklet_context_propagation() -> None:
+    """
+    Patches NDB Future to propagate Python 3 contextvars across tasklet yields.
+
+    By default, NDB saves and restores Datastore contexts (ndb.Context), namespaces,
+    and connections across tasklet yields, but does not propagate Python 3 contextvars.
+    This hook captures the caller's context when a Future is created and runs tasklet
+    execution steps inside that context, mirroring modern asyncio.Task behavior.
+    """
+    global _tasklet_context_propagation_enabled
+    if _tasklet_context_propagation_enabled:
+        return
+    _tasklet_context_propagation_enabled = True
+
+    future_cls: Any = ndb_tasklets.Future
+    orig_init = future_cls.__init__
+    orig_help = getattr(future_cls, "_help_tasklet_along", None)
+    if orig_help is None:
+        return
+
+    def new_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        orig_init(self, *args, **kwargs)
+        self._py_context = contextvars.copy_context()
+
+    def new_help(self: Any, *args: Any, **kwargs: Any) -> Any:
+        ctx = getattr(self, "_py_context", None)
+        if ctx is not None:
+            return ctx.run(orig_help, self, *args, **kwargs)
+        return orig_help(self, *args, **kwargs)
+
+    future_cls.__init__ = new_init
+    future_cls._help_tasklet_along = new_help
+
+
+# Automatically enable tasklet context propagation on module import
+enable_tasklet_context_propagation()
 
 
 def typed_tasklet(

--- a/src/backend/common/tests/profiler_test.py
+++ b/src/backend/common/tests/profiler_test.py
@@ -1,6 +1,9 @@
+import contextvars
+import gc
 from unittest.mock import patch
 
 from flask import Flask
+from google.appengine.ext import ndb
 
 from backend.common.middleware import install_middleware
 from backend.common.profiler import send_traces, Span, trace_context
@@ -218,3 +221,159 @@ def test_standalone_span_hierarchy() -> None:
     assert grandchild_dict["parentSpanId"] == child.span_id
     assert child_dict["parentSpanId"] == parent.span_id
     assert parent_dict["parentSpanId"] is None
+
+
+@patch("backend.common.profiler._make_tracing_call")
+def test_concurrent_tasklet_spans_are_siblings(mock_send_traces) -> None:
+    app = setup_app()
+
+    @ndb.tasklet
+    def async_query(name: str):
+        with Span(f"{name}.fetch_async"):
+            yield ndb.sleep(0.01)
+
+    @app.route("/")
+    def route():
+        f1 = async_query("Query1")
+        f2 = async_query("Query2")
+        f3 = async_query("Query3")
+        ndb.Future.wait_all([f1, f2, f3])
+
+        spans = trace_context.request.spans
+        assert len(spans) == 3
+
+        q1_span = next(s for s in spans if s["name"] == "Query1.fetch_async")
+        q2_span = next(s for s in spans if s["name"] == "Query2.fetch_async")
+        q3_span = next(s for s in spans if s["name"] == "Query3.fetch_async")
+
+        assert q1_span["parentSpanId"] == "SPAN_ID"
+        assert q2_span["parentSpanId"] == "SPAN_ID"
+        assert q3_span["parentSpanId"] == "SPAN_ID"
+        return "Hi!"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+
+
+@patch("backend.common.profiler._make_tracing_call")
+def test_tasklet_child_spans_are_nested(mock_send_traces) -> None:
+    app = setup_app()
+
+    @ndb.tasklet
+    def do_query(name: str):
+        with Span(f"{name}._do_query"):
+            yield ndb.sleep(0.01)
+
+    @ndb.tasklet
+    def fetch_async(name: str):
+        with Span(f"{name}.fetch_async"):
+            yield do_query(name)
+
+    @app.route("/")
+    def route():
+        f1 = fetch_async("Query1")
+        f2 = fetch_async("Query2")
+        ndb.Future.wait_all([f1, f2])
+
+        spans = trace_context.request.spans
+        assert len(spans) == 4
+
+        q1_fetch = next(s for s in spans if s["name"] == "Query1.fetch_async")
+        q1_do = next(s for s in spans if s["name"] == "Query1._do_query")
+        q2_fetch = next(s for s in spans if s["name"] == "Query2.fetch_async")
+        q2_do = next(s for s in spans if s["name"] == "Query2._do_query")
+
+        # Top-level query spans are siblings under root span
+        assert q1_fetch["parentSpanId"] == "SPAN_ID"
+        assert q2_fetch["parentSpanId"] == "SPAN_ID"
+
+        # Inner _do_query spans are nested under their respective fetch_async spans
+        assert q1_do["parentSpanId"] == q1_fetch["spanId"]
+        assert q2_do["parentSpanId"] == q2_fetch["spanId"]
+        return "Hi!"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+
+
+@patch("backend.common.profiler._make_tracing_call")
+def test_tasklet_exception_unwinds_span(mock_send_traces) -> None:
+    app = setup_app()
+
+    @ndb.tasklet
+    def failing_tasklet():
+        with Span("failing_async"):
+            yield ndb.sleep(0.01)
+            raise ValueError("Tasklet error")
+
+    @app.route("/")
+    def route():
+        try:
+            failing_tasklet().get_result()
+        except ValueError:
+            pass
+
+        with Span("after_exception"):
+            pass
+
+        spans = trace_context.request.spans
+        assert len(spans) == 2
+
+        failing_span = next(s for s in spans if s["name"] == "failing_async")
+        after_span = next(s for s in spans if s["name"] == "after_exception")
+
+        assert failing_span["parentSpanId"] == "SPAN_ID"
+        assert after_span["parentSpanId"] == "SPAN_ID"
+        return "Hi!"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+
+
+def test_span_generator_exit_handling() -> None:
+    app = setup_app()
+
+    def sample_generator():
+        with Span("gen_span"):
+            yield 1
+            yield 2
+
+    @app.route("/")
+    def route():
+        gen = sample_generator()
+        assert next(gen) == 1
+        gen.close()
+        spans = getattr(trace_context.request, "spans", [])
+        assert len(spans) == 0
+        return "Hi!"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+
+def test_span_generator_gc_cross_context() -> None:
+    def sample_generator():
+        with Span("gen_span"):
+            yield 1
+
+    ctx = contextvars.copy_context()
+    gen = ctx.run(sample_generator)
+    assert next(gen) == 1
+    del gen
+    gc.collect()
+
+
+def test_span_exit_without_request() -> None:
+    trace_context.request = None
+    with Span("no_request_span"):
+        pass


### PR DESCRIPTION
## Overview
Asynchronous queries (`@ndb.tasklet`) yielding execution inside `with Span(...)` left their spans active at the top of a shared request-global span stack. Subsequent concurrent queries running on the same thread saw that active span and adopted it as their parent, producing an unintended cascading staircase hierarchy in Cloud Trace rather than appearing as concurrent siblings.

## Changes
- **ContextVar Span Stacking**: Replaced the mutable `trace_context.request.span_stack` list with a Python 3 `ContextVar[Optional[Span]]` in `backend.common.profiler`.
- **Tasklet Context Propagation**: In `backend.common.tasklets`, added `enable_tasklet_context_propagation()` to capture `contextvars.copy_context()` on `Future.__init__` and execute generator resumes via `ctx.run()` in `Future._help_tasklet_along` (mirroring modern `asyncio.Task` context isolation).
- **Lifecycle & Generator Hardening**:
  - Handled cross-context generator cleanup by catching `ValueError` during `_active_span_var.reset(token)` in GC runs.
  - Excluded aborted/cancelled generator spans on `GeneratorExit`.
  - Safely guarded `trace_context.request` lookups during span exit.
- **Unit Tests**: Added tests in `backend/common/tests/profiler_test.py` covering concurrent sibling tasklet spans, nested child spans, exception unwinding, and generator GC/exit lifecycles.

## Verification
- `pytest src/backend/common/tests/profiler_test.py` (14 passed)
- `pytest src/backend/common/tests/` (106 passed)
- `make lint` & `make typecheck` passed cleanly