### PR TITLE
[api] Move save_etag_dependencies to after response middleware

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -29,6 +29,7 @@ from backend.common.models.match import Match
 from backend.common.models.team import Team
 from backend.common.profiler import Span
 from backend.common.queries.database_query import track_accessed_query_cache_keys
+from backend.common.run_after_response import run_after_response
 
 
 @dataclass(frozen=True)
@@ -405,11 +406,19 @@ def validate_etag(func: Callable) -> Callable:
                     if etag_header and accessed_keys:
                         normalized = normalize_etag(etag_header)
                         if normalized:
-                            with Span("etag.save_dependencies") as span:
-                                span.set_label(
-                                    "num_query_keys", str(len(accessed_keys))
-                                )
-                                save_etag_dependencies(normalized, accessed_keys)
+                            keys_to_save = set(accessed_keys)
+                            request_path = get_request_path()
+
+                            def save_dependencies() -> None:
+                                with Span("etag.save_dependencies") as span:
+                                    span.set_label(
+                                        "num_query_keys", str(len(keys_to_save))
+                                    )
+                                    save_etag_dependencies(
+                                        normalized, keys_to_save, path=request_path
+                                    )
+
+                            run_after_response(save_dependencies)
                 except Exception as e:
                     logging.warning(f"Error saving validate_etag dependencies: {e}")
 

--- a/src/backend/api/handlers/tests/conftest.py
+++ b/src/backend/api/handlers/tests/conftest.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import Client
 
 from backend.api.client_api_auth_helper import ClientApiAuthHelper
@@ -8,10 +9,18 @@ from backend.common.models.account import Account
 from backend.common.models.user import User
 
 
+class AutoClosingFlaskClient(FlaskClient):
+    def open(self, *args, **kwargs):
+        resp = super().open(*args, **kwargs)
+        resp.close()
+        return resp
+
+
 @pytest.fixture
 def api_client(gae_testbed, ndb_stub, memcache_stub, taskqueue_stub) -> Client:
     from backend.api.main import app
 
+    app.test_client_class = AutoClosingFlaskClient
     return app.test_client()
 
 

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -788,3 +788,40 @@ def test_save_etag_dependencies_batches_in_single_set_multi(
 
     # Verify memcache.set was NOT called (eliminates redundant round-trip)
     set_mock.assert_not_called()
+
+
+def test_save_etag_dependencies_runs_after_response(
+    ndb_stub, memcache_stub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from flask.testing import FlaskClient
+    from backend.api.main import app
+
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    # Use standard FlaskClient that leaves the response iterator open until close()
+    app.test_client_class = FlaskClient
+    client = app.test_client()
+
+    resp = client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp.status_code == 200
+    etag = resp.headers.get("ETag")
+    assert etag is not None
+    norm_etag = normalize_etag(etag)
+    assert norm_etag is not None
+
+    # Before response is closed: after-response callbacks have not executed
+    assert get_etag_dependencies(norm_etag, path="/api/v3/team/frc254") is None
+
+    # Closing response triggers AfterResponseMiddleware and executes save_dependencies
+    resp.close()
+    deps = get_etag_dependencies(norm_etag, path="/api/v3/team/frc254")
+    assert deps is not None
+    assert any("frc254" in k for k in deps.keys())


### PR DESCRIPTION
In validate_etag, save_etag_dependencies() was previously executed synchronously before returning the response. This forced the client to wait for Memcache round trips (get_multi and set_multi) and risked blocking on potential CFS quota throttling pauses.

- Capture request_path and accessed query keys in validate_etag, and enqueue save_dependencies via run_after_response so it runs in AfterResponseMiddleware after the response is returned to the client.
- Wrap test client responses in AutoClosingFlaskClient in api handlers tests so WSGI closing iterator hooks execute in tests matching production Gunicorn lifecycle.
- Add unit test verifying save_etag_dependencies executes in AfterResponseMiddleware upon response close.
