### PR TITLE
Add fine-grained span tracing and thread CPU time tracking for APIv3

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -324,15 +324,21 @@ def validate_keys(func):
 
             # 4. Resolve futures and populate positive / negative caches
             for validator, key, resolved_key, future in pending_checks:
-                if not future.get_result():
-                    key_does_not_exist_cache.set((validator.entity_name, key), True)
-                    return {
-                        "Error": f"{validator.key_type} key: {key} does not exist"
-                    }, 404
+                with Span(f"validate_keys.resolve:{validator.entity_name}") as span:
+                    span.set_label("lookup_key", key)
+                    entity_result = future.get_result()
+                    span.set_label("exists", str(bool(entity_result)))
+                    if not entity_result:
+                        key_does_not_exist_cache.set((validator.entity_name, key), True)
+                        return {
+                            "Error": f"{validator.key_type} key: {key} does not exist"
+                        }, 404
 
-                key_exists_cache.set((validator.entity_name, key), True)
-                if resolved_key:
-                    key_exists_cache.set((validator.entity_name, resolved_key), True)
+                    key_exists_cache.set((validator.entity_name, key), True)
+                    if resolved_key:
+                        key_exists_cache.set(
+                            (validator.entity_name, resolved_key), True
+                        )
 
         return func(*args, **kwargs)
 
@@ -390,12 +396,20 @@ def validate_etag(func: Callable) -> Callable:
             if resp.status_code == 200:
                 try:
                     if not resp.headers.get("ETag"):
-                        resp.add_etag()
+                        with Span("etag.compute_md5") as span:
+                            resp.add_etag()
+                            data = resp.get_data()
+                            if data:
+                                span.set_label("response_size_bytes", str(len(data)))
                     etag_header = resp.headers.get("ETag")
                     if etag_header and accessed_keys:
                         normalized = normalize_etag(etag_header)
                         if normalized:
-                            save_etag_dependencies(normalized, accessed_keys)
+                            with Span("etag.save_dependencies") as span:
+                                span.set_label(
+                                    "num_query_keys", str(len(accessed_keys))
+                                )
+                                save_etag_dependencies(normalized, accessed_keys)
                 except Exception as e:
                     logging.warning(f"Error saving validate_etag dependencies: {e}")
 

--- a/src/backend/api/handlers/helpers/model_query_response.py
+++ b/src/backend/api/handlers/helpers/model_query_response.py
@@ -8,6 +8,7 @@ from backend.api.handlers.helpers.profiled_jsonify import (
     TypedFlaskResponse,
 )
 from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.profiler import Span
 from backend.common.queries.database_query import CachedDatabaseQuery
 
 
@@ -34,7 +35,10 @@ def model_query_response(
             abort(404)
         return profiled_jsonify(None)
     if filter_func is not None:
-        data = filter_func([data], model_type)[0]
+        with Span("model_query_response.filter_properties") as span:
+            span.set_label("model_type", str(model_type))
+            span.set_label("item_count", "1")
+            data = filter_func([data], model_type)[0]
     return profiled_jsonify(data)
 
 
@@ -54,5 +58,8 @@ def models_query_response(
 
     data = query.fetch_dict(ApiMajorVersion.API_V3)
     if filter_func is not None and data is not None:
-        data = filter_func(data, model_type)
+        with Span("model_query_response.filter_properties") as span:
+            span.set_label("model_type", str(model_type))
+            span.set_label("item_count", str(len(data)))
+            data = filter_func(data, model_type)
     return profiled_jsonify(data)

--- a/src/backend/api/handlers/helpers/profiled_jsonify.py
+++ b/src/backend/api/handlers/helpers/profiled_jsonify.py
@@ -14,14 +14,18 @@ class TypedFlaskResponse(Response, Generic[T]):
 
 
 def profiled_jsonify(obj: Union[T, bytes, bytearray]) -> TypedFlaskResponse[T]:
-    with Span("profiled_jsonify"):
+    with Span("profiled_jsonify") as span:
         if isinstance(obj, (bytes, bytearray)):
+            span.set_label("input_type", "bytes")
+            span.set_label("response_size_bytes", str(len(obj)))
             return current_app.response_class(  # pyre-ignore[7]
                 bytes(obj),
                 mimetype="application/json",
             )  # type: ignore[return-value]
         try:
+            span.set_label("input_type", type(obj).__name__)
             payload = orjson.dumps(obj)
+            span.set_label("response_size_bytes", str(len(payload)))
             return current_app.response_class(  # pyre-ignore[7]
                 payload,
                 mimetype="application/json",
@@ -30,4 +34,5 @@ def profiled_jsonify(obj: Union[T, bytes, bytearray]) -> TypedFlaskResponse[T]:
             logging.warning(
                 f"orjson.dumps failed in profiled_jsonify, falling back to jsonify: {e}"
             )
+            span.set_label("fallback", "jsonify")
             return jsonify(obj)  # type: ignore[return-value]

--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -6,6 +6,8 @@ from typing import Any, Generator, Iterable, Optional
 
 from google.appengine.ext import ndb
 
+from backend.common.profiler import Span
+
 
 class CachedQueryResult(ndb.Model):
     """
@@ -27,21 +29,23 @@ class CachedQueryResult(ndb.Model):
         if not values or b"result_dict" not in values:
             return None
         val = values[b"result_dict"]
-        if isinstance(val, ndb.model._BaseValue):
-            b_val = val.b_val
-            if isinstance(b_val, ndb.model._CompressedValue):
-                return zlib.decompress(b_val.z_val)
-            elif isinstance(b_val, (bytes, bytearray)):
-                return bytes(b_val)
-            elif isinstance(b_val, str):
-                return b_val.encode("utf-8")
-        elif isinstance(val, (bytes, bytearray)):
-            return bytes(val)
-        elif isinstance(val, str):
-            return val.encode("utf-8")
-        elif val is not None:
-            return json.dumps(val, separators=(",", ":")).encode("utf-8")
-        return None
+        with Span("cached_query.get_json_bytes") as span:
+            target = val.b_val if isinstance(val, ndb.model._BaseValue) else val
+            if isinstance(target, ndb.model._CompressedValue):
+                res_bytes = zlib.decompress(target.z_val)
+                span.set_label("compressed_bytes", str(len(target.z_val)))
+            elif isinstance(target, (bytes, bytearray)):
+                res_bytes = bytes(target)
+            elif isinstance(target, str):
+                res_bytes = target.encode("utf-8")
+            elif target is not None:
+                res_bytes = json.dumps(target, separators=(",", ":")).encode("utf-8")
+            else:
+                res_bytes = None
+
+            if res_bytes is not None:
+                span.set_label("uncompressed_bytes", str(len(res_bytes)))
+            return res_bytes
 
     @staticmethod
     def cache_key_prefix_from_format(cache_key_format: str) -> str:
@@ -176,45 +180,50 @@ class CachedQueryResult(ndb.Model):
         if self.result is None:
             return False
 
-        # Handle both single model and list of models
-        models_to_check = []
-        if isinstance(self.result, list):
-            models_to_check = self.result
-        else:
-            models_to_check = [self.result]
+        with Span("cached_query.validate_properties") as span:
+            # Handle both single model and list of models
+            models_to_check = []
+            if isinstance(self.result, list):
+                models_to_check = self.result
+            else:
+                models_to_check = [self.result]
 
-        for model in models_to_check:
-            # Skip non-CachedModel objects and models without _properties
-            if not hasattr(model, "_properties"):
-                continue
+            span.set_label("entity_count", str(len(models_to_check)))
+            if models_to_check and hasattr(models_to_check[0], "__class__"):
+                span.set_label("model_kind", models_to_check[0].__class__.__name__)
 
-            missing_properties = []
-            for prop_name, prop in model._properties.items():
-                # Check if property is required and value is None
-                if hasattr(prop, "_required") and prop._required:
-                    value = getattr(model, prop_name, None)
-                    if value is None:
-                        missing_properties.append(prop_name)
+            for model in models_to_check:
+                # Skip non-CachedModel objects and models without _properties
+                if not hasattr(model, "_properties"):
+                    continue
 
-            # Log error if any required properties are missing
-            if missing_properties:
-                stack_trace = "".join(traceback.format_stack())
-                model_key = (
-                    model.key.urlsafe() if model.key else "No key (unsaved model)"
-                )
-                cached_result_key = (
-                    self.key.urlsafe() if self.key else "No key (unsaved result)"
-                )
-                logging.error(
-                    f"Required properties not set on {model.__class__.__name__} "
-                    f"in CachedQueryResult: {', '.join(missing_properties)}\n"
-                    f"Model key: {model_key}\n"
-                    f"CachedQueryResult key: {cached_result_key}\n"
-                    f"Stack trace:\n{stack_trace}"
-                )
-                return True
+                missing_properties = []
+                for prop_name, prop in model._properties.items():
+                    # Check if property is required and value is None
+                    if hasattr(prop, "_required") and prop._required:
+                        value = getattr(model, prop_name, None)
+                        if value is None:
+                            missing_properties.append(prop_name)
 
-        return False
+                # Log error if any required properties are missing
+                if missing_properties:
+                    stack_trace = "".join(traceback.format_stack())
+                    model_key = (
+                        model.key.urlsafe() if model.key else "No key (unsaved model)"
+                    )
+                    cached_result_key = (
+                        self.key.urlsafe() if self.key else "No key (unsaved result)"
+                    )
+                    logging.error(
+                        f"Required properties not set on {model.__class__.__name__} "
+                        f"in CachedQueryResult: {', '.join(missing_properties)}\n"
+                        f"Model key: {model_key}\n"
+                        f"CachedQueryResult key: {cached_result_key}\n"
+                        f"Stack trace:\n{stack_trace}"
+                    )
+                    return True
+
+            return False
 
     def _pre_put_hook(self) -> None:
         """
@@ -224,42 +233,47 @@ class CachedQueryResult(ndb.Model):
         if self.result is None:
             return
 
-        from google.appengine.api import datastore_errors
+        with Span("cached_query.pre_put_validation") as span:
+            from google.appengine.api import datastore_errors
 
-        # Handle both single model and list of models
-        models_to_check = []
-        if isinstance(self.result, list):
-            models_to_check = self.result
-        else:
-            models_to_check = [self.result]
+            # Handle both single model and list of models
+            models_to_check = []
+            if isinstance(self.result, list):
+                models_to_check = self.result
+            else:
+                models_to_check = [self.result]
 
-        for model in models_to_check:
-            # Skip non-CachedModel objects and models without _properties
-            if not hasattr(model, "_properties"):
-                continue
+            span.set_label("entity_count", str(len(models_to_check)))
+            if models_to_check and hasattr(models_to_check[0], "__class__"):
+                span.set_label("model_kind", models_to_check[0].__class__.__name__)
 
-            missing_properties = []
-            for prop_name, prop in model._properties.items():
-                # Check if property is required and value is None
-                if hasattr(prop, "_required") and prop._required:
-                    value = getattr(model, prop_name, None)
-                    if value is None:
-                        missing_properties.append(prop_name)
+            for model in models_to_check:
+                # Skip non-CachedModel objects and models without _properties
+                if not hasattr(model, "_properties"):
+                    continue
 
-            # Raise exception if any required properties are missing
-            if missing_properties:
-                model_key = (
-                    model.key.urlsafe() if model.key else "No key (unsaved model)"
-                )
-                cached_result_key = (
-                    self.key.urlsafe() if self.key else "No key (unsaved result)"
-                )
-                raise datastore_errors.BadValueError(
-                    f"Required properties not set on {model.__class__.__name__} "
-                    f"in CachedQueryResult (model key: {model_key}, "
-                    f"result key: {cached_result_key}): "
-                    f"{', '.join(missing_properties)}"
-                )
+                missing_properties = []
+                for prop_name, prop in model._properties.items():
+                    # Check if property is required and value is None
+                    if hasattr(prop, "_required") and prop._required:
+                        value = getattr(model, prop_name, None)
+                        if value is None:
+                            missing_properties.append(prop_name)
+
+                # Raise exception if any required properties are missing
+                if missing_properties:
+                    model_key = (
+                        model.key.urlsafe() if model.key else "No key (unsaved model)"
+                    )
+                    cached_result_key = (
+                        self.key.urlsafe() if self.key else "No key (unsaved result)"
+                    )
+                    raise datastore_errors.BadValueError(
+                        f"Required properties not set on {model.__class__.__name__} "
+                        f"in CachedQueryResult (model key: {model_key}, "
+                        f"result key: {cached_result_key}): "
+                        f"{', '.join(missing_properties)}"
+                    )
 
     @classmethod
     def _post_get_hook(cls, key: ndb.Key, future: Any) -> None:

--- a/src/backend/common/profiler.py
+++ b/src/backend/common/profiler.py
@@ -2,6 +2,7 @@
 
 import logging
 import random
+import time
 from contextvars import ContextVar, Token
 from datetime import datetime
 from typing import Any, cast, Dict, Optional
@@ -84,6 +85,7 @@ class Span:
         self._token: Optional[Token[Optional["Span"]]] = None
         self._startTime: Optional[datetime] = None
         self._endTime: Optional[datetime] = None
+        self._start_cpu: Optional[float] = None
 
         if hasattr(trace_context, "request") and trace_context.request:
             tcontext = trace_context.request.headers.get(
@@ -130,6 +132,8 @@ class Span:
         self._parent_span_id = parent._span_id if parent else self._root_span_id
         self._token = _active_span_var.set(self)
         self._startTime = datetime.now()
+        if self._do_trace:
+            self._start_cpu = time.thread_time()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
@@ -142,6 +146,23 @@ class Span:
             self._token = None
 
         if self._do_trace and exc_type is not GeneratorExit:
+            start_cpu = self._start_cpu
+            start_time = self._startTime
+            end_time = self._endTime
+            if (
+                start_cpu is not None
+                and start_time is not None
+                and end_time is not None
+            ):
+                cpu_duration_ms = (time.thread_time() - start_cpu) * 1000.0
+                self.set_label("cpu_time_ms", f"{cpu_duration_ms:.2f}")
+
+                wall_duration_ms = (end_time - start_time).total_seconds() * 1000.0
+                self.set_label("wall_time_ms", f"{wall_duration_ms:.2f}")
+                if wall_duration_ms > 0:
+                    cpu_ratio = min(1.0, cpu_duration_ms / wall_duration_ms)
+                    self.set_label("cpu_ratio", f"{cpu_ratio:.2f}")
+
             request = getattr(trace_context, "request", None)
             if request is not None:
                 if not hasattr(request, "spans"):

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -51,7 +51,8 @@ class DatabaseQuery(abc.ABC, Generic[QueryReturn, DictQueryReturn]):
     @ndb.tasklet
     def _do_query(self, *args, **kwargs) -> Generator[Any, Any, QueryReturn]:
         # This gives CachedDatabaseQuery a place to hook into
-        res = yield self._query_async(*args, **kwargs)
+        with Span(f"{self.__class__.__name__}._query_async"):
+            res = yield self._query_async(*args, **kwargs)
         return res
 
     @ndb.tasklet
@@ -59,7 +60,8 @@ class DatabaseQuery(abc.ABC, Generic[QueryReturn, DictQueryReturn]):
         self, _dict_version: ApiMajorVersion, *args, **kwargs
     ) -> Generator[Any, Any, Union[None, DictQueryReturn, List[DictQueryReturn]]]:
         # This gives CachedDatabaseQuery a place to hook into
-        res = yield self._query_async(*args, **kwargs)
+        with Span(f"{self.__class__.__name__}._query_async"):
+            res = yield self._query_async(*args, **kwargs)
 
         if self.DICT_CONVERTER is None:
             raise Exception(
@@ -208,11 +210,15 @@ class CachedDatabaseQuery(
         self._record_accessed_cache_key(cache_key)
 
         if not self.MODEL_CACHING_ENABLED:
-            result = yield self._query_async(*args, **kwargs)
+            with Span(f"{self.__class__.__name__}._query_async"):
+                result = yield self._query_async(*args, **kwargs)
             return result
 
         with Span("{}._do_query".format(self.__class__.__name__)):
-            cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+            with Span("query.cache_lookup") as span:
+                span.set_label("cache_key", cache_key)
+                cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+                span.set_label("cache_hit", str(cached_query_result is not None))
 
             # Validate cached result for corruption and treat as cache miss if corrupted
             if (
@@ -227,12 +233,14 @@ class CachedDatabaseQuery(
                 cached_query_result = None
 
             if cached_query_result is None:
-                query_result = yield self._query_async(*args, **kwargs)
+                with Span(f"{self.__class__.__name__}._query_async"):
+                    query_result = yield self._query_async(*args, **kwargs)
                 if self.CACHE_WRITES_ENABLED:
                     try:
-                        yield CachedQueryResult(
-                            id=cache_key, result=query_result
-                        ).put_async()
+                        with Span("query.async_cache_write"):
+                            yield CachedQueryResult(
+                                id=cache_key, result=query_result
+                            ).put_async()
                     except Exception as e:
                         logging.warning(
                             f"CachedQueryResult.put_async() failed: {cache_key}"
@@ -240,7 +248,11 @@ class CachedDatabaseQuery(
                         logging.exception(e)
                 return query_result
 
-            return cached_query_result.result
+            with Span("query.unpickle_models") as span:
+                result = cached_query_result.result
+                if isinstance(result, list):
+                    span.set_label("result_count", str(len(result)))
+                return result
 
     @ndb.tasklet
     def _do_dict_query(
@@ -251,14 +263,20 @@ class CachedDatabaseQuery(
             self._record_accessed_cache_key(cache_key)
 
         if not self.DICT_CACHING_ENABLED:
-            result = yield self._query_async(*args, **kwargs)
+            with Span(f"{self.__class__.__name__}._query_async"):
+                result = yield self._query_async(*args, **kwargs)
             return result
 
         with Span("{}._do_dict_query".format(self.__class__.__name__)):
             cache_key = self.dict_cache_key(_dict_version)
-            cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+            with Span("query.cache_lookup") as span:
+                span.set_label("cache_key", cache_key)
+                cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+                span.set_label("cache_hit", str(cached_query_result is not None))
+
             if cached_query_result is None:
-                query_result = yield self._query_async(*args, **kwargs)
+                with Span(f"{self.__class__.__name__}._query_async"):
+                    query_result = yield self._query_async(*args, **kwargs)
 
                 # See https://github.com/facebook/pyre-check/issues/267
                 converted_result = none_throws(self.DICT_CONVERTER)(  # pyre-ignore[45]
@@ -267,9 +285,10 @@ class CachedDatabaseQuery(
 
                 if self.CACHE_WRITES_ENABLED:
                     try:
-                        yield CachedQueryResult(
-                            id=cache_key, result_dict=converted_result
-                        ).put_async()
+                        with Span("query.async_cache_write"):
+                            yield CachedQueryResult(
+                                id=cache_key, result_dict=converted_result
+                            ).put_async()
                     except Exception as e:
                         logging.warning(
                             f"CachedQueryResult.put_async() failed: {cache_key}"
@@ -287,7 +306,9 @@ class CachedDatabaseQuery(
             raw_bytes = cached_query_result.get_json_bytes()
             if raw_bytes is not None:
                 try:
-                    return orjson.loads(raw_bytes)
+                    with Span("query.json_decode") as span:
+                        span.set_label("byte_size", str(len(raw_bytes)))
+                        return orjson.loads(raw_bytes)
                 except (orjson.JSONDecodeError, Exception) as e:
                     logging.warning(
                         f"orjson.loads failed for cache_key {cache_key}, falling back to result_dict: {e}"
@@ -319,7 +340,8 @@ class CachedDatabaseQuery(
             if dict_result is None:
                 return None
             try:
-                return orjson.dumps(dict_result)
+                with Span("query.serialize_json"):
+                    return orjson.dumps(dict_result)
             except (orjson.JSONEncodeError, TypeError) as e:
                 logging.warning(
                     f"orjson.dumps failed in _do_json_query, falling back to json.dumps: {e}"
@@ -328,9 +350,14 @@ class CachedDatabaseQuery(
 
         with Span("{}._do_json_query".format(self.__class__.__name__)):
             cache_key = self.dict_cache_key(_dict_version)
-            cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+            with Span("query.cache_lookup") as span:
+                span.set_label("cache_key", cache_key)
+                cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
+                span.set_label("cache_hit", str(cached_query_result is not None))
+
             if cached_query_result is None:
-                query_result = yield self._query_async(*args, **kwargs)
+                with Span(f"{self.__class__.__name__}._query_async"):
+                    query_result = yield self._query_async(*args, **kwargs)
 
                 converted_result = none_throws(self.DICT_CONVERTER)(  # pyre-ignore[45]
                     query_result
@@ -338,9 +365,10 @@ class CachedDatabaseQuery(
 
                 if self.CACHE_WRITES_ENABLED:
                     try:
-                        yield CachedQueryResult(
-                            id=cache_key, result_dict=converted_result
-                        ).put_async()
+                        with Span("query.async_cache_write"):
+                            yield CachedQueryResult(
+                                id=cache_key, result_dict=converted_result
+                            ).put_async()
                     except Exception as e:
                         logging.warning(
                             f"CachedQueryResult.put_async() failed: {cache_key}"
@@ -351,7 +379,8 @@ class CachedDatabaseQuery(
                     return None
 
                 try:
-                    return orjson.dumps(converted_result)
+                    with Span("query.serialize_json"):
+                        return orjson.dumps(converted_result)
                 except (orjson.JSONEncodeError, TypeError) as e:
                     logging.warning(
                         f"orjson.dumps failed for cache_key {cache_key}, falling back to json.dumps: {e}"
@@ -366,7 +395,8 @@ class CachedDatabaseQuery(
             if cached_query_result.result_dict is None:
                 return None
             try:
-                return orjson.dumps(cached_query_result.result_dict)
+                with Span("query.serialize_json"):
+                    return orjson.dumps(cached_query_result.result_dict)
             except (orjson.JSONEncodeError, TypeError) as e:
                 logging.warning(
                     f"orjson.dumps failed for cache_key {cache_key}, falling back to json.dumps: {e}"

--- a/src/backend/common/queries/dict_converters/converter_base.py
+++ b/src/backend/common/queries/dict_converters/converter_base.py
@@ -20,12 +20,13 @@ class ConverterBase(abc.ABC, Generic[QueryReturn, DictQueryReturn]):
     def convert(
         self, version: ApiMajorVersion
     ) -> Union[None, DictQueryReturn, List[DictQueryReturn]]:
-        with Span("{}.convert".format(self.__class__.__name__)):
+        with Span("{}.convert".format(self.__class__.__name__)) as span:
             if self._query_return is None:
                 return None
-            converted_query_return = self._convert_list(
-                listify(self._query_return), version
-            )
+            items = listify(self._query_return)
+            span.set_label("input_item_count", str(len(items)))
+            span.set_label("api_version", str(version))
+            converted_query_return = self._convert_list(items, version)
             if isinstance(self._query_return, list):
                 return converted_query_return
             else:

--- a/src/backend/common/tests/profiler_test.py
+++ b/src/backend/common/tests/profiler_test.py
@@ -259,6 +259,34 @@ def test_concurrent_tasklet_spans_are_siblings(mock_send_traces) -> None:
 
 
 @patch("backend.common.profiler._make_tracing_call")
+def test_span_cpu_tracking(mock_send_traces) -> None:
+    app = setup_app()
+
+    @app.route("/")
+    def route():
+        with Span("cpu_span"):
+            # Burn a tiny bit of CPU cycles
+            _ = sum(i * i for i in range(1000))
+        assert len(trace_context.request.spans) == 1
+        s_dict = trace_context.request.spans[0]
+        assert "labels" in s_dict
+        assert "cpu_time_ms" in s_dict["labels"]
+        assert "wall_time_ms" in s_dict["labels"]
+        assert "cpu_ratio" in s_dict["labels"]
+        # Verify values are valid floats
+        assert float(s_dict["labels"]["cpu_time_ms"]) >= 0.0
+        assert float(s_dict["labels"]["wall_time_ms"]) >= 0.0
+        assert 0.0 <= float(s_dict["labels"]["cpu_ratio"]) <= 1.0
+        return "OK"
+
+    with app.test_client() as client:
+        client.get("/", headers={"X-Cloud-Trace-Context": "TRACE_ID/SPAN_ID;o=1"})
+        send_traces()
+
+    mock_send_traces.assert_called_once()
+
+
+@patch("backend.common.profiler._make_tracing_call")
 def test_tasklet_child_spans_are_nested(mock_send_traces) -> None:
     app = setup_app()
 


### PR DESCRIPTION
## Description
Adds fine-grained Cloud Trace spans and per-span thread CPU time tracking across APIv3 and database query workflows:

- **Thread CPU Profiling (`Span`)**: Captures `time.thread_time()` on enter/exit to report `cpu_time_ms`, `wall_time_ms`, and `cpu_ratio` (`cpu_time / wall_time`). This distinguishes true CPU bottlenecks (`cpu_ratio > 0.8`) from GIL contention or container scheduling stalls (`cpu_ratio < 0.2`).
- **Database & Cache Spans**: Breaks down database queries into Datastore reads (`_query_async`), cache lookups (`query.cache_lookup`), model unpickling (`query.unpickle_models`), JSON decoding (`query.json_decode`), JSON serialization (`query.serialize_json`), and zlib decompression (`cached_query.get_json_bytes`).
- **Handler & ETag Spans**: Adds spans for key resolution (`validate_keys.resolve`), ETag MD5 hashing (`etag.compute_md5`), response property filtering (`model_query_response.filter_properties`), and attaches payload size/type labels to `profiled_jsonify`.

## Motivation and Context
On F1 App Engine instances, high wall-clock durations in Cloud Trace don't reveal whether latency stems from heavy Python execution (NDB deserialization, JSON parsing) or thread descheduling/throttling. The new spans and `cpu_ratio` isolate the exact bottleneck.

## How Has This Been Tested?
- `make lint` passed cleanly across all 1,113 files.
- `make typecheck` passed with zero errors across 10,147 functions.
- `make test` passed 1,178 unit tests with zero failures (including new `test_span_cpu_tracking` in `profiler_test.py`).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)