### PR TITLE
Batch and cache SmugMug album preview lookups on the review page

### DIFF
--- a/src/backend/api/handlers/moderation.py
+++ b/src/backend/api/handlers/moderation.py
@@ -20,7 +20,10 @@ from backend.common.datafeeds.datafeed_youtube import YoutubeVideoDetailsDatafee
 from backend.common.helpers.outgoing_notification_helper import (
     OutgoingNotificationHelper,
 )
-from backend.common.helpers.smugmug_helper import album_preview_images
+from backend.common.helpers.smugmug_helper import (
+    album_preview_images_many,
+    SmugmugPreviewImage,
+)
 from backend.common.helpers.suggestion_fetcher import SuggestionFetcher
 from backend.common.memcache import MemcacheClient
 from backend.common.models.api_auth_access import ApiAuthAccess
@@ -129,9 +132,19 @@ def moderation_suggestion_list(suggestion_type: str) -> Response:
     authors_by_key = {none_throws(a.key): a for a in authors if a is not None}
     review_counts = _author_review_counts(author_keys)
 
+    # One batched, cached lookup for every SmugMug album on the page
+    album_previews = album_preview_images_many(
+        s.contents.get("foreign_key", "")
+        for s in suggestions
+        if s.contents.get("media_type_enum") == MediaType.SMUGMUG_ALBUM
+    )
+
     serialized = [
         _serialize_suggestion(
-            s, authors_by_key.get(s.author), review_counts.get(s.author)
+            s,
+            authors_by_key.get(s.author),
+            review_counts.get(s.author),
+            album_previews,
         )
         for s in suggestions
     ]
@@ -314,6 +327,7 @@ def _serialize_suggestion(
     suggestion: Suggestion,
     author: Optional[Any],
     author_review_counts: Optional[Dict[str, int]] = None,
+    album_previews: Optional[Dict[str, List[SmugmugPreviewImage]]] = None,
 ) -> Dict[str, Any]:
     serialized: Dict[str, Any] = {
         "key": str(none_throws(suggestion.key.id())),
@@ -346,12 +360,16 @@ def _serialize_suggestion(
 
     # A preview of the Media that would be created, for media-backed types
     if "media_type_enum" in suggestion.contents:
-        serialized["candidate_media"] = _serialize_candidate_media(suggestion)
+        serialized["candidate_media"] = _serialize_candidate_media(
+            suggestion, album_previews or {}
+        )
 
     return serialized
 
 
-def _serialize_candidate_media(suggestion: Suggestion) -> Dict[str, Any]:
+def _serialize_candidate_media(
+    suggestion: Suggestion, album_previews: Dict[str, List[SmugmugPreviewImage]]
+) -> Dict[str, Any]:
     media = suggestion.candidate_media
     serialized = {
         "key": media.key_name,
@@ -378,7 +396,7 @@ def _serialize_candidate_media(suggestion: Suggestion) -> Dict[str, Any]:
         serialized["image_direct_url"] = details.get("cover_url_med")
         serialized["title"] = details.get("title")
         serialized["image_count"] = details.get("image_count")
-        serialized["preview_images"] = album_preview_images(media.foreign_key)
+        serialized["preview_images"] = album_previews.get(media.foreign_key, [])
     if suggestion.contents.get("is_social"):
         serialized["social_profile_url"] = media.social_profile_url
     return serialized

--- a/src/backend/api/handlers/tests/moderation_test.py
+++ b/src/backend/api/handlers/tests/moderation_test.py
@@ -486,11 +486,14 @@ def test_list_event_media_suggestions_includes_smugmug_album_preview(
         }
     ]
     with patch(
-        "backend.api.handlers.moderation.album_preview_images", return_value=previews
+        "backend.api.handlers.moderation.album_preview_images_many",
+        return_value={"2HCx3m": previews},
     ) as mock_previews:
         resp = api_client.get(f"{BASE_URL}/suggestions/event_media")
     assert resp.status_code == 200
-    mock_previews.assert_called_once_with("2HCx3m")
+    # One batched call for the whole page, not one per suggestion
+    mock_previews.assert_called_once()
+    assert list(mock_previews.call_args[0][0]) == ["2HCx3m"]
     media = resp.json["suggestions"][0]["candidate_media"]
     assert media["preview_images"] == previews
     assert media["slug_name"] == "smugmug-album"

--- a/src/backend/common/helpers/smugmug_helper.py
+++ b/src/backend/common/helpers/smugmug_helper.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any, Dict, List, TypedDict
+from concurrent.futures import ThreadPoolExecutor, wait
+from typing import Any, Dict, Iterable, List, Optional, TypedDict
 
 import requests
 
-from backend.common.decorators import memoize
+from backend.common.memcache import MemcacheClient
 from backend.common.sitevars.smugmug_api_secret import SmugmugApiSecret
 
 
@@ -20,27 +21,33 @@ PREVIEW_IMAGE_COUNT = 8
 # request and sample evenly across it for a more representative preview.
 PREVIEW_SAMPLE_WINDOW = 48
 PREVIEW_CACHE_SECONDS = 6 * 60 * 60
+# A failed or timed-out lookup is cached briefly so a flaky album can't make
+# every page load wait on it again
+PREVIEW_FAILURE_CACHE_SECONDS = 10 * 60
+REQUEST_TIMEOUT_SECONDS = 5
+# Total wall-clock budget for one batch of lookups; albums that don't come
+# back in time get no preview on this request
+FETCH_BUDGET_SECONDS = 6
+MAX_CONCURRENT_FETCHES = 8
+CACHE_KEY_PREFIX = b"smugmug_album_previews:1:"
 
 
 def _as_dict(value: Any) -> Dict:
     return value if isinstance(value, dict) else {}
 
 
-@memoize(timeout=PREVIEW_CACHE_SECONDS)
-def album_preview_images(
-    album_key: str, count: int = PREVIEW_IMAGE_COUNT
-) -> List[SmugmugPreviewImage]:
+def _cache_key(album_key: str) -> bytes:
+    return CACHE_KEY_PREFIX + album_key.encode()
+
+
+def fetch_album_preview_images(
+    album_key: str, api_key: str, count: int = PREVIEW_IMAGE_COUNT
+) -> Optional[List[SmugmugPreviewImage]]:
     """
-    The first few photos of a SmugMug album, for previewing an album without
-    leaving the page. SmugMug's embed endpoint returns an empty document, so
-    this is the only way to show a reviewer what an album actually contains.
-    Any failure degrades to an empty list; callers should treat the preview
-    as optional.
+    One uncached request for a sample of an album's photos. Returns None on
+    any failure (so callers can cache failures for a shorter time than real
+    results) and a list, possibly empty, on success. Thread-safe: no ndb.
     """
-    api_key = SmugmugApiSecret.api_key()
-    if not api_key:
-        logging.warning("No SmugMug API key! Configure SmugmugApiSecret sitevar")
-        return []
     url = ALBUM_IMAGES_URL.format(album_key)
     try:
         response = requests.get(
@@ -54,23 +61,25 @@ def album_preview_images(
                 "_expand": "ImageSizeDetails",
             },
             headers={"Accept": "application/json"},
-            timeout=10,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
     except requests.RequestException as e:
         logging.warning(f"SmugMug album images request failed for {album_key}: {e}")
-        return []
+        return None
     if response.status_code != 200:
         logging.warning(
             f"SmugMug album images returned {response.status_code} for {album_key}"
         )
-        return []
+        return None
     try:
         data = _as_dict(response.json())
     except ValueError:
         logging.warning(f"SmugMug album images returned non-JSON for {album_key}")
-        return []
+        return None
 
     images = _as_dict(data.get("Response")).get("AlbumImage") or []
+    if not isinstance(images, list):
+        return []
     expansions = _as_dict(data.get("Expansions"))
     previews: List[SmugmugPreviewImage] = []
     for image in images:
@@ -91,6 +100,81 @@ def album_preview_images(
             )
         )
     return _sample_evenly(previews, count)
+
+
+def album_preview_images_many(
+    album_keys: Iterable[str],
+) -> Dict[str, List[SmugmugPreviewImage]]:
+    """
+    Preview samples for many albums at once: memcache first, then the misses
+    fetched concurrently under a fixed time budget. Every requested key is in
+    the result; albums that failed or didn't return in time map to [].
+
+    This exists because a review page lists up to 50 suggestions, and doing
+    these lookups one at a time made the first load take over a minute.
+    """
+    keys = list(dict.fromkeys(k for k in album_keys if k))
+    if not keys:
+        return {}
+    result: Dict[str, List[SmugmugPreviewImage]] = {}
+
+    cache = MemcacheClient.get()
+    cached = cache.get_multi([_cache_key(k) for k in keys])
+    misses = []
+    for key in keys:
+        hit = cached.get(_cache_key(key))
+        if hit is None:
+            misses.append(key)
+        else:
+            result[key] = hit
+    if not misses:
+        return result
+
+    api_key = SmugmugApiSecret.api_key()
+    if not api_key:
+        logging.warning("No SmugMug API key! Configure SmugmugApiSecret sitevar")
+        for key in misses:
+            result[key] = []
+        return result
+
+    fetched: Dict[str, Optional[List[SmugmugPreviewImage]]] = {}
+    pool = ThreadPoolExecutor(max_workers=min(MAX_CONCURRENT_FETCHES, len(misses)))
+    try:
+        futures = {
+            pool.submit(fetch_album_preview_images, key, api_key): key for key in misses
+        }
+        done, not_done = wait(futures, timeout=FETCH_BUDGET_SECONDS)
+        for future in done:
+            fetched[futures[future]] = future.result()
+        if not_done:
+            logging.warning(
+                "SmugMug album previews timed out for: {}".format(
+                    ", ".join(futures[f] for f in not_done)
+                )
+            )
+    finally:
+        # Don't wait for stragglers; they finish (or time out) in the background
+        pool.shutdown(wait=False, cancel_futures=True)
+
+    successes: Dict[bytes, Any] = {}
+    failures: Dict[bytes, Any] = {}
+    for key in misses:
+        previews = fetched.get(key)
+        if previews is None:
+            result[key] = []
+            failures[_cache_key(key)] = []
+        else:
+            result[key] = previews
+            successes[_cache_key(key)] = previews
+    if successes:
+        cache.set_multi(successes, time=PREVIEW_CACHE_SECONDS)
+    if failures:
+        cache.set_multi(failures, time=PREVIEW_FAILURE_CACHE_SECONDS)
+    return result
+
+
+def album_preview_images(album_key: str) -> List[SmugmugPreviewImage]:
+    return album_preview_images_many([album_key]).get(album_key, [])
 
 
 def _sample_evenly(

--- a/src/backend/common/helpers/tests/smugmug_helper_test.py
+++ b/src/backend/common/helpers/tests/smugmug_helper_test.py
@@ -1,3 +1,5 @@
+import time
+from typing import Any, Dict, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,7 +10,7 @@ from backend.common.sitevars.smugmug_api_secret import SmugmugApiSecret
 
 
 @pytest.fixture(autouse=True)
-def api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def setup(memcache_stub, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         SmugmugApiSecret, "api_key", classmethod(lambda cls: "test-key")
     )
@@ -61,80 +63,75 @@ def _album_images_response() -> dict:
     }
 
 
-def _mock_response(status_code: int = 200, payload: object = None) -> Mock:
+EXPECTED_PREVIEWS = [
+    {
+        "thumbnail_url": "https://photos.smugmug.com/a/Th/one-Th.jpg",
+        "image_url": "https://photos.smugmug.com/a/S/one-S.jpg",
+        "web_uri": "https://nefirst.smugmug.com/album/i-J6Qzk89",
+    },
+    {
+        "thumbnail_url": "https://photos.smugmug.com/a/Th/two-Th.jpg",
+        "image_url": "https://photos.smugmug.com/a/Th/two-Th.jpg",
+        "web_uri": "https://nefirst.smugmug.com/album/i-kSV2tvD",
+    },
+]
+
+
+def _mock_response(status_code: int = 200, payload: Optional[Any] = None) -> Mock:
     response = Mock()
     response.status_code = status_code
     response.json = Mock(return_value=payload)
     return response
 
 
-def test_album_preview_images() -> None:
+def test_fetch_album_preview_images() -> None:
     with patch.object(
         smugmug_helper.requests,
         "get",
         return_value=_mock_response(200, _album_images_response()),
     ) as mock_get:
-        previews = smugmug_helper.album_preview_images("2HCx3m")
+        previews = smugmug_helper.fetch_album_preview_images("2HCx3m", "test-key")
 
-    assert previews == [
-        {
-            "thumbnail_url": "https://photos.smugmug.com/a/Th/one-Th.jpg",
-            "image_url": "https://photos.smugmug.com/a/S/one-S.jpg",
-            "web_uri": "https://nefirst.smugmug.com/album/i-J6Qzk89",
-        },
-        {
-            "thumbnail_url": "https://photos.smugmug.com/a/Th/two-Th.jpg",
-            "image_url": "https://photos.smugmug.com/a/Th/two-Th.jpg",
-            "web_uri": "https://nefirst.smugmug.com/album/i-kSV2tvD",
-        },
-    ]
+    assert previews == EXPECTED_PREVIEWS
     url, kwargs = mock_get.call_args[0][0], mock_get.call_args[1]
     assert url == "https://api.smugmug.com/api/v2/album/2HCx3m!images"
     assert kwargs["params"]["APIKey"] == "test-key"
     assert kwargs["params"]["count"] == smugmug_helper.PREVIEW_SAMPLE_WINDOW
     assert kwargs["params"]["_expand"] == "ImageSizeDetails"
+    assert kwargs["timeout"] == smugmug_helper.REQUEST_TIMEOUT_SECONDS
 
 
-def test_album_preview_images_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(SmugmugApiSecret, "api_key", classmethod(lambda cls: None))
-    with patch.object(smugmug_helper.requests, "get") as mock_get:
-        assert smugmug_helper.album_preview_images("2HCx3m") == []
-    mock_get.assert_not_called()
+@pytest.mark.parametrize(
+    "response_kwargs",
+    [
+        {"return_value": _mock_response(404, {})},
+        {"side_effect": requests.ConnectionError("boom")},
+    ],
+)
+def test_fetch_album_preview_images_failures_return_none(
+    response_kwargs: Dict[str, Any],
+) -> None:
+    with patch.object(smugmug_helper.requests, "get", **response_kwargs):
+        assert smugmug_helper.fetch_album_preview_images("2HCx3m", "k") is None
 
 
-def test_album_preview_images_http_error() -> None:
-    with patch.object(
-        smugmug_helper.requests, "get", return_value=_mock_response(404, {})
-    ):
-        assert smugmug_helper.album_preview_images("2HCx3m") == []
-
-
-def test_album_preview_images_request_exception() -> None:
-    with patch.object(
-        smugmug_helper.requests,
-        "get",
-        side_effect=requests.ConnectionError("boom"),
-    ):
-        assert smugmug_helper.album_preview_images("2HCx3m") == []
-
-
-def test_album_preview_images_bad_json() -> None:
+def test_fetch_album_preview_images_bad_json() -> None:
     response = _mock_response(200)
     response.json = Mock(side_effect=ValueError("not json"))
     with patch.object(smugmug_helper.requests, "get", return_value=response):
-        assert smugmug_helper.album_preview_images("2HCx3m") == []
+        assert smugmug_helper.fetch_album_preview_images("2HCx3m", "k") is None
 
 
-def test_album_preview_images_unexpected_shape() -> None:
+def test_fetch_album_preview_images_unexpected_shape() -> None:
     with patch.object(
         smugmug_helper.requests,
         "get",
         return_value=_mock_response(200, {"Response": {"AlbumImage": "nope"}}),
     ):
-        assert smugmug_helper.album_preview_images("2HCx3m") == []
+        assert smugmug_helper.fetch_album_preview_images("2HCx3m", "k") == []
 
 
-def test_album_preview_images_samples_evenly_across_the_window() -> None:
+def test_fetch_samples_evenly_across_the_window() -> None:
     images = [
         {
             "ImageKey": f"k{i}",
@@ -149,8 +146,9 @@ def test_album_preview_images_samples_evenly_across_the_window() -> None:
         "get",
         return_value=_mock_response(200, {"Response": {"AlbumImage": images}}),
     ):
-        previews = smugmug_helper.album_preview_images("2HCx3m")
+        previews = smugmug_helper.fetch_album_preview_images("2HCx3m", "k")
 
+    assert previews is not None
     # 8 of 48, spread across the album rather than the first 8 frames
     assert [p["thumbnail_url"].split("/")[-1] for p in previews] == [
         f"{i}-Th.jpg" for i in (0, 6, 12, 18, 24, 30, 36, 42)
@@ -166,3 +164,68 @@ def test_sample_evenly_edge_cases() -> None:
     ]
     assert smugmug_helper._sample_evenly(one, 8) == one
     assert smugmug_helper._sample_evenly(one, 0) == []
+
+
+def test_many_fetches_concurrently_and_caches() -> None:
+    with patch.object(
+        smugmug_helper.requests,
+        "get",
+        return_value=_mock_response(200, _album_images_response()),
+    ) as mock_get:
+        result = smugmug_helper.album_preview_images_many(["a", "b", "a", ""])
+        assert result == {"a": EXPECTED_PREVIEWS, "b": EXPECTED_PREVIEWS}
+        assert mock_get.call_count == 2  # deduped, one request per album
+
+        # Second call is served entirely from memcache
+        again = smugmug_helper.album_preview_images_many(["a", "b"])
+        assert again == result
+        assert mock_get.call_count == 2
+
+        # A new key alongside cached ones fetches only the new key
+        smugmug_helper.album_preview_images_many(["a", "c"])
+        assert mock_get.call_count == 3
+
+
+def test_many_caches_failures_briefly() -> None:
+    with patch.object(
+        smugmug_helper.requests, "get", return_value=_mock_response(500, {})
+    ) as mock_get:
+        assert smugmug_helper.album_preview_images_many(["bad"]) == {"bad": []}
+        assert smugmug_helper.album_preview_images_many(["bad"]) == {"bad": []}
+        assert mock_get.call_count == 1
+
+
+def test_many_respects_the_time_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(smugmug_helper, "FETCH_BUDGET_SECONDS", 0.2)
+
+    def slow_get(*args, **kwargs):
+        time.sleep(1.5)
+        return _mock_response(200, _album_images_response())
+
+    with patch.object(smugmug_helper.requests, "get", side_effect=slow_get):
+        started = time.monotonic()
+        result = smugmug_helper.album_preview_images_many(["slow"])
+        elapsed = time.monotonic() - started
+
+    assert result == {"slow": []}
+    assert elapsed < 1.0  # returned at the budget, not after the request
+
+
+def test_many_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SmugmugApiSecret, "api_key", classmethod(lambda cls: None))
+    with patch.object(smugmug_helper.requests, "get") as mock_get:
+        assert smugmug_helper.album_preview_images_many(["a"]) == {"a": []}
+    mock_get.assert_not_called()
+
+
+def test_many_empty_input() -> None:
+    assert smugmug_helper.album_preview_images_many([]) == {}
+
+
+def test_single_wrapper() -> None:
+    with patch.object(
+        smugmug_helper.requests,
+        "get",
+        return_value=_mock_response(200, _album_images_response()),
+    ):
+        assert smugmug_helper.album_preview_images("a") == EXPECTED_PREVIEWS


### PR DESCRIPTION
## Problem (regression from #10663, mine)

The event-media review page went from ~0.4 s to **63 to 80 s** on first load after #10663 deployed:

```
2026-09-11T01:48:26Z  200  79.62s   GET /api/moderation/v1/suggestions/event_media
2026-09-11T01:48:29Z  200  77.35s
2026-09-11T01:48:43Z  200  63.24s
2026-09-11T01:49:18Z  200  28.45s
2026-09-11T01:50:54Z  200  16.77s
2026-09-11T01:51:12Z  200   0.36s   ← memoize warm on that instance
```

`_serialize_candidate_media` called `album_preview_images()` inline for every SmugMug album on the page, sequentially, and the memoize was per-process, so each new API instance paid the full cost again. The queue currently has ~50 album suggestions.

## Fix

One batched lookup per page instead of one per suggestion:

- `album_preview_images_many(keys)`: memcache `get_multi` for every album on the page; misses are fetched concurrently (up to 8 workers, 5 s per request) under a **6 s wall-clock budget**; results `set_multi` for 6 hours. Memcache is shared across instances, so the warm-up happens once.
- Failures and timeouts are cached for 10 minutes so a slow or broken album can't stall every load; that album simply shows no preview until the next attempt.
- The list handler collects the album keys up front and passes the dict into serialization. `_serialize_candidate_media` no longer makes any network calls.

Worst case for a cold cache is now ~6 s (the budget), typical cold case ~1 s (50 albums / 8 workers × ~0.3 s), warm case unchanged.

## Tests

- Helper: response mapping, even sampling, failure paths, dedup, cache hit/miss/partial-miss behaviour (request count asserted), short failure caching, **time budget** (a 1.5 s mock request returns in < 1 s with `[]`), no-key, empty input.
- Moderation API: asserts a single batched call for the page.
- `make lint`, `make typecheck`, 68 tests in the two files pass.

Worth merging ahead of anything else in the queue; moderators are hitting this now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)