### PR TITLE
[api] Optimize ETag validation and dependency-saving pipeline

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -8,6 +8,7 @@ from flask import g, jsonify, make_response, request, Response
 
 from backend.api.client_api_types import VoidRequest
 from backend.api.handlers.helpers.etag_helper import (
+    etag_deps_persisted_cache,
     get_incoming_etags,
     get_request_path,
     is_etag_valid,
@@ -345,8 +346,8 @@ def validate_keys(func):
     return decorated_function
 
 
-ETAG_304_CACHE_TTL: float = 15.0  # 15 seconds
-ETAG_304_CACHE_MAX_SIZE: int = 2000
+ETAG_304_CACHE_TTL: float = 61.0  # 61 seconds (aligned with Cache-Control: max-age=61)
+ETAG_304_CACHE_MAX_SIZE: int = 5000
 etag_304_cache: InstanceCache[tuple[str, str], bool] = InstanceCache(
     ttl_seconds=ETAG_304_CACHE_TTL, max_size=ETAG_304_CACHE_MAX_SIZE
 )
@@ -380,7 +381,7 @@ def validate_etag(func: Callable) -> Callable:
                         hit_source: Optional[str] = None
                         if etag_304_cache.get((request_path, etag)):
                             hit_source = "memory"
-                        elif is_etag_valid(etag):
+                        elif is_etag_valid(etag, path=request_path):
                             etag_304_cache.set((request_path, etag), True)
                             hit_source = "memcache"
 
@@ -405,11 +406,19 @@ def validate_etag(func: Callable) -> Callable:
                     if etag_header and accessed_keys:
                         normalized = normalize_etag(etag_header)
                         if normalized:
-                            with Span("etag.save_dependencies") as span:
-                                span.set_label(
-                                    "num_query_keys", str(len(accessed_keys))
-                                )
-                                save_etag_dependencies(normalized, accessed_keys)
+                            request_path = get_request_path()
+                            if not etag_deps_persisted_cache.get(
+                                (request_path, normalized)
+                            ):
+                                with Span("etag.save_dependencies") as span:
+                                    span.set_label(
+                                        "num_query_keys", str(len(accessed_keys))
+                                    )
+                                    save_etag_dependencies(
+                                        normalized,
+                                        accessed_keys,
+                                        path=request_path,
+                                    )
                 except Exception as e:
                     logging.warning(f"Error saving validate_etag dependencies: {e}")
 

--- a/src/backend/api/handlers/helpers/etag_helper.py
+++ b/src/backend/api/handlers/helpers/etag_helper.py
@@ -3,9 +3,16 @@ from typing import Any, Dict, List, Optional
 
 from flask import request
 
+from backend.common.cache.instance_cache import InstanceCache
 from backend.common.memcache import MemcacheClient
 
 ETAG_CACHE_TTL: int = 7 * 24 * 3600  # 7 days in seconds
+ETAG_DEPS_PERSISTED_CACHE_TTL: float = 600.0  # 10 minutes
+ETAG_DEPS_PERSISTED_CACHE_MAX_SIZE: int = 5000
+etag_deps_persisted_cache: InstanceCache[tuple[str, str], bool] = InstanceCache(
+    ttl_seconds=ETAG_DEPS_PERSISTED_CACHE_TTL,
+    max_size=ETAG_DEPS_PERSISTED_CACHE_MAX_SIZE,
+)
 
 
 def normalize_etag(etag: Optional[str]) -> Optional[str]:
@@ -77,8 +84,10 @@ def is_etag_valid(normalized_etag: str, path: Optional[str] = None) -> bool:
     """
     Verifies whether all dependent query cache keys for a given ETag match their current versions.
     """
+    endpoint_path = get_request_path(path)
     deps = get_etag_dependencies(normalized_etag, path=path)
     if deps is None or not isinstance(deps, dict) or not deps:
+        etag_deps_persisted_cache.delete((endpoint_path, normalized_etag))
         return False
     try:
         memcache = MemcacheClient.get()
@@ -88,6 +97,7 @@ def is_etag_valid(normalized_etag: str, path: Optional[str] = None) -> bool:
         for k, expected_ver in deps.items():
             actual_ver = current_versions.get(f"q_ver:{k}".encode("utf-8"))
             if actual_ver is None or actual_ver != expected_ver:
+                etag_deps_persisted_cache.delete((endpoint_path, normalized_etag))
                 return False
         return True
     except Exception as e:
@@ -100,15 +110,21 @@ def save_etag_dependencies(
     query_versions: Dict[str, str],
     path: Optional[str] = None,
     ttl: int = ETAG_CACHE_TTL,
-) -> None:
+) -> bool:
     """
     Stores the mapping between an ETag and its dependent query cache keys with their current versions.
+    Skips redundant writes if the (endpoint_path, normalized_etag) pair was recently persisted.
     """
     if not query_versions:
-        return
+        return False
+
+    endpoint_path = get_request_path(path)
+    cache_key = (endpoint_path, normalized_etag)
+    if etag_deps_persisted_cache.get(cache_key):
+        return False
+
     try:
         memcache = MemcacheClient.get()
-        endpoint_path = get_request_path(path)
         versions_to_set: Dict[bytes, Any] = {
             f"q_ver:{k}".encode("utf-8"): ver for k, ver in query_versions.items()
         }
@@ -117,5 +133,9 @@ def save_etag_dependencies(
         ] = query_versions
 
         memcache.set_multi(versions_to_set, time=ttl)
+        cache_ttl = min(float(ttl), ETAG_DEPS_PERSISTED_CACHE_TTL)
+        etag_deps_persisted_cache.set(cache_key, True, ttl_seconds=cache_ttl)
+        return True
     except Exception as e:
         logging.warning(f"Error saving ETag dependencies to Memcache: {e}")
+        return False

--- a/src/backend/api/handlers/helpers/tests/etag_helper_test.py
+++ b/src/backend/api/handlers/helpers/tests/etag_helper_test.py
@@ -1,0 +1,183 @@
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from backend.api.handlers.helpers.etag_helper import (
+    etag_deps_persisted_cache,
+    get_incoming_etags,
+    get_request_path,
+    is_etag_valid,
+    normalize_etag,
+    save_etag_dependencies,
+)
+from backend.common.memcache import MemcacheClient
+
+
+@pytest.fixture
+def app() -> Flask:
+    return Flask(__name__)
+
+
+def test_normalize_etag() -> None:
+    assert normalize_etag(None) is None
+    assert normalize_etag("") is None
+    assert normalize_etag("   ") is None
+    assert normalize_etag("simple_etag") == "simple_etag"
+    assert normalize_etag('"quoted_etag"') == "quoted_etag"
+    assert normalize_etag("'single_quoted'") == "single_quoted"
+    assert normalize_etag('W/"weak_etag"') == "weak_etag"
+    assert normalize_etag('w/"weak_lowercase"') == "weak_lowercase"
+    assert normalize_etag('  W/"  spaced_etag  "  ') == "spaced_etag"
+
+
+def test_get_incoming_etags(app: Flask) -> None:
+    with app.test_request_context(
+        "/api/v3/team/frc254",
+        headers={"If-None-Match": 'W/"etag1", "etag2", etag3'},
+    ):
+        etags = get_incoming_etags()
+        assert set(etags) == {"etag1", "etag2", "etag3"}
+
+
+def test_get_incoming_etags_empty(app: Flask) -> None:
+    with app.test_request_context("/api/v3/team/frc254"):
+        assert get_incoming_etags() == []
+
+
+def test_get_request_path(app: Flask) -> None:
+    with app.test_request_context("/api/v3/team/frc254?foo=bar"):
+        assert get_request_path() == "/api/v3/team/frc254"
+        assert (
+            get_request_path("/api/v3/event/2020casj?year=2020")
+            == "/api/v3/event/2020casj"
+        )
+
+
+def test_save_etag_dependencies_deduplicates(
+    memcache_stub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    memcache = MemcacheClient.get()
+    set_multi_mock = MagicMock(wraps=memcache.set_multi)
+    monkeypatch.setattr(memcache, "set_multi", set_multi_mock)
+
+    query_versions = {"team_k1": "ver1", "team_k2": "ver2"}
+
+    # 1. First save: persists to Memcache and records in in-memory cache
+    result1 = save_etag_dependencies(
+        "etag_abc", query_versions, path="/api/v3/team/frc254"
+    )
+    assert result1 is True
+    set_multi_mock.assert_called_once()
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", "etag_abc")) is True
+
+    # 2. Second save with identical (path, etag): skipped without Memcache calls
+    set_multi_mock.reset_mock()
+    result2 = save_etag_dependencies(
+        "etag_abc", query_versions, path="/api/v3/team/frc254"
+    )
+    assert result2 is False
+    set_multi_mock.assert_not_called()
+
+    # 3. Save with altered ETag: persists to Memcache
+    result3 = save_etag_dependencies(
+        "etag_def", query_versions, path="/api/v3/team/frc254"
+    )
+    assert result3 is True
+    set_multi_mock.assert_called_once()
+
+    # 4. Save with different path but same ETag: persists independently
+    set_multi_mock.reset_mock()
+    result4 = save_etag_dependencies(
+        "etag_abc", query_versions, path="/api/v3/team/frc9999"
+    )
+    assert result4 is True
+    set_multi_mock.assert_called_once()
+
+
+def test_save_etag_dependencies_empty_keys(memcache_stub) -> None:
+    assert save_etag_dependencies("etag_empty", {}, path="/api/v3/team/frc254") is False
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", "etag_empty")) is None
+
+
+def test_save_etag_dependencies_cache_expiration(
+    memcache_stub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    memcache = MemcacheClient.get()
+    set_multi_mock = MagicMock(wraps=memcache.set_multi)
+    monkeypatch.setattr(memcache, "set_multi", set_multi_mock)
+
+    query_versions = {"team_k1": "ver1"}
+    save_etag_dependencies("etag_expire", query_versions, path="/api/v3/team/frc254")
+    set_multi_mock.assert_called_once()
+
+    # Expire the in-memory cache entry
+    etag_deps_persisted_cache.set(
+        ("/api/v3/team/frc254", "etag_expire"), True, ttl_seconds=-1.0
+    )
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", "etag_expire")) is None
+
+    # Calling save again must re-persist to Memcache
+    set_multi_mock.reset_mock()
+    result = save_etag_dependencies(
+        "etag_expire", query_versions, path="/api/v3/team/frc254"
+    )
+    assert result is True
+    set_multi_mock.assert_called_once()
+
+
+def test_save_etag_dependencies_memcache_error_does_not_cache(
+    memcache_stub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    memcache = MemcacheClient.get()
+    monkeypatch.setattr(
+        memcache,
+        "set_multi",
+        MagicMock(side_effect=Exception("Memcache write failed")),
+    )
+
+    result = save_etag_dependencies(
+        "etag_err", {"k1": "ver1"}, path="/api/v3/team/frc254"
+    )
+    assert result is False
+    # Must NOT be marked as persisted in memory after failure
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", "etag_err")) is None
+
+
+def test_is_etag_valid(memcache_stub) -> None:
+    query_versions = {"q_k1": "ver1", "q_k2": "ver2"}
+    save_etag_dependencies("etag_val", query_versions, path="/api/v3/team/frc254")
+
+    # Valid ETag for matching path
+    assert is_etag_valid("etag_val", path="/api/v3/team/frc254") is True
+
+    # Invalid for different path
+    assert is_etag_valid("etag_val", path="/api/v3/team/frc9999") is False
+
+    # Invalid when unknown ETag
+    assert is_etag_valid("unknown_etag", path="/api/v3/team/frc254") is False
+
+    # Invalidate one query key in Memcache
+    memcache = MemcacheClient.get()
+    memcache.delete(b"q_ver:q_k1")
+    assert is_etag_valid("etag_val", path="/api/v3/team/frc254") is False
+
+
+def test_is_etag_valid_failure_evicts_from_persisted_cache(memcache_stub) -> None:
+    query_versions = {"q_k1": "ver1"}
+    save_etag_dependencies("etag_heal", query_versions, path="/api/v3/team/frc254")
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", "etag_heal")) is True
+
+    # Invalidate query key in Memcache
+    memcache = MemcacheClient.get()
+    memcache.delete(b"q_ver:q_k1")
+
+    # is_etag_valid returns False and evicts from etag_deps_persisted_cache
+    assert is_etag_valid("etag_heal", path="/api/v3/team/frc254") is False
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", "etag_heal")) is None
+
+    # Next save call will re-persist since it was evicted
+    assert (
+        save_etag_dependencies("etag_heal", query_versions, path="/api/v3/team/frc254")
+        is True
+    )

--- a/src/backend/api/handlers/tests/test_validate_etag.py
+++ b/src/backend/api/handlers/tests/test_validate_etag.py
@@ -5,7 +5,12 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 from werkzeug.test import Client
 
-from backend.api.handlers.decorators import etag_304_cache
+from backend.api.handlers.decorators import (
+    etag_304_cache,
+    ETAG_304_CACHE_MAX_SIZE,
+    ETAG_304_CACHE_TTL,
+    etag_deps_persisted_cache,
+)
 from backend.api.handlers.helpers.etag_helper import (
     get_etag_dependencies,
     normalize_etag,
@@ -909,3 +914,92 @@ def test_delete_cache_multi_without_data_change_restores_etag_304(
     )
     assert resp4.status_code == 304
     mock_get_by_id_async.assert_not_called()
+
+
+def test_validate_etag_304_cache_contract() -> None:
+    assert ETAG_304_CACHE_TTL == 61.0
+    assert ETAG_304_CACHE_MAX_SIZE == 5000
+
+
+def test_validate_etag_deduplicates_dependency_writes_on_identical_200(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+
+    memcache = MemcacheClient.get()
+    set_multi_mock = MagicMock(wraps=memcache.set_multi)
+    monkeypatch.setattr(memcache, "set_multi", set_multi_mock)
+
+    # 1. First 200 request: persists dependencies to Memcache
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag1 = resp1.headers.get("ETag")
+    assert etag1 is not None
+    norm_etag1 = normalize_etag(etag1)
+    assert norm_etag1 is not None
+
+    assert set_multi_mock.call_count == 1
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", norm_etag1)) is True
+
+    # 2. Second 200 request with identical response/ETag: skips Memcache set_multi
+    set_multi_mock.reset_mock()
+    resp2 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp2.status_code == 200
+    assert resp2.headers.get("ETag") == etag1
+    set_multi_mock.assert_not_called()
+
+
+def test_validate_etag_persists_dependencies_on_altered_etag(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Environment, "flask_response_cache_enabled", lambda: False)
+
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    team = Team(id="frc254", team_number=254, nickname="The Cheesy Poofs")
+    team.put()
+
+    memcache = MemcacheClient.get()
+    set_multi_mock = MagicMock(wraps=memcache.set_multi)
+    monkeypatch.setattr(memcache, "set_multi", set_multi_mock)
+
+    # 1. First request generates initial ETag
+    resp1 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp1.status_code == 200
+    etag1 = resp1.headers.get("ETag")
+    norm_etag1 = normalize_etag(etag1)
+    assert norm_etag1 is not None
+    assert set_multi_mock.call_count == 1
+
+    # 2. Alter team data and invalidate query cache
+    team.nickname = "Updated Poofs"
+    team.put()
+    TeamQuery.delete_cache_multi({TeamQuery(team_key="frc254").cache_key})
+
+    # 3. Next request produces new ETag and must persist its dependencies
+    set_multi_mock.reset_mock()
+    resp2 = api_client.get(
+        "/api/v3/team/frc254", headers={"X-TBA-Auth-Key": "test_auth_key"}
+    )
+    assert resp2.status_code == 200
+    etag2 = resp2.headers.get("ETag")
+    assert etag2 != etag1
+    norm_etag2 = normalize_etag(etag2)
+    assert norm_etag2 is not None
+
+    set_multi_mock.assert_called_once()
+    assert etag_deps_persisted_cache.get(("/api/v3/team/frc254", norm_etag2)) is True

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -85,6 +85,7 @@ def clear_auth_key_cache() -> None:
     from backend.api.handlers.decorators import (
         auth_key_cache,
         etag_304_cache,
+        etag_deps_persisted_cache,
         key_does_not_exist_cache,
         key_exists_cache,
     )
@@ -93,6 +94,7 @@ def clear_auth_key_cache() -> None:
     key_exists_cache.clear()
     key_does_not_exist_cache.clear()
     etag_304_cache.clear()
+    etag_deps_persisted_cache.clear()
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Summary
Optimizes ETag validation and dependency persistence in the API service (`py3-api`) to eliminate redundant Memcache network round-trips and CPU overhead on both 304 Not Modified and 200 OK responses.

### Motivation & Context
- **304 Traffic**: Over 50% of API requests are conditional HTTP requests resulting in 304 Not Modified.
- **Low L1 Hit Rate**: Previously, in-memory `etag_304_cache` used a 15-second TTL, causing repeat requests after 15s to issue two Memcache RPCs (`memcache.get` + `memcache.get_multi`) even though the response carried `Cache-Control: public, max-age=61`.
- **Redundant Dependency Writes**: On 200 OK responses, `save_etag_dependencies` repeatedly re-executed `memcache.set_multi` even when consecutive requests produced the identical ETag payload.

### Changes
- **L1 304 Cache Sizing**:
  - Increased `ETAG_304_CACHE_TTL` from 15.0s to 61.0s in `decorators.py`, aligning with TBA's HTTP caching contract (`Cache-Control: max-age=61`) to maximize sub-millisecond in-memory 304 fast-path hits.
  - Increased `ETAG_304_CACHE_MAX_SIZE` from 2,000 to 5,000 entries.
  - Passed explicit `path=request_path` to `is_etag_valid`.
- **Dependency Write Deduplication**:
  - Introduced `etag_deps_persisted_cache` (`InstanceCache` with 10-minute TTL and 5,000 max size) in `etag_helper.py`.
  - Checked `etag_deps_persisted_cache` before creating `Span("etag.save_dependencies")` and executing `save_etag_dependencies`, skipping redundant Memcache writes on identical responses.
  - Added self-healing: if `is_etag_valid` fails (e.g. Memcache keys evicted or query version invalidated), `etag_deps_persisted_cache.delete` evicts the entry so the subsequent 200 response immediately re-persists the missing dependencies.
- **Test Isolation**:
  - Added `etag_deps_persisted_cache.clear()` in the `clear_auth_key_cache` autouse fixture in `conftest.py`.
- **Tests**:
  - Added unit test suite in `src/backend/api/handlers/helpers/tests/etag_helper_test.py` covering deduplication, cache expiration, error handling, path scoping, and self-healing eviction.
  - Added integration tests in `src/backend/api/handlers/tests/test_validate_etag.py` verifying 304 cache contract, write deduplication on identical 200s, and re-persisting on altered ETags.

### Verification
- `test_validate_etag.py` & `etag_helper_test.py`: 32 passed
- `pyre check`: 0 type errors
- `ops/lint_py3.sh`: 0 errors