### PR TITLE
Fix GameDay hydration mismatch

### DIFF
--- a/pwa/vite.config.ts
+++ b/pwa/vite.config.ts
@@ -22,7 +22,6 @@ const staticRoutes = [
   '/apidocs/v3',
   '/contact',
   '/donate',
-  '/gameday',
   '/privacy',
   '/thanks',
 ];


### PR DESCRIPTION
## Summary

- Stop prerendering `/gameday` because query parameters affect its initial render.
- Prevent hydration errors after event-route redirects.

## Testing

- `CI=1 pnpm exec playwright test tests/routes.spec.ts --project=chromium`