### PR TITLE
[pwa] Tune App Engine autoscaling to cut P90 SSR latency

### DIFF
--- a/pwa/pwa-preview.yaml
+++ b/pwa/pwa-preview.yaml
@@ -4,6 +4,6 @@ runtime: nodejs24
 instance_class: F1
 automatic_scaling:
   max_idle_instances: 0
-  target_cpu_utilization: 0.9
-  target_throughput_utilization: 0.9
-  max_concurrent_requests: 80
+  target_cpu_utilization: 0.6
+  target_throughput_utilization: 0.6
+  max_concurrent_requests: 10

--- a/pwa/pwa.yaml
+++ b/pwa/pwa.yaml
@@ -4,6 +4,9 @@ runtime: nodejs24
 instance_class: F2
 automatic_scaling:
   max_idle_instances: 1
-  target_cpu_utilization: 0.9
-  target_throughput_utilization: 0.9
-  max_concurrent_requests: 80
+  # SSR is single-threaded and CPU-bound; keep per-instance concurrency low so
+  # App Engine scales out before renders queue on the event loop.
+  target_cpu_utilization: 0.6
+  target_throughput_utilization: 0.6
+  max_concurrent_requests: 10
+  max_instances: 40


### PR DESCRIPTION
## Problem

The PWA renders every page with single-threaded React SSR (one Node process per instance). Since the F1→F2 move (#10609, pre-registered in #10608), p50 is fast but the latency tail is not.

Fresh Cloud Monitoring baseline (`module_id="pwa"`, pulled 2026-09-09):

| Signal | Value |
|---|---|
| Non-loading HTTP 200 rate | ~33.3k / 3h ≈ **3.1 req/s** sustained, ~10 req/s at daily peak |
| SSR latency (200, non-loading) | p50 **256–362 ms**, mean 1.11 s, **p90 2.05–2.90 s**, p95 4.1–5.8 s, p99 8.2–11.6 s |
| p90 during peak-hour buckets | degrades to **4.1–5.8 s** (quiet buckets ~1.4–2.0 s) |
| Loading (cold-start) 200s | **0.13%** of 200s — too rare to move aggregate p90 |
| Instances (24h) | active mean 0.46 / max 9; idle mean ~2.4 / max 10 |

p90 is 7–10× p50 and gets worse exactly when traffic rises. That is event-loop queueing: at `max_concurrent_requests: 80` and 0.9 utilization targets, one F2 instance accepts ~72 concurrent requests before App Engine asks for another. With ~300–500 ms of single-threaded CPU per render, even a handful of concurrent renders push the last request to multiple seconds.

## Change

Lower per-instance concurrency so App Engine scales out earlier. `instance_class: F2` is unchanged.

`pwa.yaml`:
- `max_concurrent_requests` 80 → **10**
- `target_cpu_utilization` 0.9 → **0.6**
- `target_throughput_utilization` 0.9 → **0.6**
- pin `max_instances: 40` — headroom above App Engine's new default of 20, since scale-out is now more aggressive (recent peak was 9)

`pwa-preview.yaml` gets the same concurrency/utilization values (stays F1, `max_idle_instances: 0`).

No test files (config only; CI's `check_node_versions.sh` only asserts `runtime:`, untouched).

## Expected tradeoff

- **Latency:** p90/p95 SSR should fall materially — target p90 back toward the ~1.4–2.0 s quiet-bucket level and holding there under peak load. p50 roughly unchanged.
- **Cost:** more instances held more often. Billed frontend-instance hours expected to rise from ~29/day toward ~45–70/day; at the F2 rate (~\$0.10/h) roughly **+\$100–250/month** over the current F2 bill. Refine against the FOCUS billing export once live.

## Rollout measurement plan

Follow #10608's method: filter `module_id="pwa"` + `version_id="<new version>"`, normalize counts per 1,000 requests, compare the 7 days after deploy against the 7 days immediately before (equivalent traffic windows; sanity-check same-weekday a week earlier given ~10× offseason swings). Record deploy timestamp + version id.

| # | Metric | Source | Baseline |
|---|---|---|---|
| 1 | Latency **p50 / p90 / p95** (primary) | Monitoring `http/server/response_latencies`, daily align, `ALIGN_PERCENTILE_50/90/95`, `REDUCE_MEAN` | p50 ~0.3 s, p90 ~2.0–2.9 s (peak 4–5.8 s), p95 ~4–5.8 s |
| 2 | Instance count + **instance-hours / cost** | `system/instance_count` for shape; billing truth from the FOCUS export query in #10608 (`ChargeDescription="Frontend Instances"`, `ResourceName LIKE "%services/pwa%"`), reported as **hours per 1,000 requests** | ~29 h/day; ~0.4–1.0 h per 1,000 req |
| 3 | Cold / loading-request frequency | `response_latencies` / `response_count` split on `loading="true"`; `instance_count{state="loading"}` | loading ≈ 0.13% of 200s |
| 4 | Error rate | `http/server/response_count`, `response_code>=500`, per 1,000 req | ~0 5xx/day |
| 5 | Brotli backpressure (mechanism check) | `gcloud logging read … textPayload:"MaxListenersExceededWarning"`, per 1,000 req | ~0.3–1.5 per 1,000 req |
| 6 | Traffic volume (normalizer) | `http/server/response_count` total | ~3 req/s sustained |

## Rollback thresholds

Revert both files to `80 / 0.9 / 0.9` (and drop `max_instances`) if **any** hold over the first 7 post-change days:

- **Latency not improved:** median daily p90 drops < 15% vs. the pre-change window (still ≳ 2.4 s), or p50 regresses > 20%.
- **Cost:** instance-hours per 1,000 requests rise > 2× baseline, or projected steady-state PWA frontend-instance cost exceeds **+\$100/month** over the current F2 bill.
- **Errors:** 5xx per 1,000 requests > 2× baseline and > 1 per 1,000 absolute.
- **Cold starts:** loading-request share of 200s rises above ~1% (scale in/out thrash).

Inconclusive (hold, extend a week): p90 improves 15–30% with cost within +\$100/month and no error regression; or fewer than 5 clean days due to an offseason spike or unrelated PWA deploy.

Fast rollback: revert the commit and let the push workflow redeploy, or `gcloud app services set-traffic pwa --splits <prev-version>=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)