### PR TITLE
Add Beta Link to Mod Cron Nag Text

### DIFF
--- a/src/backend/tasks_io/handlers/cron_misc.py
+++ b/src/backend/tasks_io/handlers/cron_misc.py
@@ -36,9 +36,7 @@ def nag_pending_suggestions() -> str:
             )
 
     if suggestions_to_nag:
-        nag_text += (
-            "_Review them on <https://www.thebluealliance.com/suggest/review|TBA> or on <https://beta.thebluealliance.com/suggest/review|Beta>_"
-        )
+        nag_text += "_Review them on <https://www.thebluealliance.com/suggest/review|TBA> or on <https://beta.thebluealliance.com/suggest/review|Beta>_"
         OutgoingNotificationHelper.send_slack_alert(channel_url, nag_text)
 
     return ""

--- a/src/backend/tasks_io/handlers/cron_misc.py
+++ b/src/backend/tasks_io/handlers/cron_misc.py
@@ -37,7 +37,7 @@ def nag_pending_suggestions() -> str:
 
     if suggestions_to_nag:
         nag_text += (
-            "_Review them on <https://www.thebluealliance.com/suggest/review|TBA>_"
+            "_Review them on <https://www.thebluealliance.com/suggest/review|TBA> or on <https://beta.thebluealliance.com/suggest/review|Beta>_"
         )
         OutgoingNotificationHelper.send_slack_alert(channel_url, nag_text)
 


### PR DESCRIPTION
## Description

Adds a link to the Suggestion Review page on `beta` to the Slack Mod Cron Nag text.

## Motivation and Context

Moderate motivation. Willing to be motivated more. ;) /s

## How Has This Been Tested?

YOLO Text Only Change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
