### PR TITLE
[api] Use models_query_response in district and insights handlers

### DIFF
--- a/src/backend/api/handlers/district.py
+++ b/src/backend/api/handlers/district.py
@@ -12,6 +12,7 @@ from backend.api.handlers.helpers.model_properties import (
     filter_team_properties,
     ModelType,
 )
+from backend.api.handlers.helpers.model_query_response import models_query_response
 from backend.api.handlers.helpers.profiled_jsonify import (
     profiled_jsonify,
     TypedFlaskResponse,
@@ -47,12 +48,9 @@ def district_history(
     Returns a list of District objects with the given district abbreviation. Accounts for abbreviation changes.
     """
     track_call_after_response("district", district_abbreviation)
-
-    districts = DistrictAbbreviationQuery(
-        abbreviation=district_abbreviation
-    ).fetch_dict(ApiMajorVersion.API_V3)
-
-    return profiled_jsonify(districts)
+    return models_query_response(
+        DistrictAbbreviationQuery(abbreviation=district_abbreviation)
+    )
 
 
 @api_authenticated
@@ -66,13 +64,11 @@ def district_events(
     Returns a list of events for a given DistrictKey.
     """
     track_call_after_response("district/events", district_key, model_type)
-
-    events = DistrictEventsQuery(district_key=district_key).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        DistrictEventsQuery(district_key=district_key),
+        model_type=model_type,
+        filter_func=filter_event_properties,
     )
-    if model_type is not None:
-        events = filter_event_properties(events, model_type)
-    return profiled_jsonify(events)
 
 
 @api_authenticated
@@ -86,13 +82,11 @@ def district_teams(
     Returns a list of teams for a given DistrictKey.
     """
     track_call_after_response("district/teams", district_key, model_type)
-
-    teams = DistrictTeamsQuery(district_key=district_key).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        DistrictTeamsQuery(district_key=district_key),
+        model_type=model_type,
+        filter_func=filter_team_properties,
     )
-    if model_type is not None:
-        teams = filter_team_properties(teams, model_type)
-    return profiled_jsonify(teams)
 
 
 @api_authenticated
@@ -119,9 +113,7 @@ def district_list_year(year: int) -> TypedFlaskResponse[list[DistrictDict]]:
     Returns a list of all districts for a given year.
     """
     track_call_after_response("district/list", str(year))
-
-    districts = DistrictsInYearQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(districts)
+    return models_query_response(DistrictsInYearQuery(year=year))
 
 
 @api_authenticated

--- a/src/backend/api/handlers/insights.py
+++ b/src/backend/api/handlers/insights.py
@@ -1,9 +1,8 @@
 from flask import abort, Response
 
 from backend.api.handlers.decorators import api_authenticated, validate_etag
-from backend.api.handlers.helpers.profiled_jsonify import profiled_jsonify
+from backend.api.handlers.helpers.model_query_response import models_query_response
 from backend.api.handlers.helpers.track_call import track_call_after_response
-from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.decorators import cached_public
 from backend.common.models.insight_v2 import InsightCategory
 from backend.common.models.keys import DistrictAbbreviation
@@ -34,12 +33,7 @@ _VALID_INSIGHT_V2_CATEGORIES = frozenset(
 @validate_etag
 def insights_leaderboards_year(year: int) -> Response:
     track_call_after_response("insights/leaderboards", str(year))
-
-    insights = InsightsLeaderboardsYearQuery(year=year).fetch_dict(
-        ApiMajorVersion.API_V3
-    )
-
-    return profiled_jsonify(insights)
+    return models_query_response(InsightsLeaderboardsYearQuery(year=year))
 
 
 @api_authenticated
@@ -47,9 +41,7 @@ def insights_leaderboards_year(year: int) -> Response:
 @validate_etag
 def insights_notables_year(year: int) -> Response:
     track_call_after_response("insights/notables", str(year))
-
-    insights = InsightsNotablesYearQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(insights)
+    return models_query_response(InsightsNotablesYearQuery(year=year))
 
 
 @api_authenticated
@@ -57,9 +49,7 @@ def insights_notables_year(year: int) -> Response:
 @validate_etag
 def insights_v2_year(year: int) -> Response:
     track_call_after_response("insights/v2", str(year))
-
-    insights = InsightV2YearQuery(year=year).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(insights)
+    return models_query_response(InsightV2YearQuery(year=year))
 
 
 @api_authenticated
@@ -70,11 +60,9 @@ def insights_v2_year_category(year: int, category: str) -> Response:
         abort(404)
 
     track_call_after_response("insights/v2/category", f"{year}/{category}")
-
-    insights = InsightV2YearCategoryQuery(year=year, category=category).fetch_dict(
-        ApiMajorVersion.API_V3
+    return models_query_response(
+        InsightV2YearCategoryQuery(year=year, category=category)
     )
-    return profiled_jsonify(insights)
 
 
 @api_authenticated
@@ -84,11 +72,11 @@ def insights_v2_year_district(
     year: int, district_abbreviation: DistrictAbbreviation
 ) -> Response:
     track_call_after_response("insights/v2/district", f"{year}/{district_abbreviation}")
-
-    insights = InsightV2YearDistrictQuery(
-        year=year, district_abbreviation=district_abbreviation
-    ).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(insights)
+    return models_query_response(
+        InsightV2YearDistrictQuery(
+            year=year, district_abbreviation=district_abbreviation
+        )
+    )
 
 
 @api_authenticated
@@ -103,8 +91,8 @@ def insights_v2_year_category_district(
     track_call_after_response(
         "insights/v2/category/district", f"{year}/{category}/{district_abbreviation}"
     )
-
-    insights = InsightV2YearCategoryDistrictQuery(
-        year=year, category=category, district_abbreviation=district_abbreviation
-    ).fetch_dict(ApiMajorVersion.API_V3)
-    return profiled_jsonify(insights)
+    return models_query_response(
+        InsightV2YearCategoryDistrictQuery(
+            year=year, category=category, district_abbreviation=district_abbreviation
+        )
+    )

--- a/src/backend/api/handlers/tests/district_test.py
+++ b/src/backend/api/handlers/tests/district_test.py
@@ -12,6 +12,7 @@ from backend.api.handlers.tests.helpers import (
     validate_simple_event_keys,
     validate_simple_team_keys,
 )
+from backend.common.consts.api_version import ApiMajorVersion
 from backend.common.consts.auth_type import AuthType
 from backend.common.consts.award_type import AwardType
 from backend.common.consts.cmp_qualification import CmpQualificationMethod
@@ -28,6 +29,12 @@ from backend.common.models.district_team import DistrictTeam
 from backend.common.models.event import Event
 from backend.common.models.insight import Insight
 from backend.common.models.team import Team
+from backend.common.queries.district_query import (
+    DistrictAbbreviationQuery,
+    DistrictsInYearQuery,
+)
+from backend.common.queries.event_query import DistrictEventsQuery
+from backend.common.queries.team_query import DistrictTeamsQuery
 
 
 def test_district_events(ndb_stub, api_client: Client) -> None:
@@ -744,3 +751,106 @@ def test_district_endpoints_validate(endpoint, ndb_stub, api_client: Client) -> 
             headers={"X-TBA-Auth-Key": "test_auth_key"},
         )
         assert resp.status_code == 200
+
+
+def test_district_models_query_response_passthrough(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+    District(
+        id="2020fim",
+        year=2020,
+        abbreviation="fim",
+        display_name="Michigan",
+    ).put()
+    Event(
+        id="2020casj",
+        year=2020,
+        event_short="casj",
+        event_type_enum=EventType.REGIONAL,
+        district_key=ndb.Key(District, "2020fim"),
+    ).put()
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+    DistrictTeam(
+        id="2020fim_frc254",
+        district_key=ndb.Key(District, "2020fim"),
+        team=ndb.Key(Team, "frc254"),
+        year=2020,
+    ).put()
+
+    headers = {"X-TBA-Auth-Key": "test_auth_key"}
+
+    from backend.common.queries.database_query import CachedDatabaseQuery
+
+    orig_fetch_json = CachedDatabaseQuery.fetch_json
+    orig_fetch_dict = CachedDatabaseQuery.fetch_dict
+    calls_fetch_json = []
+    calls_fetch_dict = []
+
+    def spy_fetch_json(self, version):
+        calls_fetch_json.append((type(self), version))
+        return orig_fetch_json(self, version)
+
+    def spy_fetch_dict(self, version):
+        calls_fetch_dict.append((type(self), version))
+        return orig_fetch_dict(self, version)
+
+    monkeypatch.setattr(CachedDatabaseQuery, "fetch_json", spy_fetch_json)
+    monkeypatch.setattr(CachedDatabaseQuery, "fetch_dict", spy_fetch_dict)
+
+    # 1. district_history (nominal -> fetch_json)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/district/fim/history", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (DistrictAbbreviationQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 2. district_list_year (nominal -> fetch_json)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/districts/2020", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (DistrictsInYearQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 3. district_events (nominal -> fetch_json)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/district/2020fim/events", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (DistrictEventsQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 4. district_events (simple -> fetch_dict)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/district/2020fim/events/simple", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 0
+    assert len(calls_fetch_dict) == 1
+    assert calls_fetch_dict[0] == (DistrictEventsQuery, ApiMajorVersion.API_V3)
+
+    # 5. district_teams (nominal -> fetch_json)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/district/2020fim/teams", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (DistrictTeamsQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 6. district_teams (simple -> fetch_dict)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/district/2020fim/teams/simple", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 0
+    assert len(calls_fetch_dict) == 1
+    assert calls_fetch_dict[0] == (DistrictTeamsQuery, ApiMajorVersion.API_V3)

--- a/src/backend/api/handlers/tests/insight_test.py
+++ b/src/backend/api/handlers/tests/insight_test.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from werkzeug.test import Client
 
 from backend.common.consts.auth_type import AuthType
@@ -104,3 +105,69 @@ def test_insights_notables_single_year_endpoint(ndb_stub, api_client: Client) ->
     )
     assert resp.status_code == 200
     assert resp.json == []
+
+
+def test_insights_models_query_response_passthrough(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ApiAuthAccess(
+        id="test_auth_key",
+        auth_types_enum=[AuthType.READ_API],
+    ).put()
+
+    Insight(
+        name=Insight.INSIGHT_NAMES[Insight.TYPED_LEADERBOARD_BLUE_BANNERS],
+        year=2024,
+        data_json=json.dumps({"key_type": "team", "rankings": []}),
+    ).put()
+    Insight(
+        name=Insight.INSIGHT_NAMES[Insight.TYPED_NOTABLES_DIVISION_WINNERS],
+        year=2024,
+        data_json=json.dumps({"entries": []}),
+    ).put()
+
+    headers = {"X-TBA-Auth-Key": "test_auth_key"}
+
+    from backend.common.consts.api_version import ApiMajorVersion
+    from backend.common.queries.database_query import CachedDatabaseQuery
+    from backend.common.queries.insight_query import (
+        InsightsLeaderboardsYearQuery,
+        InsightsNotablesYearQuery,
+    )
+
+    orig_fetch_json = CachedDatabaseQuery.fetch_json
+    orig_fetch_dict = CachedDatabaseQuery.fetch_dict
+    calls_fetch_json = []
+    calls_fetch_dict = []
+
+    def spy_fetch_json(self, version):
+        calls_fetch_json.append((type(self), version))
+        return orig_fetch_json(self, version)
+
+    def spy_fetch_dict(self, version):
+        calls_fetch_dict.append((type(self), version))
+        return orig_fetch_dict(self, version)
+
+    monkeypatch.setattr(CachedDatabaseQuery, "fetch_json", spy_fetch_json)
+    monkeypatch.setattr(CachedDatabaseQuery, "fetch_dict", spy_fetch_dict)
+
+    # 1. insights_leaderboards_year (fetch_json)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/insights/leaderboards/2024", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (
+        InsightsLeaderboardsYearQuery,
+        ApiMajorVersion.API_V3,
+    )
+    assert len(calls_fetch_dict) == 0
+
+    # 2. insights_notables_year (fetch_json)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/insights/notables/2024", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (InsightsNotablesYearQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0

--- a/src/backend/api/handlers/tests/insight_v2_test.py
+++ b/src/backend/api/handlers/tests/insight_v2_test.py
@@ -1,3 +1,4 @@
+import pytest
 from werkzeug.test import Client
 
 from backend.common.consts.auth_type import AuthType
@@ -345,3 +346,84 @@ def test_insights_year_category_clubs(ndb_stub, api_client: Client) -> None:
     assert len(resp.json) == 1
     assert resp.json[0]["category"] == InsightCategory.CLUBS
     assert resp.json[0]["name"] == "hall_of_fame"
+
+
+def test_insights_v2_models_query_response_passthrough(
+    ndb_stub, api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _put_auth()
+    _put_insight(2024, name="blue_banners", category=InsightCategory.LEADERBOARD)
+    _put_insight(
+        2024,
+        name="fim_banners",
+        category=InsightCategory.LEADERBOARD,
+        district_abbreviation="fim",
+    )
+
+    headers = {"X-TBA-Auth-Key": "test_auth_key"}
+
+    from backend.common.consts.api_version import ApiMajorVersion
+    from backend.common.queries.database_query import CachedDatabaseQuery
+    from backend.common.queries.insight_v2_query import (
+        InsightV2YearCategoryDistrictQuery,
+        InsightV2YearCategoryQuery,
+        InsightV2YearDistrictQuery,
+        InsightV2YearQuery,
+    )
+
+    orig_fetch_json = CachedDatabaseQuery.fetch_json
+    orig_fetch_dict = CachedDatabaseQuery.fetch_dict
+    calls_fetch_json = []
+    calls_fetch_dict = []
+
+    def spy_fetch_json(self, version):
+        calls_fetch_json.append((type(self), version))
+        return orig_fetch_json(self, version)
+
+    def spy_fetch_dict(self, version):
+        calls_fetch_dict.append((type(self), version))
+        return orig_fetch_dict(self, version)
+
+    monkeypatch.setattr(CachedDatabaseQuery, "fetch_json", spy_fetch_json)
+    monkeypatch.setattr(CachedDatabaseQuery, "fetch_dict", spy_fetch_dict)
+
+    # 1. insights_v2_year (/insights/2024)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/insights/2024", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (InsightV2YearQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 2. insights_v2_year_category (/insights/2024/leaderboard)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/insights/2024/leaderboard", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (InsightV2YearCategoryQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 3. insights_v2_year_district (/insights/2024/district/fim)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get("/api/v3/insights/2024/district/fim", headers=headers)
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (InsightV2YearDistrictQuery, ApiMajorVersion.API_V3)
+    assert len(calls_fetch_dict) == 0
+
+    # 4. insights_v2_year_category_district (/insights/2024/leaderboard/district/fim)
+    calls_fetch_json.clear()
+    calls_fetch_dict.clear()
+    resp = api_client.get(
+        "/api/v3/insights/2024/leaderboard/district/fim", headers=headers
+    )
+    assert resp.status_code == 200
+    assert len(calls_fetch_json) == 1
+    assert calls_fetch_json[0] == (
+        InsightV2YearCategoryDistrictQuery,
+        ApiMajorVersion.API_V3,
+    )
+    assert len(calls_fetch_dict) == 0


### PR DESCRIPTION
## Summary
Refactor several endpoints in `src/backend/api/handlers/district.py` and `src/backend/api/handlers/insights.py` to use `models_query_response()`.

Previously, `district_history`, `district_events`, `district_teams`, `district_list_year`, and all 6 `insights_*` handlers called `fetch_dict()` followed by `profiled_jsonify()`. Even when no property filtering was requested (`model_type=None`), this unnecessarily deserialized pre-cached JSON bytes into Python dicts via `orjson.loads`, only to immediately re-serialize them with `orjson.dumps`.

With `models_query_response()`:
- When `model_type is None`, `models_query_response()` leverages `fetch_json()` to stream pre-serialized JSON bytes directly from `CachedQueryResult` to Flask's response class with zero deserialization and zero re-serialization.
- When `model_type` is specified (e.g. `district_events` and `district_teams` with `simple` or `keys`), `models_query_response()` fetches the dicts and runs the appropriate `filter_func` (`filter_event_properties` or `filter_team_properties`).

## Changes
- `src/backend/api/handlers/district.py`:
  - `district_history`: use `models_query_response`
  - `district_events`: use `models_query_response` with `filter_event_properties`
  - `district_teams`: use `models_query_response` with `filter_team_properties`
  - `district_list_year`: use `models_query_response`
- `src/backend/api/handlers/insights.py`:
  - `insights_leaderboards_year`: use `models_query_response`
  - `insights_notables_year`: use `models_query_response`
  - `insights_v2_year`: use `models_query_response`
  - `insights_v2_year_category`: use `models_query_response`
  - `insights_v2_year_district`: use `models_query_response`
  - `insights_v2_year_category_district`: use `models_query_response`
- Unit tests:
  - Added passthrough tests in `district_test.py`, `insight_test.py`, and `insight_v2_test.py` asserting `fetch_json()` is called directly when `model_type=None` and `fetch_dict()` is called when property filtering is requested.

## Verification
- Lint checks passed (`./ops/lint_py3.sh`).
- Type checks passed with 0 errors (`./ops/typecheck_py3.sh`).
- All targeted API handler tests passed.