### PR TITLE
Allow 5 digit teams in EventWizard Add Multiple Teams

### DIFF
--- a/src/frontend/eventwizard/components/teamsTab/AddMultipleTeams.tsx
+++ b/src/frontend/eventwizard/components/teamsTab/AddMultipleTeams.tsx
@@ -35,7 +35,7 @@ const AddMultipleTeams: React.FC<AddMultipleTeamsProps> = ({
     const teamInput = inputTeams.split("\n");
     for (let i = 0; inputTeams && i < teamInput.length; i++) {
       const teamNum = parseInt(teamInput[i], 10);
-      if (!teamNum || isNaN(teamNum) || teamNum <= 0 || teamNum > 9999) {
+      if (!teamNum || isNaN(teamNum) || teamNum <= 0 || teamNum > 25599) {
         showErrorMessage(`Invalid team ${teamInput[i]}`);
         return;
       }


### PR DESCRIPTION
## Description
Raise the upper bound on team numbers in EventWizard's "Add Multiple Teams" box from 9999 to 25599.

## Motivation and Context
Fixes #10679.

The check dates from before 5 digit team numbers existed, so pasting a real team list that contains one (for example 2026miwyo) fails the whole submit with `Invalid team 10666`.

25599 is the highest team number expressible in the `10.TE.AM.YY` addressing scheme, since `TE` has to fit in one octet: team 25599 is `10.255.99.0/24`, and 25600 would need `10.256.0.0/24`.

Nothing else in the codebase shares the old limit. The trusted API validates with `Team.validate_key_name` (`^frc[1-9]\d*$`), so the server already accepted these keys, and `AddRemoveSingleTeam` has no numeric bound at all. This client-side check was the only blocker.

## How Has This Been Tested?
`npx jest src/frontend/eventwizard/components/teamsTab/__tests__/AddMultipleTeams.test.tsx` - 7 passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change API specifications or require data migrations)
