### PR TITLE
Remove the apple-app-site-association file

### DIFF
--- a/src/backend/web/static/well-known/apple-app-site-association
+++ b/src/backend/web/static/well-known/apple-app-site-association
@@ -1,5 +1,0 @@
-{
-  "activitycontinuation": {
-    "apps": ["LKZ8X6P249.com.the-blue-alliance.tba"]
-  }
-}


### PR DESCRIPTION
## Summary

- Deletes `src/backend/web/static/well-known/apple-app-site-association`. It only ever declared `activitycontinuation` (Handoff) for the iOS app.
- The iOS app no longer carries an associated-domains entitlement. Its universal-link/Handoff handler was removed along with Core Data in the-blue-alliance-ios#978, and the orphaned entitlement itself was removed in the Swift 6 cleanup. Nothing fetches this file for the current app.
- Installs of older iOS versions that still carry the entitlement will get a 404 from `/.well-known/apple-app-site-association`, which iOS treats as "no associations." That's the same no-op those users had: Handoff offered the app, and the app ignored the activity.
- `assetlinks.json` (Android) is untouched. No handler or test references the file; it's served by the `static_dir` rule in `src/web.yaml`.

## Test plan

- [x] `git grep` for the filename and for `activitycontinuation` across `src/` finds nothing else.
- [ ] After deploy: `curl -I https://www.thebluealliance.com/.well-known/apple-app-site-association` returns 404; `.../assetlinks.json` still returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
