### PR TITLE
[api] Batch ETag dependency and query version writes in Memcache

### DIFF
--- a/src/backend/api/handlers/helpers/etag_helper.py
+++ b/src/backend/api/handlers/helpers/etag_helper.py
@@ -123,13 +123,10 @@ def save_etag_dependencies(
             versions_to_set[q_key] = ver
             deps[k] = str(ver)
 
-        if versions_to_set:
-            memcache.set_multi(versions_to_set, time=ttl)
+        versions_to_set[
+            f"etag_deps:{endpoint_path}:{normalized_etag}".encode("utf-8")
+        ] = deps
 
-        memcache.set(
-            f"etag_deps:{endpoint_path}:{normalized_etag}".encode("utf-8"),
-            deps,
-            time=ttl,
-        )
+        memcache.set_multi(versions_to_set, time=ttl)
     except Exception as e:
         logging.warning(f"Error saving ETag dependencies to Memcache: {e}")

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -9,6 +9,7 @@ from backend.api.handlers.decorators import etag_304_cache
 from backend.api.handlers.helpers.etag_helper import (
     get_etag_dependencies,
     normalize_etag,
+    save_etag_dependencies,
 )
 from backend.common.consts.auth_type import AuthType
 from backend.common.environment import Environment
@@ -758,3 +759,32 @@ def test_validate_etag_in_memory_cache_different_path(
     assert etag_304_cache.get(("/api/v3/team/frc254", norm_etag)) is True
     # Different endpoint path must not be in cache
     assert etag_304_cache.get(("/api/v3/team/frc9999", norm_etag)) is None
+
+
+def test_save_etag_dependencies_batches_in_single_set_multi(
+    memcache_stub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    memcache = MemcacheClient.get()
+    set_mock = MagicMock(wraps=memcache.set)
+    set_multi_mock = MagicMock(wraps=memcache.set_multi)
+    monkeypatch.setattr(memcache, "set", set_mock)
+    monkeypatch.setattr(memcache, "set_multi", set_multi_mock)
+
+    query_keys = {"team_query_1", "team_query_2"}
+    save_etag_dependencies("test_etag_123", query_keys, path="/api/v3/team/frc254")
+
+    # Verify set_multi was called exactly once
+    set_multi_mock.assert_called_once()
+    mapping = set_multi_mock.call_args[0][0]
+
+    # Verify query version keys and etag_deps key are all batched in a single mapping
+    assert b"q_ver:team_query_1" in mapping
+    assert b"q_ver:team_query_2" in mapping
+    assert b"etag_deps:/api/v3/team/frc254:test_etag_123" in mapping
+    assert mapping[b"etag_deps:/api/v3/team/frc254:test_etag_123"] == {
+        "team_query_1": str(mapping[b"q_ver:team_query_1"]),
+        "team_query_2": str(mapping[b"q_ver:team_query_2"]),
+    }
+
+    # Verify memcache.set was NOT called (eliminates redundant round-trip)
+    set_mock.assert_not_called()


### PR DESCRIPTION
## Description
In `save_etag_dependencies()`, two separate Memcache write operations were being executed sequentially:
1. `memcache.set_multi(versions_to_set, time=ttl)` to refresh or store query version keys (`q_ver:...`).
2. `memcache.set(f"etag_deps:...", deps, time=ttl)` to store the ETag-to-query-keys dependency map.

Because both writes target the exact same Memcache service with the exact same TTL (`ETAG_CACHE_TTL`), performing them in two separate sequential calls causes an extra network round-trip.

Production trace analysis across APIv3 requests revealed that sequential synchronous network I/O calls at the end of a request can suffer severe latency spikes on App Engine F1 instances. On an F1 instance (600 MHz CPU) running 8 Gunicorn threads, when CPU quota is exhausted, each synchronous network I/O boundary releases the GIL and thread execution; upon resuming, the thread can be throttled by the Linux CFS scheduler for ~100 ms per boundary.

### Changes
- Batch the `etag_deps:{endpoint_path}:{normalized_etag}` key directly into `versions_to_set`.
- Execute a single `memcache.set_multi(versions_to_set, time=ttl)` call instead of `set_multi` followed by `set`.
- Add unit test `test_save_etag_dependencies_batches_in_single_set_multi` in `test_validate_etag.py` to assert that only a single `set_multi` is invoked and `memcache.set` is not called.

## Testing
- `make test ARGS="src/backend/api/handlers/tests/test_validate_etag.py"` passed (16/16 tests).
- `make lint` passed.
- `make typecheck` passed with 0 errors.
