### PR TITLE
Review page follow-ups: "Event Media" queue name, one User row on API key requests

### DIFF
--- a/pwa/app/components/tba/moderation/suggestionReviewCard.tsx
+++ b/pwa/app/components/tba/moderation/suggestionReviewCard.tsx
@@ -1006,8 +1006,8 @@ function ApiWriteDetails({
       </FieldRow>
       <FieldRow label="User">
         {suggestion.author?.nickname ?? 'unknown'}
+        {suggestion.author?.email ? ` (${suggestion.author.email})` : ''}
       </FieldRow>
-      <FieldRow label="Email">{suggestion.author?.email ?? 'unknown'}</FieldRow>
       <FieldRow label="Affiliation">
         {contentsString(suggestion, 'affiliation')}
       </FieldRow>

--- a/pwa/app/routes/suggest.review.$suggestionType.tsx
+++ b/pwa/app/routes/suggest.review.$suggestionType.tsx
@@ -45,7 +45,7 @@ const TYPE_NAMES: Record<SuggestionType, string> = {
   [SuggestionType.OFFSEASON_EVENT]: 'Offseason Events',
   [SuggestionType.API_AUTH_ACCESS]: 'API Key Requests',
   [SuggestionType.ROBOT]: 'CAD Models',
-  [SuggestionType.EVENT_MEDIA]: 'Event Videos',
+  [SuggestionType.EVENT_MEDIA]: 'Event Media',
 };
 
 function WebcastEventGroup({

--- a/src/backend/common/consts/suggestion_type.py
+++ b/src/backend/common/consts/suggestion_type.py
@@ -27,5 +27,5 @@ TYPE_NAMES = {
     SuggestionType.OFFSEASON_EVENT: "Offseason Events",
     SuggestionType.API_AUTH_ACCESS: "API Key Requests",
     SuggestionType.ROBOT: "CAD Models",
-    SuggestionType.EVENT_MEDIA: "Event Videos",
+    SuggestionType.EVENT_MEDIA: "Event Media",
 }


### PR DESCRIPTION
Two small follow-ups from reviewing the PWA suggestion queue.

## "Event Videos" → "Event Media"

The `event_media` queue now takes SmugMug albums (#10663) as well as YouTube videos, so the label was wrong. Changed in both places it lives: `TYPE_NAMES` in `suggestion_type.py` (feeds the moderation API's `type_names`, the Jinja review pages, and the PWA queue index) and the PWA route's local `TYPE_NAMES` (page title and breadcrumb).

## One User row on API key request cards

`User` and `Email` were separate rows; now one row reads `User: nickname (email@example.com)`, with the email omitted when the account has none.

## Verification

- `make lint`; suggestion review handler tests and moderation API tests pass (218).
- `pnpm run format`, `lint`, `typecheck` clean.
- Screenshot of the API key request card in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)