### PR TITLE
[pwa] Cut team robot-image load times

### DIFF
--- a/pwa/app/components/tba/teamMediaGallery.tsx
+++ b/pwa/app/components/tba/teamMediaGallery.tsx
@@ -4,8 +4,8 @@ import { InstagramEmbed } from 'react-social-media-embed';
 import { Media } from '~/api/tba/read';
 import {
   getEmbedMedia,
-  getMediaImageUrl,
   getMediaLinkUrl,
+  getMediaThumbUrl,
 } from '~/lib/mediaUtils';
 
 export default function TeamMediaGallery({
@@ -45,7 +45,7 @@ function ImgurEmbed({ media }: { media: Media }): React.JSX.Element | null {
   const [failed, setFailed] = useState(false);
   const [visible, setVisible] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
-  const thumbnailUrl = getMediaImageUrl(media);
+  const thumbnailUrl = getMediaThumbUrl(media);
 
   useEffect(() => {
     const img = imgRef.current;

--- a/pwa/app/components/tba/teamRobotPicsCarousel.tsx
+++ b/pwa/app/components/tba/teamRobotPicsCarousel.tsx
@@ -1,39 +1,88 @@
 import Autoplay from 'embla-carousel-autoplay';
+import { useEffect, useState } from 'react';
 
 import { Media } from '~/api/tba/read';
 import {
   Carousel,
+  type CarouselApi,
   CarouselContent,
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
 } from '~/components/ui/carousel';
-import { getMediaImageUrl, getMediaLinkUrl } from '~/lib/mediaUtils';
+import {
+  getMediaLinkUrl,
+  getMediaThumbSrcSet,
+  getMediaThumbUrl,
+} from '~/lib/mediaUtils';
+
+function neighbors(index: number, length: number): number[] {
+  return [index - 1, index, index + 1].filter((i) => i >= 0 && i < length);
+}
 
 export default function TeamRobotPicsCarousel({
   media,
 }: {
   media: Media[];
 }): React.JSX.Element {
+  const [api, setApi] = useState<CarouselApi>();
+  const [loaded, setLoaded] = useState<ReadonlySet<number>>(
+    () => new Set(neighbors(0, media.length)),
+  );
+
+  useEffect(() => {
+    if (!api) return;
+    const sync = () => {
+      const selected = api.selectedScrollSnap();
+      setLoaded((prev) => {
+        const next = new Set(prev);
+        for (const i of neighbors(selected, media.length)) next.add(i);
+        return next;
+      });
+    };
+    sync();
+    api.on('select', sync);
+    return () => {
+      api.off('select', sync);
+    };
+  }, [api, media.length]);
+
   return (
-    <Carousel className="w-full max-w-xs" plugins={[Autoplay({ delay: 5000 })]}>
+    <Carousel
+      className="w-full max-w-xs"
+      setApi={setApi}
+      plugins={[Autoplay({ delay: 5000 })]}
+    >
       <CarouselContent className="items-center">
         {media.map((m, index) => {
-          const imageUrl = getMediaImageUrl(m);
+          const imageUrl = getMediaThumbUrl(m);
           const linkUrl = getMediaLinkUrl(m);
           if (!imageUrl) return null;
 
-          const img = (
+          const isFirst = index === 0;
+          const img = loaded.has(index) ? (
             <img
               className="max-h-[250px] w-full rounded object-contain"
               src={imageUrl}
+              srcSet={getMediaThumbSrcSet(m)}
+              sizes="320px"
+              width={320}
+              height={250}
               alt=""
+              decoding="async"
+              loading={isFirst ? 'eager' : 'lazy'}
+              fetchPriority={isFirst ? 'high' : 'low'}
             />
+          ) : (
+            <div className="h-[250px] w-full" />
           );
 
           return (
             <CarouselItem key={index}>
-              <div className="rounded-lg border-2 border-neutral-300">
+              <div
+                className="flex h-[250px] w-full items-center justify-center
+                  rounded-lg border-2 border-neutral-300"
+              >
                 {linkUrl ? (
                   <a href={linkUrl} target="_blank" rel="noreferrer">
                     {img}

--- a/pwa/app/lib/mediaUtils.test.ts
+++ b/pwa/app/lib/mediaUtils.test.ts
@@ -3,9 +3,53 @@ import { describe, expect, test } from 'vitest';
 import type { Media } from '~/api/tba/read';
 import {
   getEventVideos,
+  getMediaImageUrl,
   getMediaLinkUrl,
+  getMediaThumbSrcSet,
+  getMediaThumbUrl,
   getSmugmugAlbums,
 } from '~/lib/mediaUtils';
+
+function imgurMedia(overrides: Partial<Media> = {}): Media {
+  return {
+    type: 'imgur',
+    foreign_key: 'aB3d9Xk',
+    team_keys: ['frc254'],
+    preferred: true,
+    view_url: 'https://imgur.com/aB3d9Xk',
+    direct_url: 'https://i.imgur.com/aB3d9Xk.jpg',
+    details: {},
+    ...overrides,
+  } as Media;
+}
+
+function cdThreadMedia(overrides: Partial<Media> = {}): Media {
+  return {
+    type: 'cd-thread',
+    foreign_key: '12345',
+    team_keys: ['frc254'],
+    preferred: false,
+    view_url: 'https://www.chiefdelphi.com/t/12345',
+    direct_url: undefined,
+    details: {
+      thread_title: 'Robot',
+      image_url: 'https://www.chiefdelphi.com/uploads/robot.jpg',
+    },
+    ...overrides,
+  } as Media;
+}
+
+function externalLinkMedia(overrides: Partial<Media> = {}): Media {
+  return {
+    type: 'external-link',
+    foreign_key: 'https://example.com/robot.jpg',
+    team_keys: ['frc254'],
+    preferred: false,
+    direct_url: 'https://example.com/robot.jpg',
+    details: {},
+    ...overrides,
+  } as Media;
+}
 
 function smugmugAlbum(overrides: Partial<Media> = {}): Media {
   return {
@@ -88,6 +132,90 @@ describe.concurrent('getSmugmugAlbums', () => {
 
   test('returns an empty array when there are no albums', () => {
     expect(getSmugmugAlbums([youtubeMedia('abc')])).toEqual([]);
+  });
+});
+
+describe.concurrent('getMediaThumbUrl', () => {
+  test('imgur inserts the large size suffix before the extension', () => {
+    expect(getMediaThumbUrl(imgurMedia())).toBe(
+      'https://i.imgur.com/aB3d9Xkl.jpg',
+    );
+  });
+
+  test('imgur preserves the original extension', () => {
+    const media = imgurMedia({
+      direct_url: 'https://i.imgur.com/aB3d9Xk.png',
+    });
+    expect(getMediaThumbUrl(media)).toBe('https://i.imgur.com/aB3d9Xkl.png');
+  });
+
+  test('imgur non-i.imgur.com URLs are returned unchanged', () => {
+    const media = imgurMedia({
+      direct_url: 'https://imgur.com/a/aB3d9Xk',
+    });
+    expect(getMediaThumbUrl(media)).toBe('https://imgur.com/a/aB3d9Xk');
+  });
+
+  test('imgur already-suffixed URLs are not double-suffixed', () => {
+    const media = imgurMedia({
+      direct_url: 'https://i.imgur.com/aB3d9Xkl.jpg',
+    });
+    expect(getMediaThumbUrl(media)).toBe('https://i.imgur.com/aB3d9Xkl.jpg');
+  });
+
+  test('imgur missing direct_url falls back to undefined', () => {
+    const media = imgurMedia({ direct_url: undefined });
+    expect(getMediaThumbUrl(media)).toBeUndefined();
+  });
+
+  test('imgur malformed direct_url falls back to the raw value', () => {
+    const media = imgurMedia({ direct_url: 'not a url' });
+    expect(getMediaThumbUrl(media)).toBe('not a url');
+  });
+
+  test('smugmug-photo uses the medium image', () => {
+    expect(getMediaThumbUrl(smugmugPhoto())).toBe(
+      'https://photos.smugmug.com/x-M.jpg',
+    );
+  });
+
+  test('smugmug-photo falls back to direct_url without details', () => {
+    const media = smugmugPhoto({ details: undefined });
+    expect(getMediaThumbUrl(media)).toBe('https://photos.smugmug.com/x-L.jpg');
+  });
+
+  test('smugmug-album uses the medium cover image', () => {
+    expect(getMediaThumbUrl(smugmugAlbum())).toBe(
+      'https://photos.smugmug.com/i-57rxPBW-M.png',
+    );
+  });
+
+  test('cd-thread matches getMediaImageUrl', () => {
+    const media = cdThreadMedia();
+    expect(getMediaThumbUrl(media)).toBe(getMediaImageUrl(media));
+  });
+
+  test('external-link matches getMediaImageUrl', () => {
+    const media = externalLinkMedia();
+    expect(getMediaThumbUrl(media)).toBe(getMediaImageUrl(media));
+  });
+});
+
+describe.concurrent('getMediaThumbSrcSet', () => {
+  test('imgur returns 1x/2x descriptors', () => {
+    expect(getMediaThumbSrcSet(imgurMedia())).toBe(
+      'https://i.imgur.com/aB3d9Xkl.jpg 1x, https://i.imgur.com/aB3d9Xkh.jpg 2x',
+    );
+  });
+
+  test('imgur without a usable direct_url returns undefined', () => {
+    expect(
+      getMediaThumbSrcSet(imgurMedia({ direct_url: 'https://imgur.com/x' })),
+    ).toBeUndefined();
+  });
+
+  test('non-imgur media returns undefined', () => {
+    expect(getMediaThumbSrcSet(smugmugPhoto())).toBeUndefined();
   });
 });
 

--- a/pwa/app/lib/mediaUtils.ts
+++ b/pwa/app/lib/mediaUtils.ts
@@ -29,6 +29,50 @@ export function getMediaImageUrl(media: Media): string | undefined {
   return media.direct_url || undefined;
 }
 
+function imgurThumbUrl(
+  directUrl: string | undefined,
+  size: 'l' | 'h',
+): string | undefined {
+  if (!directUrl) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(directUrl);
+  } catch {
+    return undefined;
+  }
+  if (parsed.hostname !== 'i.imgur.com') return undefined;
+  const match = parsed.pathname.match(
+    /^\/([A-Za-z0-9]+)\.(jpe?g|png|gif|webp)$/i,
+  );
+  if (!match) return undefined;
+  const [, id, ext] = match;
+  if (id.length === 8 && /[sbtmlh]$/.test(id)) return undefined;
+  return `https://i.imgur.com/${id}${size}.${ext}`;
+}
+
+/** Returns an appropriately sized thumbnail URL for a media item, falling back to the full-resolution URL when the provider has no resized variant. */
+export function getMediaThumbUrl(media: Media): string | undefined {
+  if (media.type === 'imgur') {
+    return imgurThumbUrl(media.direct_url, 'l') ?? getMediaImageUrl(media);
+  }
+  if (media.type === 'smugmug-photo') {
+    return media.details?.image_url_med ?? getMediaImageUrl(media);
+  }
+  if (media.type === 'smugmug-album') {
+    return media.details?.cover_url_med ?? getMediaImageUrl(media);
+  }
+  return getMediaImageUrl(media);
+}
+
+/** Returns a `srcset` string for providers that expose multiple thumbnail sizes, or undefined when only a single URL is available. */
+export function getMediaThumbSrcSet(media: Media): string | undefined {
+  if (media.type !== 'imgur') return undefined;
+  const medium = imgurThumbUrl(media.direct_url, 'l');
+  const large = imgurThumbUrl(media.direct_url, 'h');
+  if (!medium || !large) return undefined;
+  return `${medium} 1x, ${large} 2x`;
+}
+
 /** Returns all embeddable image media (imgur + instagram-image). */
 export function getEmbedMedia(media: Media[]): Media[] {
   return media.filter((m) => EMBED_MEDIA_TYPES.has(m.type));

--- a/pwa/tests/carousel.spec.ts
+++ b/pwa/tests/carousel.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+
+// Regression tests for the team robot-pic carousel performance work: the first
+// slide loads eagerly at high priority with a resized image, later slides are
+// deferred, and navigation / the original-media link still work.
+
+const TEAM_PAGE = '/team/254/2026';
+
+function isImgurThumb(url: string): boolean {
+  return /i\.imgur\.com\/[A-Za-z0-9]{7}[lh]\.\w+(\?.*)?$/.test(url);
+}
+
+function isImgurOriginal(url: string): boolean {
+  return (
+    /i\.imgur\.com\/[A-Za-z0-9]+\.\w+(\?.*)?$/.test(url) && !isImgurThumb(url)
+  );
+}
+
+test.describe('team robot-pic carousel', () => {
+  test('first slide eager + resized, later slides deferred', async ({
+    page,
+  }) => {
+    const imageRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.resourceType() === 'image') imageRequests.push(req.url());
+    });
+
+    await page.goto(TEAM_PAGE);
+    await page.locator('body[data-hydrated]').waitFor();
+
+    const carousel = page.locator('[aria-roledescription="carousel"]').first();
+    await expect(carousel).toBeVisible();
+
+    const slides = carousel.locator('[aria-roledescription="slide"]');
+    const imgs = carousel.locator('img');
+    const slideCount = await slides.count();
+    expect(slideCount).toBeGreaterThan(3);
+    expect(await imgs.count()).toBeLessThan(slideCount);
+
+    await expect(imgs.first()).toHaveAttribute('loading', 'eager');
+    await expect(imgs.first()).toHaveAttribute('fetchpriority', 'high');
+    await expect(imgs.nth(1)).toHaveAttribute('loading', 'lazy');
+    await expect(imgs.nth(1)).toHaveAttribute('fetchpriority', 'low');
+
+    const firstSrc = await imgs
+      .first()
+      .evaluate((el) => (el as HTMLImageElement).currentSrc);
+    expect(isImgurThumb(firstSrc)).toBe(true);
+    expect(imageRequests).toContain(firstSrc);
+
+    for (const url of imageRequests) {
+      expect(isImgurOriginal(url)).toBe(false);
+    }
+
+    const lastSlideImgs = slides.last().locator('img');
+    expect(await lastSlideImgs.count()).toBe(0);
+  });
+
+  test('navigation and the original-media link still work', async ({
+    page,
+  }) => {
+    await page.goto(TEAM_PAGE);
+    await page.locator('body[data-hydrated]').waitFor();
+
+    const carousel = page.locator('[aria-roledescription="carousel"]').first();
+    await expect(carousel).toBeVisible();
+
+    const link = carousel.locator('a[target="_blank"]').first();
+    await expect(link).toHaveAttribute('href', /^https?:\/\//);
+
+    const slide0 = carousel.locator('[aria-roledescription="slide"]').first();
+    const x = () => slide0.evaluate((el) => el.getBoundingClientRect().x);
+    const startX = await x();
+
+    const next = page.getByRole('button', { name: 'Next slide' });
+    const prev = page.getByRole('button', { name: 'Previous slide' });
+
+    await next.click();
+    await expect(prev).toBeEnabled();
+    await expect.poll(x).toBeLessThan(startX - 100);
+
+    await prev.click();
+    await expect.poll(x).toBeGreaterThan(startX - 100);
+  });
+
+  test('mobile: first slide is eager and later slides are lazy', async ({
+    page,
+  }) => {
+    await page.goto(TEAM_PAGE);
+    await page.locator('body[data-hydrated]').waitFor();
+
+    const imgs = page
+      .locator('[aria-roledescription="carousel"]')
+      .first()
+      .locator('img');
+    await expect(imgs.first()).toHaveAttribute('loading', 'eager');
+    await expect(imgs.first()).toHaveAttribute('fetchpriority', 'high');
+    await expect(imgs.nth(1)).toHaveAttribute('loading', 'lazy');
+  });
+});
+
+test.describe('team media gallery', () => {
+  test('Imgur cards load resized images, not full-res originals', async ({
+    page,
+  }) => {
+    const imgurRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.resourceType() === 'image' && req.url().includes('i.imgur.com')) {
+        imgurRequests.push(req.url());
+      }
+    });
+
+    await page.goto(TEAM_PAGE);
+    await page.locator('body[data-hydrated]').waitFor();
+
+    const gallery = page.getByTestId('team-media-gallery');
+    await expect(gallery).toBeVisible();
+    await gallery.locator('img').first().waitFor();
+    await expect.poll(() => imgurRequests.length).toBeGreaterThan(3);
+
+    for (const url of imgurRequests) {
+      expect(isImgurOriginal(url)).toBe(false);
+    }
+
+    const link = gallery.locator('a[target="_blank"]').first();
+    await expect(link).toHaveAttribute('href', /^https?:\/\//);
+  });
+});


### PR DESCRIPTION
On media-heavy team pages the robot-pic carousel was the mobile LCP element: every slide (and every gallery card) downloaded the full-resolution Imgur original — multi-MB images shown in a ~316×250 box.

## Changes
- **`getMediaThumbUrl` / `getMediaThumbSrcSet`** (`mediaUtils.ts`): resized variants for Imgur (`l`/`h` size suffix) and SmugMug (`*_med`). Unsupported/malformed URLs fall back to the original untouched.
- **Carousel**: first slide loads eager + `fetchpriority=high` with a resized `src`/`srcSet`; later slides only get a `src` once selected (± 1 neighbour, sticky). Fixed-height slide box removes layout shift. Link still opens the original.
- **Team media gallery**: `ImgurEmbed` probe uses the resized URL (this is where most bytes were).

## Measured — `/team/254/2026`, prod build, Lighthouse mobile (5 runs)
| Metric | Before | After |
|---|---|---|
| LCP median | 11.1 s | 6.2 s |
| CLS p90 | 0.19 | 0.05 |
| Total transfer | 7.6 MB | 3.7 MB |
| Image transfer | 4.7 MB | 0.7 MB |

## Tests
- `mediaUtils.test.ts`: thumbnail generation + fallbacks for every provider.
- `tests/carousel.spec.ts`: eager/priority first slide, deferred later slides, navigation, original-media link, gallery uses resized images.
