### PR TITLE
Name events and matches on insight leaderboards instead of showing keys

### DIFF
--- a/pwa/app/components/tba/leaderboard.tsx
+++ b/pwa/app/components/tba/leaderboard.tsx
@@ -4,6 +4,7 @@ import { Fragment, type ReactNode } from 'react';
 
 import MaterialSymbolsTrophy from '~icons/material-symbols/trophy';
 
+import { type Event } from '~/api/tba/read';
 import { InsightCard } from '~/components/tba/insightCard';
 import { MatchLink, TeamLink } from '~/components/tba/links';
 import {
@@ -20,11 +21,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '~/components/ui/tooltip';
+import { getEventNormalizedName } from '~/lib/eventUtils';
 import {
   PRE_EXPANDED_ROWS,
   rankRowClassName,
   rankTextClassName,
 } from '~/lib/insightUtils';
+import { formatMatchKeyName, parseMatchKey } from '~/lib/matchUtils';
 import { pluralize } from '~/lib/utils';
 
 const MAX_KEYS_PER_ROW = 20;
@@ -65,6 +68,7 @@ export function Leaderboard({
   contextTooltipMap,
   year,
   renderKey,
+  eventsByKey,
 }: {
   subtitle?: string;
   leaderboard: LeaderboardShape;
@@ -72,6 +76,8 @@ export function Leaderboard({
   contextTooltipMap?: Record<string, ReactNode>;
   year: number;
   renderKey?: (key: string) => ReactNode;
+  /** Lets event and match keys render as names instead of keys. */
+  eventsByKey?: ReadonlyMap<string, Event>;
 }) {
   const displayName = displayNameProp ?? leaderboard.name;
 
@@ -125,6 +131,7 @@ export function Leaderboard({
                         contextTooltipMap={contextTooltipMap}
                         year={year}
                         renderKey={renderKey}
+                        eventsByKey={eventsByKey}
                       />
                     </TableCell>
                   </TableRow>
@@ -160,6 +167,7 @@ function LeaderboardKeyList({
   contextTooltipMap,
   year,
   renderKey,
+  eventsByKey,
 }: {
   keyType: KeyType;
   keyVals: Array<string> | Array<Array<string>>;
@@ -168,6 +176,7 @@ function LeaderboardKeyList({
   contextTooltipMap?: Record<string, ReactNode>;
   year: number;
   renderKey?: (key: string) => ReactNode;
+  eventsByKey?: ReadonlyMap<string, Event>;
 }) {
   const entries = normalizeKeyEntries(keyVals);
 
@@ -181,6 +190,7 @@ function LeaderboardKeyList({
             entry={entry}
             year={year}
             renderKey={renderKey}
+            eventsByKey={eventsByKey}
             context={contexts?.[i]}
             contextTooltipMap={contextTooltipMap}
           />
@@ -206,6 +216,7 @@ function LeaderboardKeyList({
                       entry={entry}
                       year={year}
                       renderKey={renderKey}
+                      eventsByKey={eventsByKey}
                     />
                   </Fragment>
                 ))}
@@ -223,6 +234,7 @@ function LeaderboardKeyTooltip({
   entry,
   year,
   renderKey,
+  eventsByKey,
   context,
   contextTooltipMap,
 }: {
@@ -230,11 +242,12 @@ function LeaderboardKeyTooltip({
   entry: string | Array<string>;
   year: number;
   renderKey?: (key: string) => ReactNode;
+  eventsByKey?: ReadonlyMap<string, Event>;
   context?: LeaderboardContext;
   contextTooltipMap?: Record<string, ReactNode>;
 }) {
   const tooltipContent = context
-    ? contextFromLeaderboardContext(context)
+    ? contextFromLeaderboardContext(context, eventsByKey)
     : (contextTooltipMap?.[entryToId(entry)] ?? null);
 
   return (
@@ -246,6 +259,7 @@ function LeaderboardKeyTooltip({
             entry={entry}
             year={year}
             renderKey={renderKey}
+            eventsByKey={eventsByKey}
           />
         </TooltipTrigger>
         {tooltipContent ? (
@@ -258,13 +272,14 @@ function LeaderboardKeyTooltip({
   );
 }
 
-function contextFromLeaderboardContext(context: LeaderboardContext): ReactNode {
+function contextFromLeaderboardContext(
+  context: LeaderboardContext,
+  eventsByKey?: ReadonlyMap<string, Event>,
+): ReactNode {
   if ('match_key' in context) {
     return (
       <>
-        <MatchLink matchOrKey={context.match_key}>
-          {context.match_key}
-        </MatchLink>
+        <MatchKeyLink matchKey={context.match_key} eventsByKey={eventsByKey} />
         {context.alliance.length > 0 && (
           <>
             {' '}
@@ -293,12 +308,42 @@ function contextFromLeaderboardContext(context: LeaderboardContext): ReactNode {
       {context.event_keys.map((eventKey, i) => (
         <Fragment key={eventKey}>
           {i > 0 && ', '}
-          <Link to="/event/$eventKey" params={{ eventKey }}>
-            {eventKey}
-          </Link>
+          <EventKeyLink eventKey={eventKey} eventsByKey={eventsByKey} />
         </Fragment>
       ))}
     </>
+  );
+}
+
+/** An event key as a link, named after the event when we know it. */
+function EventKeyLink({
+  eventKey,
+  eventsByKey,
+}: {
+  eventKey: string;
+  eventsByKey?: ReadonlyMap<string, Event>;
+}) {
+  const event = eventsByKey?.get(eventKey);
+  return (
+    <Link to="/event/$eventKey" params={{ eventKey }} title={eventKey}>
+      {event ? getEventNormalizedName(event) : eventKey}
+    </Link>
+  );
+}
+
+/** A match key as a link, named after its event and match when we know it. */
+function MatchKeyLink({
+  matchKey,
+  eventsByKey,
+}: {
+  matchKey: string;
+  eventsByKey?: ReadonlyMap<string, Event>;
+}) {
+  const event = eventsByKey?.get(parseMatchKey(matchKey)?.eventKey ?? '');
+  return (
+    <MatchLink matchOrKey={matchKey} event={event} title={matchKey}>
+      {formatMatchKeyName(matchKey, event)}
+    </MatchLink>
   );
 }
 
@@ -311,11 +356,13 @@ function LeaderboardKeyGroupLink({
   keyType,
   year,
   renderKey,
+  eventsByKey,
 }: {
   keyType: KeyType;
   entry: string | Array<string>;
   year: number;
   renderKey?: (key: string) => ReactNode;
+  eventsByKey?: ReadonlyMap<string, Event>;
 }) {
   if (!Array.isArray(entry)) {
     return (
@@ -324,6 +371,7 @@ function LeaderboardKeyGroupLink({
         keyVal={entry}
         year={year}
         renderKey={renderKey}
+        eventsByKey={eventsByKey}
       />
     );
   }
@@ -340,6 +388,7 @@ function LeaderboardKeyGroupLink({
             keyVal={k}
             year={year}
             renderKey={renderKey}
+            eventsByKey={eventsByKey}
           />
         </Fragment>
       ))}
@@ -352,11 +401,13 @@ function LeaderboardKeyLink({
   keyType,
   year,
   renderKey,
+  eventsByKey,
 }: {
   keyType: KeyType;
   keyVal: string;
   year: number;
   renderKey?: (key: string) => ReactNode;
+  eventsByKey?: ReadonlyMap<string, Event>;
 }) {
   if (renderKey) {
     return <>{renderKey(keyVal)}</>;
@@ -369,13 +420,9 @@ function LeaderboardKeyLink({
     );
   }
   if (keyType === 'event') {
-    return (
-      <Link to="/event/$eventKey" params={{ eventKey: keyVal }}>
-        {keyVal}
-      </Link>
-    );
+    return <EventKeyLink eventKey={keyVal} eventsByKey={eventsByKey} />;
   }
   if (keyType === 'match') {
-    return <MatchLink matchOrKey={keyVal}>{keyVal}</MatchLink>;
+    return <MatchKeyLink matchKey={keyVal} eventsByKey={eventsByKey} />;
   }
 }

--- a/pwa/app/lib/matchUtils.test.ts
+++ b/pwa/app/lib/matchUtils.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, test } from 'vitest';
 
 import type { Match } from '~/api/tba/read';
-import { AllianceColor, CompLevel } from '~/api/tba/read';
-import { getAllianceMatchResult, isValidMatchKey } from '~/lib/matchUtils';
+import {
+  AllianceColor,
+  CompLevel,
+  EventType,
+  PlayoffType,
+} from '~/api/tba/read';
+import {
+  formatMatchKeyName,
+  getAllianceMatchResult,
+  isValidMatchKey,
+  parseMatchKey,
+} from '~/lib/matchUtils';
 
 describe('isValidMatchKey', () => {
   test.each([
@@ -221,5 +231,76 @@ describe('getAllianceMatchResult', () => {
     expect(
       getAllianceMatchResult(match, AllianceColor.BLUE, 'score-based'),
     ).toBe('loss');
+  });
+});
+
+describe('parseMatchKey', () => {
+  test('parses playoff keys with a set number', () => {
+    expect(parseMatchKey('2026arc_sf3m1')).toEqual({
+      eventKey: '2026arc',
+      compLevel: CompLevel.SF,
+      setNumber: 3,
+      matchNumber: 1,
+    });
+  });
+
+  test('parses qualification keys with an implied set of 1', () => {
+    expect(parseMatchKey('2026gal_qm87')).toEqual({
+      eventKey: '2026gal',
+      compLevel: CompLevel.QM,
+      setNumber: 1,
+      matchNumber: 87,
+    });
+  });
+
+  test('rejects malformed keys', () => {
+    expect(parseMatchKey('frc254')).toBeNull();
+    expect(parseMatchKey('2026arc_xx1')).toBeNull();
+  });
+});
+
+describe('formatMatchKeyName', () => {
+  const archimedes = {
+    event_type: EventType.CMP_DIVISION,
+    year: 2026,
+    city: 'Houston',
+    short_name: 'Archimedes',
+    name: 'Archimedes Division',
+    playoff_type: PlayoffType.DOUBLE_ELIM_8_TEAM,
+  };
+
+  test('double-elim playoff match', () => {
+    expect(formatMatchKeyName('2026arc_sf3m1', archimedes)).toBe(
+      'Archimedes Division Match 3',
+    );
+  });
+
+  test('qualification match', () => {
+    expect(formatMatchKeyName('2026arc_qm87', archimedes)).toBe(
+      'Archimedes Division Quals 87',
+    );
+  });
+
+  test('finals', () => {
+    expect(formatMatchKeyName('2026arc_f1m2', archimedes)).toBe(
+      'Archimedes Division Finals 2',
+    );
+  });
+
+  test('legacy single-elim bracket names the set and match', () => {
+    expect(
+      formatMatchKeyName('2019casj_sf2m3', {
+        ...archimedes,
+        year: 2019,
+        event_type: EventType.REGIONAL,
+        short_name: 'Silicon Valley',
+        playoff_type: PlayoffType.BRACKET_8_TEAM,
+      }),
+    ).toBe('Silicon Valley Regional Semis 2 Match 3');
+  });
+
+  test('without the event, just the match title; unparseable keys pass through', () => {
+    expect(formatMatchKeyName('2026arc_qm87')).toBe('Quals 87');
+    expect(formatMatchKeyName('garbage')).toBe('garbage');
   });
 });

--- a/pwa/app/lib/matchUtils.ts
+++ b/pwa/app/lib/matchUtils.ts
@@ -7,6 +7,7 @@ import {
   PlayoffType,
   WltRecord,
 } from '~/api/tba/read';
+import { getEventNormalizedName } from '~/lib/eventUtils';
 
 const COMP_LEVEL_SORT_ORDER: Record<CompLevel, number> = {
   [CompLevel.F]: 5,
@@ -59,8 +60,8 @@ export function sortMultipleEventsMatches(matches: Match[], events: Event[]) {
 }
 
 export function matchTitleShort(
-  match: Match,
-  playoffType: PlayoffType,
+  match: Pick<Match, 'comp_level' | 'set_number' | 'match_number'>,
+  playoffType: PlayoffType | null,
 ): string {
   if (match.comp_level === CompLevel.QM || match.comp_level === CompLevel.F) {
     return `${COMP_LEVEL_SHORT_STRINGS[match.comp_level]} ${match.match_number}`;
@@ -336,4 +337,56 @@ export function getMatchScoreWithoutAdjustPoints(match: Match): {
     redScore: match.alliances.red.score,
     blueScore: match.alliances.blue.score,
   };
+}
+
+const MATCH_KEY_PATTERN =
+  /^(?<eventKey>[1-9]\d{3}[a-z]+[0-9]*)_(?<compLevel>qm|ef|qf|sf|f)(?:(?<setNumber>\d{1,2})m)?(?<matchNumber>\d+)$/;
+
+export interface ParsedMatchKey {
+  eventKey: string;
+  compLevel: CompLevel;
+  setNumber: number;
+  matchNumber: number;
+}
+
+/** Splits a match key like `2026arc_sf3m1` into its parts; null if malformed. */
+export function parseMatchKey(key: string): ParsedMatchKey | null {
+  const groups = MATCH_KEY_PATTERN.exec(key)?.groups;
+  if (!groups) {
+    return null;
+  }
+  return {
+    eventKey: groups.eventKey,
+    compLevel: groups.compLevel as CompLevel,
+    setNumber: groups.setNumber ? Number(groups.setNumber) : 1,
+    matchNumber: Number(groups.matchNumber),
+  };
+}
+
+/**
+ * Human-friendly name for a match key, e.g. "Archimedes Division Match 3" or
+ * "Galileo Division Quals 87", using the same title strings the event and
+ * match pages use. Without the event (not loaded, or unknown) it falls back
+ * to the match title alone, and to the raw key if it can't be parsed.
+ */
+export function formatMatchKeyName(
+  key: string,
+  event?: Pick<
+    Event,
+    'event_type' | 'year' | 'city' | 'short_name' | 'name' | 'playoff_type'
+  >,
+): string {
+  const parsed = parseMatchKey(key);
+  if (!parsed) {
+    return key;
+  }
+  const title = matchTitleShort(
+    {
+      comp_level: parsed.compLevel,
+      set_number: parsed.setNumber,
+      match_number: parsed.matchNumber,
+    },
+    event?.playoff_type ?? null,
+  );
+  return event ? `${getEventNormalizedName(event)} ${title}` : title;
 }

--- a/pwa/app/routes/insights.{-$year}.tsx
+++ b/pwa/app/routes/insights.{-$year}.tsx
@@ -1,17 +1,23 @@
+import { useSuspenseQueries } from '@tanstack/react-query';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 
 import {
+  type Event,
   type InsightV2GameStats,
   type InsightV2Leaderboard,
   type InsightV2Streak,
   type InsightV2Timeseries,
 } from '~/api/tba/read';
-import { getInsightsV2YearOptions } from '~/api/tba/read/@tanstack/react-query.gen';
+import {
+  getEventsByYearOptions,
+  getInsightsV2YearOptions,
+} from '~/api/tba/read/@tanstack/react-query.gen';
 import { Leaderboard } from '~/components/tba/leaderboard';
 import { StreakInsight } from '~/components/tba/streakInsight';
 import { SuccessRateInsight } from '~/components/tba/successRateInsight';
 import { TimeseriesInsight } from '~/components/tba/timeseriesInsight';
 import { YearSelector } from '~/components/tba/yearSelector';
+import { parseMatchKey } from '~/lib/matchUtils';
 import { STALE_TIME, staleTimeForYear } from '~/lib/queryClient';
 import { publicCacheControlHeaders, useValidYears } from '~/lib/utils';
 
@@ -63,8 +69,20 @@ export const Route = createFileRoute('/insights/{-$year}')({
       }
     }
 
+    // Event and match leaderboards render names, not keys, which needs the
+    // events behind those keys. Overall (year 0) boards can span seasons.
+    const eventYears = leaderboardEventYears(leaderboards);
+    await Promise.all(
+      eventYears.map((eventYear) =>
+        queryClient.ensureQueryData({
+          ...getEventsByYearOptions({ path: { year: eventYear } }),
+          staleTime: staleTimeForYear(eventYear),
+        }),
+      ),
+    );
     return {
       year: numericYear,
+      eventYears,
       leaderboards,
       streaks,
       timeseries,
@@ -100,13 +118,51 @@ export const Route = createFileRoute('/insights/{-$year}')({
   component: InsightsPage,
 });
 
+/** Seasons whose events are referenced by event or match keys in the boards. */
+function leaderboardEventYears(leaderboards: InsightV2Leaderboard[]): number[] {
+  const years = new Set<number>();
+  for (const board of leaderboards) {
+    const keyType = board.data.key_type;
+    if (keyType !== 'event' && keyType !== 'match') {
+      continue;
+    }
+    for (const ranking of board.data.rankings) {
+      for (const key of ranking.keys) {
+        if (typeof key !== 'string') {
+          continue;
+        }
+        const eventKey =
+          keyType === 'match' ? parseMatchKey(key)?.eventKey : key;
+        const year = Number(eventKey?.slice(0, 4));
+        if (year > 0) {
+          years.add(year);
+        }
+      }
+    }
+  }
+  return [...years].sort((a, b) => a - b);
+}
+
 function InsightsPage() {
-  const { leaderboards, streaks, timeseries, successRates, year } =
+  const { leaderboards, streaks, timeseries, successRates, year, eventYears } =
     Route.useLoaderData();
+  const eventQueries = useSuspenseQueries({
+    queries: eventYears.map((eventYear) => ({
+      ...getEventsByYearOptions({ path: { year: eventYear } }),
+      staleTime: staleTimeForYear(eventYear),
+    })),
+  });
+  const eventsByKey = new Map<string, Event>();
+  for (const query of eventQueries) {
+    for (const event of query.data) {
+      eventsByKey.set(event.key, event);
+    }
+  }
 
   return (
     <div>
       <SingleYearInsights
+        eventsByKey={eventsByKey}
         leaderboards={leaderboards}
         streaks={streaks}
         timeseries={timeseries}
@@ -131,12 +187,14 @@ function SectionHeading({ children }: { children: string }) {
 
 function SingleYearInsights({
   year,
+  eventsByKey,
   leaderboards,
   streaks,
   timeseries,
   successRates,
 }: {
   year: number;
+  eventsByKey: ReadonlyMap<string, Event>;
   leaderboards: InsightV2Leaderboard[];
   streaks: InsightV2Streak[];
   timeseries: InsightV2Timeseries[];
@@ -203,6 +261,7 @@ function SingleYearInsights({
                 displayName={l.display_name}
                 key={l.name}
                 year={year}
+                eventsByKey={eventsByKey}
               />
             ))}
           </div>

--- a/pwa/tests/insights.spec.ts
+++ b/pwa/tests/insights.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('/insights/2026 leaderboards', () => {
+  test('match leaderboards name the event and match rather than the key', async ({
+    page,
+  }) => {
+    await page.goto('/insights/2026');
+    await page.locator('body[data-hydrated]').waitFor();
+    const link = page
+      .locator('a[href^="/match/"]')
+      .filter({ hasNot: page.locator('[data-slot="tooltip-content"]') })
+      .first();
+    await link.waitFor();
+    const text = (await link.textContent())?.trim() ?? '';
+    // e.g. "Archimedes Division Match 3", never "2026arc_sf3m1"
+    expect(text).not.toMatch(/^\d{4}[a-z0-9]+_/);
+    expect(text).toMatch(/Match \d+|Quals \d+|Finals \d+/);
+    // The key is still available on hover
+    await expect(link).toHaveAttribute('title', /^\d{4}[a-z0-9]+_/);
+  });
+});


### PR DESCRIPTION
Stacked on #10677 (it reuses that PR's `getEventNormalizedName`). Merge #10677 first; this diff then shrinks to `matchUtils`, `leaderboard.tsx`, the insights route, and tests.

## Problem

Match leaderboards on `/insights/2026` ("Highest Auto Score" etc.) listed raw keys: `2026arc_sf3m1`, `2026cancmp_qm53`. Event leaderboards did the same with event keys.

## Change

- Match keys render as `<normalized event name> <match title>`, e.g. **Archimedes Division Match 3**, **Galileo Division Quals 87**, **Silicon Valley Regional Semis 2 Match 3** for a pre-2023 bracket. The match title comes from the existing `matchTitleShort`, so it agrees with the event and match pages; the event name is the Jinja site's `normalized_name`. Event keys render as the normalized event name. The raw key stays on the link as `title`, so it's one hover away.
- Context tooltips (the match behind a team's high score, the events behind a count) use the same names.
- The insights loader collects every season referenced by event/match keys (overall boards can span years) and prefetches those seasons' events, so the names are in the SSR HTML. The component reads them with `useSuspenseQueries` and hands an `eventsByKey` map to `Leaderboard`. When an event isn't known the match title alone is shown; an unparseable key passes through unchanged.

## Tests

- `matchUtils.test.ts`: `parseMatchKey` (playoff, quals, malformed) and `formatMatchKeyName` (double-elim, quals, finals, legacy bracket, no event, garbage).
- `tests/insights.spec.ts`: on `/insights/2026`, the first match link's text is not a key, matches a match-title pattern, and its `title` is the key.
- `pnpm run format:fix`, `lint`, `typecheck` clean; 129 vitest tests pass.

## Screenshots

In a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)