### PR TITLE
[api] Use deterministic MD5 hashing for query versions to avoid Memcache read in save_etag_dependencies

### DIFF
--- a/src/backend/api/handlers/helpers/etag_helper.py
+++ b/src/backend/api/handlers/helpers/etag_helper.py
@@ -1,6 +1,5 @@
 import logging
-import uuid
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from flask import request
 
@@ -98,34 +97,24 @@ def is_etag_valid(normalized_etag: str, path: Optional[str] = None) -> bool:
 
 def save_etag_dependencies(
     normalized_etag: str,
-    query_cache_keys: Set[str],
+    query_versions: Dict[str, str],
     path: Optional[str] = None,
     ttl: int = ETAG_CACHE_TTL,
 ) -> None:
     """
     Stores the mapping between an ETag and its dependent query cache keys with their current versions.
     """
-    if not query_cache_keys:
+    if not query_versions:
         return
     try:
         memcache = MemcacheClient.get()
         endpoint_path = get_request_path(path)
-        q_ver_keys = [f"q_ver:{k}".encode("utf-8") for k in query_cache_keys]
-        existing_versions = memcache.get_multi(q_ver_keys)
-        versions_to_set: Dict[bytes, Any] = {}
-        deps: Dict[str, str] = {}
-        for k in query_cache_keys:
-            q_key = f"q_ver:{k}".encode("utf-8")
-            ver = existing_versions.get(q_key)
-            if ver is None:
-                ver = uuid.uuid4().hex
-            # Refresh TTL for existing and new query versions
-            versions_to_set[q_key] = ver
-            deps[k] = str(ver)
-
+        versions_to_set: Dict[bytes, Any] = {
+            f"q_ver:{k}".encode("utf-8"): ver for k, ver in query_versions.items()
+        }
         versions_to_set[
             f"etag_deps:{endpoint_path}:{normalized_etag}".encode("utf-8")
-        ] = deps
+        ] = query_versions
 
         memcache.set_multi(versions_to_set, time=ttl)
     except Exception as e:

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -765,26 +765,147 @@ def test_save_etag_dependencies_batches_in_single_set_multi(
     memcache_stub, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     memcache = MemcacheClient.get()
+    get_mock = MagicMock(wraps=memcache.get)
+    get_multi_mock = MagicMock(wraps=memcache.get_multi)
     set_mock = MagicMock(wraps=memcache.set)
     set_multi_mock = MagicMock(wraps=memcache.set_multi)
+    monkeypatch.setattr(memcache, "get", get_mock)
+    monkeypatch.setattr(memcache, "get_multi", get_multi_mock)
     monkeypatch.setattr(memcache, "set", set_mock)
     monkeypatch.setattr(memcache, "set_multi", set_multi_mock)
 
-    query_keys = {"team_query_1", "team_query_2"}
-    save_etag_dependencies("test_etag_123", query_keys, path="/api/v3/team/frc254")
+    query_versions = {
+        "team_query_1": "e2a9c7677594150d2629d0ffe18699f9",
+        "team_query_2": "608de49a4600dbb5b173492759792e4a",
+    }
+    save_etag_dependencies("test_etag_123", query_versions, path="/api/v3/team/frc254")
 
-    # Verify set_multi was called exactly once
+    # Verify no memcache read round-trips occurred
+    get_mock.assert_not_called()
+    get_multi_mock.assert_not_called()
+
+    # Verify set was not called (eliminates redundant round-trip)
+    set_mock.assert_not_called()
+
+    # Verify set_multi was called once with the exact precomputed MD5 hashes and etag_deps
     set_multi_mock.assert_called_once()
     mapping = set_multi_mock.call_args[0][0]
+    assert mapping[b"q_ver:team_query_1"] == "e2a9c7677594150d2629d0ffe18699f9"
+    assert mapping[b"q_ver:team_query_2"] == "608de49a4600dbb5b173492759792e4a"
+    assert mapping[b"etag_deps:/api/v3/team/frc254:test_etag_123"] == query_versions
 
-    # Verify query version keys and etag_deps key are all batched in a single mapping
-    assert b"q_ver:team_query_1" in mapping
-    assert b"q_ver:team_query_2" in mapping
-    assert b"etag_deps:/api/v3/team/frc254:test_etag_123" in mapping
-    assert mapping[b"etag_deps:/api/v3/team/frc254:test_etag_123"] == {
-        "team_query_1": str(mapping[b"q_ver:team_query_1"]),
-        "team_query_2": str(mapping[b"q_ver:team_query_2"]),
-    }
 
-    # Verify memcache.set was NOT called (eliminates redundant round-trip)
-    set_mock.assert_not_called()
+def test_database_query_tracks_deterministic_md5_hashes(
+    ndb_stub,
+) -> None:
+    from backend.common.consts.api_version import ApiMajorVersion
+    from backend.common.models.team import Team
+    from backend.common.queries.database_query import track_accessed_query_cache_keys
+    from backend.common.queries.team_query import TeamQuery
+
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    with track_accessed_query_cache_keys() as accessed_keys_1:
+        TeamQuery(team_key="frc254").fetch_dict(ApiMajorVersion.API_V3)
+
+    with track_accessed_query_cache_keys() as accessed_keys_2:
+        TeamQuery(team_key="frc254").fetch_dict(ApiMajorVersion.API_V3)
+
+    assert len(accessed_keys_1) == 1
+    key = TeamQuery(team_key="frc254").dict_cache_key(ApiMajorVersion.API_V3)
+    assert key in accessed_keys_1
+    assert accessed_keys_1[key] == accessed_keys_2[key]
+    assert len(accessed_keys_1[key]) == 32  # Valid MD5 hex digest length
+
+
+def test_database_query_tracks_deterministic_md5_hashes_with_unicode(
+    ndb_stub,
+) -> None:
+    from backend.common.consts.api_version import ApiMajorVersion
+    from backend.common.models.team import Team
+    from backend.common.queries.database_query import track_accessed_query_cache_keys
+    from backend.common.queries.team_query import TeamQuery
+
+    Team(id="frc9999", team_number=9999, nickname="Café Robotics").put()
+
+    # Test fetch_dict cache miss vs cache hit
+    with track_accessed_query_cache_keys() as dict_miss_keys:
+        TeamQuery(team_key="frc9999").fetch_dict(ApiMajorVersion.API_V3)
+
+    with track_accessed_query_cache_keys() as dict_hit_keys:
+        TeamQuery(team_key="frc9999").fetch_dict(ApiMajorVersion.API_V3)
+
+    key = TeamQuery(team_key="frc9999").dict_cache_key(ApiMajorVersion.API_V3)
+    assert dict_miss_keys[key] == dict_hit_keys[key]
+
+    # Invalidate cache to test fetch_json cache miss vs cache hit
+    TeamQuery.delete_cache_multi({TeamQuery(team_key="frc9999").cache_key})
+
+    with track_accessed_query_cache_keys() as json_miss_keys:
+        raw_miss = TeamQuery(team_key="frc9999").fetch_json(ApiMajorVersion.API_V3)
+
+    with track_accessed_query_cache_keys() as json_hit_keys:
+        raw_hit = TeamQuery(team_key="frc9999").fetch_json(ApiMajorVersion.API_V3)
+
+    assert raw_miss == raw_hit
+    assert json_miss_keys[key] == json_hit_keys[key]
+
+
+def test_delete_cache_multi_without_data_change_restores_etag_304(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    from backend.common.queries.team_query import TeamQuery
+
+    # 1. Initial request -> 200
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag = resp1.headers.get("ETag")
+    assert etag is not None
+
+    # Track handler execution via Team.get_by_id_async
+    original_get_by_id_async = Team.get_by_id_async
+    mock_get_by_id_async = MagicMock(side_effect=original_get_by_id_async)
+    monkeypatch.setattr(Team, "get_by_id_async", mock_get_by_id_async)
+
+    # 2. Re-request with If-None-Match -> 304 via @validate_etag fastpath (handler bypassed)
+    resp2 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+    mock_get_by_id_async.assert_not_called()
+
+    # 3. Simulate cache wipe without modifying the underlying data
+    TeamQuery.delete_cache_multi({TeamQuery(team_key="frc254").cache_key})
+    etag_304_cache.clear()
+
+    # 4. Request with old ETag misses fastpath because q_ver key was wiped;
+    # handler executes, re-records identical MD5 hash, and Werkzeug returns 304
+    resp3 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp3.status_code == 304
+    mock_get_by_id_async.assert_called_once()
+    mock_get_by_id_async.reset_mock()
+
+    # Clear in-memory cache to force checking Memcache fastpath
+    etag_304_cache.clear()
+
+    # 5. Subsequent request hits @validate_etag fastpath in Memcache because MD5 matched!
+    resp4 = api_client.get(
+        "/api/v3/team/frc254",
+        headers={"X-TBA-Auth-Key": "test_auth_key", "If-None-Match": etag},
+    )
+    assert resp4.status_code == 304
+    mock_get_by_id_async.assert_not_called()

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -142,16 +142,28 @@ class CachedDatabaseQuery(
 
     @classmethod
     def _compute_result_hash(cls, result: Any) -> str:
-        if result is None:
-            return "none"
-        if isinstance(result, (bytes, bytearray)):
-            return hashlib.md5(result).hexdigest()
-        if isinstance(result, str):
-            return hashlib.md5(result.encode("utf-8")).hexdigest()
-        try:
-            return hashlib.md5(orjson.dumps(result)).hexdigest()
-        except (TypeError, orjson.JSONEncodeError):
-            return hashlib.md5(pickle.dumps(result, protocol=4)).hexdigest()
+        with Span("query.compute_result_hash") as span:
+            if result is None:
+                span.set_label("result_type", "none")
+                return "none"
+            if isinstance(result, (bytes, bytearray)):
+                span.set_label("result_type", "bytes")
+                span.set_label("byte_size", str(len(result)))
+                return hashlib.md5(result).hexdigest()
+            if isinstance(result, str):
+                span.set_label("result_type", "str")
+                span.set_label("byte_size", str(len(result)))
+                return hashlib.md5(result.encode("utf-8")).hexdigest()
+            try:
+                span.set_label("result_type", "json")
+                serialized = orjson.dumps(result)
+                span.set_label("byte_size", str(len(serialized)))
+                return hashlib.md5(serialized).hexdigest()
+            except (TypeError, orjson.JSONEncodeError):
+                span.set_label("result_type", "pickle")
+                pickled = pickle.dumps(result, protocol=4)
+                span.set_label("byte_size", str(len(pickled)))
+                return hashlib.md5(pickled).hexdigest()
 
     @classmethod
     def _record_accessed_cache_key(cls, cache_key: str, result: Any = None) -> None:

--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import abc
+import hashlib
 import json
 import logging
+import pickle
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Dict, Generator, Generic, List, Optional, Set, Type, Union
@@ -19,18 +21,26 @@ from backend.common.profiler import Span
 from backend.common.queries.dict_converters.converter_base import ConverterBase
 from backend.common.queries.types import DictQueryReturn, QueryReturn
 
-accessed_query_cache_keys_ctx: ContextVar[Optional[Set[str]]] = ContextVar[
-    Optional[Set[str]]
+# ContextVar holding a mapping of {query_cache_key: result_md5_hash} for CachedDatabaseQuery
+# instances accessed within the active track_accessed_query_cache_keys() context:
+# - Key (str): The query cache key (e.g., "team_query_frc254~dictv3.1" or "team_query_frc254").
+# - Value (str): The deterministic 32-character hex MD5 hash of the query result.
+accessed_query_cache_keys_ctx: ContextVar[Optional[Dict[str, str]]] = ContextVar[
+    Optional[Dict[str, str]]
 ]("accessed_query_cache_keys_ctx", default=None)
 
 
 @contextmanager
-def track_accessed_query_cache_keys() -> Generator[Set[str], None, None]:
+def track_accessed_query_cache_keys() -> Generator[Dict[str, str], None, None]:
     """
-    Context manager to collect cache keys of all CachedDatabaseQuery instances
+    Context manager to collect cache keys and MD5 result hashes of all CachedDatabaseQuery instances
     accessed during the block execution.
+
+    Yields:
+        Dict[str, str]: Mapping of query cache key (e.g., "team_query_frc254~dictv3.1")
+        to the deterministic 32-character hex MD5 hash of its query result.
     """
-    keys: Set[str] = set()
+    keys: Dict[str, str] = {}
     token = accessed_query_cache_keys_ctx.set(keys)
     try:
         yield keys
@@ -131,10 +141,23 @@ class CachedDatabaseQuery(
         return f"{cache_key}~dictv{dict_version}.{subvserion}"
 
     @classmethod
-    def _record_accessed_cache_key(cls, cache_key: str) -> None:
+    def _compute_result_hash(cls, result: Any) -> str:
+        if result is None:
+            return "none"
+        if isinstance(result, (bytes, bytearray)):
+            return hashlib.md5(result).hexdigest()
+        if isinstance(result, str):
+            return hashlib.md5(result.encode("utf-8")).hexdigest()
+        try:
+            return hashlib.md5(orjson.dumps(result)).hexdigest()
+        except (TypeError, orjson.JSONEncodeError):
+            return hashlib.md5(pickle.dumps(result, protocol=4)).hexdigest()
+
+    @classmethod
+    def _record_accessed_cache_key(cls, cache_key: str, result: Any = None) -> None:
         accessed_keys = accessed_query_cache_keys_ctx.get()
         if accessed_keys is not None:
-            accessed_keys.add(cache_key)
+            accessed_keys[cache_key] = cls._compute_result_hash(result)
 
     @classmethod
     def delete_cache_multi(cls, cache_keys: Set[str]) -> None:
@@ -207,11 +230,11 @@ class CachedDatabaseQuery(
     @ndb.tasklet
     def _do_query(self, *args, **kwargs) -> Generator[Any, Any, QueryReturn]:
         cache_key = self.cache_key
-        self._record_accessed_cache_key(cache_key)
 
         if not self.MODEL_CACHING_ENABLED:
             with Span(f"{self.__class__.__name__}._query_async"):
                 result = yield self._query_async(*args, **kwargs)
+            self._record_accessed_cache_key(cache_key, result)
             return result
 
         with Span("{}._do_query".format(self.__class__.__name__)):
@@ -246,29 +269,33 @@ class CachedDatabaseQuery(
                             f"CachedQueryResult.put_async() failed: {cache_key}"
                         )
                         logging.exception(e)
+                self._record_accessed_cache_key(cache_key, query_result)
                 return query_result
 
             with Span("query.unpickle_models") as span:
                 result = cached_query_result.result
                 if isinstance(result, list):
                     span.set_label("result_count", str(len(result)))
+                self._record_accessed_cache_key(cache_key, result)
                 return result
 
     @ndb.tasklet
     def _do_dict_query(
         self, _dict_version: ApiMajorVersion, *args, **kwargs
     ) -> Generator[Any, Any, Union[None, DictQueryReturn, List[DictQueryReturn]]]:
-        if self.DICT_CONVERTER is not None:
-            cache_key = self.dict_cache_key(_dict_version)
-            self._record_accessed_cache_key(cache_key)
+        cache_key = (
+            self.dict_cache_key(_dict_version)
+            if self.DICT_CONVERTER is not None
+            else self.cache_key
+        )
 
         if not self.DICT_CACHING_ENABLED:
             with Span(f"{self.__class__.__name__}._query_async"):
                 result = yield self._query_async(*args, **kwargs)
+            self._record_accessed_cache_key(cache_key, result)
             return result
 
         with Span("{}._do_dict_query".format(self.__class__.__name__)):
-            cache_key = self.dict_cache_key(_dict_version)
             with Span("query.cache_lookup") as span:
                 span.set_label("cache_key", cache_key)
                 cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
@@ -294,6 +321,7 @@ class CachedDatabaseQuery(
                             f"CachedQueryResult.put_async() failed: {cache_key}"
                         )
                         logging.exception(e)
+                self._record_accessed_cache_key(cache_key, converted_result)
                 return converted_result
 
             values = getattr(cached_query_result, "_values", None)
@@ -301,19 +329,25 @@ class CachedDatabaseQuery(
             if val is not None and not isinstance(
                 val, (ndb.model._BaseValue, bytes, bytearray, str)
             ):
-                return cached_query_result.result_dict
+                result = cached_query_result.result_dict
+                self._record_accessed_cache_key(cache_key, result)
+                return result
 
             raw_bytes = cached_query_result.get_json_bytes()
             if raw_bytes is not None:
                 try:
                     with Span("query.json_decode") as span:
                         span.set_label("byte_size", str(len(raw_bytes)))
-                        return orjson.loads(raw_bytes)
+                        result = orjson.loads(raw_bytes)
+                        self._record_accessed_cache_key(cache_key, result)
+                        return result
                 except (orjson.JSONDecodeError, Exception) as e:
                     logging.warning(
                         f"orjson.loads failed for cache_key {cache_key}, falling back to result_dict: {e}"
                     )
-            return cached_query_result.result_dict
+            result = cached_query_result.result_dict
+            self._record_accessed_cache_key(cache_key, result)
+            return result
 
     def fetch_json(self, version: ApiMajorVersion) -> Optional[bytes]:
         fut: TypedFuture[Optional[bytes]] = self.fetch_json_async(version)
@@ -331,25 +365,29 @@ class CachedDatabaseQuery(
     def _do_json_query(
         self, _dict_version: ApiMajorVersion, *args, **kwargs
     ) -> Generator[Any, Any, Optional[bytes]]:
-        if self.DICT_CONVERTER is not None:
-            cache_key = self.dict_cache_key(_dict_version)
-            self._record_accessed_cache_key(cache_key)
+        cache_key = (
+            self.dict_cache_key(_dict_version)
+            if self.DICT_CONVERTER is not None
+            else self.cache_key
+        )
 
         if not self.DICT_CACHING_ENABLED:
             dict_result = yield self._do_dict_query(_dict_version, *args, **kwargs)
             if dict_result is None:
+                self._record_accessed_cache_key(cache_key, None)
                 return None
             try:
                 with Span("query.serialize_json"):
-                    return orjson.dumps(dict_result)
+                    res = orjson.dumps(dict_result)
             except (orjson.JSONEncodeError, TypeError) as e:
                 logging.warning(
                     f"orjson.dumps failed in _do_json_query, falling back to json.dumps: {e}"
                 )
-                return json.dumps(dict_result, separators=(",", ":")).encode("utf-8")
+                res = json.dumps(dict_result, separators=(",", ":")).encode("utf-8")
+            self._record_accessed_cache_key(cache_key, res)
+            return res
 
         with Span("{}._do_json_query".format(self.__class__.__name__)):
-            cache_key = self.dict_cache_key(_dict_version)
             with Span("query.cache_lookup") as span:
                 span.set_label("cache_key", cache_key)
                 cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
@@ -363,12 +401,11 @@ class CachedDatabaseQuery(
                     query_result
                 ).convert(_dict_version)
 
+                cqr = CachedQueryResult(id=cache_key, result_dict=converted_result)
                 if self.CACHE_WRITES_ENABLED:
                     try:
                         with Span("query.async_cache_write"):
-                            yield CachedQueryResult(
-                                id=cache_key, result_dict=converted_result
-                            ).put_async()
+                            yield cqr.put_async()
                     except Exception as e:
                         logging.warning(
                             f"CachedQueryResult.put_async() failed: {cache_key}"
@@ -376,31 +413,40 @@ class CachedDatabaseQuery(
                         logging.exception(e)
 
                 if converted_result is None:
+                    self._record_accessed_cache_key(cache_key, None)
                     return None
 
-                try:
-                    with Span("query.serialize_json"):
-                        return orjson.dumps(converted_result)
-                except (orjson.JSONEncodeError, TypeError) as e:
-                    logging.warning(
-                        f"orjson.dumps failed for cache_key {cache_key}, falling back to json.dumps: {e}"
-                    )
-                    return json.dumps(converted_result, separators=(",", ":")).encode(
-                        "utf-8"
-                    )
+                res = cqr.get_json_bytes()
+                if res is None:
+                    try:
+                        with Span("query.serialize_json"):
+                            res = orjson.dumps(converted_result)
+                    except (orjson.JSONEncodeError, TypeError) as e:
+                        logging.warning(
+                            f"orjson.dumps failed for cache_key {cache_key}, falling back to json.dumps: {e}"
+                        )
+                        res = json.dumps(
+                            converted_result, separators=(",", ":")
+                        ).encode("utf-8")
+                self._record_accessed_cache_key(cache_key, res)
+                return res
 
             raw_bytes = cached_query_result.get_json_bytes()
             if raw_bytes is not None:
+                self._record_accessed_cache_key(cache_key, raw_bytes)
                 return raw_bytes
             if cached_query_result.result_dict is None:
+                self._record_accessed_cache_key(cache_key, None)
                 return None
             try:
                 with Span("query.serialize_json"):
-                    return orjson.dumps(cached_query_result.result_dict)
+                    res = orjson.dumps(cached_query_result.result_dict)
             except (orjson.JSONEncodeError, TypeError) as e:
                 logging.warning(
                     f"orjson.dumps failed for cache_key {cache_key}, falling back to json.dumps: {e}"
                 )
-                return json.dumps(
+                res = json.dumps(
                     cached_query_result.result_dict, separators=(",", ":")
                 ).encode("utf-8")
+            self._record_accessed_cache_key(cache_key, res)
+            return res


### PR DESCRIPTION
### Summary
Replaces random UUID query versions in `@validate_etag` with **deterministic MD5 hashes of query results**, eliminating the `memcache.get_multi` read round-trip on every 200 response.

### Changes
- **Deterministic Hashing**: `track_accessed_query_cache_keys()` now records `{cache_key: md5_hash}` for executed queries via `_compute_result_hash()`.
- **Single Batched Write**: `save_etag_dependencies()` sets both `q_ver:*` and `etag_deps:*` in a single `memcache.set_multi()` call without reading existing versions first.
- **Cache Hit/Miss Consistency**: Unified `fetch_dict` and `fetch_json` return paths in `database_query.py` so responses and MD5 hashes match byte-for-byte across hits and misses (including non-ASCII unicode).
- **Unit Tests**: Added coverage in `test_validate_etag.py` for single-batch writes, MD5 tracking, unicode determinism, and 304 fastpath restoration on cache flush.

### Verification
- `pytest -n 0 src/backend/api/handlers/tests/`: 489 passed
- `pytest -n 0 src/backend/common/queries/tests/`: 179 passed
- `pyre check`: 0 type errors
- `ops/lint_py3.sh`: clean