### PR TITLE
[pwa] Cut match page load times by lazyloading youtube embed

### DIFF
--- a/pwa/app/components/tba/match/matchDetails.tsx
+++ b/pwa/app/components/tba/match/matchDetails.tsx
@@ -311,6 +311,7 @@ export default function MatchDetails({
               key={v.key}
               videoId={v.key}
               title={`${event.name} ${match.match_number} ${v.key}`}
+              deferUntilIdle
             />
           ))}
       </div>

--- a/pwa/app/components/tba/videoEmbeds.tsx
+++ b/pwa/app/components/tba/videoEmbeds.tsx
@@ -1,22 +1,77 @@
 import { cn } from 'cn';
+import { useEffect, useState } from 'react';
+
+interface YoutubeEmbedProps {
+  videoId: string;
+  title: string;
+  className?: string;
+  deferUntilIdle?: boolean;
+}
 
 export function YoutubeEmbed({
   videoId,
   title,
   className,
-}: {
-  videoId: string;
-  title: string;
-  className?: string;
-}) {
+  deferUntilIdle = false,
+}: YoutubeEmbedProps) {
+  const [shouldLoad, setShouldLoad] = useState(!deferUntilIdle);
+
+  useEffect(() => {
+    if (!deferUntilIdle) {
+      return;
+    }
+
+    let idleCallbackId: number | undefined;
+    let fallbackTimeoutId: number | undefined;
+
+    const scheduleLoad = () => {
+      const requestIdleCallback = window.requestIdleCallback as
+        typeof window.requestIdleCallback | undefined;
+      if (requestIdleCallback) {
+        idleCallbackId = requestIdleCallback(() => setShouldLoad(true), {
+          timeout: 2_000,
+        });
+      } else {
+        fallbackTimeoutId = window.setTimeout(() => setShouldLoad(true), 1_000);
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      scheduleLoad();
+    } else {
+      window.addEventListener('load', scheduleLoad, { once: true });
+    }
+
+    return () => {
+      window.removeEventListener('load', scheduleLoad);
+      if (idleCallbackId !== undefined) {
+        window.cancelIdleCallback(idleCallbackId);
+      }
+      if (fallbackTimeoutId !== undefined) {
+        window.clearTimeout(fallbackTimeoutId);
+      }
+    };
+  }, [deferUntilIdle]);
+
   return (
     <div className={cn('relative aspect-video h-auto w-full', className)}>
-      <iframe
-        src={`https://www.youtube.com/embed/${videoId.replace('?t=', '?start=')}`}
-        title={title}
-        allowFullScreen
-        className="absolute inset-0 h-full w-full rounded-lg shadow-lg"
-      />
+      {shouldLoad ? (
+        <iframe
+          src={`https://www.youtube.com/embed/${videoId.replace('?t=', '?start=')}`}
+          title={title}
+          allowFullScreen
+          loading="lazy"
+          className="absolute inset-0 h-full w-full rounded-lg shadow-lg"
+        />
+      ) : (
+        <div
+          data-testid="youtube-embed-placeholder"
+          className="absolute inset-0 h-full w-full animate-pulse rounded-lg
+            bg-muted shadow-lg"
+        >
+          <span className="sr-only">Loading {title}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/pwa/tests/lazy-chunks.spec.ts
+++ b/pwa/tests/lazy-chunks.spec.ts
@@ -1,5 +1,49 @@
 import { expect, test } from '@playwright/test';
 
+test.describe('lazy YouTube embeds', () => {
+  test('loads match players automatically after the browser is idle', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.requestIdleCallback = (callback) => {
+        window.addEventListener(
+          'test-run-idle-callbacks',
+          () =>
+            callback({
+              didTimeout: false,
+              timeRemaining: () => 50,
+            }),
+          { once: true },
+        );
+        return 1;
+      };
+      window.cancelIdleCallback = () => {};
+    });
+
+    await page.goto('/match/2026cmptx_f1m1');
+    await page.locator('body[data-hydrated]').waitFor();
+
+    const players = page.locator('iframe[src*="youtube.com/embed"]');
+    const placeholders = page.getByTestId('youtube-embed-placeholder');
+    await expect(players).toHaveCount(0);
+    await expect(placeholders).toHaveCount(2);
+
+    const placeholderBoxes = await placeholders.evaluateAll((elements) =>
+      elements.map((element) => element.getBoundingClientRect().toJSON()),
+    );
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('test-run-idle-callbacks'));
+    });
+
+    await expect(players).toHaveCount(2);
+    const playerBoxes = await players.evaluateAll((elements) =>
+      elements.map((element) => element.getBoundingClientRect().toJSON()),
+    );
+    expect(playerBoxes).toEqual(placeholderBoxes);
+  });
+});
+
 // Regression tests for GH #10240: heavy libraries (score breakdowns, recharts,
 // devtools) were statically imported into route/entry chunks even though most
 // visitors never render them. These assert the lazy-loaded UI still renders


### PR DESCRIPTION

  Performance on /match/2026cmptx_f1m1:

```
   Median    Before    After
  ━━━━━━━━  ━━━━━━━━  ━━━━━━━
   Score         45       60
  ────────  ────────  ───────
   LCP        11.1s     5.4s
  ────────  ────────  ───────
   TBT        782ms    452ms
  ────────  ────────  ───────
   TTI        13.7s    12.7s
  ────────  ────────  ───────
   CLS        0.008    0.000

```