### PR TITLE
Polish the PWA suggestion review pages: no link underline on queue rows, tinted accept/reject buttons

### DIFF
--- a/pwa/app/components/tba/moderation/suggestionReviewCard.tsx
+++ b/pwa/app/components/tba/moderation/suggestionReviewCard.tsx
@@ -1090,12 +1090,15 @@ export function SuggestionReviewCard(
         <div className="flex gap-2">
           <Button
             size="sm"
-            variant={decision === 'accept' ? 'default' : 'outline'}
-            className={
+            variant="outline"
+            className={cn(
+              // Tinted at rest, more saturated on hover, solid when chosen
               decision === 'accept'
-                ? 'bg-green-700 text-white hover:bg-green-800'
-                : ''
-            }
+                ? 'border-green-700 bg-green-700 text-white hover:bg-green-800'
+                : `border-green-600/60 bg-green-50 text-green-800
+                  hover:bg-green-200 hover:text-green-900 dark:bg-green-950
+                  dark:text-green-300 dark:hover:bg-green-900`,
+            )}
             onClick={() =>
               onDecisionChange(decision === 'accept' ? undefined : 'accept')
             }
@@ -1104,7 +1107,14 @@ export function SuggestionReviewCard(
           </Button>
           <Button
             size="sm"
-            variant={decision === 'reject' ? 'destructive' : 'outline'}
+            variant="outline"
+            className={cn(
+              decision === 'reject'
+                ? 'border-red-700 bg-red-700 text-white hover:bg-red-800'
+                : `border-red-600/60 bg-red-50 text-red-800 hover:bg-red-200
+                  hover:text-red-900 dark:bg-red-950 dark:text-red-300
+                  dark:hover:bg-red-900`,
+            )}
             onClick={() =>
               onDecisionChange(decision === 'reject' ? undefined : 'reject')
             }

--- a/pwa/app/routes/suggest.review.index.tsx
+++ b/pwa/app/routes/suggest.review.index.tsx
@@ -95,6 +95,7 @@ function SuggestionReviewHome(): JSX.Element {
             key={type}
             to="/suggest/review/$suggestionType"
             params={{ suggestionType: type }}
+            className="text-foreground hover:no-underline"
           >
             <Card
               className="flex items-center justify-between p-4 transition-colors


### PR DESCRIPTION
Two small visual fixes on `beta.thebluealliance.com/suggest/review`, both from Greg's review.

## 1. Queue rows: blue underline on hover

The index page wraps each `Card` in a TanStack `Link`. The site-wide anchor rule (`a { @apply text-blue-800 hover:underline }`) underlines on hover in link blue, but the row's text is foreground-colored, so the underline didn't match the text. The rows are cards, not inline links, so the `Link` now gets `text-foreground hover:no-underline`, the same treatment the navbar uses for its block links.

## 2. Accept / reject buttons: tinted, saturating on hover

Previously both were neutral outline buttons until chosen. Now:

| state | accept | reject |
|---|---|---|
| rest | green-50 bg, green-800 text, green border | red-50 bg, red-800 text, red border |
| hover | green-200 bg | red-200 bg |
| chosen | solid green-700, white text (hover green-800) | solid red-700, white text (hover red-800) |

Dark-mode shades included. The keyboard-shortcut hints in the labels are unchanged.

## Screenshots

Posted in a comment below (before/after, rest/hover/selected).

## Test plan

- [x] `pnpm run format`, `lint`, `typecheck`
- [x] vitest on `app/components/tba/moderation` and `app/routes`
- [x] Rendered locally with the auth emulator and a mocked moderation API; screenshots below are from that

🤖 Generated with [Claude Code](https://claude.com/claude-code)