### PR TITLE
Standardize on orjson across models and client_api_method

### DIFF
--- a/src/backend/api/handlers/decorators.py
+++ b/src/backend/api/handlers/decorators.py
@@ -1,10 +1,10 @@
 import datetime
-import json
 import logging
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any, Callable, Optional, Type, TypeVar
 
+import orjson
 from flask import g, jsonify, make_response, request, Response
 
 from backend.api.client_api_types import VoidRequest
@@ -211,12 +211,12 @@ def client_api_method(
         def decorated_function(*args, **kwargs) -> Response:
             data = request.get_data()
             if data:
-                req = json.loads(data)
+                req = orjson.loads(data)
             else:
                 req = VoidRequest()
 
             resp = func(req)
-            return jsonify(resp)
+            return Response(orjson.dumps(resp), mimetype="application/json")
 
         return decorated_function
 

--- a/src/backend/api/handlers/tests/decorator_order_test.py
+++ b/src/backend/api/handlers/tests/decorator_order_test.py
@@ -1,8 +1,11 @@
+from typing import Any
 from unittest.mock import MagicMock
 
+import orjson
 import pytest
 from werkzeug.test import Client
 
+from backend.api.handlers.decorators import client_api_method
 from backend.common.consts.auth_type import AuthType
 from backend.common.models.api_auth_access import ApiAuthAccess
 from backend.common.models.team import Team
@@ -212,3 +215,44 @@ def test_apiv3_query_params_ignored_for_caching(
     )
     assert resp4.status_code == 304
     mock_get_by_id_async.assert_not_called()
+
+
+def test_client_api_method_uses_orjson(
+    api_client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from backend.api.main import app
+
+    loads_called = False
+    dumps_called = False
+    real_loads = orjson.loads
+    real_dumps = orjson.dumps
+
+    def mock_loads(val: Any) -> Any:
+        nonlocal loads_called
+        loads_called = True
+        return real_loads(val)
+
+    def mock_dumps(val: Any) -> bytes:
+        nonlocal dumps_called
+        dumps_called = True
+        return real_dumps(val)
+
+    monkeypatch.setattr("backend.api.handlers.decorators.orjson.loads", mock_loads)
+    monkeypatch.setattr("backend.api.handlers.decorators.orjson.dumps", mock_dumps)
+
+    @client_api_method(dict, dict)
+    def dummy_handler(req: dict) -> dict:
+        return {"echo": req.get("msg")}
+
+    with app.test_request_context(
+        "/",
+        method="POST",
+        data=b'{"msg": "hello"}',
+        content_type="application/json",
+    ):
+        resp = dummy_handler()
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/json"
+        assert resp.data == b'{"echo":"hello"}'
+        assert loads_called is True
+        assert dumps_called is True

--- a/src/backend/common/models/award.py
+++ b/src/backend/common/models/award.py
@@ -1,6 +1,7 @@
 import json
 from typing import cast, Dict, List, Optional
 
+import orjson
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
@@ -141,7 +142,7 @@ class Award(CachedModel):
         if self._recipient_list is None:
             recipient_list = []
             for recipient_json in self.recipient_json_list:
-                recipient_list.append(json.loads(recipient_json))
+                recipient_list.append(orjson.loads(recipient_json))
             self._recipient_list = recipient_list
         return none_throws(self._recipient_list)
 

--- a/src/backend/common/models/cached_query_result.py
+++ b/src/backend/common/models/cached_query_result.py
@@ -1,9 +1,9 @@
-import json
 import logging
 import traceback
 import zlib
 from typing import Any, Generator, Iterable, Optional
 
+import orjson
 from google.appengine.ext import ndb
 
 from backend.common.profiler import Span
@@ -39,7 +39,7 @@ class CachedQueryResult(ndb.Model):
             elif isinstance(target, str):
                 res_bytes = target.encode("utf-8")
             elif target is not None:
-                res_bytes = json.dumps(target, separators=(",", ":")).encode("utf-8")
+                res_bytes = orjson.dumps(target)
             else:
                 res_bytes = None
 

--- a/src/backend/common/models/media.py
+++ b/src/backend/common/models/media.py
@@ -1,6 +1,6 @@
-import json
 from typing import cast, Dict, List, Optional, Set
 
+import orjson
 from google.appengine.ext import ndb
 from pyre_extensions import none_throws
 
@@ -83,14 +83,14 @@ class Media(CachedModel):
     def details(self) -> Optional[Dict]:
         # TODO add better typing
         if self._details is None and self.details_json is not None:
-            self._details = json.loads(self.details_json)
+            self._details = orjson.loads(self.details_json)
         return self._details
 
     @property
     def private_details(self) -> Optional[Dict]:
         # TODO add better typing
         if self._private_details is None and self.private_details_json is not None:
-            self._private_details = json.loads(self.private_details_json)
+            self._private_details = orjson.loads(self.private_details_json)
         return self._private_details
 
     @classmethod
@@ -278,7 +278,7 @@ class Media(CachedModel):
 
     @property
     def avatar_base64_image(self) -> str:
-        image = json.loads(self.details_json)
+        image = orjson.loads(self.details_json)
         return image["base64Image"]
 
     @property

--- a/src/backend/common/models/tests/award_test.py
+++ b/src/backend/common/models/tests/award_test.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime
+from typing import Any
 
+import orjson
 import pytest
 from google.appengine.api import datastore_errors
 from google.appengine.ext import ndb
@@ -240,3 +242,27 @@ def test_recipients_individual() -> None:
     recipient_dict = a1.recipient_dict
     assert None in recipient_dict
     assert recipient_dict[None] == ["Woodie Flowers"]
+
+
+def test_recipient_list_uses_orjson(monkeypatch: pytest.MonkeyPatch) -> None:
+    recipients = [AwardRecipient(awardee="Woodie Flowers", team_number=None)]
+    a = Award(
+        id="2010ct_3",
+        year=2010,
+        award_type_enum=AwardType.WOODIE_FLOWERS,
+        event_type_enum=EventType.REGIONAL,
+        event=ndb.Key(Event, "2010ct"),
+        name_str="WFFA",
+        recipient_json_list=[json.dumps(r) for r in recipients],
+    )
+    loads_called = False
+    real_loads = orjson.loads
+
+    def mock_loads(val: Any) -> Any:
+        nonlocal loads_called
+        loads_called = True
+        return real_loads(val)
+
+    monkeypatch.setattr("backend.common.models.award.orjson.loads", mock_loads)
+    assert a.recipient_list == recipients
+    assert loads_called is True

--- a/src/backend/common/models/tests/cached_query_result_test.py
+++ b/src/backend/common/models/tests/cached_query_result_test.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any, Generator, List
 
+import orjson
 import pytest
 from google.appengine.ext import ndb
 
@@ -479,3 +480,22 @@ def test_get_json_bytes_raw_types() -> None:
     c_str = CachedQueryResult()
     setattr(c_str, "_values", {b"result_dict": '{"raw": "str"}'})
     assert c_str.get_json_bytes() == b'{"raw": "str"}'
+
+
+def test_get_json_bytes_uses_orjson(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"hello": "world"}
+    c = CachedQueryResult(result_dict=data)
+    dumps_called = False
+    real_dumps = orjson.dumps
+
+    def mock_dumps(val: Any) -> bytes:
+        nonlocal dumps_called
+        dumps_called = True
+        return real_dumps(val)
+
+    monkeypatch.setattr(
+        "backend.common.models.cached_query_result.orjson.dumps", mock_dumps
+    )
+    json_bytes = c.get_json_bytes()
+    assert dumps_called is True
+    assert json_bytes == b'{"hello":"world"}'

--- a/src/backend/common/models/tests/media_test.py
+++ b/src/backend/common/models/tests/media_test.py
@@ -1,5 +1,7 @@
 import json
+from typing import Any
 
+import orjson
 import pytest
 from google.appengine.api import datastore_errors
 
@@ -111,3 +113,51 @@ def test_smugmug_album_urls() -> None:
 def test_smugmug_is_image(media_type: MediaType, is_image: bool) -> None:
     m = Media(id="smugmug_abc", media_type_enum=media_type, foreign_key="abc")
     assert m.is_image is is_image
+
+
+def test_media_details_uses_orjson(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"author": "frc254", "views": 100}
+    m = Media(
+        id="media_123",
+        media_type_enum=MediaType.CD_PHOTO_THREAD,
+        foreign_key="123",
+        details_json=json.dumps(data),
+    )
+    loads_called = False
+    real_loads = orjson.loads
+
+    def mock_loads(val: Any) -> Any:
+        nonlocal loads_called
+        loads_called = True
+        return real_loads(val)
+
+    monkeypatch.setattr("backend.common.models.media.orjson.loads", mock_loads)
+    assert m.details == data
+    assert loads_called is True
+    loads_called = False
+    assert m.details == data
+    assert loads_called is False
+
+
+def test_media_private_details_uses_orjson(monkeypatch: pytest.MonkeyPatch) -> None:
+    priv = {"deletehash": "xyz"}
+    m = Media(
+        id="media_456",
+        media_type_enum=MediaType.IMGUR,
+        foreign_key="456",
+        private_details_json=json.dumps(priv),
+    )
+    loads_called = False
+    real_loads = orjson.loads
+
+    def mock_loads(val: Any) -> Any:
+        nonlocal loads_called
+        loads_called = True
+        return real_loads(val)
+
+    monkeypatch.setattr("backend.common.models.media.orjson.loads", mock_loads)
+    assert m.private_details == priv
+    assert loads_called is True
+    loads_called = False
+    assert m.private_details == priv
+    assert loads_called is False


### PR DESCRIPTION
## Summary
Replaces Python standard library `json.loads` and `json.dumps` with `orjson` across hot paths in models and client API helpers to reduce parsing and serialization overhead:
- **`Award.recipient_list`** (`src/backend/common/models/award.py`): Replaced `json.loads` in loop over `self.recipient_json_list` with `orjson.loads`.
- **`Media.details` & `Media.private_details`** (`src/backend/common/models/media.py`): Replaced `json.loads` with `orjson.loads` (and also updated `Media.avatar_base64_image`).
- **`CachedQueryResult.get_json_bytes`** (`src/backend/common/models/cached_query_result.py`): Standardized on `orjson.dumps(target)`, returning compact UTF-8 bytes directly without intermediate string creation and re-encoding.
- **`client_api_method`** (`src/backend/api/handlers/decorators.py`): Replaced `json.loads(data)` with `orjson.loads(data)` and `jsonify(resp)` with `Response(orjson.dumps(resp), mimetype="application/json")`.

## Testing
- Added unit tests verifying `orjson` usage in `award_test.py`, `media_test.py`, `cached_query_result_test.py`, and `decorator_order_test.py`.
- Ran all models tests (`503 passed`).
- Ran all API handler tests (`504 passed`).
- Verified zero lint errors with `./ops/lint_py3.sh`.
- Verified type check with `pyre --version none check`.