### PR TITLE
[api] Disable dict caching for point queries and fix CachedDatabaseQuery._do_dict_query

### DIFF
--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -303,9 +303,13 @@ class CachedDatabaseQuery(
 
         if not self.DICT_CACHING_ENABLED:
             with Span(f"{self.__class__.__name__}._query_async"):
-                result = yield self._query_async(*args, **kwargs)
-            self._record_accessed_cache_key(cache_key, result)
-            return result
+                query_result = yield self._query_async(*args, **kwargs)
+            # See https://github.com/facebook/pyre-check/issues/267
+            converted_result = none_throws(self.DICT_CONVERTER)(  # pyre-ignore[45]
+                query_result
+            ).convert(_dict_version)
+            self._record_accessed_cache_key(cache_key, converted_result)
+            return converted_result
 
         with Span("{}._do_dict_query".format(self.__class__.__name__)):
             with Span("query.cache_lookup") as span:

--- a/src/backend/common/queries/district_query.py
+++ b/src/backend/common/queries/district_query.py
@@ -18,6 +18,8 @@ from backend.common.tasklets import typed_tasklet
 class DistrictQuery(CachedDatabaseQuery[Optional[District], Optional[DistrictDict]]):
     CACHE_VERSION = 3
     CACHE_KEY_FORMAT = "district_{district_key}"
+    MODEL_CACHING_ENABLED = False  # No need to cache a point query
+    DICT_CACHING_ENABLED = False  # No need to cache a point query dict
     DICT_CONVERTER = DistrictConverter
 
     def __init__(self, district_key: DistrictKey) -> None:

--- a/src/backend/common/queries/event_query.py
+++ b/src/backend/common/queries/event_query.py
@@ -23,6 +23,7 @@ class EventQuery(CachedDatabaseQuery[Optional[Event], Optional[EventDict]]):
     CACHE_VERSION = 3
     CACHE_KEY_FORMAT = "event_{event_key}"
     MODEL_CACHING_ENABLED = False  # No need to cache a point query
+    DICT_CACHING_ENABLED = False  # No need to cache a point query dict
     DICT_CONVERTER = EventConverter
 
     def __init__(self, event_key: EventKey) -> None:

--- a/src/backend/common/queries/match_query.py
+++ b/src/backend/common/queries/match_query.py
@@ -17,6 +17,7 @@ class MatchQuery(CachedDatabaseQuery[Optional[Match], Optional[MatchDict]]):
     CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "match_{match_key}"
     MODEL_CACHING_ENABLED = False  # No need to cache a point query
+    DICT_CACHING_ENABLED = False  # No need to cache a point query dict
     DICT_CONVERTER = MatchConverter
 
     def __init__(self, match_key: MatchKey) -> None:

--- a/src/backend/common/queries/team_query.py
+++ b/src/backend/common/queries/team_query.py
@@ -25,6 +25,7 @@ class TeamQuery(CachedDatabaseQuery[Optional[Team], Optional[TeamDict]]):
     CACHE_VERSION = 2
     CACHE_KEY_FORMAT = "team_{team_key}"
     MODEL_CACHING_ENABLED = False  # No need to cache a point query
+    DICT_CACHING_ENABLED = False  # No need to cache a point query dict
     DICT_CONVERTER = TeamConverter
 
     def __init__(self, team_key: TeamKey) -> None:

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -10,7 +10,11 @@ from pyre_extensions import none_throws
 from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.models.cached_model import CachedModel
 from backend.common.models.cached_query_result import CachedQueryResult
-from backend.common.queries.database_query import CachedDatabaseQuery, DatabaseQuery
+from backend.common.queries.database_query import (
+    CachedDatabaseQuery,
+    DatabaseQuery,
+    track_accessed_query_cache_keys,
+)
 from backend.common.queries.dict_converters.converter_base import ConverterBase
 
 
@@ -85,6 +89,21 @@ class CachedDummyModelPointQuery(
 ):
     CACHE_KEY_FORMAT = "test_point_query_{model_key}"
     DICT_CONVERTER = DummyConverter
+    CACHE_WRITES_ENABLED = True
+
+    @ndb.tasklet
+    def _query_async(self, model_key: str) -> Generator[Any, Any, Optional[DummyModel]]:
+        model = yield DummyModel.get_by_id_async(model_key)
+        return model
+
+
+class CachedDummyModelPointQueryNoDictCache(
+    CachedDatabaseQuery[Optional[DummyModel], Optional[DummyDict]]
+):
+    CACHE_KEY_FORMAT = "test_point_query_no_dict_cache_{model_key}"
+    DICT_CONVERTER = DummyConverter
+    MODEL_CACHING_ENABLED = False
+    DICT_CACHING_ENABLED = False
     CACHE_WRITES_ENABLED = True
 
     @ndb.tasklet
@@ -467,3 +486,81 @@ def test_cached_query_fetch_dict_pre_inflated_bypasses_orjson(monkeypatch) -> No
 
     assert result == [{"int_val": 1}]
     assert len(called) == 0
+
+
+def test_dict_caching_disabled_fetch_dict_exists() -> None:
+    m = DummyModel(id="test_disabled", int_prop=42)
+    m.put()
+
+    query = CachedDummyModelPointQueryNoDictCache(model_key="test_disabled")
+    result_dict = query.fetch_dict(ApiMajorVersion.API_V3)
+    assert result_dict == {"int_val": 42}
+
+    # Verify nothing was written to CachedQueryResult
+    cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+    assert CachedQueryResult.get_by_id(cache_key) is None
+
+
+def test_dict_caching_disabled_fetch_dict_not_exists() -> None:
+    query = CachedDummyModelPointQueryNoDictCache(model_key="nonexistent")
+    result_dict = query.fetch_dict(ApiMajorVersion.API_V3)
+    assert result_dict is None
+
+
+def test_dict_caching_disabled_fetch_json_exists() -> None:
+    m = DummyModel(id="test_disabled_json", int_prop=99)
+    m.put()
+
+    query = CachedDummyModelPointQueryNoDictCache(model_key="test_disabled_json")
+    result_json = query.fetch_json(ApiMajorVersion.API_V3)
+    assert result_json is not None
+    assert isinstance(result_json, bytes)
+    assert orjson.loads(result_json) == {"int_val": 99}
+
+    # Verify nothing was written to CachedQueryResult
+    cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+    assert CachedQueryResult.get_by_id(cache_key) is None
+
+
+def test_dict_caching_disabled_fetch_json_not_exists() -> None:
+    query = CachedDummyModelPointQueryNoDictCache(model_key="nonexistent")
+    result_json = query.fetch_json(ApiMajorVersion.API_V3)
+    assert result_json is None
+
+
+def test_dict_caching_disabled_bypasses_cached_query_result_lookup() -> None:
+    m = DummyModel(id="test_bypass", int_prop=1)
+    m.put()
+
+    query = CachedDummyModelPointQueryNoDictCache(model_key="test_bypass")
+    with patch.object(
+        CachedQueryResult, "get_by_id_async", return_value=ndb.Future()
+    ) as mock_get:
+        dict_result = query.fetch_dict(ApiMajorVersion.API_V3)
+        json_result = query.fetch_json(ApiMajorVersion.API_V3)
+        mock_get.assert_not_called()
+
+    assert dict_result == {"int_val": 1}
+    assert json_result is not None
+    assert orjson.loads(json_result) == {"int_val": 1}
+
+
+def test_dict_caching_disabled_records_accessed_cache_key() -> None:
+    m = DummyModel(id="test_etag_track", int_prop=7)
+    m.put()
+
+    query = CachedDummyModelPointQueryNoDictCache(model_key="test_etag_track")
+    expected_cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+
+    with track_accessed_query_cache_keys() as accessed_keys_dict:
+        query.fetch_dict(ApiMajorVersion.API_V3)
+
+    with track_accessed_query_cache_keys() as accessed_keys_json:
+        query.fetch_json(ApiMajorVersion.API_V3)
+
+    assert expected_cache_key in accessed_keys_dict
+    assert expected_cache_key in accessed_keys_json
+    assert (
+        accessed_keys_dict[expected_cache_key] == accessed_keys_json[expected_cache_key]
+    )
+    assert len(accessed_keys_json[expected_cache_key]) == 32


### PR DESCRIPTION
## Summary
- Disables `DICT_CACHING_ENABLED` on single-entity point queries (`MatchQuery`, `TeamQuery`, `EventQuery`, `DistrictQuery`) to eliminate redundant `CachedQueryResult` Datastore/Memcache lookups and writes.
- Leverages the entity already fetched into python-ndb's in-memory WSGI context cache by `@validate_keys`, resulting in instant (0.00 ms) in-memory lookups during `fetch_json_async()`.
- Fixes a bug in `CachedDatabaseQuery._do_dict_query` so `DICT_CONVERTER` is properly applied to convert model entities to dictionaries when `DICT_CACHING_ENABLED = False`, integrating seamlessly with deterministic MD5 query version hashing.
- Added comprehensive unit tests in `database_query_test.py`.

## Test Plan
- `uv run --group test pytest src/backend/common/queries/tests/database_query_test.py` (25 passed)
- `uv run --group test pytest src/backend/api/handlers/tests/{match,team,event,district}_test.py src/backend/api/handlers/tests/test_validate_etag.py` (77 passed)
- `uv run --group lint ./ops/lint_py3.sh`
- `uv run --group typecheck ./ops/typecheck_py3.sh`
