### PR TITLE
Preview SmugMug album contents on the PWA suggestion review page

### DIFF
--- a/pwa/app/api/tba/moderation/index.ts
+++ b/pwa/app/api/tba/moderation/index.ts
@@ -42,6 +42,7 @@ export {
   type RejectResponse,
   ReviewResult,
   type SimilarEvent,
+  type SmugmugPreviewImage,
   type SuggestionAuthor,
   type SuggestionListResponse,
   type SuggestionReference,

--- a/pwa/app/api/tba/moderation/types.gen.ts
+++ b/pwa/app/api/tba/moderation/types.gen.ts
@@ -84,6 +84,18 @@ export type CandidateMedia = {
   view_image_url?: string;
   image_direct_url?: string;
   social_profile_url?: string;
+  /**
+   * Album or photo title, when the provider supplied one (SmugMug)
+   */
+  title?: string;
+  /**
+   * Number of photos in the album (SmugMug albums)
+   */
+  image_count?: number;
+  /**
+   * The first few photos of the album, for previewing its contents (SmugMug albums)
+   */
+  preview_images?: Array<SmugmugPreviewImage>;
 };
 
 /**
@@ -330,6 +342,18 @@ export type RejectResponse = {
 
 export type ErrorResponse = {
   Error?: string;
+};
+
+export type SmugmugPreviewImage = {
+  thumbnail_url?: string;
+  /**
+   * Small-size rendition, suitable for a preview grid
+   */
+  image_url?: string;
+  /**
+   * The photo's page on SmugMug
+   */
+  web_uri?: string;
 };
 
 export type GetModerationQueueData = {

--- a/pwa/app/components/tba/moderation/suggestionReviewCard.tsx
+++ b/pwa/app/components/tba/moderation/suggestionReviewCard.tsx
@@ -350,6 +350,9 @@ function MediaPreview({
       </div>
     ) : null;
   }
+  if (media.slug_name === 'smugmug-album') {
+    return <SmugmugAlbumPreview media={media} />;
+  }
   if (media.is_image) {
     const imageUrl =
       media.image_direct_url ??
@@ -396,6 +399,69 @@ function MediaPreview({
     );
   }
   return null;
+}
+
+/**
+ * SmugMug albums arrive with a cover, title, photo count and the album's
+ * first few photos (the moderation API fetches them; SmugMug's own embed
+ * endpoint serves an empty page). Show a thumbnail grid so a reviewer can
+ * see what the album actually contains, with the cover as the fallback.
+ */
+function SmugmugAlbumPreview({
+  media,
+}: {
+  media: NonNullable<ModerationSuggestion['candidate_media']>;
+}): JSX.Element {
+  const previews = (media.preview_images ?? []).filter((p) => p.image_url);
+  const caption = [
+    media.title,
+    media.image_count !== undefined
+      ? `${media.image_count.toLocaleString()} ${
+          media.image_count === 1 ? 'photo' : 'photos'
+        }`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return (
+    <div className="flex max-w-xl flex-col gap-2">
+      {previews.length > 0 ? (
+        <div
+          className="grid grid-cols-4 gap-1 overflow-hidden rounded-lg border"
+          data-testid="smugmug-album-previews"
+        >
+          {previews.map((photo, i) => (
+            <a
+              key={photo.web_uri || i}
+              href={photo.web_uri || media.external_link}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`Photo ${i + 1}${media.title ? ` of ${media.title}` : ''}`}
+              className="aspect-square bg-muted"
+            >
+              <img
+                src={photo.image_url}
+                alt=""
+                loading="lazy"
+                className="size-full object-cover"
+              />
+            </a>
+          ))}
+        </div>
+      ) : (
+        media.image_direct_url && (
+          <img
+            src={media.image_direct_url}
+            alt={media.title ?? 'SmugMug album cover'}
+            className="max-h-80 w-fit max-w-full rounded-lg border"
+          />
+        )
+      )}
+      {caption && (
+        <div className="text-sm text-muted-foreground">{caption}</div>
+      )}
+    </div>
+  );
 }
 
 function TeamMediaDetails({

--- a/src/backend/api/handlers/moderation.py
+++ b/src/backend/api/handlers/moderation.py
@@ -13,13 +13,14 @@ from backend.api.handlers.decorators import require_moderation_permission
 from backend.common.consts.account_permission import SUGGESTION_PERMISSIONS
 from backend.common.consts.auth_type import WRITE_TYPE_NAMES
 from backend.common.consts.event_type import EventType
-from backend.common.consts.media_type import IMAGE_TYPES
+from backend.common.consts.media_type import IMAGE_TYPES, MediaType
 from backend.common.consts.suggestion_state import SuggestionState
 from backend.common.consts.suggestion_type import SuggestionType, TYPE_NAMES
 from backend.common.datafeeds.datafeed_youtube import YoutubeVideoDetailsDatafeed
 from backend.common.helpers.outgoing_notification_helper import (
     OutgoingNotificationHelper,
 )
+from backend.common.helpers.smugmug_helper import album_preview_images
 from backend.common.helpers.suggestion_fetcher import SuggestionFetcher
 from backend.common.memcache import MemcacheClient
 from backend.common.models.api_auth_access import ApiAuthAccess
@@ -368,6 +369,16 @@ def _serialize_candidate_media(suggestion: Suggestion) -> Dict[str, Any]:
     if media.is_image:
         serialized["view_image_url"] = media.view_image_url
         serialized["image_direct_url"] = media.image_direct_url_med
+    elif media.media_type_enum == MediaType.SMUGMUG_ALBUM:
+        # Albums aren't single images, but the parser already fetched the
+        # cover and album metadata at suggestion time; surface it so
+        # reviewers can preview the gallery instead of following a bare link
+        details = media.details or {}
+        serialized["view_image_url"] = details.get("web_uri")
+        serialized["image_direct_url"] = details.get("cover_url_med")
+        serialized["title"] = details.get("title")
+        serialized["image_count"] = details.get("image_count")
+        serialized["preview_images"] = album_preview_images(media.foreign_key)
     if suggestion.contents.get("is_social"):
         serialized["social_profile_url"] = media.social_profile_url
     return serialized

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from typing import Any, cast, Dict, List, Optional
+from unittest.mock import patch
 
 import pytest
 from google.appengine.ext import ndb
@@ -449,6 +450,58 @@ def test_list_webcast_suggestions_existing_webcasts(
     ]
     assert suggestion["event"]["start_date"] == "2016-03-24"
     assert suggestion["event"]["end_date"] == "2016-03-27"
+
+
+def test_list_event_media_suggestions_includes_smugmug_album_preview(
+    api_client: Client, moderator, author: Account, event: Event
+) -> None:
+    moderator([AccountPermission.REVIEW_EVENT_MEDIA])
+    create_suggestion(
+        author,
+        "event_media",
+        "2016necmp",
+        {
+            "media_type_enum": MediaType.SMUGMUG_ALBUM,
+            "foreign_key": "2HCx3m",
+            "reference_type": "event",
+            "reference_key": "2016necmp",
+            "year": 2016,
+            "details_json": json.dumps(
+                {
+                    "title": "2025 CT States",
+                    "web_uri": "https://nefirst.smugmug.com/2025-FIRST-DIVE/2025-CT-States",
+                    "image_count": 412,
+                    "cover_url": "https://photos.smugmug.com/x/L/cover-L.jpg",
+                    "cover_url_med": "https://photos.smugmug.com/x/M/cover-M.jpg",
+                    "cover_url_sm": "https://photos.smugmug.com/x/S/cover-S.jpg",
+                }
+            ),
+        },
+    )
+    previews = [
+        {
+            "thumbnail_url": "https://photos.smugmug.com/x/Th/one-Th.jpg",
+            "image_url": "https://photos.smugmug.com/x/S/one-S.jpg",
+            "web_uri": "https://nefirst.smugmug.com/x/i-one",
+        }
+    ]
+    with patch(
+        "backend.api.handlers.moderation.album_preview_images", return_value=previews
+    ) as mock_previews:
+        resp = api_client.get(f"{BASE_URL}/suggestions/event_media")
+    assert resp.status_code == 200
+    mock_previews.assert_called_once_with("2HCx3m")
+    media = resp.json["suggestions"][0]["candidate_media"]
+    assert media["preview_images"] == previews
+    assert media["slug_name"] == "smugmug-album"
+    assert media["is_image"] is False
+    assert media["title"] == "2025 CT States"
+    assert media["image_count"] == 412
+    assert media["image_direct_url"] == "https://photos.smugmug.com/x/M/cover-M.jpg"
+    assert (
+        media["view_image_url"]
+        == "https://nefirst.smugmug.com/2025-FIRST-DIVE/2025-CT-States"
+    )
 
 
 def test_list_team_media_suggestions_includes_reference_and_preferred(

--- a/src/backend/common/helpers/smugmug_helper.py
+++ b/src/backend/common/helpers/smugmug_helper.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Any, Dict, List, TypedDict
+
+import requests
+
+from backend.common.decorators import memoize
+from backend.common.sitevars.smugmug_api_secret import SmugmugApiSecret
+
+
+class SmugmugPreviewImage(TypedDict):
+    thumbnail_url: str
+    image_url: str
+    web_uri: str
+
+
+ALBUM_IMAGES_URL = "https://api.smugmug.com/api/v2/album/{}!images"
+PREVIEW_IMAGE_COUNT = 8
+# Albums are uploaded in shooting order, so the first N photos are usually N
+# near-identical frames of the same moment. Fetch a wider window in the one
+# request and sample evenly across it for a more representative preview.
+PREVIEW_SAMPLE_WINDOW = 48
+PREVIEW_CACHE_SECONDS = 6 * 60 * 60
+
+
+def _as_dict(value: Any) -> Dict:
+    return value if isinstance(value, dict) else {}
+
+
+@memoize(timeout=PREVIEW_CACHE_SECONDS)
+def album_preview_images(
+    album_key: str, count: int = PREVIEW_IMAGE_COUNT
+) -> List[SmugmugPreviewImage]:
+    """
+    The first few photos of a SmugMug album, for previewing an album without
+    leaving the page. SmugMug's embed endpoint returns an empty document, so
+    this is the only way to show a reviewer what an album actually contains.
+    Any failure degrades to an empty list; callers should treat the preview
+    as optional.
+    """
+    api_key = SmugmugApiSecret.api_key()
+    if not api_key:
+        logging.warning("No SmugMug API key! Configure SmugmugApiSecret sitevar")
+        return []
+    url = ALBUM_IMAGES_URL.format(album_key)
+    try:
+        response = requests.get(
+            url,
+            params={
+                "APIKey": api_key,
+                "count": max(count, PREVIEW_SAMPLE_WINDOW),
+                "start": 1,
+                # Every size URL is individually signed, so sizes only come
+                # from this expansion (same as MediaParser's album lookup)
+                "_expand": "ImageSizeDetails",
+            },
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+    except requests.RequestException as e:
+        logging.warning(f"SmugMug album images request failed for {album_key}: {e}")
+        return []
+    if response.status_code != 200:
+        logging.warning(
+            f"SmugMug album images returned {response.status_code} for {album_key}"
+        )
+        return []
+    try:
+        data = _as_dict(response.json())
+    except ValueError:
+        logging.warning(f"SmugMug album images returned non-JSON for {album_key}")
+        return []
+
+    images = _as_dict(data.get("Response")).get("AlbumImage") or []
+    expansions = _as_dict(data.get("Expansions"))
+    previews: List[SmugmugPreviewImage] = []
+    for image in images:
+        image = _as_dict(image)
+        details_uri = _as_dict(_as_dict(image.get("Uris")).get("ImageSizeDetails")).get(
+            "Uri"
+        )
+        sizes = _as_dict(_as_dict(expansions.get(details_uri)).get("ImageSizeDetails"))
+        thumbnail_url = image.get("ThumbnailUrl") or ""
+        image_url = _as_dict(sizes.get("ImageSizeSmall")).get("Url") or thumbnail_url
+        if not thumbnail_url and not image_url:
+            continue
+        previews.append(
+            SmugmugPreviewImage(
+                thumbnail_url=thumbnail_url or image_url,
+                image_url=image_url,
+                web_uri=image.get("WebUri") or "",
+            )
+        )
+    return _sample_evenly(previews, count)
+
+
+def _sample_evenly(
+    items: List[SmugmugPreviewImage], count: int
+) -> List[SmugmugPreviewImage]:
+    if count <= 0:
+        return []
+    if len(items) <= count:
+        return items
+    step = len(items) / count
+    return [items[int(i * step)] for i in range(count)]

--- a/src/backend/common/helpers/tests/smugmug_helper_test.py
+++ b/src/backend/common/helpers/tests/smugmug_helper_test.py
@@ -1,0 +1,168 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from backend.common.helpers import smugmug_helper
+from backend.common.sitevars.smugmug_api_secret import SmugmugApiSecret
+
+
+@pytest.fixture(autouse=True)
+def api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        SmugmugApiSecret, "api_key", classmethod(lambda cls: "test-key")
+    )
+
+
+def _album_images_response() -> dict:
+    return {
+        "Response": {
+            "AlbumImage": [
+                {
+                    "ImageKey": "J6Qzk89",
+                    "ThumbnailUrl": "https://photos.smugmug.com/a/Th/one-Th.jpg",
+                    "WebUri": "https://nefirst.smugmug.com/album/i-J6Qzk89",
+                    "Uris": {
+                        "ImageSizeDetails": {
+                            "Uri": "/api/v2/image/J6Qzk89-0!sizedetails"
+                        }
+                    },
+                },
+                {
+                    # No expansion for this one: falls back to the thumbnail
+                    "ImageKey": "kSV2tvD",
+                    "ThumbnailUrl": "https://photos.smugmug.com/a/Th/two-Th.jpg",
+                    "WebUri": "https://nefirst.smugmug.com/album/i-kSV2tvD",
+                    "Uris": {
+                        "ImageSizeDetails": {
+                            "Uri": "/api/v2/image/kSV2tvD-0!sizedetails"
+                        }
+                    },
+                },
+                {
+                    # Nothing usable: skipped
+                    "ImageKey": "empty",
+                    "Uris": {},
+                },
+            ]
+        },
+        "Expansions": {
+            "/api/v2/image/J6Qzk89-0!sizedetails": {
+                "ImageSizeDetails": {
+                    "ImageSizeSmall": {
+                        "Url": "https://photos.smugmug.com/a/S/one-S.jpg"
+                    },
+                    "ImageSizeMedium": {
+                        "Url": "https://photos.smugmug.com/a/M/one-M.jpg"
+                    },
+                }
+            }
+        },
+    }
+
+
+def _mock_response(status_code: int = 200, payload: object = None) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.json = Mock(return_value=payload)
+    return response
+
+
+def test_album_preview_images() -> None:
+    with patch.object(
+        smugmug_helper.requests,
+        "get",
+        return_value=_mock_response(200, _album_images_response()),
+    ) as mock_get:
+        previews = smugmug_helper.album_preview_images("2HCx3m")
+
+    assert previews == [
+        {
+            "thumbnail_url": "https://photos.smugmug.com/a/Th/one-Th.jpg",
+            "image_url": "https://photos.smugmug.com/a/S/one-S.jpg",
+            "web_uri": "https://nefirst.smugmug.com/album/i-J6Qzk89",
+        },
+        {
+            "thumbnail_url": "https://photos.smugmug.com/a/Th/two-Th.jpg",
+            "image_url": "https://photos.smugmug.com/a/Th/two-Th.jpg",
+            "web_uri": "https://nefirst.smugmug.com/album/i-kSV2tvD",
+        },
+    ]
+    url, kwargs = mock_get.call_args[0][0], mock_get.call_args[1]
+    assert url == "https://api.smugmug.com/api/v2/album/2HCx3m!images"
+    assert kwargs["params"]["APIKey"] == "test-key"
+    assert kwargs["params"]["count"] == smugmug_helper.PREVIEW_SAMPLE_WINDOW
+    assert kwargs["params"]["_expand"] == "ImageSizeDetails"
+
+
+def test_album_preview_images_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SmugmugApiSecret, "api_key", classmethod(lambda cls: None))
+    with patch.object(smugmug_helper.requests, "get") as mock_get:
+        assert smugmug_helper.album_preview_images("2HCx3m") == []
+    mock_get.assert_not_called()
+
+
+def test_album_preview_images_http_error() -> None:
+    with patch.object(
+        smugmug_helper.requests, "get", return_value=_mock_response(404, {})
+    ):
+        assert smugmug_helper.album_preview_images("2HCx3m") == []
+
+
+def test_album_preview_images_request_exception() -> None:
+    with patch.object(
+        smugmug_helper.requests,
+        "get",
+        side_effect=requests.ConnectionError("boom"),
+    ):
+        assert smugmug_helper.album_preview_images("2HCx3m") == []
+
+
+def test_album_preview_images_bad_json() -> None:
+    response = _mock_response(200)
+    response.json = Mock(side_effect=ValueError("not json"))
+    with patch.object(smugmug_helper.requests, "get", return_value=response):
+        assert smugmug_helper.album_preview_images("2HCx3m") == []
+
+
+def test_album_preview_images_unexpected_shape() -> None:
+    with patch.object(
+        smugmug_helper.requests,
+        "get",
+        return_value=_mock_response(200, {"Response": {"AlbumImage": "nope"}}),
+    ):
+        assert smugmug_helper.album_preview_images("2HCx3m") == []
+
+
+def test_album_preview_images_samples_evenly_across_the_window() -> None:
+    images = [
+        {
+            "ImageKey": f"k{i}",
+            "ThumbnailUrl": f"https://photos.smugmug.com/a/Th/{i}-Th.jpg",
+            "WebUri": f"https://nefirst.smugmug.com/album/i-k{i}",
+            "Uris": {},
+        }
+        for i in range(48)
+    ]
+    with patch.object(
+        smugmug_helper.requests,
+        "get",
+        return_value=_mock_response(200, {"Response": {"AlbumImage": images}}),
+    ):
+        previews = smugmug_helper.album_preview_images("2HCx3m")
+
+    # 8 of 48, spread across the album rather than the first 8 frames
+    assert [p["thumbnail_url"].split("/")[-1] for p in previews] == [
+        f"{i}-Th.jpg" for i in (0, 6, 12, 18, 24, 30, 36, 42)
+    ]
+
+
+def test_sample_evenly_edge_cases() -> None:
+    assert smugmug_helper._sample_evenly([], 8) == []
+    one = [
+        smugmug_helper.SmugmugPreviewImage(
+            thumbnail_url="t", image_url="i", web_uri="w"
+        )
+    ]
+    assert smugmug_helper._sample_evenly(one, 8) == one
+    assert smugmug_helper._sample_evenly(one, 0) == []

--- a/src/backend/web/static/swagger/api_moderation_v1.json
+++ b/src/backend/web/static/swagger/api_moderation_v1.json
@@ -119,6 +119,21 @@
           },
           "social_profile_url": {
             "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "description": "Album or photo title, when the provider supplied one (SmugMug)"
+          },
+          "image_count": {
+            "type": "integer",
+            "description": "Number of photos in the album (SmugMug albums)"
+          },
+          "preview_images": {
+            "type": "array",
+            "description": "The first few photos of the album, for previewing its contents (SmugMug albums)",
+            "items": {
+              "$ref": "#/components/schemas/SmugmugPreviewImage"
+            }
           }
         }
       },
@@ -534,6 +549,22 @@
         "properties": {
           "Error": {
             "type": "string"
+          }
+        }
+      },
+      "SmugmugPreviewImage": {
+        "type": "object",
+        "properties": {
+          "thumbnail_url": {
+            "type": "string"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "Small-size rendition, suitable for a preview grid"
+          },
+          "web_uri": {
+            "type": "string",
+            "description": "The photo's page on SmugMug"
           }
         }
       }


### PR DESCRIPTION
## Problem

SmugMug album suggestions on `beta.thebluealliance.com/suggest/review/event_media` render as a bare link. A reviewer has to open every album in a new tab to see whether it's a real gallery for that event.

## What's already there

`MediaParser._parse_smugmug` looks the album up in SmugMug's API when the suggestion is created, so the suggestion's `details_json` already holds the title, `web_uri`, `image_count`, and cover URLs. The moderation API only surfaced image fields for `is_image` media, which albums are not, so none of it reached the PWA.

## Why not an embed

SmugMug's oEmbed endpoint returns `<iframe src="https://api.smugmug.com/services/embed/album/<key>">`, and that page serves an empty `<body>` (verified both top-level and framed, headless Chromium, no console errors, no images). The gallery page itself sends `X-Frame-Options: DENY`. So there is no iframe that shows anything.

## Change

**Backend**
- New `common/helpers/smugmug_helper.py` with `album_preview_images(album_key)`: one `album!images` request (`count=48`, `_expand=ImageSizeDetails`) using the existing `SmugmugApiSecret` key, then 8 photos sampled evenly across the window. Albums are uploaded in shooting order, so the first 8 are usually eight frames of the same moment; the first screenshot below is what that looked like. Memoized 6 hours. Any failure (no key, non-200, bad JSON, odd shapes) returns `[]`.
- `_serialize_candidate_media` for `SMUGMUG_ALBUM` now emits `view_image_url` (album page), `image_direct_url` (cover), `title`, `image_count`, and `preview_images: [{thumbnail_url, image_url, web_uri}]`.
- OpenAPI spec updated (`CandidateMedia` gains the three fields; new `SmugmugPreviewImage` schema); PWA client regenerated.

**PWA**
- `SmugmugAlbumPreview` in the review card: a 4×2 grid of the sampled photos, each linking to its SmugMug page, with `title · N photos` beneath. Falls back to the cover image when there is no sample. `is_image` stays false, so nothing else about album handling changes.

## Tests

- `smugmug_helper_test.py`: response mapping incl. the size expansion and thumbnail fallback, even sampling across the window, and every failure path (no key, HTTP error, request exception, bad JSON, unexpected shape).
- `moderation_test.py`: an event-media SmugMug album suggestion returns the new fields with the helper patched.
- `make lint`, `make typecheck`, 63 tests in the two files pass; `pnpm run format/lint/typecheck` clean.

## Screenshots

In a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)