### PR TITLE
[api] Unify _do_json_query pipeline to ensure single JSON serialization

### DIFF
--- a/src/backend/common/queries/database_query.py
+++ b/src/backend/common/queries/database_query.py
@@ -397,40 +397,35 @@ class CachedDatabaseQuery(
             else self.cache_key
         )
 
-        if not self.DICT_CACHING_ENABLED:
-            dict_result = yield self._do_dict_query(_dict_version, *args, **kwargs)
-            if dict_result is None:
-                self._record_accessed_cache_key(cache_key, None)
-                return None
-            try:
-                with Span("query.serialize_json"):
-                    res = orjson.dumps(dict_result)
-            except (orjson.JSONEncodeError, TypeError) as e:
-                logging.warning(
-                    f"orjson.dumps failed in _do_json_query, falling back to json.dumps: {e}"
-                )
-                res = json.dumps(dict_result, separators=(",", ":")).encode("utf-8")
-            self._record_accessed_cache_key(cache_key, res)
-            return res
-
         with Span("{}._do_json_query".format(self.__class__.__name__)):
-            with Span("query.cache_lookup") as span:
-                span.set_label("cache_key", cache_key)
-                cached_query_result = yield CachedQueryResult.get_by_id_async(cache_key)
-                span.set_label("cache_hit", str(cached_query_result is not None))
+            cached_query_result = None
+            if self.DICT_CACHING_ENABLED:
+                with Span("query.cache_lookup") as span:
+                    span.set_label("cache_key", cache_key)
+                    cached_query_result = yield CachedQueryResult.get_by_id_async(
+                        cache_key
+                    )
+                    span.set_label("cache_hit", str(cached_query_result is not None))
 
             if cached_query_result is None:
                 with Span(f"{self.__class__.__name__}._query_async"):
                     query_result = yield self._query_async(*args, **kwargs)
 
-                converted_result = none_throws(self.DICT_CONVERTER)(  # pyre-ignore[45]
-                    query_result
-                ).convert(_dict_version)
+                converted_result = (
+                    none_throws(self.DICT_CONVERTER)(  # pyre-ignore[45]
+                        query_result
+                    ).convert(_dict_version)
+                    if self.DICT_CONVERTER is not None
+                    else query_result
+                )
 
-                cqr = CachedQueryResult(id=cache_key, result_dict=converted_result)
-                if self.CACHE_WRITES_ENABLED:
+                cqr = None
+                if self.DICT_CACHING_ENABLED and self.CACHE_WRITES_ENABLED:
                     try:
                         with Span("query.async_cache_write"):
+                            cqr = CachedQueryResult(
+                                id=cache_key, result_dict=converted_result
+                            )
                             yield cqr.put_async()
                     except Exception as e:
                         logging.warning(
@@ -442,7 +437,7 @@ class CachedDatabaseQuery(
                     self._record_accessed_cache_key(cache_key, None)
                     return None
 
-                res = cqr.get_json_bytes()
+                res = cqr.get_json_bytes() if cqr else None
                 if res is None:
                     try:
                         with Span("query.serialize_json"):

--- a/src/backend/common/queries/tests/database_query_test.py
+++ b/src/backend/common/queries/tests/database_query_test.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 from typing import Any, Generator, Iterable, List, Optional, TypedDict
@@ -8,14 +9,24 @@ from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
 from backend.common.consts.api_version import ApiMajorVersion
+from backend.common.consts.comp_level import CompLevel
+from backend.common.consts.event_type import EventType
 from backend.common.models.cached_model import CachedModel
 from backend.common.models.cached_query_result import CachedQueryResult
+from backend.common.models.district import District
+from backend.common.models.event import Event
+from backend.common.models.match import Match
+from backend.common.models.team import Team
 from backend.common.queries.database_query import (
     CachedDatabaseQuery,
     DatabaseQuery,
     track_accessed_query_cache_keys,
 )
 from backend.common.queries.dict_converters.converter_base import ConverterBase
+from backend.common.queries.district_query import DistrictQuery
+from backend.common.queries.event_query import EventQuery
+from backend.common.queries.match_query import MatchQuery
+from backend.common.queries.team_query import TeamQuery
 
 
 class DummyModel(ndb.Model):
@@ -564,3 +575,73 @@ def test_dict_caching_disabled_records_accessed_cache_key() -> None:
         accessed_keys_dict[expected_cache_key] == accessed_keys_json[expected_cache_key]
     )
     assert len(accessed_keys_json[expected_cache_key]) == 32
+
+
+def test_dict_caching_disabled_single_serialization() -> None:
+    m = DummyModel(id="test_single_ser", int_prop=42)
+    m.put()
+
+    query = CachedDummyModelPointQueryNoDictCache(model_key="test_single_ser")
+    expected_cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+
+    with patch(
+        "backend.common.queries.database_query.orjson.dumps", wraps=orjson.dumps
+    ) as mock_dumps:
+        with track_accessed_query_cache_keys() as accessed_keys:
+            result_json = query.fetch_json(ApiMajorVersion.API_V3)
+
+        # Verify orjson.dumps was called exactly once during the entire fetch_json execution
+        assert mock_dumps.call_count == 1
+
+    assert result_json is not None
+    assert orjson.loads(result_json) == {"int_val": 42}
+    assert expected_cache_key in accessed_keys
+    expected_hash = hashlib.md5(result_json).hexdigest()
+    assert accessed_keys[expected_cache_key] == expected_hash
+
+
+def test_production_point_queries_single_serialization() -> None:
+    Team(id="frc254", team_number=254, nickname="The Cheesy Poofs").put()
+    Event(
+        id="2024casf",
+        year=2024,
+        event_type_enum=EventType.REGIONAL,
+        event_short="casf",
+    ).put()
+    Match(
+        id="2024casf_qm1",
+        event=ndb.Key(Event, "2024casf"),
+        year=2024,
+        comp_level=CompLevel.QM,
+        set_number=1,
+        match_number=1,
+        alliances_json=json.dumps(
+            {
+                "red": {"teams": [], "score": 0, "surrogates": [], "dqs": []},
+                "blue": {"teams": [], "score": 0, "surrogates": [], "dqs": []},
+            }
+        ),
+    ).put()
+    District(id="2024fim", year=2024, abbreviation="fim").put()
+
+    queries = [
+        TeamQuery(team_key="frc254"),
+        EventQuery(event_key="2024casf"),
+        MatchQuery(match_key="2024casf_qm1"),
+        DistrictQuery(district_key="2024fim"),
+    ]
+
+    for query in queries:
+        assert not query.DICT_CACHING_ENABLED
+        cache_key = query.dict_cache_key(ApiMajorVersion.API_V3)
+
+        with patch(
+            "backend.common.queries.database_query.orjson.dumps", wraps=orjson.dumps
+        ) as mock_dumps:
+            with track_accessed_query_cache_keys() as accessed_keys:
+                res = query.fetch_json(ApiMajorVersion.API_V3)
+            assert mock_dumps.call_count == 1
+
+        assert res is not None
+        assert cache_key in accessed_keys
+        assert accessed_keys[cache_key] == hashlib.md5(res).hexdigest()


### PR DESCRIPTION
## Description
Unifies `CachedDatabaseQuery._do_json_query` into a single, clean pipeline across all query types:
- `DICT_CACHING_ENABLED` purely gates `CachedQueryResult.get_by_id_async` lookup and `CachedQueryResult.put_async` write.
- Cache misses and non-dict-cached queries execute a single path: query Datastore asynchronously, convert to dict once, serialize to JSON bytes once via `orjson.dumps`, and pass the serialized bytes directly to `_record_accessed_cache_key` for ETag hash computation.
- Bypasses redundant secondary serialization in `_compute_result_hash` (which directly MD5-hashes `bytes`).
- Cache hits continue to stream/return raw decompressed JSON bytes directly.
- Keeps `_do_dict_query` completely clean without special parameters or branching.

## Motivation and Context
In `CachedDatabaseQuery._do_json_query`, point queries with `DICT_CACHING_ENABLED = False` (`TeamQuery`, `EventQuery`, `MatchQuery`, `DistrictQuery`) previously serialized converted dictionaries twice per request:
1. Inside `_do_dict_query`, `self._record_accessed_cache_key(cache_key, converted_result)` serialized the dictionary to JSON to compute its MD5 hash for ETag tracking.
2. Inside `_do_json_query`, `orjson.dumps(dict_result)` serialized the same dictionary a second time to produce response bytes.

This change optimizes point queries and cache misses to serialize the dictionary exactly once, eliminating CPU overhead on high-traffic endpoints.

## How Has This Been Tested?
- Added unit tests in `src/backend/common/queries/tests/database_query_test.py`:
  - `test_dict_caching_disabled_single_serialization`: Asserts `orjson.dumps` is called exactly 1 time during `fetch_json` and verifies the recorded MD5 hash.
  - `test_production_point_queries_single_serialization`: Validates single serialization and matching ETag hash across all production point queries (`TeamQuery`, `EventQuery`, `MatchQuery`, `DistrictQuery`).
- Verified that hash tracking matches between `fetch_dict` and `fetch_json`.
- Ran unit tests: all 237 query and ETag tests passed (`uv run --group test pytest src/backend/common/queries/ src/backend/api/handlers/tests/test_validate_etag.py`).
- Linters and typecheck passed cleanly (`flake8`, `black --check`, and `pyre check` with 0 errors).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)